### PR TITLE
feat: webhook notifications (Slack, Discord, Teams, generic)

### DIFF
--- a/internal/engine/policy.go
+++ b/internal/engine/policy.go
@@ -35,6 +35,9 @@ type Config struct {
 	// Policies is the ordered list of policy rules.
 	Policies []Policy `yaml:"policies"`
 
+	// Notify configures webhook notifications for policy decisions.
+	Notify *NotifyConfig `yaml:"notify,omitempty"`
+
 	responseRegexCache map[string]*regexp.Regexp
 }
 
@@ -182,6 +185,21 @@ func (c Condition) IsEmpty() bool {
 //	tool: "exec"           → ["exec"]
 //	tool: ["exec", "read"] → ["exec", "read"]
 type StringOrSlice []string
+
+// NotifyConfig configures webhook notifications for policy decisions.
+type NotifyConfig struct {
+	// URL is the webhook endpoint to send notifications to.
+	URL string `yaml:"url"`
+
+	// Platform specifies the notification format.
+	// Valid values: "auto", "slack", "discord", "teams", "webhook".
+	// "auto" detects the platform based on the URL. Default: "auto".
+	Platform string `yaml:"platform"`
+
+	// On specifies which decision types trigger notifications.
+	// Valid values: "deny", "log". Can be a string or list of strings.
+	On []string `yaml:"on"`
+}
 
 // UnmarshalYAML implements custom YAML unmarshaling for string-or-slice fields.
 func (s *StringOrSlice) UnmarshalYAML(value *yaml.Node) error {

--- a/internal/notify/detect.go
+++ b/internal/notify/detect.go
@@ -1,0 +1,50 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package notify
+
+import "strings"
+
+// DetectPlatform detects the webhook platform based on the URL.
+// Returns "slack", "discord", "teams", or "webhook" for generic webhooks.
+func DetectPlatform(url string) string {
+	if strings.Contains(url, "hooks.slack.com") {
+		return "slack"
+	}
+	if strings.Contains(url, "discord.com/api/webhooks") {
+		return "discord"
+	}
+	if strings.Contains(url, "webhook.office.com") || strings.Contains(url, "outlook.office.com") {
+		return "teams"
+	}
+	return "webhook"
+}
+
+// NewNotifier creates a notifier for the specified platform.
+// If platform is "auto" or empty, it will auto-detect based on the URL.
+func NewNotifier(url, platform string) Notifier {
+	if platform == "auto" || platform == "" {
+		platform = DetectPlatform(url)
+	}
+
+	switch platform {
+	case "slack":
+		return NewSlackNotifier(url)
+	case "discord":
+		return NewDiscordNotifier(url)
+	case "teams":
+		return NewTeamsNotifier(url)
+	default:
+		return NewGenericNotifier(url)
+	}
+}

--- a/internal/notify/discord.go
+++ b/internal/notify/discord.go
@@ -1,0 +1,101 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package notify
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// DiscordNotifier sends notifications to Discord using webhook embeds.
+type DiscordNotifier struct {
+	url    string
+	client *http.Client
+}
+
+// NewDiscordNotifier creates a new Discord notifier.
+func NewDiscordNotifier(url string) *DiscordNotifier {
+	return &DiscordNotifier{
+		url: url,
+		client: &http.Client{
+			Timeout: 5 * time.Second,
+		},
+	}
+}
+
+type discordPayload struct {
+	Embeds []discordEmbed `json:"embeds"`
+}
+
+type discordEmbed struct {
+	Title     string         `json:"title"`
+	Color     int            `json:"color"`
+	Fields    []discordField `json:"fields"`
+	Timestamp string         `json:"timestamp"`
+}
+
+type discordField struct {
+	Name   string `json:"name"`
+	Value  string `json:"value"`
+	Inline bool   `json:"inline"`
+}
+
+// Send sends a notification to Discord using embeds format.
+func (n *DiscordNotifier) Send(event NotifyEvent) error {
+	// Choose color and title based on action
+	color := 0xf85149 // red for deny
+	title := "Rampart: Command Denied"
+	if event.Action == "log" {
+		color = 0xd29922 // orange for log
+		title = "Rampart: Command Logged"
+	}
+
+	// Build the embed
+	embed := discordEmbed{
+		Title:     title,
+		Color:     color,
+		Timestamp: event.Timestamp,
+		Fields: []discordField{
+			{Name: "Tool", Value: event.Tool, Inline: true},
+			{Name: "Agent", Value: event.Agent, Inline: true},
+			{Name: "Policy", Value: event.Policy, Inline: true},
+			{Name: "Command/Path", Value: event.Command, Inline: false},
+			{Name: "Message", Value: event.Message, Inline: false},
+		},
+	}
+
+	payload := discordPayload{
+		Embeds: []discordEmbed{embed},
+	}
+
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal discord payload: %w", err)
+	}
+
+	resp, err := n.client.Post(n.url, "application/json", bytes.NewBuffer(data))
+	if err != nil {
+		return fmt.Errorf("post discord webhook: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("discord webhook returned status %d", resp.StatusCode)
+	}
+
+	return nil
+}

--- a/internal/notify/notifier.go
+++ b/internal/notify/notifier.go
@@ -1,0 +1,75 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package notify sends webhook notifications for policy decisions.
+package notify
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// NotifyEvent contains the data for a webhook notification.
+type NotifyEvent struct {
+	Action    string // "deny" or "log"
+	Tool      string // e.g. "exec", "read", "write"
+	Command   string // the command or path
+	Policy    string // policy name that matched
+	Message   string // human-readable reason
+	Agent     string // agent identifier
+	Timestamp string // ISO 8601
+}
+
+// Notifier sends notifications.
+type Notifier interface {
+	Send(event NotifyEvent) error
+}
+
+// GenericNotifier sends notifications to any webhook URL by POSTing the event as JSON.
+type GenericNotifier struct {
+	url    string
+	client *http.Client
+}
+
+// NewGenericNotifier creates a new generic webhook notifier.
+func NewGenericNotifier(url string) *GenericNotifier {
+	return &GenericNotifier{
+		url: url,
+		client: &http.Client{
+			Timeout: 5 * time.Second,
+		},
+	}
+}
+
+// Send posts the event as JSON to the webhook URL.
+func (n *GenericNotifier) Send(event NotifyEvent) error {
+	data, err := json.Marshal(event)
+	if err != nil {
+		return fmt.Errorf("marshal event: %w", err)
+	}
+
+	resp, err := n.client.Post(n.url, "application/json", bytes.NewBuffer(data))
+	if err != nil {
+		return fmt.Errorf("post webhook: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("webhook returned status %d", resp.StatusCode)
+	}
+
+	return nil
+}

--- a/internal/notify/slack.go
+++ b/internal/notify/slack.go
@@ -1,0 +1,132 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package notify
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// SlackNotifier sends notifications to Slack using incoming webhooks with Block Kit formatting.
+type SlackNotifier struct {
+	url    string
+	client *http.Client
+}
+
+// NewSlackNotifier creates a new Slack notifier.
+func NewSlackNotifier(url string) *SlackNotifier {
+	return &SlackNotifier{
+		url: url,
+		client: &http.Client{
+			Timeout: 5 * time.Second,
+		},
+	}
+}
+
+type slackPayload struct {
+	Attachments []slackAttachment `json:"attachments"`
+}
+
+type slackAttachment struct {
+	Color  string        `json:"color"`
+	Blocks []interface{} `json:"blocks"`
+}
+
+type slackSection struct {
+	Type   string                 `json:"type"`
+	Text   *slackText             `json:"text,omitempty"`
+	Fields []slackText            `json:"fields,omitempty"`
+}
+
+type slackContext struct {
+	Type     string              `json:"type"`
+	Elements []slackContextElement `json:"elements"`
+}
+
+type slackContextElement struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type slackText struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// Send sends a notification to Slack using Block Kit format.
+func (n *SlackNotifier) Send(event NotifyEvent) error {
+	// Choose color based on action
+	color := "#f85149" // red for deny
+	actionText := "Command Denied"
+	if event.Action == "log" {
+		color = "#d29922" // orange for log
+		actionText = "Command Logged"
+	}
+
+	// Build the payload
+	payload := slackPayload{
+		Attachments: []slackAttachment{
+			{
+				Color: color,
+				Blocks: []interface{}{
+					// Header section
+					slackSection{
+						Type: "section",
+						Text: &slackText{
+							Type: "mrkdwn",
+							Text: fmt.Sprintf("*🛡️ Rampart: %s*", actionText),
+						},
+					},
+					// Fields section
+					slackSection{
+						Type: "section",
+						Fields: []slackText{
+							{Type: "mrkdwn", Text: fmt.Sprintf("*Tool:*\n%s", event.Tool)},
+							{Type: "mrkdwn", Text: fmt.Sprintf("*Command/Path:*\n%s", event.Command)},
+							{Type: "mrkdwn", Text: fmt.Sprintf("*Policy:*\n%s", event.Policy)},
+							{Type: "mrkdwn", Text: fmt.Sprintf("*Message:*\n%s", event.Message)},
+						},
+					},
+					// Context section with timestamp
+					slackContext{
+						Type: "context",
+						Elements: []slackContextElement{
+							{Type: "mrkdwn", Text: fmt.Sprintf("Agent: %s | %s", event.Agent, event.Timestamp)},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal slack payload: %w", err)
+	}
+
+	resp, err := n.client.Post(n.url, "application/json", bytes.NewBuffer(data))
+	if err != nil {
+		return fmt.Errorf("post slack webhook: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("slack webhook returned status %d", resp.StatusCode)
+	}
+
+	return nil
+}

--- a/internal/notify/teams.go
+++ b/internal/notify/teams.go
@@ -1,0 +1,107 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package notify
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// TeamsNotifier sends notifications to Microsoft Teams using Office 365 connector cards.
+type TeamsNotifier struct {
+	url    string
+	client *http.Client
+}
+
+// NewTeamsNotifier creates a new Teams notifier.
+func NewTeamsNotifier(url string) *TeamsNotifier {
+	return &TeamsNotifier{
+		url: url,
+		client: &http.Client{
+			Timeout: 5 * time.Second,
+		},
+	}
+}
+
+type teamsMessageCard struct {
+	Type       string         `json:"@type"`
+	Context    string         `json:"@context"`
+	Summary    string         `json:"summary"`
+	Title      string         `json:"title"`
+	ThemeColor string         `json:"themeColor"`
+	Sections   []teamsSection `json:"sections"`
+}
+
+type teamsSection struct {
+	Facts []teamsFact `json:"facts"`
+}
+
+type teamsFact struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+// Send sends a notification to Teams using MessageCard format.
+func (n *TeamsNotifier) Send(event NotifyEvent) error {
+	// Choose theme color and title based on action
+	themeColor := "f85149" // red for deny
+	title := "🛡️ Rampart: Command Denied"
+	summary := "Rampart policy engine denied a command"
+	if event.Action == "log" {
+		themeColor = "d29922" // orange for log
+		title = "🛡️ Rampart: Command Logged"
+		summary = "Rampart policy engine logged a command"
+	}
+
+	// Build the message card
+	card := teamsMessageCard{
+		Type:       "MessageCard",
+		Context:    "https://schema.org/extensions",
+		Summary:    summary,
+		Title:      title,
+		ThemeColor: themeColor,
+		Sections: []teamsSection{
+			{
+				Facts: []teamsFact{
+					{Name: "Tool", Value: event.Tool},
+					{Name: "Command/Path", Value: event.Command},
+					{Name: "Policy", Value: event.Policy},
+					{Name: "Message", Value: event.Message},
+					{Name: "Agent", Value: event.Agent},
+					{Name: "Timestamp", Value: event.Timestamp},
+				},
+			},
+		},
+	}
+
+	data, err := json.Marshal(card)
+	if err != nil {
+		return fmt.Errorf("marshal teams payload: %w", err)
+	}
+
+	resp, err := n.client.Post(n.url, "application/json", bytes.NewBuffer(data))
+	if err != nil {
+		return fmt.Errorf("post teams webhook: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("teams webhook returned status %d", resp.StatusCode)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Adds a `notify:` section to policy YAML for real-time webhook notifications on deny/log events.

## What's new
- `internal/notify/` package with platform-specific formatters
- **Slack**: Block Kit with color-coded attachments
- **Discord**: Rich embeds with fields
- **Teams**: MessageCard with facts
- **Generic**: JSON POST to any URL
- Auto-detects platform from webhook URL
- Async delivery (never blocks tool call response)
- 5s HTTP timeout

## Config
```yaml
notify:
  url: https://hooks.slack.com/services/T.../B.../xxx
  platform: auto  # auto-detect, or: slack, discord, teams, webhook
  on: [deny]      # deny, log, or both
```

## Tests
277 lines of tests covering detection, payload formatting, and error cases.