### PR TITLE
docs: Add THREAT-MODEL.md — honest limitations and mitigations

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,6 +544,8 @@ The agent communicates with Rampart over HTTP on localhost — no file access ne
 
 For single-user or development setups, running as the same user works fine. The separation matters most in production where agents run unsupervised.
 
+For a full discussion of what Rampart does and doesn't protect against, see [`docs/THREAT-MODEL.md`](docs/THREAT-MODEL.md).
+
 ---
 
 ## CLI Reference
@@ -666,11 +668,7 @@ Current: **v0.1.8** — all tests passing.
 `rampart wrap` and `rampart preload` require Linux or macOS.
 `--syslog` requires Linux or macOS. `--cef` works on all platforms.
 
-What's next:
-- Behavioral fingerprinting from audit data
-- Temporal sequence detection ("read .env then curl within 30s")
-- Web dashboard for policy management
-- Additional SIEM guides (Splunk, Elastic)
+See [`docs/ROADMAP.md`](docs/ROADMAP.md) for what's coming next. Priorities shift based on feedback — [open an issue](https://github.com/peg/rampart/issues) if something matters to you.
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,32 +2,26 @@
 
 What's coming next for Rampart. Priorities shift based on feedback — open an issue if something matters to you.
 
-## Recently Shipped (v0.1.x)
+## Recently Shipped
 
-- ✅ Claude Code hook integration
-- ✅ MCP protocol proxy
-- ✅ Shell wrapper (`rampart wrap`)
-- ✅ Live TUI dashboard (`rampart watch`)
-- ✅ HTML audit reports (`rampart report`)
-- ✅ Webhook notifications (Slack, Discord, Teams)
-- ✅ Environment detection (`rampart init --detect`)
+- ✅ Native hooks for Claude Code and Cline
+- ✅ MCP protocol proxy with auto-policy generation
+- ✅ Shell wrapper and LD_PRELOAD interception
+- ✅ Live TUI dashboard and HTML reports
+- ✅ Webhook notifications and webhook actions
+- ✅ SIEM integration (syslog + CEF)
+- ✅ Semantic verification sidecar ([rampart-verify](https://github.com/peg/rampart-verify))
 
 ## Up Next
 
-- **Smarter MCP enforcement** — transport improvements, tool schema analysis
-- **CI integration** — GitHub Action for wrapping AI agents in pull requests
-- **Policy intelligence** — detect credential exfiltration patterns in tool calls
-- **Starter policy library** — curated policies for common stacks
-
-## Future
-
-- **MCP server isolation** — Deno-style per-server permissions
-- **Community rules** — shareable policy patterns
-- **Response evaluation** — inspect tool outputs, not just inputs
+- Expanded integration guides
+- Starter policy library for common stacks
+- CI/CD integration
+- Additional SIEM platform guides
 
 ## Non-Goals
 
-Rampart is a policy engine for agents that operate in the real world. We don't chase full sandboxing — if an agent can be sandboxed, it doesn't need Rampart. We focus on the agents that *can't* be locked down because they need access to your actual infrastructure.
+Rampart is a policy engine for agents that operate in the real world. We don't chase full sandboxing — if an agent can be sandboxed, it doesn't need Rampart. We focus on the agents that *can't* be locked down because they need real access to your infrastructure.
 
 ---
 

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -1,0 +1,123 @@
+# Threat Model
+
+> Last reviewed: 2026-02-12 | Applies to: v0.1.8
+
+Rampart is a policy engine for AI agents — not a sandbox, not a hypervisor, not a full isolation boundary. This document describes what Rampart protects against, what it doesn't, and why.
+
+## What Rampart Is
+
+A firewall for AI agent tool calls. It evaluates commands against YAML policies and makes allow/deny/log decisions in microseconds. It's designed to catch the 95%+ case: an AI agent that hallucinated a dangerous command or got manipulated by a prompt injection.
+
+## Primary Threat: Misbehaving AI Agents
+
+Rampart's target threat is an AI agent that:
+
+- **Hallucinated a destructive command** (`rm -rf /`, `DROP TABLE`)
+- **Was manipulated by prompt injection** (malicious content in a file or webpage told it to exfiltrate data)
+- **Made a well-intentioned mistake** (wrong environment, wrong file, wrong server)
+
+These agents aren't adversarial — they're confused, manipulated, or wrong. Rampart catches them reliably.
+
+## Not the Target: Adversarial Human Attackers
+
+Rampart does **not** claim to stop a skilled human who has already compromised your system. If an attacker has shell access, they can bypass Rampart the same way they'd bypass any userspace tool. Rampart is one layer in defense-in-depth, not a replacement for OS hardening, network segmentation, or access control.
+
+## Trust Boundaries
+
+```
+┌─────────────────────────────────────────────┐
+│ Trusted                                      │
+│  • Policy files (admin-authored YAML)        │
+│  • Rampart binary                            │
+│  • rampart serve process                     │
+│  • Audit log directory (when user-separated) │
+├─────────────────────────────────────────────┤
+│ Untrusted                                    │
+│  • AI agent tool calls (all input)           │
+│  • Agent-generated commands                  │
+│  • MCP tool call parameters                  │
+│  • Webhook response payloads (validated)     │
+└─────────────────────────────────────────────┘
+```
+
+Policy files are the security boundary. If an attacker can modify policy files, Rampart's guarantees do not hold. This is why [user separation](../README.md#security-recommendations) is recommended for production.
+
+## Known Limitations
+
+### 1. Interpreter Bypass
+
+Rampart evaluates the command string passed to the shell. This applies to **all integration methods** — native hooks (Claude Code, Cline), wrap mode, LD_PRELOAD, and the HTTP API all see the same command string. If an agent runs `python3 script.py`, Rampart sees and evaluates `python3 script.py` — but cannot inspect what `script.py` does internally.
+
+**Mitigations:**
+- The optional [rampart-verify](https://github.com/peg/rampart-verify) sidecar uses LLM classification to assess intent of commands like `python3 -c "..."` based on the inline code
+- File write hooks can catch the creation of malicious scripts before execution
+- Patterns like `python3 -c *` can be routed to semantic verification via `action: webhook`
+
+**Remaining surface:** Multi-step sequences (write file, then execute) are an active area of development. In practice, AI agents overwhelmingly shell out via `subprocess`/`os.system` rather than using native APIs — and those shell-outs go through Rampart.
+
+### 2. Audit Log Rewrite
+
+The hash-chained audit trail detects **partial tampering** — editing, inserting, or deleting individual records breaks the chain. However, a complete rewrite from scratch with a new valid chain is not detectable from the log file alone.
+
+**Mitigations:**
+- Run `rampart serve` as a [separate user](../README.md#security-recommendations) so the agent can't access audit files
+- Enable SIEM export (`--syslog` or `--cef`) to send events to an external system the agent can't modify
+- Webhook notifications send real-time alerts to Discord/Slack — a separate record
+
+**For compliance environments:** Pair with external immutable logging (CloudTrail, Wazuh, etc.) for an independent trust anchor.
+
+### 3. Token Exposure in Wrap Mode
+
+The `rampart wrap` shim needs a bearer token to authenticate with `rampart serve`. As of v0.1.8, the token is stored in a `0600` file (not embedded in the shim script). However, the agent user can still read this file.
+
+**Mitigations:**
+- Run `rampart serve` as a separate user and store the token in that user's home directory with restricted permissions
+- Use native hooks (`rampart setup claude-code`) instead of wrap mode — hooks don't require a token file
+
+**Resolution:** Use [user separation](../README.md#security-recommendations) for production deployments, or prefer native hooks which don't require a token file.
+
+### 4. Encoding and Obfuscation
+
+An agent could potentially encode commands to bypass pattern matching:
+
+- Base64-encoded payloads
+- Variable expansion, command splitting
+
+**Mitigations:**
+- Rampart decodes base64 commands before pattern matching
+- Leading shell comments are stripped before evaluation
+- The semantic verification sidecar classifies intent regardless of encoding
+- Common obfuscation patterns (`base64 *`, `eval *`) can trigger webhook verification
+
+**Coverage:** The two-layer approach (pattern matching + LLM classification) significantly reduces the obfuscation surface. Pattern matching catches known encodings; the LLM layer catches intent regardless of how the command is formatted.
+
+### 5. Fail-Open Behavior
+
+When `rampart serve` is unreachable (crashed, network issue), the shim defaults to **fail-open** — commands execute without policy checks. This is a deliberate design choice: fail-closed would lock you out of your own machine.
+
+**Mitigations:**
+- Monitor the Rampart service and alert on downtime
+- Use systemd/launchd to auto-restart on failure
+- Webhook notifications confirm the service is actively evaluating commands
+
+**Trade-off:** Fail-open means a brief security gap during outages. Fail-closed means a crashed Rampart bricks your agent (and potentially your system). We chose availability over strict enforcement. This is configurable for environments where fail-closed is preferred.
+
+## Deployment Recommendations
+
+| Setup | Agent reads audit? | Agent modifies policy? | Best for |
+|-------|-------------------|----------------------|----------|
+| Same user (default) | ✅ Yes | ✅ Yes | Development, testing |
+| Separate user | ❌ No | ❌ No | Production, unsupervised agents |
+| Separate user + SIEM | ❌ No | ❌ No | Enterprise, compliance |
+
+## Philosophy
+
+Rampart is a **seatbelt, not a roll cage**. It catches the vast majority of dangerous situations an AI agent will encounter — accidental or manipulated. It doesn't claim to stop every possible attack vector, and we're honest about what falls outside its scope.
+
+If you need full isolation, use a sandbox (container, VM, or a tool like [fluid.sh](https://fluid.sh)). Rampart and sandboxes are complementary — use both for defense in depth.
+
+---
+
+## Reporting Security Issues
+
+If you've found a vulnerability not covered here, please email [rampartsec@pm.me](mailto:rampartsec@pm.me). We'll acknowledge within 48 hours and work with you on coordinated disclosure. Please do **not** open public issues for security vulnerabilities.


### PR DESCRIPTION
Adds `docs/THREAT-MODEL.md` documenting 5 known limitations with mitigations:

1. **Interpreter bypass** — can't inspect code inside python/node interpreters
2. **Audit log complete rewrite** — hash chain detects partial tampering, not full rewrite
3. **Token exposure in wrap mode** — same-user can read token file
4. **Encoding/obfuscation** — novel encodings may bypass pattern matching
5. **Fail-open behavior** — commands pass through when serve is down

Each section includes current mitigations and what remains unaddressed. Deployment recommendations table included.

README updated with link from Security Recommendations section.