### PR TITLE
Fix macOS symlink bypass, doc corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,10 +394,9 @@ version: "1"
 default_action: allow
 
 notify:
-  webhook:
-    url: "https://discord.com/api/webhooks/your/webhook"
-    # Or Slack: "https://hooks.slack.com/services/your/webhook"
-    events: ["deny"]  # Only notify on denied commands (options: deny, log, ask, allow)
+  url: "https://discord.com/api/webhooks/your/webhook"
+  # Or Slack: "https://hooks.slack.com/services/your/webhook"
+  on: ["deny"]  # Only notify on denied commands (options: deny, log)
 
 policies:
   # ... your policies

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -11,7 +11,7 @@ Agent → Tool Call → Rampart → Policy Engine → Allow / Deny / Log
 
 ## Design Decisions
 
-**Fail-closed.** If Rampart crashes, tool calls fail. The agent doesn't get unrestricted access. A security layer that fails open is a logging tool.
+**Fail-open by default.** If Rampart crashes or is unreachable, tool calls pass through. This is deliberate — fail-closed locks you out of your own machine. See the [threat model](THREAT-MODEL.md) for trade-offs and mitigations.
 
 **Custom YAML over OPA/Rego.** The domain is narrow — "should this tool call run?" — and doesn't need a general-purpose policy language. Three lines of YAML beats fifteen lines of Rego. The custom engine also evaluates in <10µs vs OPA's 0.1-1ms.
 

--- a/docs/PRELOAD-SPEC.md
+++ b/docs/PRELOAD-SPEC.md
@@ -1,8 +1,7 @@
 # Rampart Preload — Syscall-Level Agent Protection
 
-**Status:** Spec / Not yet implemented  
-**Target:** v0.2.0  
-**Effort:** 4-5 weeks
+**Status:** Shipped (v0.1.5+)  
+**See also:** `rampart preload --help`, [README](../README.md#ld_preload)
 
 ## Overview
 

--- a/docs/guides/securing-claude-desktop.md
+++ b/docs/guides/securing-claude-desktop.md
@@ -161,7 +161,7 @@ policies:
     match:
       tool: ["write"]
     rules:
-      - action: ask
+      - action: require_approval
         when:
           path_matches: ["**/.*"]  # Hidden files
         message: "Writing to hidden file — approve?"

--- a/internal/engine/matcher_test.go
+++ b/internal/engine/matcher_test.go
@@ -59,7 +59,7 @@ func TestMatchGlob(t *testing.T) {
 	}
 }
 
-func TestCleanPath(t *testing.T) {
+func TestCleanPaths(t *testing.T) {
 	tests := []struct {
 		input string
 		want  string
@@ -72,9 +72,9 @@ func TestCleanPath(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			got := cleanPath(tt.input)
-			if got != tt.want {
-				t.Errorf("cleanPath(%q) = %q, want %q", tt.input, got, tt.want)
+			cleaned, _ := cleanPaths(tt.input)
+			if cleaned != tt.want {
+				t.Errorf("cleanPaths(%q) cleaned = %q, want %q", tt.input, cleaned, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes from Codex code review:

- **P1**: macOS symlink path bypass — policies now match both cleaned and resolved paths (e.g. /etc and /private/etc)
- **P2**: README notify example corrected to match engine schema
- **P2**: Claude Desktop guide uses require_approval instead of ask
- **P2**: ARCHITECTURE.md corrected to fail-open (matches actual behavior)
- **P3**: PRELOAD-SPEC.md updated to shipped status

All 15 test suites pass.