### PR TITLE
feat: policy test framework — rampart test

### DIFF
--- a/internal/engine/testrunner.go
+++ b/internal/engine/testrunner.go
@@ -1,0 +1,180 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TestSuite is a collection of test cases to run against a policy.
+type TestSuite struct {
+	// Policy is the path to the policy file to test against.
+	Policy string `yaml:"policy"`
+
+	// Tests is the list of test cases.
+	Tests []TestCase `yaml:"tests"`
+}
+
+// TestCase defines a single policy test expectation.
+type TestCase struct {
+	// Name describes what this test verifies.
+	Name string `yaml:"name"`
+
+	// Tool is the tool type (exec, read, write).
+	Tool string `yaml:"tool"`
+
+	// Agent is the agent identity for the test call (default: "test").
+	Agent string `yaml:"agent,omitempty"`
+
+	// Params are tool-specific parameters.
+	Params map[string]any `yaml:"params"`
+
+	// Expect is the expected action (allow, deny, log, require_approval, webhook).
+	Expect string `yaml:"expect"`
+
+	// ExpectMessage is an optional glob pattern to match against the decision message.
+	ExpectMessage string `yaml:"expect_message,omitempty"`
+}
+
+// TestResult holds the outcome of running a single test case.
+type TestResult struct {
+	Case           TestCase
+	Passed         bool
+	Decision       Decision
+	ExpectedAction Action
+	Error          error
+}
+
+// LoadTestSuite reads a test suite from a YAML file.
+func LoadTestSuite(path string) (*TestSuite, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read test file: %w", err)
+	}
+
+	var suite TestSuite
+	if err := yaml.Unmarshal(data, &suite); err != nil {
+		return nil, fmt.Errorf("parse test file: %w", err)
+	}
+
+	if len(suite.Tests) == 0 {
+		return nil, fmt.Errorf("test file contains no tests")
+	}
+
+	// Resolve policy path relative to the test file's directory.
+	if suite.Policy != "" && !filepath.IsAbs(suite.Policy) {
+		dir := filepath.Dir(path)
+		suite.Policy = filepath.Join(dir, suite.Policy)
+	}
+
+	return &suite, nil
+}
+
+// LoadInlineTests extracts inline tests from a policy file.
+// Returns nil, nil if no tests key is present.
+func LoadInlineTests(policyPath string) (*TestSuite, error) {
+	data, err := os.ReadFile(policyPath)
+	if err != nil {
+		return nil, fmt.Errorf("read policy file: %w", err)
+	}
+
+	var raw map[string]any
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("parse policy file: %w", err)
+	}
+
+	testsRaw, ok := raw["tests"]
+	if !ok {
+		return nil, nil
+	}
+
+	testsYAML, err := yaml.Marshal(testsRaw)
+	if err != nil {
+		return nil, fmt.Errorf("marshal inline tests: %w", err)
+	}
+
+	var cases []TestCase
+	if err := yaml.Unmarshal(testsYAML, &cases); err != nil {
+		return nil, fmt.Errorf("parse inline tests: %w", err)
+	}
+
+	if len(cases) == 0 {
+		return nil, nil
+	}
+
+	abs, _ := filepath.Abs(policyPath)
+	return &TestSuite{
+		Policy: abs,
+		Tests:  cases,
+	}, nil
+}
+
+// RunTests executes all test cases in a suite against the given engine.
+func RunTests(eng *Engine, suite *TestSuite) []TestResult {
+	results := make([]TestResult, 0, len(suite.Tests))
+	for _, tc := range suite.Tests {
+		results = append(results, runSingleTest(eng, tc))
+	}
+	return results
+}
+
+func runSingleTest(eng *Engine, tc TestCase) TestResult {
+	expectedAction, err := ParseAction(tc.Expect)
+	if err != nil {
+		return TestResult{Case: tc, Error: fmt.Errorf("invalid expect value %q: %w", tc.Expect, err)}
+	}
+
+	if tc.Tool == "" {
+		return TestResult{Case: tc, Error: fmt.Errorf("test case %q: tool is required", tc.Name)}
+	}
+
+	agent := tc.Agent
+	if agent == "" {
+		agent = "test"
+	}
+
+	params := tc.Params
+	if params == nil {
+		params = make(map[string]any)
+	}
+
+	call := ToolCall{
+		Tool:      tc.Tool,
+		Agent:     agent,
+		Params:    params,
+		Timestamp: time.Now(),
+	}
+
+	decision := eng.Evaluate(call)
+	passed := decision.Action == expectedAction
+
+	if passed && tc.ExpectMessage != "" {
+		matched, _ := filepath.Match(tc.ExpectMessage, decision.Message)
+		if !matched {
+			passed = false
+		}
+	}
+
+	return TestResult{
+		Case:           tc,
+		Passed:         passed,
+		Decision:       decision,
+		ExpectedAction: expectedAction,
+	}
+}

--- a/internal/engine/testrunner_test.go
+++ b/internal/engine/testrunner_test.go
@@ -1,0 +1,242 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+var testPolicy = `
+default_action: allow
+policies:
+  - name: block-rm
+    match:
+      tool: ["exec"]
+    rules:
+      - action: deny
+        when:
+          command_matches:
+            - "rm -rf *"
+        message: "Blocked rm -rf"
+  - name: block-secrets
+    match:
+      tool: ["read"]
+    rules:
+      - action: deny
+        when:
+          path_matches:
+            - "/etc/shadow"
+        message: "Blocked secret read"
+  - name: approve-deploy
+    match:
+      tool: ["exec"]
+    rules:
+      - action: require_approval
+        when:
+          command_matches:
+            - "kubectl apply *"
+        message: "Deploy needs approval"
+`
+
+func setupTestEngine(t *testing.T) (*Engine, string) {
+	t.Helper()
+	dir := t.TempDir()
+	policyFile := filepath.Join(dir, "policy.yaml")
+	if err := os.WriteFile(policyFile, []byte(testPolicy), 0644); err != nil {
+		t.Fatal(err)
+	}
+	store := NewFileStore(policyFile)
+	eng, err := New(store, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return eng, dir
+}
+
+func TestRunTests_AllPass(t *testing.T) {
+	eng, _ := setupTestEngine(t)
+
+	suite := &TestSuite{
+		Tests: []TestCase{
+			{Name: "deny rm", Tool: "exec", Params: map[string]any{"command": "rm -rf /"}, Expect: "deny"},
+			{Name: "allow git", Tool: "exec", Params: map[string]any{"command": "git status"}, Expect: "allow"},
+			{Name: "deny shadow", Tool: "read", Params: map[string]any{"path": "/etc/shadow"}, Expect: "deny"},
+			{Name: "approve kubectl", Tool: "exec", Params: map[string]any{"command": "kubectl apply -f app.yaml"}, Expect: "require_approval"},
+		},
+	}
+
+	results := RunTests(eng, suite)
+	for _, r := range results {
+		if r.Error != nil {
+			t.Errorf("test %q error: %v", r.Case.Name, r.Error)
+		}
+		if !r.Passed {
+			t.Errorf("test %q failed: expected %s, got %s", r.Case.Name, r.ExpectedAction, r.Decision.Action)
+		}
+	}
+}
+
+func TestRunTests_Failure(t *testing.T) {
+	eng, _ := setupTestEngine(t)
+
+	suite := &TestSuite{
+		Tests: []TestCase{
+			{Name: "wrong expect", Tool: "exec", Params: map[string]any{"command": "rm -rf /"}, Expect: "allow"},
+		},
+	}
+
+	results := RunTests(eng, suite)
+	if len(results) != 1 {
+		t.Fatal("expected 1 result")
+	}
+	if results[0].Passed {
+		t.Error("expected test to fail")
+	}
+}
+
+func TestRunTests_InvalidExpect(t *testing.T) {
+	eng, _ := setupTestEngine(t)
+
+	suite := &TestSuite{
+		Tests: []TestCase{
+			{Name: "bad expect", Tool: "exec", Params: map[string]any{"command": "ls"}, Expect: "bogus"},
+		},
+	}
+
+	results := RunTests(eng, suite)
+	if results[0].Error == nil {
+		t.Error("expected error for invalid expect value")
+	}
+}
+
+func TestRunTests_ExpectMessage(t *testing.T) {
+	eng, _ := setupTestEngine(t)
+
+	suite := &TestSuite{
+		Tests: []TestCase{
+			{Name: "msg match", Tool: "exec", Params: map[string]any{"command": "rm -rf /"}, Expect: "deny", ExpectMessage: "Blocked*"},
+			{Name: "msg mismatch", Tool: "exec", Params: map[string]any{"command": "rm -rf /"}, Expect: "deny", ExpectMessage: "Wrong*"},
+		},
+	}
+
+	results := RunTests(eng, suite)
+	if !results[0].Passed {
+		t.Error("expected message glob match to pass")
+	}
+	if results[1].Passed {
+		t.Error("expected message glob mismatch to fail")
+	}
+}
+
+func TestRunTests_MissingTool(t *testing.T) {
+	eng, _ := setupTestEngine(t)
+
+	suite := &TestSuite{
+		Tests: []TestCase{
+			{Name: "no tool", Params: map[string]any{"command": "ls"}, Expect: "allow"},
+		},
+	}
+
+	results := RunTests(eng, suite)
+	if results[0].Error == nil {
+		t.Error("expected error for missing tool")
+	}
+}
+
+func TestLoadTestSuite(t *testing.T) {
+	dir := t.TempDir()
+
+	policyFile := filepath.Join(dir, "policy.yaml")
+	os.WriteFile(policyFile, []byte(testPolicy), 0644)
+
+	suiteFile := filepath.Join(dir, "tests.yaml")
+	os.WriteFile(suiteFile, []byte(`
+policy: ./policy.yaml
+tests:
+  - name: "test1"
+    tool: exec
+    params:
+      command: "rm -rf /"
+    expect: deny
+`), 0644)
+
+	suite, err := LoadTestSuite(suiteFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(suite.Tests) != 1 {
+		t.Fatalf("expected 1 test, got %d", len(suite.Tests))
+	}
+	if suite.Policy != filepath.Join(dir, "policy.yaml") {
+		t.Errorf("policy path not resolved: %s", suite.Policy)
+	}
+}
+
+func TestLoadInlineTests(t *testing.T) {
+	dir := t.TempDir()
+	policyFile := filepath.Join(dir, "policy.yaml")
+	os.WriteFile(policyFile, []byte(testPolicy+`
+tests:
+  - name: "inline test"
+    tool: exec
+    params:
+      command: "rm -rf /"
+    expect: deny
+`), 0644)
+
+	suite, err := LoadInlineTests(policyFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if suite == nil {
+		t.Fatal("expected inline tests")
+	}
+	if len(suite.Tests) != 1 {
+		t.Fatalf("expected 1 test, got %d", len(suite.Tests))
+	}
+}
+
+func TestLoadInlineTests_NoTests(t *testing.T) {
+	dir := t.TempDir()
+	policyFile := filepath.Join(dir, "policy.yaml")
+	os.WriteFile(policyFile, []byte(testPolicy), 0644)
+
+	suite, err := LoadInlineTests(policyFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if suite != nil {
+		t.Error("expected nil for policy without tests")
+	}
+}
+
+func TestRunTests_DefaultAgent(t *testing.T) {
+	eng, _ := setupTestEngine(t)
+
+	suite := &TestSuite{
+		Tests: []TestCase{
+			{Name: "default agent", Tool: "exec", Params: map[string]any{"command": "ls"}, Expect: "allow"},
+			{Name: "custom agent", Tool: "exec", Agent: "myagent", Params: map[string]any{"command": "ls"}, Expect: "allow"},
+		},
+	}
+
+	results := RunTests(eng, suite)
+	for _, r := range results {
+		if !r.Passed {
+			t.Errorf("test %q failed", r.Case.Name)
+		}
+	}
+}

--- a/policies/demo.yaml
+++ b/policies/demo.yaml
@@ -13,6 +13,9 @@
 #   echo "hello world"          → allowed
 #   rm -rf /                    → blocked
 #   kubectl apply -f app.yaml   → waits for your approval
+#
+# Run inline tests:
+#   rampart test policies/demo.yaml
 
 version: "1"
 default_action: allow
@@ -80,3 +83,42 @@ policies:
             - "curl *"
             - "wget *"
         message: "Network request logged"
+
+# Inline tests — validate with: rampart test policies/demo.yaml
+tests:
+  - name: "blocks rm -rf /"
+    tool: exec
+    params:
+      command: "rm -rf /"
+    expect: deny
+    expect_message: "Destructive command blocked"
+
+  - name: "allows echo"
+    tool: exec
+    params:
+      command: "echo hello"
+    expect: allow
+
+  - name: "blocks reading .env"
+    tool: read
+    params:
+      path: "/home/user/project/.env"
+    expect: deny
+
+  - name: "allows reading .env.example"
+    tool: read
+    params:
+      path: "/home/user/project/.env.example"
+    expect: allow
+
+  - name: "requires approval for kubectl apply"
+    tool: exec
+    params:
+      command: "kubectl apply -f app.yaml"
+    expect: require_approval
+
+  - name: "logs curl requests"
+    tool: exec
+    params:
+      command: "curl https://example.com"
+    expect: log


### PR DESCRIPTION
Validate policies before deploying them.

```bash
rampart test policy.yaml        # inline tests
rampart test tests.yaml         # standalone suite
rampart test --verbose          # show matched rules
rampart test --run "*deploy*"   # filter by name
```

- TestSuite/TestCase/TestResult types in `internal/engine/testrunner.go`
- CLI integration detects YAML files and runs test suites
- Colored ✅/❌ output with summary, exit code 1 on failure
- `expect_message` glob matching, optional `agent` field
- 6 example tests added to `policies/demo.yaml`
- Backward compatible with existing `rampart test "rm -rf /"` usage