### PR TITLE
feat: response-side scanning — detect credential leaks in tool output

### DIFF
--- a/cmd/rampart/cli/hook_fuzz_test.go
+++ b/cmd/rampart/cli/hook_fuzz_test.go
@@ -60,8 +60,9 @@ func FuzzParseClaudeCodeInput(f *testing.F) {
 		reader := strings.NewReader(data)
 
 		// Should never panic, even with malformed JSON
-		tool, params, agent, err := parseClaudeCodeInput(reader, logger)
-		_, _, _, _ = tool, params, agent, err
+		parsed, err := parseClaudeCodeInput(reader, logger)
+		_ = parsed
+		_ = err
 		// We don't care if it fails, just that it doesn't panic
 	})
 }
@@ -129,8 +130,9 @@ func FuzzParseClineInput(f *testing.F) {
 		reader := strings.NewReader(data)
 
 		// Should never panic, even with malformed JSON
-		tool, params, agent, err := parseClineInput(reader, logger)
-		_, _, _, _ = tool, params, agent, err
+		parsed, err := parseClineInput(reader, logger)
+		_ = parsed
+		_ = err
 		// We don't care if it fails, just that it doesn't panic
 	})
 }

--- a/policies/standard.yaml
+++ b/policies/standard.yaml
@@ -241,3 +241,21 @@ policies:
 #            - "apt install *"
 #            - "brew install *"
 #        message: "Package install — approve or deny?"
+
+  # Response scanning — detect credentials leaked in tool output.
+  # These rules evaluate PostToolUse responses (tool output after execution).
+  # Uses regex patterns (response_matches) not glob patterns.
+  - name: block-credential-leakage
+    match:
+      tool: ["exec", "read"]
+    rules:
+      - action: deny
+        when:
+          response_matches:
+            - "AWS_SECRET_ACCESS_KEY\\s*="
+            - "-----BEGIN (RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----"
+            - "ghp_[A-Za-z0-9_]{36,}"
+            - "sk-[A-Za-z0-9]{20,}"
+            - "AKIA[0-9A-Z]{16}"
+            - "xox[bpras]-[0-9a-zA-Z-]+"
+        message: "Response contains potential credentials — output blocked"


### PR DESCRIPTION
Wires PostToolUse response scanning into the hook integration.

- PostToolUse events now route through `EvaluateResponse()`
- Default `block-credential-leakage` policy in `standard.yaml`:
  - AWS keys, private keys, GitHub PATs, OpenAI keys, Slack tokens
- Blocked responses return `permissionDecision: block` on PostToolUse hooks
- 7 new test cases covering PostToolUse parsing and response blocking
- Docs expanded with response scanning setup and examples

The engine's response evaluation and regex matching were already implemented — this PR wires them into the actual hook integration so they fire in practice.