### PR TITLE
docs: update roadmap, remove stale version refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,7 +514,7 @@ rampart setup openclaw --patch-tools
 
 This patches OpenClaw's Read, Write, Edit, and Grep tools to check Rampart before file operations. Requires write access to the OpenClaw installation directory (typically needs `sudo` for global npm installs).
 
-Supports OpenClaw `2026.1.30` – `2026.2.12` (latest).
+Supports recent OpenClaw versions with shell shim capabilities.
 
 ⚠️ **Re-run after OpenClaw upgrades** — the patch modifies files in `node_modules` that get replaced on update. Between upgrade and re-patch, file tools bypass Rampart (exec shim remains active).
 
@@ -655,24 +655,7 @@ All work goes through the `staging` branch. PRs to `main` require one approving 
 
 ## Roadmap
 
-Current: **v0.2.0** — all tests passing.
-- `rampart hook` — native Claude Code/Cline hook handler
-- `rampart wrap` — zero-config agent wrapping via `$SHELL`
-- `rampart preload` — syscall-level interception via LD_PRELOAD (works with any agent)
-- `rampart mcp` — MCP protocol proxy with policy enforcement
-- `rampart mcp scan` — auto-generate policies from MCP server tool lists
-- `action: webhook` — delegate decisions to external HTTP endpoints
-- SIEM integration — `--syslog` (RFC 5424), `--cef` (Common Event Format)
-- Python SDK (`sdks/python/`) — decorators, async support
-- Four interceptors (exec, read, write, fetch)
-- Response-side evaluation (catch credential leaks in output)
-- Hash-chained audit trail with verification
-- Human approval flow
-- Live terminal dashboard
-- Webhook notifications (Slack, Discord, Teams, generic)
-- HTML audit reports
-- OpenClaw daemon integration
-- Three security profiles (standard, paranoid, yolo)
+See [`docs/ROADMAP.md`](docs/ROADMAP.md) for what's planned. Priorities shift based on feedback — [open an issue](https://github.com/peg/rampart/issues) if something matters to you.
 
 ## Compatibility
 
@@ -697,8 +680,6 @@ Current: **v0.2.0** — all tests passing.
 `rampart hook`, `rampart mcp`, `rampart mcp scan`, and `rampart serve` work on Linux, macOS, and Windows.
 `rampart wrap` and `rampart preload` require Linux or macOS.
 `--syslog` requires Linux or macOS. `--cef` works on all platforms.
-
-See [`docs/ROADMAP.md`](docs/ROADMAP.md) for what's coming next. Priorities shift based on feedback — [open an issue](https://github.com/peg/rampart/issues) if something matters to you.
 
 ---
 

--- a/docs-site/integrations/openclaw.md
+++ b/docs-site/integrations/openclaw.md
@@ -49,7 +49,7 @@ OpenClaw
 
 ## Compatibility
 
-Supports OpenClaw `2026.1.30`+ with pi-coding-agent `0.50.7`+.
+Supports recent OpenClaw versions with pi-coding-agent.
 
 ## Monitor
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,31 +1,34 @@
 # Roadmap
 
-What's coming next for Rampart. Priorities shift based on feedback — open an issue if something matters to you.
+What's coming next for Rampart. Priorities shift based on feedback — [open an issue](https://github.com/peg/rampart/issues) if something matters to you.
 
 ## Recently Shipped
 
-- ✅ Native hooks for Claude Code and Cline
-- ✅ MCP protocol proxy with auto-policy generation
-- ✅ Shell wrapper and LD_PRELOAD interception
+- ✅ Native hooks for Claude Code (PreToolUse + PostToolUse) and Cline
+- ✅ MCP protocol proxy with auto-policy generation (`rampart mcp scan`)
+- ✅ Shell wrapper (`rampart wrap`) and LD_PRELOAD interception
 - ✅ Live TUI dashboard and HTML reports
 - ✅ Webhook notifications and webhook actions
 - ✅ SIEM integration (syslog + CEF)
 - ✅ Semantic verification sidecar ([rampart-verify](https://github.com/peg/rampart-verify))
-- ✅ `require_approval` — human-in-the-loop approval for sensitive operations
-- ✅ Signed resolve URLs (HMAC-SHA256, self-authenticating)
+- ✅ Human-in-the-loop approval flow with HMAC-signed resolve URLs
 - ✅ Embedded web dashboard with security headers
 - ✅ OpenClaw integration (auto-detection, chat-based approval)
-- ✅ Regex complexity limits (ReDoS protection)
-- ✅ LD_PRELOAD constructor-based symbol resolution
-- ✅ Cross-platform release builds (goreleaser)
+- ✅ Shell-aware command normalization (prevents quote/backslash/env var evasion)
+- ✅ Response-side scanning (detects credential leaks in tool output)
+- ✅ Policy test framework (`rampart test`)
+- ✅ Policy linter (`rampart policy lint`) with typo suggestions
+- ✅ Prometheus metrics endpoint (opt-in via `--metrics`)
+- ✅ Cross-platform release builds (goreleaser + Homebrew)
+- ✅ Security audit — govulncheck CI, SHA-pinned actions, audit file hardening
 
 ## Up Next
 
-- Fuzz testing for parsers and policy evaluation
-- Expanded integration guides
-- Starter policy library for common stacks
-- CI/CD integration (GitHub Actions, GitLab CI)
-- Additional SIEM platform guides
+- Shell-aware parsing for `$(...)` and process substitution
+- Starter policy library for common stacks (web dev, infra, data science)
+- Tutorial docs ("Protect your first agent in 5 minutes")
+- Dashboard improvements
+- CI/CD integration examples (GitHub Actions, GitLab CI)
 - Fleet management and centralized policy distribution
 
 ## Non-Goals


### PR DESCRIPTION
- Roadmap reflects v0.2.25 shipped features (shell parsing, response scanning, policy test/lint, metrics)
- Removed stale 'v0.2.0' feature dump from README, replaced with link to docs/ROADMAP.md
- Removed specific OpenClaw version numbers that anchor to dates
- Removed duplicate roadmap link at bottom of README