### PR TITLE
fix: pass HOMEBREW_TAP_GITHUB_TOKEN to goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,3 +28,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -59,6 +59,7 @@ brews:
   - repository:
       owner: peg
       name: homebrew-rampart
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     homepage: "https://rampart.sh"
     description: "Open-source firewall for AI agents"
     license: "Apache-2.0"


### PR DESCRIPTION
Adds the `HOMEBREW_TAP_GITHUB_TOKEN` env var to the release workflow and goreleaser config so the Homebrew tap auto-updates on release.

Requires a fine-grained PAT added as repo secret `HOMEBREW_TAP_GITHUB_TOKEN` with Contents:write on `peg/homebrew-rampart`.