### PR TITLE
fix: security audit — daemon race, shell hardening, proxy fail-closed

### DIFF
--- a/cmd/rampart/cli/doctor.go
+++ b/cmd/rampart/cli/doctor.go
@@ -129,7 +129,7 @@ func doctorServer(w io.Writer) int {
 		url := fmt.Sprintf("http://localhost:%d/health", port)
 		resp, err := client.Get(url)
 		if err == nil {
-			resp.Body.Close()
+			defer resp.Body.Close()
 			fmt.Fprintf(w, "✓ Server: rampart %s running on :%d\n", label, port)
 		} else {
 			fmt.Fprintf(w, "✗ Server: not running on :%d\n", port)

--- a/cmd/rampart/cli/status.go
+++ b/cmd/rampart/cli/status.go
@@ -100,7 +100,7 @@ func detectProtectedAgents() []string {
 	// OpenClaw shim
 	client := &http.Client{Timeout: 1 * time.Second}
 	if resp, err := client.Get("http://localhost:19090/health"); err == nil {
-		resp.Body.Close()
+		defer resp.Body.Close()
 		agents = append(agents, "OpenClaw (shim)")
 	}
 

--- a/internal/audit/event.go
+++ b/internal/audit/event.go
@@ -24,6 +24,7 @@ package audit
 
 import (
 	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -139,7 +140,7 @@ func (e *Event) VerifyHash() (bool, error) {
 	computed := e.Hash
 	e.Hash = expected
 
-	return computed == expected, nil
+	return subtle.ConstantTimeCompare([]byte(computed), []byte(expected)) == 1, nil
 }
 
 // ChainAnchor records the hash chain state at a checkpoint.

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -692,7 +692,7 @@ policies:
 	got := e.EvaluateResponse(call, "secret")
 	elapsed := time.Since(start)
 
-	assert.Equal(t, ActionAllow, got.Action, "timeout should be treated as no-match")
+	assert.Equal(t, ActionDeny, got.Action, "timeout should fail closed — deny rule fires")
 	assert.GreaterOrEqual(t, elapsed, 90*time.Millisecond)
 	assert.Less(t, elapsed, 190*time.Millisecond)
 }


### PR DESCRIPTION
Fixes all high and medium findings from security + code quality audit.

## Daemon (Quality #1-5)
- **WebSocket ping race condition** — was using `d.mu`, now uses `d.writeMu` like all other write paths
- **Swallowed json.Marshal error** — now logged and returns early
- **Close() cleanup** — closes approval store, returns collected errors via `errors.Join()`
- **resp.Body.Close()** — consistent `defer` pattern in CLI commands
- **HTTP server dedup** — extracted `newHTTPServer()` helper

## Shell Parsing (Security #1-3)
- **SanitizeCommand** — strips null bytes, ANSI escapes (`\x1b[0m`), control chars; called at top of NormalizeCommand and ExtractSubcommands
- **Process substitution** — extracts commands from `<(...)` and `>(...)`
- **Newline splitting** — `SplitCompoundCommand` now splits on unquoted `\n`
- **Glob DoS** — `MatchGlob` caps input at 8192 bytes, `matchSuffixGlob` caps iterations at 10000

## Proxy (Security #4-6)
- **Webhook misconfiguration** → deny (was silently allowing)
- **Hardcoded port 9090** → returns empty + log warning
- **VerifyHash** → constant-time comparison (`subtle.ConstantTimeCompare`)
- **Replay protection** → already-resolved approvals return 410 Gone

All tests pass. 11 files changed, 287 insertions, 35 deletions.