### PR TITLE
fix: goreleaser writes formula to Formula/ directory

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -56,7 +56,8 @@ release:
 # Requires HOMEBREW_TAP_GITHUB_TOKEN secret in GitHub Actions — a PAT with repo scope
 # that has write access to the peg/homebrew-rampart repository.
 brews:
-  - repository:
+  - directory: Formula
+    repository:
       owner: peg
       name: homebrew-rampart
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"


### PR DESCRIPTION
Fixes the Homebrew tap not updating — goreleaser was writing rampart.rb to the repo root instead of Formula/rampart.rb.