### PR TITLE
feat(agent-teams): v0.4.0 — run ID, bulk approve, dashboard grouping

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,7 +10,7 @@ on:
       - '.github/workflows/docs.yml'
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   deploy:
@@ -24,4 +24,22 @@ jobs:
 
       - run: pip install mkdocs-material mkdocs-minify-plugin
 
-      - run: mkdocs gh-deploy --force
+      - name: Build docs
+        run: mkdocs build
+
+      # Deploy to peg/rampart-docs (the repo that serves docs.rampart.sh via GitHub Pages).
+      # Requires a PAT with contents:write on peg/rampart-docs stored as DOCS_DEPLOY_TOKEN.
+      - name: Push to peg/rampart-docs
+        env:
+          DOCS_DEPLOY_TOKEN: ${{ secrets.DOCS_DEPLOY_TOKEN }}
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          cd /tmp
+          git clone --depth=1 https://x-access-token:${DOCS_DEPLOY_TOKEN}@github.com/peg/rampart-docs.git rampart-docs
+          rsync -a --delete --exclude='.git' "${GITHUB_WORKSPACE}/site/" rampart-docs/
+          cd rampart-docs
+          git add -A
+          git diff --cached --quiet && echo "No changes" && exit 0
+          git commit -m "docs: deploy from peg/rampart@${GITHUB_SHA::8}"
+          git push origin gh-pages

--- a/cmd/rampart/cli/hook.go
+++ b/cmd/rampart/cli/hook.go
@@ -21,8 +21,21 @@ import (
 )
 
 // hookInput is the JSON sent by Claude Code on stdin for PreToolUse/PostToolUse hooks.
-// PostToolUse includes tool_response (free-form object whose schema varies by tool).
+// The base object (from oZ() in Claude Code source) includes session_id, transcript_path,
+// cwd, and permission_mode. PreToolUse adds hook_event_name, tool_name, tool_input, and
+// tool_use_id. PostToolUse additionally includes tool_response.
 type hookInput struct {
+	// Base fields (present on all hook events)
+	SessionID      string `json:"session_id"`
+	TranscriptPath string `json:"transcript_path,omitempty"`
+	CWD            string `json:"cwd,omitempty"`
+	PermissionMode string `json:"permission_mode,omitempty"`
+
+	// Event-type fields
+	HookEventName string `json:"hook_event_name,omitempty"`
+	ToolUseID     string `json:"tool_use_id,omitempty"`
+
+	// Tool-specific fields
 	ToolName     string         `json:"tool_name"`
 	ToolInput    map[string]any `json:"tool_input"`
 	ToolResponse map[string]any `json:"tool_response,omitempty"`
@@ -72,12 +85,35 @@ type hookParseResult struct {
 	Params   map[string]any
 	Agent    string
 	Response string // non-empty for PostToolUse events
+	RunID    string // run ID derived from session_id (or env overrides)
 }
 
 // gitContext holds the git repository context for the current working directory.
 type gitContext struct {
 	session string // "reponame/branch" e.g. "myapp/main"
 	root    string // absolute git root path e.g. "/home/user/projects/myapp"
+}
+
+// deriveRunID returns the run ID for the current hook invocation, used to group
+// all tool calls from the same agent orchestration run.
+//
+// Priority order:
+//  1. RAMPART_RUN env var — explicit override, useful for scripted orchestration
+//  2. sessionID — the session_id field from Claude Code's hook stdin JSON,
+//     shared across all agents in the same Claude Code session
+//  3. CLAUDE_CONVERSATION_ID env var — fallback for future Claude Code versions
+//  4. "" — no grouping; each call is standalone
+func deriveRunID(sessionID string) string {
+	if v := strings.TrimSpace(os.Getenv("RAMPART_RUN")); v != "" {
+		return v
+	}
+	if sessionID != "" {
+		return sessionID
+	}
+	if v := strings.TrimSpace(os.Getenv("CLAUDE_CONVERSATION_ID")); v != "" {
+		return v
+	}
+	return ""
 }
 
 // deriveGitContext returns the git context for the current working directory.
@@ -292,6 +328,7 @@ Cline setup: Use "rampart setup cline" to install hooks automatically.`,
 				ID:        audit.NewEventID(),
 				Agent:     parsed.Agent,
 				Session:   hookSession,
+				RunID:     parsed.RunID,
 				Tool:      parsed.Tool,
 				Params:    parsed.Params,
 				Timestamp: time.Now().UTC(),
@@ -320,6 +357,7 @@ Cline setup: Use "rampart setup cline" to install hooks automatically.`,
 				Timestamp: call.Timestamp,
 				Agent:     call.Agent,
 				Session:   call.Session,
+				RunID:     call.RunID,
 				Tool:      call.Tool,
 				Request:   parsed.Params,
 				Decision:  eventDecision,
@@ -364,7 +402,7 @@ Cline setup: Use "rampart setup cline" to install hooks automatically.`,
 					}
 					command, _ := call.Params["command"].(string)
 					path := call.Path() // handles both "file_path" (Claude Code) and "path"
-					result := approvalClient.requestApprovalCtx(cmd.Context(), call.Tool, command, call.Agent, path, decision.Message, 5*time.Minute)
+					result := approvalClient.requestApprovalCtx(cmd.Context(), call.Tool, command, call.Agent, path, call.RunID, decision.Message, 5*time.Minute)
 					return outputHookResult(cmd, format, result, false, decision.Message, cmdStr)
 				}
 				return outputHookResult(cmd, format, hookAsk, false, decision.Message, cmdStr)
@@ -403,6 +441,7 @@ func parseClaudeCodeInput(reader interface{ Read([]byte) (int, error) }, logger 
 		Tool:   toolType,
 		Params: params,
 		Agent:  "claude-code",
+		RunID:  deriveRunID(input.SessionID),
 	}
 
 	// Extract response text from PostToolUse tool_response.
@@ -464,6 +503,9 @@ func parseClineInput(reader interface{ Read([]byte) (int, error) }, logger *slog
 		Tool:   toolType,
 		Params: params,
 		Agent:  "cline",
+		// Cline's taskId is scoped to a single task/conversation — equivalent
+		// to Claude Code's session_id for run grouping purposes.
+		RunID: deriveRunID(input.TaskID),
 	}
 
 	// For PostToolUse, extract output from parameters if present

--- a/cmd/rampart/cli/hook_approval.go
+++ b/cmd/rampart/cli/hook_approval.go
@@ -33,6 +33,7 @@ type createApprovalRequest struct {
 	Agent   string `json:"agent"`
 	Path    string `json:"path,omitempty"`
 	Message string `json:"message"`
+	RunID   string `json:"run_id,omitempty"`
 }
 
 // createApprovalResponse is the JSON returned from POST /v1/approvals.
@@ -52,12 +53,12 @@ type pollApprovalResponse struct {
 // Returns hookAllow if approved, hookDeny if denied/expired/error.
 // Falls back to hookAsk if the serve instance is unreachable.
 // The context allows cancellation (e.g., user Ctrl-C).
-func (c *hookApprovalClient) requestApproval(tool, command, agent, path, message string, timeout time.Duration) hookDecisionType {
-	return c.requestApprovalCtx(context.Background(), tool, command, agent, path, message, timeout)
+func (c *hookApprovalClient) requestApproval(tool, command, agent, path, runID, message string, timeout time.Duration) hookDecisionType {
+	return c.requestApprovalCtx(context.Background(), tool, command, agent, path, runID, message, timeout)
 }
 
 // requestApprovalCtx is like requestApproval but accepts a context for cancellation.
-func (c *hookApprovalClient) requestApprovalCtx(ctx context.Context, tool, command, agent, path, message string, timeout time.Duration) hookDecisionType {
+func (c *hookApprovalClient) requestApprovalCtx(ctx context.Context, tool, command, agent, path, runID, message string, timeout time.Duration) hookDecisionType {
 	// Create the approval
 	body := createApprovalRequest{
 		Tool:    tool,
@@ -65,6 +66,7 @@ func (c *hookApprovalClient) requestApprovalCtx(ctx context.Context, tool, comma
 		Agent:   agent,
 		Path:    path,
 		Message: message,
+		RunID:   runID,
 	}
 
 	data, err := json.Marshal(body)
@@ -93,6 +95,19 @@ func (c *hookApprovalClient) requestApprovalCtx(ctx context.Context, tool, comma
 		return hookAsk
 	}
 	defer resp.Body.Close()
+
+	// 200 means the run was already bulk-approved — no queuing needed.
+	if resp.StatusCode == http.StatusOK {
+		var autoResp struct {
+			Status string `json:"status"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&autoResp); err == nil && autoResp.Status == "approved" {
+			c.logger.Debug("hook: run auto-approved by bulk-resolve, skipping queue")
+			return hookAllow
+		}
+		c.logger.Error("hook: unexpected 200 from approval create", "url", c.serveURL)
+		return hookAsk
+	}
 
 	if resp.StatusCode != http.StatusCreated {
 		respBody, _ := io.ReadAll(resp.Body)

--- a/cmd/rampart/cli/hook_approval_test.go
+++ b/cmd/rampart/cli/hook_approval_test.go
@@ -46,7 +46,7 @@ func TestHookApprovalClient_Approved(t *testing.T) {
 		logger:   testLogger(),
 	}
 
-	result := client.requestApproval("exec", "kubectl delete pod foo", "claude-code", "/tmp", "needs approval", 10*time.Second)
+	result := client.requestApproval("exec", "kubectl delete pod foo", "claude-code", "/tmp", "", "needs approval", 10*time.Second)
 	if result != hookAllow {
 		t.Fatalf("expected hookAllow, got %d", result)
 	}
@@ -77,7 +77,7 @@ func TestHookApprovalClient_Denied(t *testing.T) {
 		logger:   testLogger(),
 	}
 
-	result := client.requestApproval("exec", "rm -rf /tmp/stuff", "claude-code", "/tmp", "dangerous", 10*time.Second)
+	result := client.requestApproval("exec", "rm -rf /tmp/stuff", "claude-code", "/tmp", "", "dangerous", 10*time.Second)
 	if result != hookDeny {
 		t.Fatalf("expected hookDeny, got %d", result)
 	}
@@ -90,7 +90,7 @@ func TestHookApprovalClient_Unreachable(t *testing.T) {
 		logger:   testLogger(),
 	}
 
-	result := client.requestApproval("exec", "echo hi", "claude-code", "/tmp", "test", 2*time.Second)
+	result := client.requestApproval("exec", "echo hi", "claude-code", "/tmp", "", "test", 2*time.Second)
 	if result != hookAsk {
 		t.Fatalf("expected hookAsk (fallback), got %d", result)
 	}
@@ -107,7 +107,7 @@ func TestHookApprovalClient_FallbackOnUnreachablePort1(t *testing.T) {
 		logger:   logger,
 	}
 
-	result := client.requestApproval("exec", "echo hi", "claude-code", "/tmp", "test", 5*time.Second)
+	result := client.requestApproval("exec", "echo hi", "claude-code", "/tmp", "", "test", 5*time.Second)
 	if result != hookAsk {
 		t.Fatalf("expected hookAsk (native prompt fallback), got %d", result)
 	}
@@ -146,7 +146,7 @@ func TestHookApprovalClient_AutoDiscoverApproved(t *testing.T) {
 		autoDiscovered: true,
 	}
 
-	result := client.requestApproval("exec", "kubectl apply -f deploy.yaml", "claude-code", "/tmp", "needs approval", 10*time.Second)
+	result := client.requestApproval("exec", "kubectl apply -f deploy.yaml", "claude-code", "/tmp", "", "needs approval", 10*time.Second)
 	if result != hookAllow {
 		t.Fatalf("expected hookAllow, got %d", result)
 	}
@@ -165,7 +165,7 @@ func TestHookApprovalClient_AutoDiscoverUnreachableSilent(t *testing.T) {
 		autoDiscovered: true,
 	}
 
-	result := client.requestApproval("exec", "echo hi", "claude-code", "/tmp", "test", 5*time.Second)
+	result := client.requestApproval("exec", "echo hi", "claude-code", "/tmp", "", "test", 5*time.Second)
 	if result != hookAsk {
 		t.Fatalf("expected hookAsk (silent fallback), got %d", result)
 	}
@@ -193,7 +193,7 @@ func TestHookApprovalClient_ExplicitUnreachableShowsWarning(t *testing.T) {
 		autoDiscovered: false,
 	}
 
-	result := client.requestApproval("exec", "echo hi", "claude-code", "/tmp", "test", 5*time.Second)
+	result := client.requestApproval("exec", "echo hi", "claude-code", "/tmp", "", "test", 5*time.Second)
 	if result != hookAsk {
 		t.Fatalf("expected hookAsk, got %d", result)
 	}
@@ -231,7 +231,7 @@ func TestHookApprovalClient_Timeout(t *testing.T) {
 	}
 
 	start := time.Now()
-	result := client.requestApproval("exec", "echo hi", "claude-code", "/tmp", "test", 2*time.Second)
+	result := client.requestApproval("exec", "echo hi", "claude-code", "/tmp", "", "test", 2*time.Second)
 	elapsed := time.Since(start)
 
 	if result != hookDeny {

--- a/docs-site/features/agent-teams.md
+++ b/docs-site/features/agent-teams.md
@@ -1,0 +1,158 @@
+# Agent Team Oversight
+
+When you run Claude Code with multiple sub-agents — or any orchestrator spawning parallel workers — every agent in the session shares the same **run ID**. Rampart groups their pending approvals together so you can review and approve the whole team in one click.
+
+!!! info "Available since v0.4.0"
+
+---
+
+## How It Works
+
+Claude Code assigns a `session_id` to every session. When you run an orchestrator that spawns sub-agents, all of them share that same `session_id`. Rampart reads it from the `PreToolUse` hook payload and uses it as the **run ID** for grouping.
+
+Cline uses `taskId` instead — Rampart maps that automatically.
+
+You don't configure anything. If you already use Rampart, agent team grouping just works.
+
+---
+
+## Dashboard View
+
+When 2 or more pending approvals share a run ID, the dashboard's **Active** tab groups them into a cluster card:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Run: a1b2c3d4…  (3 pending)                ▼           │
+├─────────────────────────────────────────────────────────┤
+│  exec  kubectl apply -f deploy.yaml    claude-code      │
+│  exec  kubectl delete pod old-pod      claude-code      │
+│  exec  kubectl rollout restart app     claude-code      │
+├─────────────────────────────────────────────────────────┤
+│              [✓ Approve All]  [✗ Deny All]              │
+└─────────────────────────────────────────────────────────┘
+```
+
+**Approve All** resolves every pending approval in the run and caches the decision — subsequent tool calls from that run are auto-approved for the remainder of the approval timeout (default: 1 hour). No more approvals queue for that run.
+
+**Deny All** blocks all pending requests. The agents get a denial response and can try a different approach.
+
+Solo approvals (no run ID, or unique run ID) render exactly as before — no UI change for single-agent users.
+
+---
+
+## Auto-Approve Cache
+
+After you click **Approve All**, Rampart caches the approval for that run ID. New tool calls from the same run are allowed immediately — the agent doesn't wait, no approval card is created.
+
+The cache expires after the configured `--approval-timeout` (default 1 hour). After expiry, the next call from that run will queue for approval again.
+
+To disable the cache for a specific run, use the API directly:
+
+```bash
+# Deny a run, preventing future auto-approvals
+curl -X POST http://localhost:18275/v1/approvals/bulk-resolve \
+  -H "Authorization: Bearer $RAMPART_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"run_id": "YOUR_RUN_ID", "action": "deny"}'
+```
+
+---
+
+## API
+
+### Bulk resolve a run
+
+```http
+POST /v1/approvals/bulk-resolve
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+  "run_id": "SESSION_ID_HERE",
+  "action": "approve",
+  "resolved_by": "dashboard"
+}
+```
+
+Response:
+
+```json
+{
+  "resolved": 3,
+  "ids": ["01KHT3...", "01KHT4...", "01KHT5..."]
+}
+```
+
+`run_id` is required. Empty or missing `run_id` returns `400` — Rampart refuses to bulk-resolve without a run ID to prevent accidental mass-approval.
+
+### List approvals with run groups
+
+```http
+GET /v1/approvals
+Authorization: Bearer <token>
+```
+
+Response includes both the flat `approvals` array and a `run_groups` array:
+
+```json
+{
+  "approvals": [...],
+  "run_groups": [
+    {
+      "run_id": "abc123...",
+      "count": 3,
+      "earliest_created_at": "2026-02-19T04:30:00Z",
+      "items": [...]
+    }
+  ]
+}
+```
+
+`run_groups` only includes groups with 2+ pending items, sorted by `earliest_created_at`. Fully backwards compatible — existing consumers ignore the new field.
+
+---
+
+## Override the Run ID
+
+By default, Rampart derives the run ID from Claude Code's `session_id` (or Cline's `taskId`). You can override it with the `RAMPART_RUN` environment variable — useful for scripted orchestration or CI:
+
+```bash
+RAMPART_RUN=my-deploy-run claude
+```
+
+Priority order:
+
+1. `RAMPART_RUN` env var (explicit override)
+2. `session_id` from the Claude Code hook payload
+3. `CLAUDE_CONVERSATION_ID` env var (fallback)
+4. Empty string (no grouping)
+
+---
+
+## Audit Trail
+
+Every audit event includes `run_id` when present:
+
+```json
+{
+  "timestamp": "2026-02-19T04:30:00Z",
+  "run_id": "abc123...",
+  "tool": "exec",
+  "command": "kubectl apply -f deploy.yaml",
+  "agent": "claude-code",
+  "decision": { "action": "approved" }
+}
+```
+
+This means you can trace the full activity of an agent team run across the entire audit log — filter by `run_id` to see everything that run touched.
+
+---
+
+## Supported Agents
+
+| Agent | Run ID source | Notes |
+|-------|--------------|-------|
+| Claude Code | `session_id` from PreToolUse hook | Shared across orchestrator + all sub-agents |
+| Cline | `taskId` from hook payload | Per-task grouping |
+| Any agent via `RAMPART_RUN` | Env var override | Set before launching your orchestrator |
+| MCP proxy | `run_id` in tool call params | Pass explicitly from your MCP client |

--- a/internal/audit/event.go
+++ b/internal/audit/event.go
@@ -46,8 +46,13 @@ type Event struct {
 	// Agent identifies which agent made the call.
 	Agent string `json:"agent"`
 
-	// Session identifies the agent's session.
+	// Session identifies the agent's session (git repo/branch or RAMPART_SESSION).
 	Session string `json:"session"`
+
+	// RunID groups events from the same orchestration run.
+	// Sourced from Claude Code's session_id field, RAMPART_RUN env override,
+	// or CLAUDE_CONVERSATION_ID fallback. Empty if no grouping applies.
+	RunID string `json:"run_id,omitempty"`
 
 	// Tool is the tool that was invoked (e.g., "exec", "read").
 	Tool string `json:"tool"`

--- a/internal/dashboard/static/index.html
+++ b/internal/dashboard/static/index.html
@@ -225,6 +225,21 @@ body{font-family:'Inter',system-ui,sans-serif;font-size:13px;line-height:1.4;bac
 .denial-cmd{color:var(--text-bright);font-family:'JetBrains Mono',monospace;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex:1}
 .denial-reason{color:#52525b;font-size:11px;flex-shrink:0;max-width:160px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 
+/* Run cluster — grouped approvals sharing a run_id */
+.run-cluster{border:1px solid var(--border);border-radius:var(--radius);margin:8px 0;overflow:hidden}
+.run-cluster-header{display:flex;align-items:center;gap:10px;padding:9px 12px;background:var(--surface);border-bottom:1px solid var(--border);cursor:pointer;user-select:none}
+.run-cluster-chevron{font-size:10px;color:var(--text-dim);transition:transform .2s;flex-shrink:0}
+.run-cluster.collapsed .run-cluster-chevron{transform:rotate(-90deg)}
+.run-cluster-label{font-family:'JetBrains Mono',monospace;font-size:12px;font-weight:600;color:var(--text-bright);flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.run-cluster-count{font-size:10px;color:var(--text-dim);background:var(--surface-3);padding:1px 7px;border-radius:10px;flex-shrink:0}
+.run-cluster-actions{display:flex;gap:5px;flex-shrink:0}
+.run-cluster-body{display:block}
+.run-cluster.collapsed .run-cluster-body{display:none}
+/* Items inside a cluster get a subtle left inset */
+.run-cluster .pend-item{padding-left:20px}
+.run-cluster .pend-detail{border-bottom:1px solid var(--border)}
+.run-cluster .pend-item:hover{background:var(--surface-2)}
+
 /* Sentinel for infinite scroll */
 #hist-sentinel{height:4px;margin:4px 0}
 
@@ -390,6 +405,7 @@ function isDangerous(cmd){return DANGEROUS.some(r=>r.test(cmd||''))}
 let token='',pollTimer=null,connected=false,expandedId=null,initialPoll=true;
 const pendingMap=new Map();
 const selectedIds=new Set();
+let runGroupsData=[];
 
 // ── Theme ──────────────────────────────────────────────────────────────────
 function initTheme(){
@@ -476,7 +492,7 @@ function initResizeHandles(){
     switchTab(btn.dataset.tab);
   });
 
-  // Pending table events
+  // Pending table events (including run-cluster bulk buttons)
   document.getElementById('pending-body').addEventListener('click',handlePendingClick);
 
   // Select-all
@@ -578,7 +594,7 @@ async function poll(){
       document.getElementById('main-content').classList.add('visible');
       if(!_denialsStarted){_denialsStarted=true;loadRecentDenials()}
     }
-    updatePending(data.approvals||[]);
+    updatePending(data.approvals||[],data.run_groups||[]);
     const delay=pendingMap.size>0?2000:5000;
     if(!document.hidden)pollTimer=setTimeout(poll,delay);
   }catch(e){
@@ -616,7 +632,8 @@ function extractAction(ev){
   return ev.action||'';
 }
 
-function updatePending(approvals){
+function updatePending(approvals,runGroups){
+  runGroupsData=runGroups||[];
   const incoming=new Map(approvals.map(a=>[a.id,a]));
   // Track which IDs are brand-new before mutating the map
   const newIds=new Set();
@@ -631,23 +648,44 @@ function updatePending(approvals){
 
 function renderPending(newIds){
   const tbody=document.getElementById('pending-body');
-  // Sort by session name (empty sorts last), then by created_at ascending
-  const entries=[...pendingMap.values()].sort((a,b)=>{
+  // Build set of IDs that belong to a run group (2+ items sharing run_id)
+  const groupedIds=new Set();
+  for(const g of runGroupsData){for(const item of g.items){groupedIds.add(item.id);}}
+
+  // Rebuild container from scratch
+  tbody.innerHTML='';
+
+  // 1. Render run clusters (groups with 2+ items) sorted by earliest_created_at
+  for(const g of runGroupsData){
+    // Filter to currently-pending items from this group
+    const groupItems=g.items.filter(item=>pendingMap.has(item.id));
+    if(groupItems.length<2)continue; // cluster dissolved to 0 or 1 — render remaining as solo below
+    const cluster=createRunCluster(g,groupItems,newIds);
+    tbody.appendChild(cluster);
+  }
+
+  // 2. Render solo items: either no run_id, or run_id unique (not in any current group)
+  const soloEntries=[...pendingMap.values()].filter(a=>{
+    if(!groupedIds.has(a.id))return true;
+    // Still in groupedIds but group dissolved to <2 currently pending
+    const g=runGroupsData.find(g=>g.items.some(item=>item.id===a.id));
+    if(!g)return true;
+    const stillPending=g.items.filter(item=>pendingMap.has(item.id));
+    return stillPending.length<2;
+  }).sort((a,b)=>{
     const sa=a.session||'',sb=b.session||'';
     if(sa===''&&sb!=='')return 1;if(sa!==''&&sb==='')return -1;
     if(sa!==sb)return sa.localeCompare(sb);
     return (a.created_at||'').localeCompare(b.created_at||'');
   });
-  // Show group headers only when more than one distinct session exists
-  const sessions=[...new Set(entries.map(a=>a.session||''))];
+  // Show session headers only when more than one distinct session exists among solo items
+  const sessions=[...new Set(soloEntries.map(a=>a.session||''))];
   const showHeaders=sessions.length>1;
-  // Rebuild container from scratch
-  tbody.innerHTML='';
   let lastSession=undefined;
-  for(const a of entries){
+  for(const a of soloEntries){
     const session=a.session||'';
     if(showHeaders&&session!==lastSession){
-      const count=entries.filter(x=>(x.session||'')===session).length;
+      const count=soloEntries.filter(x=>(x.session||'')===session).length;
       const hdr=document.createElement('div');hdr.className='session-group-header';
       hdr.innerHTML=`<span class="session-group-label">${esc(session||'(no session)')}</span><span class="session-group-count">${count}</span>`;
       tbody.appendChild(hdr);lastSession=session;
@@ -658,11 +696,87 @@ function renderPending(newIds){
     tbody.appendChild(row);tbody.appendChild(detail);
     if(expandedId===a.id)detail.classList.add('open');
   }
+
   // Badge and empty state
   const n=pendingMap.size;
   const badge=document.getElementById('badge-active');
   badge.textContent=n;badge.style.display=n?'':'none';
   document.getElementById('pending-empty').style.display=n?'none':'block';
+}
+
+function createRunCluster(g,groupItems,newIds){
+  const cluster=document.createElement('div');
+  cluster.className='run-cluster';
+  cluster.dataset.runId=g.run_id;
+
+  const shortId=g.run_id.slice(0,8);
+  const count=groupItems.length;
+
+  const header=document.createElement('div');
+  header.className='run-cluster-header';
+  header.innerHTML=`
+    <span class="run-cluster-chevron">▾</span>
+    <span class="run-cluster-label" title="${esc(g.run_id)}">Run: ${esc(shortId)}…</span>
+    <span class="run-cluster-count">${count} pending</span>
+    <div class="run-cluster-actions">
+      <button class="act-btn approve run-approve-all" data-run-id="${esc(g.run_id)}" data-count="${count}" title="Approve all pending calls from this run">✓ Approve All</button>
+      <button class="act-btn deny run-deny-all" data-run-id="${esc(g.run_id)}" data-count="${count}" title="Deny all pending calls from this run">✗ Deny All</button>
+    </div>`;
+  // Toggle collapse on header click (but not button clicks)
+  header.addEventListener('click',e=>{
+    if(e.target.closest('button'))return;
+    cluster.classList.toggle('collapsed');
+    header.querySelector('.run-cluster-chevron').textContent=cluster.classList.contains('collapsed')?'▸':'▾';
+  });
+  cluster.appendChild(header);
+
+  const body=document.createElement('div');
+  body.className='run-cluster-body';
+  // Sort items within cluster by created_at ascending
+  const sorted=[...groupItems].sort((a,b)=>(a.created_at||'').localeCompare(b.created_at||''));
+  for(const a of sorted){
+    const{row,detail}=createPendingRow(a);
+    if(newIds&&newIds.has(a.id))row.classList.add('new-item');
+    row.querySelector('.row-chk').checked=selectedIds.has(a.id);
+    body.appendChild(row);body.appendChild(detail);
+    if(expandedId===a.id)detail.classList.add('open');
+  }
+  cluster.appendChild(body);
+  return cluster;
+}
+
+async function bulkResolveRun(runId,action,count){
+  const label=action==='approve'?'Approve':'Deny';
+  const actionVerb=action==='approve'?'Approve':'Deny';
+  if(!confirm(`${actionVerb} all ${count} pending call${count===1?'':'s'} from this run?`))return;
+  try{
+    await api('/v1/approvals/bulk-resolve',{
+      method:'POST',
+      headers:{'Content-Type':'application/json'},
+      body:JSON.stringify({run_id:runId,action})
+    });
+    toast(`${label}d run ${runId.slice(0,8)}…`);
+    // Re-poll immediately to update the dashboard
+    clearTimeout(pollTimer);poll();
+  }catch(e){
+    // Bulk-resolve endpoint may not be deployed yet (built by W2 in parallel).
+    // Fall back to resolving each pending item in the group individually.
+    if(e.message&&(e.message.includes('404')||e.message.includes('405'))){
+      const group=runGroupsData.find(g=>g.run_id===runId);
+      if(group){
+        const ids=group.items.filter(item=>pendingMap.has(item.id)).map(item=>item.id);
+        const approved=action==='approve';
+        for(const id of ids){
+          try{await api('/v1/approvals/'+id+'/resolve',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({approved,resolved_by:'dashboard'})})}
+          catch(err){/* best effort */}
+        }
+        clearTimeout(pollTimer);poll();
+        toast(`${label}d ${ids.length} approval${ids.length===1?'':'s'}`);
+      }
+    }else{
+      toast('Error: '+e.message);
+    }
+  }
 }
 
 function createPendingRow(a){
@@ -707,6 +821,19 @@ function createPendingRow(a){
 }
 
 function handlePendingClick(e){
+  // Run cluster: Approve All / Deny All buttons
+  const runApprove=e.target.closest('.run-approve-all');
+  if(runApprove){
+    e.stopPropagation();
+    bulkResolveRun(runApprove.dataset.runId,'approve',parseInt(runApprove.dataset.count,10));
+    return;
+  }
+  const runDeny=e.target.closest('.run-deny-all');
+  if(runDeny){
+    e.stopPropagation();
+    bulkResolveRun(runDeny.dataset.runId,'deny',parseInt(runDeny.dataset.count,10));
+    return;
+  }
   if(e.target.classList.contains('row-chk')){
     e.stopPropagation();
     const id=e.target.dataset.id;

--- a/internal/engine/decision.go
+++ b/internal/engine/decision.go
@@ -85,6 +85,12 @@ type ToolCall struct {
 	// Session identifies the agent's current session.
 	Session string
 
+	// RunID groups tool calls from the same orchestration run.
+	// Sourced from Claude Code's session_id (shared across all agents in a session),
+	// RAMPART_RUN env override, or CLAUDE_CONVERSATION_ID fallback.
+	// Empty string means no grouping (standalone call).
+	RunID string
+
 	// Tool is the tool being invoked (e.g., "exec", "read", "write").
 	Tool string
 

--- a/internal/proxy/server_test.go
+++ b/internal/proxy/server_test.go
@@ -868,3 +868,302 @@ func TestHandleTest_HTTP(t *testing.T) {
 		assert.NotEmpty(t, result["action"])
 	})
 }
+
+// ── W2: Bulk resolve + auto-approve cache ──────────────────────────────────
+
+func TestBulkResolve_ApprovesAllInRun(t *testing.T) {
+	configYAML := `version: "1"
+default_action: allow
+policies: []`
+
+	srv, token, _ := setupTestServer(t, configYAML, "enforce")
+	ts := httptest.NewServer(srv.handler())
+	defer ts.Close()
+
+	runID := "run-test-abc123"
+
+	// Create two approvals with the same run_id.
+	createApproval := func(cmd string) string {
+		body := fmt.Sprintf(`{"tool":"exec","command":%q,"agent":"claude-code","run_id":%q,"message":"needs approval"}`, cmd, runID)
+		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/approvals", strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
+		var result map[string]any
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
+		return result["id"].(string)
+	}
+
+	id1 := createApproval("rm -rf /tmp/a")
+	id2 := createApproval("rm -rf /tmp/b")
+
+	// Bulk-resolve: approve the run.
+	bulkBody := fmt.Sprintf(`{"run_id":%q,"action":"approve","resolved_by":"test"}`, runID)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/approvals/bulk-resolve", strings.NewReader(bulkBody))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	var bulkResult map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&bulkResult))
+	assert.Equal(t, float64(2), bulkResult["resolved"])
+
+	ids, ok := bulkResult["ids"].([]any)
+	require.True(t, ok)
+	assert.Len(t, ids, 2)
+	gotIDs := map[string]bool{ids[0].(string): true, ids[1].(string): true}
+	assert.True(t, gotIDs[id1], "id1 should be in resolved ids")
+	assert.True(t, gotIDs[id2], "id2 should be in resolved ids")
+
+	// Both approvals should now be resolved.
+	getStatus := func(id string) string {
+		req, _ := http.NewRequest(http.MethodGet, ts.URL+"/v1/approvals/"+id, nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp, _ := http.DefaultClient.Do(req)
+		defer resp.Body.Close()
+		var r map[string]any
+		_ = json.NewDecoder(resp.Body).Decode(&r)
+		s, _ := r["status"].(string)
+		return s
+	}
+	assert.Equal(t, "approved", getStatus(id1))
+	assert.Equal(t, "approved", getStatus(id2))
+}
+
+func TestBulkResolve_EmptyRunIDRejected(t *testing.T) {
+	configYAML := `version: "1"
+default_action: allow
+policies: []`
+
+	srv, token, _ := setupTestServer(t, configYAML, "enforce")
+	ts := httptest.NewServer(srv.handler())
+	defer ts.Close()
+
+	// Empty run_id must return 400 — never batch-approve everything.
+	for _, body := range []string{
+		`{"run_id":"","action":"approve"}`,
+		`{"run_id":"   ","action":"approve"}`,
+		`{"action":"approve"}`,
+	} {
+		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/approvals/bulk-resolve", strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		resp.Body.Close()
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "body: %s", body)
+	}
+}
+
+func TestBulkResolve_NoAuth(t *testing.T) {
+	configYAML := `version: "1"
+default_action: allow
+policies: []`
+
+	srv, _, _ := setupTestServer(t, configYAML, "enforce")
+	ts := httptest.NewServer(srv.handler())
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/approvals/bulk-resolve",
+		strings.NewReader(`{"run_id":"x","action":"approve"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+func TestBulkResolve_ZeroResolved_WhenNoPendingForRun(t *testing.T) {
+	configYAML := `version: "1"
+default_action: allow
+policies: []`
+
+	srv, token, _ := setupTestServer(t, configYAML, "enforce")
+	ts := httptest.NewServer(srv.handler())
+	defer ts.Close()
+
+	// Bulk-resolve a run that has no pending approvals.
+	body := `{"run_id":"run-nonexistent","action":"approve"}`
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/approvals/bulk-resolve", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	var result map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
+	assert.Equal(t, float64(0), result["resolved"])
+	// ids should be an empty array, not null.
+	ids, ok := result["ids"].([]any)
+	assert.True(t, ok, "ids should be a JSON array")
+	assert.Empty(t, ids)
+}
+
+func TestAutoApproveCache_SubsequentCallsSkipQueue(t *testing.T) {
+	configYAML := `version: "1"
+default_action: allow
+policies: []`
+
+	srv, token, _ := setupTestServer(t, configYAML, "enforce")
+	ts := httptest.NewServer(srv.handler())
+	defer ts.Close()
+
+	runID := "run-auto-approve-test"
+
+	// Create and bulk-approve two approvals to seed the auto-approve cache.
+	for _, cmd := range []string{"rm /tmp/x", "rm /tmp/y"} {
+		body := fmt.Sprintf(`{"tool":"exec","command":%q,"agent":"claude-code","run_id":%q,"message":"needs approval"}`, cmd, runID)
+		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/approvals", strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		resp, _ := http.DefaultClient.Do(req)
+		resp.Body.Close()
+	}
+
+	bulkBody := fmt.Sprintf(`{"run_id":%q,"action":"approve"}`, runID)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/approvals/bulk-resolve", strings.NewReader(bulkBody))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := http.DefaultClient.Do(req)
+	resp.Body.Close()
+
+	// Now a NEW approval from the same run should be auto-approved (status="approved", not "pending").
+	newBody := fmt.Sprintf(`{"tool":"exec","command":"rm /tmp/z","agent":"claude-code","run_id":%q,"message":"new call"}`, runID)
+	req2, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/approvals", strings.NewReader(newBody))
+	req2.Header.Set("Authorization", "Bearer "+token)
+	req2.Header.Set("Content-Type", "application/json")
+	resp2, err := http.DefaultClient.Do(req2)
+	require.NoError(t, err)
+	defer resp2.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp2.StatusCode, "auto-approved should return 200 not 201")
+	var result map[string]any
+	require.NoError(t, json.NewDecoder(resp2.Body).Decode(&result))
+	assert.Equal(t, "approved", result["status"], "subsequent call from auto-approved run should be auto-approved")
+}
+
+// ── W3: run_groups in list response ───────────────────────────────────────
+
+func TestListApprovals_RunGroups(t *testing.T) {
+	configYAML := `version: "1"
+default_action: allow
+policies: []`
+
+	srv, token, _ := setupTestServer(t, configYAML, "enforce")
+	ts := httptest.NewServer(srv.handler())
+	defer ts.Close()
+
+	runID := "run-group-test-xyz"
+
+	// Create 3 approvals: 2 with same run_id (should form a group), 1 solo.
+	createApproval := func(cmd, rid string) {
+		body := fmt.Sprintf(`{"tool":"exec","command":%q,"agent":"claude-code","run_id":%q,"message":"approval"}`, cmd, rid)
+		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/approvals", strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		resp, _ := http.DefaultClient.Do(req)
+		resp.Body.Close()
+	}
+
+	createApproval("cmd-a", runID)
+	time.Sleep(5 * time.Millisecond) // ensure distinct created_at ordering
+	createApproval("cmd-b", runID)
+	createApproval("cmd-solo", "") // no run_id — should not appear in run_groups
+
+	// List approvals.
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/v1/approvals", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	var result map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
+
+	// run_groups must be present.
+	runGroups, ok := result["run_groups"].([]any)
+	require.True(t, ok, "run_groups should be a JSON array")
+
+	// Exactly one group with our run_id.
+	var found map[string]any
+	for _, g := range runGroups {
+		group := g.(map[string]any)
+		if group["run_id"] == runID {
+			found = group
+			break
+		}
+	}
+	require.NotNil(t, found, "run_id %q should appear in run_groups", runID)
+	assert.Equal(t, float64(2), found["count"])
+	assert.NotEmpty(t, found["earliest_created_at"])
+
+	items, ok := found["items"].([]any)
+	require.True(t, ok)
+	assert.Len(t, items, 2)
+
+	// Solo approval should not create a group.
+	for _, g := range runGroups {
+		group := g.(map[string]any)
+		assert.NotEqual(t, "", group["run_id"], "solo (empty run_id) should not appear in run_groups")
+	}
+
+	// Flat approvals array should still have all 3 items.
+	approvals, ok := result["approvals"].([]any)
+	require.True(t, ok)
+	assert.Len(t, approvals, 3)
+}
+
+func TestListApprovals_RunGroupsSortedByEarliestCreatedAt(t *testing.T) {
+	configYAML := `version: "1"
+default_action: allow
+policies: []`
+
+	srv, token, _ := setupTestServer(t, configYAML, "enforce")
+	ts := httptest.NewServer(srv.handler())
+	defer ts.Close()
+
+	// Create two groups: group B created first, group A created second.
+	// run_groups should return B before A (chronological, not by run_id).
+	// Use distinct commands per group to avoid deduplication.
+	createPair := func(runID, cmdPrefix string) {
+		for i, cmd := range []string{cmdPrefix + "-1", cmdPrefix + "-2"} {
+			_ = i
+			body := fmt.Sprintf(`{"tool":"exec","command":%q,"agent":"claude-code","run_id":%q,"message":"m"}`, cmd, runID)
+			req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/approvals", strings.NewReader(body))
+			req.Header.Set("Authorization", "Bearer "+token)
+			req.Header.Set("Content-Type", "application/json")
+			resp, _ := http.DefaultClient.Do(req)
+			resp.Body.Close()
+		}
+	}
+
+	createPair("run-B", "sort-b-cmd")
+	time.Sleep(10 * time.Millisecond)
+	createPair("run-A", "sort-a-cmd")
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/v1/approvals", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	var result map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
+
+	runGroups := result["run_groups"].([]any)
+	require.Len(t, runGroups, 2)
+
+	first := runGroups[0].(map[string]any)["run_id"].(string)
+	second := runGroups[1].(map[string]any)["run_id"].(string)
+	assert.Equal(t, "run-B", first, "group created first should sort first")
+	assert.Equal(t, "run-A", second)
+}

--- a/internal/proxy/server_test.go
+++ b/internal/proxy/server_test.go
@@ -925,7 +925,10 @@ policies: []`
 	getStatus := func(id string) string {
 		req, _ := http.NewRequest(http.MethodGet, ts.URL+"/v1/approvals/"+id, nil)
 		req.Header.Set("Authorization", "Bearer "+token)
-		resp, _ := http.DefaultClient.Do(req)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return ""
+		}
 		defer resp.Body.Close()
 		var r map[string]any
 		_ = json.NewDecoder(resp.Body).Decode(&r)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -129,6 +129,7 @@ nav:
     - Audit Trail: features/audit-trail.md
     - Webhook Notifications: features/webhooks.md
     - Approval Dashboard: features/dashboard.md
+    - Agent Team Oversight: features/agent-teams.md
     - MCP Proxy: features/mcp-proxy.md
     - Semantic Verification: features/semantic-verification.md
     - SIEM Integration: features/siem-integration.md

--- a/scripts/test-hook-env.sh
+++ b/scripts/test-hook-env.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Diagnostic hook — logs full stdin JSON + env to /tmp/rampart-hook-test.json
+# Usage: add to ~/.claude/settings.json PreToolUse temporarily, run any Claude Code command
+
+LOG=/tmp/rampart-hook-test.json
+STDIN=$(cat)
+
+python3 -c "
+import json, os, sys
+
+stdin = json.loads('$STDIN'.replace(\"'\", \"'\")) if False else json.loads(sys.stdin.read())
+env_vars = {k: v for k, v in os.environ.items() if any(x in k.upper() for x in ['CLAUDE', 'RAMPART', 'SESSION', 'CONVERSATION', 'TRACE', 'PARENT'])}
+
+result = {'stdin_fields': list(stdin.keys()), 'stdin': stdin, 'relevant_env': env_vars}
+with open('$LOG', 'w') as f:
+    json.dump(result, f, indent=2)
+print(json.dumps(result, indent=2), file=sys.stderr)
+" <<< "$STDIN"
+
+exit 0  # always allow


### PR DESCRIPTION
Clean cherry-pick onto main (no squash drift conflicts).

## v0.4.0

**Agent team oversight** — when Claude Code orchestrates sub-agents, all agents in a session share a `run_id`. Rampart groups their pending approvals in the dashboard so you can approve the whole team run in one click.

- Run ID grouping (`session_id` / Cline `taskId` / `RAMPART_RUN` override)
- `POST /v1/approvals/bulk-resolve` — bulk approve/deny a run
- Auto-approve cache — subsequent calls from approved run skip the queue
- Dashboard run cluster cards with Approve All / Deny All
- `run_groups` in `GET /v1/approvals` (backwards compatible)
- Full PreToolUse hook schema parsed
- Bug fix: hook client now handles 200 auto-approve response correctly
- Docs: overhauled 5-minute tutorial, quickstart, new agent teams feature page

See [CHANGELOG](CHANGELOG.md) for full details.