### PR TITLE
docs: promote go install as recommended, demote homebrew tap

### DIFF
--- a/docs-site/getting-started/quickstart.md
+++ b/docs-site/getting-started/quickstart.md
@@ -8,6 +8,26 @@ Get Rampart protecting your AI agent in one command.
 !!! tip "Zero risk to try"
     Rampart **fails open** — if the service is unreachable or the policy engine crashes, your tools keep working. You'll never get locked out of your own machine.
 
+## Install
+
+=== "Go install (recommended)"
+
+    ```bash
+    go install github.com/peg/rampart/cmd/rampart@latest
+    ```
+
+=== "Script"
+
+    ```bash
+    curl -fsSL https://rampart.sh/install.sh | sh
+    ```
+
+=== "Homebrew"
+
+    ```bash
+    brew tap peg/rampart && brew install rampart
+    ```
+
 ## One-Command Setup
 
 ```bash

--- a/docs-site/getting-started/tutorial.md
+++ b/docs-site/getting-started/tutorial.md
@@ -11,20 +11,14 @@ Let's set it up.
 ## Prerequisites
 
 - **macOS or Linux** (Windows WSL works too)
-- **Homebrew** (recommended) or **Go 1.24+** for building from source
+- **Go 1.24+** (recommended) or the install script for a no-Go option
 - **Claude Code, Codex, or Cline** — this guide uses Claude Code, but Rampart works with [many agents](../integrations/index.md)
 
 ---
 
 ## Step 1: Install
 
-=== "Homebrew (recommended)"
-
-    ```bash
-    brew tap peg/rampart && brew install rampart
-    ```
-
-=== "Go install"
+=== "Go install (recommended)"
 
     ```bash
     go install github.com/peg/rampart/cmd/rampart@latest
@@ -34,6 +28,12 @@ Let's set it up.
 
     ```bash
     curl -fsSL https://rampart.sh/install.sh | sh
+    ```
+
+=== "Homebrew"
+
+    ```bash
+    brew tap peg/rampart && brew install rampart
     ```
 
 Verify:


### PR DESCRIPTION
Go install → Script → Homebrew. Avoids recommending curl|sh for a tool that blocks curl|sh, and avoids leading with a third-party tap.