### PR TITLE
fix(build): Windows cross-compilation for v0.4.3

### DIFF
--- a/cmd/rampart/cli/serve.go
+++ b/cmd/rampart/cli/serve.go
@@ -114,7 +114,7 @@ func newServeCmd(opts *rootOptions, deps *serveDeps) *cobra.Command {
 				child := exec.Command(exePath, childArgs...)
 				child.Stdout = logFile
 				child.Stderr = logFile
-				child.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+				setDetachAttrs(child)
 
 				if err := child.Start(); err != nil {
 					return fmt.Errorf("serve: start background process: %w", err)

--- a/cmd/rampart/cli/serve_background_unix.go
+++ b/cmd/rampart/cli/serve_background_unix.go
@@ -1,0 +1,27 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows
+
+package cli
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// setDetachAttrs configures the command to run in a new session (detached
+// from the parent terminal) on Unix systems.
+func setDetachAttrs(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+}

--- a/cmd/rampart/cli/serve_background_windows.go
+++ b/cmd/rampart/cli/serve_background_windows.go
@@ -1,0 +1,22 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+
+package cli
+
+import "os/exec"
+
+// setDetachAttrs is a no-op on Windows; background detachment via
+// Setsid is not supported. The process runs without a new session.
+func setDetachAttrs(_ *exec.Cmd) {}

--- a/cmd/rampart/cli/upgrade.go
+++ b/cmd/rampart/cli/upgrade.go
@@ -637,7 +637,7 @@ func replaceExecutableAtomically(path string, payload []byte, deps upgradeDeps) 
 }
 
 func isPermissionError(err error) bool {
-	return errors.Is(err, os.ErrPermission) || errors.Is(err, syscall.EACCES) || errors.Is(err, syscall.EPERM)
+	return os.IsPermission(err) || errors.Is(err, os.ErrPermission)
 }
 
 func fixStalePathCopies(out io.Writer, installedBinary string, deps upgradeDeps) {


### PR DESCRIPTION
Fixes goreleaser failure on `v0.4.3` tag.

- `serve_background_unix.go` / `serve_background_windows.go`: split `Setsid` (Unix-only field in `syscall.SysProcAttr`) behind `//go:build !windows` — Windows gets a no-op stub
- `upgrade.go`: replace `syscall.EACCES`/`syscall.EPERM` with `os.IsPermission()` (cross-platform)

Verified: `GOOS=windows GOARCH=amd64 go build ./...` passes locally.