### PR TITLE
fix(dashboard): responsive header on mobile

### DIFF
--- a/internal/dashboard/static/index.html
+++ b/internal/dashboard/static/index.html
@@ -252,6 +252,15 @@ body{font-family:'Inter',system-ui,sans-serif;font-size:13px;line-height:1.4;bac
   #token-input{width:160px}
   .stat:nth-child(n+4){display:none}
 }
+@media(max-width:480px){
+  #auth-bar{gap:6px;padding:8px 0}
+  #auth-bar .logo{flex-shrink:0;margin-right:0}
+  #token-input{flex:1;min-width:0;width:auto}
+  #connect-btn{flex-shrink:0}
+  #auth-connected{flex:1;min-width:0;justify-content:flex-end}
+  .tabs{overflow-x:auto;-webkit-overflow-scrolling:touch}
+  .tab-btn{padding:8px 12px;font-size:12px;white-space:nowrap}
+}
 </style>
 </head>
 <body>


### PR DESCRIPTION
## Problem
Auth bar header overflowed on mobile viewports. At 375px (iPhone SE), the total width of logo + theme-toggle + token input (160px) + Connect button ≈ 394px, which is 51px over the 343px usable viewport. Connect button was visually clipped and partially untappable.

## Fix
`@media(max-width:480px)` overrides:
- **Logo**: `flex-shrink:0; margin-right:0` — removes the `margin-right:auto` auto-push, logo stays natural size
- **Token input**: `flex:1; min-width:0; width:auto` — fills all remaining horizontal space (≈115px at 375px) — functional for paste
- **Connect button**: `flex-shrink:0` — always gets its full ~80px, never clipped
- **auth-connected**: `flex:1` — fills space correctly in post-auth state
- **Tabs**: `overflow-x:auto` + `white-space:nowrap` — scrollable if tabs overflow narrow screens

Found via mobile QA automated testing at iPhone SE (375×667) and iPhone 14 (390×844) viewports.