### PR TITLE
fix: correct stale port 18275 in CLI flag descriptions

### DIFF
--- a/cmd/rampart/cli/hook.go
+++ b/cmd/rampart/cli/hook.go
@@ -427,7 +427,7 @@ Cline setup: Use "rampart setup cline" to install hooks automatically.`,
 	cmd.Flags().StringVar(&mode, "mode", "enforce", "Mode: enforce | monitor | audit")
 	cmd.Flags().StringVar(&format, "format", "claude-code", "Input format: claude-code | cline")
 	cmd.Flags().StringVar(&auditDir, "audit-dir", "", "Directory for audit logs (default: ~/.rampart/audit)")
-	cmd.Flags().StringVar(&serveURL, "serve-url", "", "URL of rampart serve instance (default: auto-discover on localhost:18275, env: RAMPART_SERVE_URL)")
+	cmd.Flags().StringVar(&serveURL, "serve-url", "", "URL of rampart serve instance (default: auto-discover on localhost:9090, env: RAMPART_SERVE_URL)")
 	cmd.Flags().StringVar(&serveToken, "serve-token", "", "Auth token for rampart serve (env: RAMPART_TOKEN)")
 	cmd.Flags().MarkDeprecated("serve-token", "use RAMPART_TOKEN env var instead (--serve-token is visible in process list)")
 	cmd.Flags().StringVar(&configDir, "config-dir", "", "Directory of additional policy YAML files (default: ~/.rampart/policies/ if it exists)")

--- a/cmd/rampart/cli/setup.go
+++ b/cmd/rampart/cli/setup.go
@@ -97,7 +97,7 @@ Use --remove to uninstall the Rampart hooks from Claude Code settings.`,
 				return nil
 			}
 
-			// Build the hook config — no --serve-url needed, hook auto-discovers on localhost:18275.
+			// Build the hook config — no --serve-url needed, hook auto-discovers on localhost:9090.
 			// Use absolute path so the hook works regardless of Claude Code's PATH.
 			// The hook reads RAMPART_TOKEN from ~/.rampart/token automatically, so
 			// settings.json never needs to contain credentials.


### PR DESCRIPTION
## Problem

`rampart hook` auto-discovers `rampart serve` on `defaultServePort` (9090), but two places in the CLI still referenced the old port 18275:

- `hook.go`: `--serve-url` flag description said "auto-discover on localhost:18275"  
- `setup.go`: comment said "hook auto-discovers on localhost:18275"

This caused user confusion — particularly when setting up Tailscale serve, users were proxying port 18275 (nothing there) instead of 9090.

## Fix

Updated both string literals to reference port 9090, matching `defaultServePort` in `doctor.go`.

## Testing

```
rampart hook --help  # --serve-url description now shows :9090
```

Closes validator finding: stale port 18275 in CLI descriptions