### PR TITLE
feat(policy): block environment variable injection attacks

### DIFF
--- a/policies/standard.yaml
+++ b/policies/standard.yaml
@@ -127,6 +127,44 @@ policies:
             - "printenv *"
         message: "Environment variable dump logged"
 
+  - name: block-env-var-injection
+    description: "Block dangerous environment variable injection used to hijack interpreters, preloaders, and runtimes"
+    match:
+      tool: ["exec"]
+    rules:
+      - action: deny
+        when:
+          command_contains:
+            # Preloader / shared library injection (Linux + macOS)
+            # Note: command_contains runs on raw command string, bypassing env-assignment normalization.
+            # Rampart itself uses LD_PRELOAD at the process level (not in command strings) — no conflict.
+            - "LD_PRELOAD="
+            - "DYLD_INSERT_LIBRARIES="
+            - "LD_LIBRARY_PATH="
+            - "LD_AUDIT="
+            # Node.js: --require / --import inject arbitrary code before any script
+            - "NODE_OPTIONS="
+            - "NODE_PATH="
+            # JVM: -javaagent injects arbitrary bytecode into all JVM processes
+            - "JAVA_TOOL_OPTIONS="
+            - "JAVA_OPTS="
+            - "JVM_OPTS="
+            - "_JAVA_OPTIONS="
+            # .NET runtime startup hooks
+            - "DOTNET_STARTUP_HOOKS="
+            # Python: execute arbitrary file before REPL or script
+            - "PYTHONSTARTUP="
+            # Shell: sourced by bash/sh in non-interactive mode — code injection via environment
+            - "BASH_ENV="
+            # Perl / Ruby arbitrary module injection
+            - "PERL5OPT="
+            - "RUBYOPT="
+            # Git binary/SSH replacement — can redirect git operations to attacker-controlled binaries
+            - "GIT_EXEC_PATH="
+            - "GIT_SSH="
+            - "GIT_SSH_COMMAND="
+        message: "Dangerous environment variable injection blocked"
+
   - name: require-privileged-approval
     match:
       tool: ["exec"]


### PR DESCRIPTION
## What

Adds `block-env-var-injection` to `standard.yaml` — blocks dangerous env var assignments used to hijack interpreters and preloaders.

## Why

The `command_contains` condition runs against the raw command string before env-assignment normalization. This means `LD_PRELOAD=/evil.so curl ...` was previously stripped to just `curl ...` before policy matching, silently bypassing any glob rules. `command_contains` catches all forms: prefix form (`LD_PRELOAD=... cmd`), export form, and env invocation.

No conflict with Rampart's own LD_PRELOAD usage — Rampart injects at the process environment level, never via shell command strings.

## Coverage

| Variable | Attack vector |
|---|---|
| `LD_PRELOAD`, `DYLD_INSERT_LIBRARIES` | Load malicious shared library into all processes |
| `LD_LIBRARY_PATH`, `LD_AUDIT` | Redirect library resolution |
| `NODE_OPTIONS`, `NODE_PATH` | `--require /evil.js` before any Node script |
| `JAVA_TOOL_OPTIONS`, `JAVA_OPTS`, `JVM_OPTS`, `_JAVA_OPTIONS` | `-javaagent:/evil.jar` on all JVM invocations |
| `DOTNET_STARTUP_HOOKS` | .NET runtime startup DLL injection |
| `PYTHONSTARTUP` | Execute arbitrary Python before REPL/script |
| `BASH_ENV` | Sourced by bash in non-interactive mode |
| `PERL5OPT`, `RUBYOPT` | Perl/Ruby arbitrary module injection |
| `GIT_EXEC_PATH`, `GIT_SSH`, `GIT_SSH_COMMAND` | Replace git sub-commands or SSH binary |

## Tests

All test suites pass (`go test ./...`).