### PR TITLE
fix(reliability): audit permissions check, reload error logging, PostToolUseFailure audit, dead code cleanup

### DIFF
--- a/cmd/rampart/cli/doctor.go
+++ b/cmd/rampart/cli/doctor.go
@@ -131,7 +131,9 @@ func runDoctor(w io.Writer, jsonOut bool) error {
 	issues += doctorHooks(emit)
 
 	// 7. Audit directory
-	issues += doctorAudit(emit)
+	auditIssues, auditWarnings := doctorAudit(emit)
+	issues += auditIssues
+	warnings += auditWarnings
 
 	// 8. Server running on default port
 	serverIssues, serveURL := doctorServer(emit)
@@ -533,24 +535,24 @@ func countClaudeHookMatchers(settings map[string]any) int {
 	return count
 }
 
-func doctorAudit(emit emitFn) int {
+func doctorAudit(emit emitFn) (issues int, warnings int) {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return 0
+		return 0, 0
 	}
 	auditDir := filepath.Join(home, ".rampart", "audit")
 
 	entries, err := os.ReadDir(auditDir)
 	if err != nil {
 		emit("Audit", "fail", fmt.Sprintf("%s (not found)", auditDir))
-		return 1
+		return 1, 0
 	}
 
 	// Check writable
 	testFile := filepath.Join(auditDir, ".doctor-write-test")
 	if err := os.WriteFile(testFile, []byte("test"), 0o600); err != nil {
 		emit("Audit", "fail", fmt.Sprintf("%s (not writable)", auditDir))
-		return 1
+		return 1, 0
 	}
 	// Defer removal so the temp file is cleaned up on every exit path,
 	// including early returns and panics, not just the happy path.
@@ -566,7 +568,7 @@ func doctorAudit(emit emitFn) int {
 
 	if len(files) == 0 {
 		emit("Audit", "ok", fmt.Sprintf("~/%s (0 files)", relHome(auditDir, home)))
-		return 0
+		return 0, 0
 	}
 
 	// Find latest modification time
@@ -579,7 +581,33 @@ func doctorAudit(emit emitFn) int {
 	}
 
 	emit("Audit", "ok", fmt.Sprintf("~/%s (%d files, latest: %s)", relHome(auditDir, home), len(files), latest))
-	return 0
+
+	worldReadable := make([]string, 0, 4)
+	_ = filepath.WalkDir(auditDir, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil || d.IsDir() {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return nil
+		}
+		if info.Mode().Perm()&0o004 != 0 {
+			if len(worldReadable) < 3 {
+				worldReadable = append(worldReadable, relHome(path, home))
+			}
+			warnings++
+		}
+		return nil
+	})
+	if warnings > 0 {
+		sample := strings.Join(worldReadable, ", ")
+		msg := fmt.Sprintf("%d world-readable audit file(s) found", warnings)
+		if sample != "" {
+			msg += fmt.Sprintf(" (e.g. ~/%s)", sample)
+		}
+		emit("Audit perms", "warn", msg)
+	}
+	return 0, warnings
 }
 
 func doctorVersionCheck(w io.Writer, silent bool, emit emitFn) int {

--- a/cmd/rampart/cli/hook.go
+++ b/cmd/rampart/cli/hook.go
@@ -341,6 +341,24 @@ Cline setup: Use "rampart setup cline" to install hooks automatically.`,
 			// Rampart. Inject additionalContext telling Claude to stop retrying rather than
 			// burning 3-5 turns on workarounds.
 			if parsed.HookEventName == "PostToolUseFailure" {
+				postToolUseFailureEvent := audit.Event{
+					ID:        audit.NewEventID(),
+					Timestamp: time.Now().UTC(),
+					Agent:     parsed.Agent,
+					Session:   hookSession,
+					RunID:     parsed.RunID,
+					Tool:      parsed.Tool,
+					Request:   parsed.Params,
+					Decision: audit.EventDecision{
+						Action:  "allow",
+						Message: "PostToolUseFailure short-circuit feedback injection",
+					},
+				}
+				if line, marshalErr := json.Marshal(postToolUseFailureEvent); marshalErr == nil {
+					line = append(line, '\n')
+					_, _ = auditFile.Write(line)
+				}
+
 				msg := "This tool call failed or was blocked by a security policy. " +
 					"Do not attempt alternative approaches or workarounds — " +
 					"if an operation is restricted, report it to the user and stop."

--- a/internal/mcp/proxy.go
+++ b/internal/mcp/proxy.go
@@ -176,6 +176,7 @@ func (p *Proxy) Run(ctx context.Context, parentIn io.Reader, parentOut io.Writer
 		childErr := <-childErrCh
 		return joinProxyErrors(err, childErr)
 	case err := <-childErrCh:
+		_ = p.childIn.Close()
 		return err
 	}
 }

--- a/internal/proxy/rules_handlers.go
+++ b/internal/proxy/rules_handlers.go
@@ -138,7 +138,9 @@ func (s *Server) handleDeleteAutoAllowed(w http.ResponseWriter, r *http.Request)
 		}
 		// Force immediate engine reload so the revoked rule stops applying right away.
 		if s.engine != nil {
-			_ = s.engine.Reload()
+			if reloadErr := s.engine.Reload(); reloadErr != nil {
+				s.logger.Error("proxy: post-change reload failed", "error", reloadErr)
+			}
 		}
 		writeJSON(w, http.StatusOK, map[string]any{"deleted": true})
 		return
@@ -181,7 +183,9 @@ func (s *Server) handleDeleteAutoAllowed(w http.ResponseWriter, r *http.Request)
 
 	// Force immediate engine reload so the revoked rule stops applying right away.
 	if s.engine != nil {
-		_ = s.engine.Reload()
+		if reloadErr := s.engine.Reload(); reloadErr != nil {
+			s.logger.Error("proxy: post-change reload failed", "error", reloadErr)
+		}
 	}
 
 	writeJSON(w, http.StatusOK, map[string]any{"deleted": true})

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -944,7 +944,9 @@ authorized:
 			s.logger.Info("proxy: allow rule persisted", "path", policyPath, "tool", resolved.Call.Tool)
 			// Force immediate reload so the new rule takes effect without waiting for hot-reload.
 			if s.engine != nil {
-				_ = s.engine.Reload()
+				if reloadErr := s.engine.Reload(); reloadErr != nil {
+					s.logger.Error("proxy: post-change reload failed", "error", reloadErr)
+				}
 			}
 		}
 	}

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -416,7 +416,6 @@ func (m *Model) View() string {
 	lines = append(lines, frameLineBody(innerWidth, "  "+summaryLine))
 
 	// Pending approvals section.
-	approvalLines := 0
 	if len(m.pendingApprovals) > 0 {
 		lines = append(lines, frameLineMid(innerWidth))
 		lines = append(lines, frameLineBody(innerWidth, m.pendingStyle.Render("  ┌─ PENDING APPROVALS ─────────────────────────────────────┐")))
@@ -443,16 +442,13 @@ func (m *Model) View() string {
 			}
 		}
 		lines = append(lines, frameLineBody(innerWidth, m.pendingStyle.Render("  └─────────────────────────────────────────────────────────┘")))
-		approvalLines = 3 + len(m.pendingApprovals)*2 // header + footer + 2 per approval
 	}
 	if m.resolveStatus != "" {
 		lines = append(lines, frameLineBody(innerWidth, "  "+m.allowStyle.Render(m.resolveStatus)))
-		approvalLines++
 	}
 
 	lines = append(lines, frameLineMid(innerWidth))
 	lines = append(lines, frameLineBody(innerWidth, m.sectionStyle.Render("  LIVE FEED")))
-	_ = approvalLines
 
 	visible := m.visibleEvents(feedRows)
 	for i, event := range visible {


### PR DESCRIPTION
## Changes
- **doctor**: scan `~/.rampart/audit/` for world-readable files (`mode & 0o004`), warn in summary
- **rules_handlers.go** + **server.go**: log `engine.Reload()` errors at Error level (was silently discarded in 3 places)
- **hook.go**: write audit event before PostToolUseFailure early return (was missing entirely)
- **watch.go**: remove dead `approvalLines` variable and all its assignments
- **mcp/proxy.go**: close `childIn` on all exit paths in child error handler

Fixes: PostToolUseFailure audit gap, silent Reload() error discard, world-readable audit file detection