### PR TITLE
fix(ux): hook fail-closed warning, policy explain auto-discover, watch token/URL auto, --version flag, status fixes

### DIFF
--- a/cmd/rampart/cli/cli_test.go
+++ b/cmd/rampart/cli/cli_test.go
@@ -35,6 +35,12 @@ func TestVersionCommand(t *testing.T) {
 	assert.Contains(t, stdout, "rampart "+build.Version)
 }
 
+func TestVersionFlag(t *testing.T) {
+	stdout, _, err := runCLI(t, "--version")
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "rampart "+build.Version)
+}
+
 func TestInitCreatesFile(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)

--- a/cmd/rampart/cli/hook.go
+++ b/cmd/rampart/cli/hook.go
@@ -429,6 +429,7 @@ Cline setup: Use "rampart setup cline" to install hooks automatically.`,
 						token:          serveToken,
 						logger:         logger,
 						autoDiscovered: serveAutoDiscovered,
+						errWriter:      cmd.ErrOrStderr(),
 					}
 					command, _ := call.Params["command"].(string)
 					path := call.Path() // handles both "file_path" (Claude Code) and "path"

--- a/cmd/rampart/cli/root.go
+++ b/cmd/rampart/cli/root.go
@@ -62,6 +62,7 @@ func ExitCode(err error) int {
 // NewRootCmd builds the rampart root command.
 func NewRootCmd(ctx context.Context, outWriter, errWriter io.Writer) *cobra.Command {
 	opts := &rootOptions{}
+	var showVersion bool
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -72,6 +73,9 @@ func NewRootCmd(ctx context.Context, outWriter, errWriter io.Writer) *cobra.Comm
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if showVersion {
+				return writeVersion(cmd.OutOrStdout())
+			}
 			return cmd.Help()
 		},
 	}
@@ -81,6 +85,7 @@ func NewRootCmd(ctx context.Context, outWriter, errWriter io.Writer) *cobra.Comm
 
 	cmd.PersistentFlags().StringVar(&opts.configPath, "config", "rampart.yaml", "Path to policy config file")
 	cmd.PersistentFlags().BoolVar(&opts.verbose, "verbose", false, "Enable debug logging")
+	cmd.PersistentFlags().BoolVar(&showVersion, "version", false, "Print version information and exit")
 
 	cmd.AddCommand(newVersionCmd())
 	cmd.AddCommand(newInitCmd(opts))

--- a/cmd/rampart/cli/status.go
+++ b/cmd/rampart/cli/status.go
@@ -67,7 +67,11 @@ func runStatus(w io.Writer) error {
 		if len(lastDeny.Decision.MatchedPolicies) > 0 {
 			policy = lastDeny.Decision.MatchedPolicies[0]
 		}
-		fmt.Fprintf(w, "Last deny: %s — %s (%s)\n", ago, cmd, policy)
+		if isUnknownOrEmpty(cmd) || isUnknownOrEmpty(policy) {
+			fmt.Fprintf(w, "Last deny: %s — %s\n", ago, cmd)
+		} else {
+			fmt.Fprintf(w, "Last deny: %s — %s (%s)\n", ago, cmd, policy)
+		}
 	}
 
 	return nil
@@ -217,4 +221,9 @@ func formatAgo(d time.Duration) string {
 	default:
 		return fmt.Sprintf("%dd ago", int(d.Hours()/24))
 	}
+}
+
+func isUnknownOrEmpty(value string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	return normalized == "" || normalized == "unknown" || normalized == "(unknown)"
 }

--- a/cmd/rampart/cli/status_test.go
+++ b/cmd/rampart/cli/status_test.go
@@ -66,3 +66,21 @@ func TestExtractEventCommandFallback(t *testing.T) {
 		t.Errorf("expected tool name fallback, got %q", got)
 	}
 }
+
+func TestIsUnknownOrEmpty(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"", true},
+		{"unknown", true},
+		{"UNKNOWN", true},
+		{"(unknown)", true},
+		{"exec ls", false},
+	}
+	for _, tt := range tests {
+		if got := isUnknownOrEmpty(tt.input); got != tt.want {
+			t.Errorf("isUnknownOrEmpty(%q)=%v want %v", tt.input, got, tt.want)
+		}
+	}
+}

--- a/cmd/rampart/cli/upgrade.go
+++ b/cmd/rampart/cli/upgrade.go
@@ -306,6 +306,7 @@ func newUpgradeCmdWithDeps(_ *rootOptions, deps *upgradeDeps) *cobra.Command {
 			}
 
 			fmt.Fprintf(cmd.OutOrStdout(), "✓ rampart upgraded to %s\n", target)
+			fmt.Fprintln(cmd.OutOrStdout(), "Reminder: restart rampart serve to ensure it uses the new binary.")
 
 			// Refresh standard.yaml so security fixes reach existing users.
 			// Only updates the named profile files (standard.yaml, paranoid.yaml, yolo.yaml).

--- a/cmd/rampart/cli/version.go
+++ b/cmd/rampart/cli/version.go
@@ -15,6 +15,7 @@ package cli
 
 import (
 	"fmt"
+	"io"
 	"runtime"
 
 	"github.com/peg/rampart/internal/build"
@@ -26,11 +27,14 @@ func newVersionCmd() *cobra.Command {
 		Use:   "version",
 		Short: "Print build and runtime version information",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			_, err := fmt.Fprintf(cmd.OutOrStdout(), "rampart %s (%s) built %s\nGo %s\n", build.Version, build.Commit, build.Date, runtime.Version())
-			if err != nil {
-				return fmt.Errorf("cli: write version output: %w", err)
-			}
-			return nil
+			return writeVersion(cmd.OutOrStdout())
 		},
 	}
+}
+
+func writeVersion(w io.Writer) error {
+	if _, err := fmt.Fprintf(w, "rampart %s (%s) built %s\nGo %s\n", build.Version, build.Commit, build.Date, runtime.Version()); err != nil {
+		return fmt.Errorf("cli: write version output: %w", err)
+	}
+	return nil
 }

--- a/cmd/rampart/cli/watch_test.go
+++ b/cmd/rampart/cli/watch_test.go
@@ -1,10 +1,13 @@
 package cli
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/spf13/cobra"
 )
 
 func TestExpandHome(t *testing.T) {
@@ -74,4 +77,69 @@ func containsStr(s, sub string) bool {
 		}
 	}
 	return false
+}
+
+func TestResolveWatchServeConfig_DefaultURLAndTokenFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("RAMPART_SERVE_URL", "")
+	t.Setenv("RAMPART_TOKEN", "")
+
+	if err := os.MkdirAll(filepath.Join(home, ".rampart"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".rampart", "token"), []byte("tok-123\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var errBuf bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetErr(&errBuf)
+	cmd.Flags().String("serve-url", "", "")
+	cmd.Flags().String("serve-token", "", "")
+
+	url, token, err := resolveWatchServeConfig(cmd, "", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if url != "http://localhost:9090" {
+		t.Fatalf("expected localhost URL, got %s", url)
+	}
+	if token != "tok-123" {
+		t.Fatalf("expected token from file, got %q", token)
+	}
+	if !containsStr(errBuf.String(), "auto-discovered serve URL") {
+		t.Fatalf("expected URL note, got: %s", errBuf.String())
+	}
+	if !containsStr(errBuf.String(), "auto-discovered serve token") {
+		t.Fatalf("expected token note, got: %s", errBuf.String())
+	}
+}
+
+func TestResolveWatchServeConfig_ExplicitWins(t *testing.T) {
+	var errBuf bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetErr(&errBuf)
+	cmd.Flags().String("serve-url", "", "")
+	cmd.Flags().String("serve-token", "", "")
+	if err := cmd.Flags().Set("serve-url", "http://example:9090"); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Flags().Set("serve-token", "tok-explicit"); err != nil {
+		t.Fatal(err)
+	}
+
+	url, token, err := resolveWatchServeConfig(cmd, "http://example:9090", "tok-explicit")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if url != "http://example:9090" {
+		t.Fatalf("unexpected URL: %s", url)
+	}
+	if token != "tok-explicit" {
+		t.Fatalf("unexpected token: %s", token)
+	}
+	if errBuf.Len() != 0 {
+		t.Fatalf("expected no notes for explicit flags, got: %s", errBuf.String())
+	}
 }


### PR DESCRIPTION
## Changes
- **hook_approval.go**: always print `WARNING: rampart serve unreachable` when serve is down (was silent for auto-discovered URLs)
- **policy.go**: `resolveExplainPolicyPath()` — auto-discovers `~/.rampart/policies/standard.yaml`, then cwd `rampart.yaml`, then helpful error (critical broken UX fix)
- **watch.go**: `resolveWatchServeConfig()` — auto-discovers URL (localhost:9090) and token from `~/.rampart/token`
- **root.go**: `--version` persistent flag
- **status.go**: suppress `(unknown)` parenthetical when cmd or policy is unknown
- **upgrade.go**: print restart reminder after successful upgrade
- **Tests**: 12 new test cases