### PR TITLE
fix(dashboard): conn-dot states, empty states, mobile overflow, tab fade, UX polish

### DIFF
--- a/internal/dashboard/static/index.html
+++ b/internal/dashboard/static/index.html
@@ -55,6 +55,8 @@ body{font-family:'Inter',system-ui,sans-serif;font-size:13px;line-height:1.4;bac
 .tab-btn:hover{color:var(--text-bright)}.tab-btn.active{color:var(--accent);border-bottom-color:var(--accent)}
 .tab-badge{background:var(--accent);color:#fff;font-size:10px;font-weight:700;padding:1px 5px;border-radius:10px;min-width:18px;text-align:center}
 .tab-panel{display:none}.tab-panel.active{display:block}
+.tab-panel.active{animation:tabFadeIn .15s ease forwards}
+@keyframes tabFadeIn{from{opacity:0}to{opacity:1}}
 #main-content{display:none}
 #main-content.visible{display:block}
 
@@ -80,7 +82,7 @@ body{font-family:'Inter',system-ui,sans-serif;font-size:13px;line-height:1.4;bac
 /* pend-item: no border-bottom; the pend-detail sibling always carries the separator */
 .pend-item{display:flex;align-items:center;gap:12px;padding:11px 12px;cursor:pointer;transition:background .1s;position:relative}
 .pend-item:hover{background:var(--surface)}
-.pend-item.dangerous{border-left:2px solid var(--orange);padding-left:10px}
+.pend-item.dangerous{border-left:3px solid var(--orange);padding-left:10px;background:rgba(245,158,11,.04)}
 .pend-item.new-item{animation:fadeHighlight 2s ease-out}
 .pend-item.flash-green{background:rgba(34,197,94,.15)!important}
 .pend-item.flash-red{background:rgba(239,68,68,.15)!important}
@@ -261,6 +263,18 @@ body{font-family:'Inter',system-ui,sans-serif;font-size:13px;line-height:1.4;bac
   .tabs{overflow-x:auto;-webkit-overflow-scrolling:touch}
   .tab-btn{padding:8px 12px;font-size:12px;white-space:nowrap}
 }
+@media(max-width:540px){
+  .pend-item{flex-wrap:wrap}
+  .pend-body{width:calc(100% - 44px)}
+  .pend-right{width:100%;justify-content:flex-end;padding-top:6px}
+}
+@media(max-width:540px){
+  .policy-test-row{flex-wrap:wrap}
+  #cmd-input,#policy-test-input{min-width:100%}
+}
+@media(max-width:420px){
+  #bulk-bar{left:12px;right:12px;transform:none}
+}
 </style>
 </head>
 <body>
@@ -272,6 +286,7 @@ body{font-family:'Inter',system-ui,sans-serif;font-size:13px;line-height:1.4;bac
     <button id="theme-toggle" title="Toggle theme">🌙</button>
     <!-- Pre-auth -->
     <input type="password" id="token-input" placeholder="API token" autocomplete="off">
+    <button id="token-show-btn" title="Show/hide token" onclick="toggleTokenVis()" style="background:none;border:none;color:var(--text-dim);cursor:pointer;font-size:14px;padding:0 4px">👁</button>
     <button id="connect-btn">Connect</button>
     <!-- Post-auth (shown after connect) -->
     <div id="auth-connected">
@@ -304,15 +319,23 @@ body{font-family:'Inter',system-ui,sans-serif;font-size:13px;line-height:1.4;bac
       <label><input type="checkbox" id="select-all"> Select all</label>
     </div>
     <div id="pending-body"></div>
-    <div class="empty" id="pending-empty">No pending approvals</div>
+    <div class="empty" id="pending-empty">
+      <div class="icon">✅</div>
+      <div>All quiet — no pending approvals</div>
+      <div style="color:var(--text-dim);font-size:12px;margin-top:4px">Approvals appear here when Claude requests them</div>
+    </div>
 
     <!-- Recent Denials feed -->
     <div class="section-divider" style="margin-top:24px">
       <span class="section-title">Recent Denials</span>
       <span class="count-badge" id="denials-badge" style="display:none"></span>
+      <button onclick="switchTab('history')" style="margin-left:auto;background:none;border:none;color:var(--text-dim);font-size:11px;cursor:pointer;text-decoration:underline">View all →</button>
     </div>
     <div id="denials-feed"></div>
-    <div id="denials-empty" style="color:#52525b;font-size:12px;padding:6px 0">No recent denials</div>
+    <div class="empty" id="denials-empty">
+      <div class="icon">🛡️</div>
+      <div>No recent denials — policy running clean</div>
+    </div>
   </div>
 
   <!-- ═══ HISTORY TAB ═══ -->
@@ -352,7 +375,12 @@ body{font-family:'Inter',system-ui,sans-serif;font-size:13px;line-height:1.4;bac
         </tr></thead>
         <tbody id="hist-body"></tbody>
       </table>
-      <div class="empty" id="hist-empty" style="display:none">No events for this date</div>
+      <div class="empty" id="hist-empty" style="display:none">
+        <div class="icon">📭</div>
+        <div>No events for this date</div>
+        <div style="color:var(--text-dim);font-size:12px;margin-top:4px">Try selecting a different date</div>
+      </div>
+      <div id="hist-loading" style="display:none;text-align:center;padding:24px;color:var(--text-dim);font-size:12px">Loading history…</div>
       <div id="hist-sentinel" style="height:4px"></div>
     </div>
   </div>
@@ -547,6 +575,7 @@ function initResizeHandles(){
 // ── Helpers ────────────────────────────────────────────────────────────────
 function todayStr(){return new Date().toISOString().slice(0,10)}
 function esc(s){return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;')}
+function toggleTokenVis(){const i=document.getElementById('token-input');i.type=i.type==="password"?"text":"password";}
 function setConnected(yes){
   const input=document.getElementById('token-input');
   const btn=document.getElementById('connect-btn');
@@ -555,14 +584,19 @@ function setConnected(yes){
   if(yes){
     input.style.display='none';btn.style.display='none';
     connDiv.style.display='flex';
+    setDot('ok');
     document.getElementById('token-hint').textContent=token.slice(0,8)+'…';
     if(help)help.style.display='none';
   }else{
     input.style.display='';btn.style.display='';
     connDiv.style.display='none';
+    setDot('err');
   }
 }
-function setDot(cls){/* dot now inside auth-connected, update via setConnected */}
+function setDot(cls){
+  const dot=document.querySelector('.conn-dot');
+  if(dot)dot.className='conn-dot '+cls;
+}
 function showError(msg){const b=document.getElementById('error-banner');b.style.display='flex';document.getElementById('error-msg').textContent=msg}
 function hideError(){document.getElementById('error-banner').style.display='none'}
 function toast(msg){const t=document.getElementById('toast');t.textContent=msg;t.classList.add('show');setTimeout(()=>t.classList.remove('show'),2000)}
@@ -592,6 +626,7 @@ function connect(){
   localStorage.setItem('rampart_token',token);
   const p=document.getElementById('auth-prompt');if(p)p.style.display='none';
   hideError();
+  setDot('wait');
   initialPoll=true;
   poll();
 }
@@ -604,6 +639,7 @@ function startSSE(){
     try{
       const msg=JSON.parse(e.data);
       if(msg.type==="connected")return;
+      setDot('ok');
       if(msg.type==="audit"){
         prependAuditEvent(msg.event);
       }
@@ -621,6 +657,7 @@ function startSSE(){
     }catch(_){}
   };
   evtSource.onerror=function(){
+    setDot('wait');
     if(pollTimer)clearTimeout(pollTimer);
     pollTimer=setTimeout(poll,5000);
   };
@@ -846,7 +883,7 @@ function createPendingRow(a){
       <span class="pend-timer" id="timer-${esc(a.id)}"></span>
       <div class="pend-actions">
         <button class="act-btn approve" data-action="approve" data-id="${esc(a.id)}" title="Approve once">Allow</button>
-        <button class="act-btn always" data-action="always" data-id="${esc(a.id)}" title="Always allow this command pattern">Always</button>
+        <button class="act-btn always" data-action="always" data-id="${esc(a.id)}" title="Always allow this command pattern">Always Allow</button>
         <button class="act-btn deny" data-action="deny" data-id="${esc(a.id)}" title="Deny">Deny</button>
       </div>
     </div>`;
@@ -992,8 +1029,9 @@ function renderDenials(events){
     const cmd=extractCmd(ev);
     const t=ev.timestamp?new Date(ev.timestamp).toLocaleTimeString():'—';
     const reason=(ev.decision&&ev.decision.message)||ev.reason||ev.message||'';
+    const reasonText=String(reason||'');
     const div=document.createElement('div');div.className='denial-row';
-    div.innerHTML=`<span class="denial-time">${esc(t)}</span><span class="denial-tool">${esc(ev.tool||'exec')}</span><span class="denial-cmd" title="${esc(cmd)}">${esc(cmd)}</span>${reason?`<span class="denial-reason" title="${esc(reason)}">${esc(reason)}</span>`:''}`;
+    div.innerHTML=`<span class="denial-time">${esc(t)}</span><span class="denial-tool">${esc(ev.tool||'exec')}</span><span class="denial-cmd" title="${esc(cmd)}">${esc(cmd)}</span>${reasonText?`<span class="denial-reason" title="${esc(reasonText)}">${esc(reasonText)}</span>`:''}`;
     feed.append(div);
   });
 }
@@ -1018,6 +1056,8 @@ function onHistoryTabOpen(){
 
 async function loadHistoryTab(reset){
   if(histLoading)return;histLoading=true;
+  const loading=document.getElementById('hist-loading');
+  if(loading)loading.style.display='block';
   if(reset){
     histOffset=0;histEvents=[];histSeenIds=new Set();histTabLoaded=false;
     document.getElementById('hist-body').innerHTML='';
@@ -1039,6 +1079,9 @@ async function loadHistoryTab(reset){
     applyHistFilters();
     await loadHistStats(date);
   }catch(e){toast('History error: '+e.message)}
+  finally{
+    if(loading)loading.style.display='none';
+  }
   histLoading=false;
 }
 


### PR DESCRIPTION
## Changes
- **conn-dot**: wire CSS classes (.ok/.err/.wait) — was always green
- **Empty states**: icons + subtitles for pending/history/denials
- **Mobile**: flex-wrap at ≤540px; bulk-bar fix at ≤420px
- **Tab animation**: tabFadeIn 0.15s ease
- **Token input**: 👁 show/hide toggle
- **Denials**: 'View all →' link, title attr for truncated reason hover
- **Pending**: 'Always Allow' label, 3px dangerous border + bg tint
- **History**: loading indicator