### PR TITLE
feat(policy): agent_depth and tool_param_matches conditions

### DIFF
--- a/cmd/rampart/cli/hook.go
+++ b/cmd/rampart/cli/hook.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -354,14 +355,20 @@ Cline setup: Use "rampart setup cline" to install hooks automatically.`,
 			}
 
 			// Build tool call for evaluation
+			depth, _ := strconv.Atoi(strings.TrimSpace(os.Getenv("RAMPART_AGENT_DEPTH")))
+			if parsed.Tool == "agent" {
+				depth++
+			}
 			call := engine.ToolCall{
-				ID:        audit.NewEventID(),
-				Agent:     parsed.Agent,
-				Session:   hookSession,
-				RunID:     parsed.RunID,
-				Tool:      parsed.Tool,
-				Params:    parsed.Params,
-				Timestamp: time.Now().UTC(),
+				ID:         audit.NewEventID(),
+				Agent:      parsed.Agent,
+				AgentDepth: depth,
+				Session:    hookSession,
+				RunID:      parsed.RunID,
+				Tool:       parsed.Tool,
+				Params:     parsed.Params,
+				Input:      parsed.Params,
+				Timestamp:  time.Now().UTC(),
 			}
 
 			isPostToolUse := parsed.Response != ""

--- a/docs-site/reference/policy-schema.md
+++ b/docs-site/reference/policy-schema.md
@@ -62,10 +62,18 @@ rules:
     when:                   # Optional. Conditions (omit for unconditional).
       command_matches: list
       command_not_matches: list
+      command_contains: list
       path_matches: list
       path_not_matches: list
       url_matches: list
       domain_matches: list
+      session_matches: list
+      session_not_matches: list
+      agent_depth:
+        gte: integer
+        lte: integer
+        eq: integer
+      tool_param_matches: map[string]string
       response_matches: list
       response_not_matches: list
       default: boolean          # Catch-all — matches when true
@@ -142,6 +150,38 @@ when:
     - "AKIA[0-9A-Z]{16}"                           # AWS key
     - "-----BEGIN (RSA |EC )?PRIVATE KEY-----"      # Private key
     - "ghp_[a-zA-Z0-9]{36}"                        # GitHub PAT
+```
+
+#### `agent_depth`
+
+Match nested sub-agent depth (`0` = top-level agent, `1+` = sub-agents):
+
+```yaml
+when:
+  agent_depth:
+    gte: 1
+    lte: 2
+```
+
+Exact match:
+
+```yaml
+when:
+  agent_depth:
+    eq: 0
+```
+
+#### `tool_param_matches`
+
+Match MCP tool input parameters by case-insensitive glob pattern.
+Keys are parameter names, values are glob patterns. Rule matches if any
+parameter condition matches.
+
+```yaml
+when:
+  tool_param_matches:
+    path: "**/.env*"
+    url: "*webhook.site*"
 ```
 
 ### Webhook Configuration

--- a/internal/engine/decision.go
+++ b/internal/engine/decision.go
@@ -82,6 +82,10 @@ type ToolCall struct {
 	// Used for agent-scoped policy matching.
 	Agent string
 
+	// AgentDepth is how deeply nested this call is in sub-agent orchestration.
+	// 0 is top-level agent; each sub-agent level increments by 1.
+	AgentDepth int `json:"agent_depth,omitempty"`
+
 	// Session identifies the agent's current session.
 	Session string
 
@@ -98,6 +102,9 @@ type ToolCall struct {
 	// For exec: {"command": "git push", "workdir": "/home/user/project"}
 	// For read: {"path": "/etc/passwd"}
 	Params map[string]any
+
+	// Input contains raw MCP tool input arguments (if available).
+	Input map[string]any `json:"input,omitempty"`
 
 	// Timestamp is when the tool call was initiated.
 	Timestamp time.Time

--- a/internal/engine/lint.go
+++ b/internal/engine/lint.go
@@ -25,7 +25,7 @@ import (
 type LintSeverity int
 
 const (
-	LintInfo    LintSeverity = iota
+	LintInfo LintSeverity = iota
 	LintWarning
 	LintError
 )
@@ -89,6 +89,8 @@ var validConditionFields = map[string]bool{
 	"response_not_matches": true,
 	"session_matches":      true,
 	"session_not_matches":  true,
+	"agent_depth":          true,
+	"tool_param_matches":   true,
 	"default":              true,
 }
 
@@ -97,15 +99,15 @@ var commonFieldTypos = map[string]string{
 	"command_match":    "command_matches",
 	"commands_match":   "command_matches",
 	"commands_matches": "command_matches",
-	"path_match":      "path_matches",
-	"paths_match":     "path_matches",
-	"paths_matches":   "path_matches",
-	"url_match":       "url_matches",
-	"urls_match":      "url_matches",
-	"urls_matches":    "url_matches",
-	"domain_match":    "domain_matches",
-	"domains_match":   "domain_matches",
-	"domains_matches": "domain_matches",
+	"path_match":       "path_matches",
+	"paths_match":      "path_matches",
+	"paths_matches":    "path_matches",
+	"url_match":        "url_matches",
+	"urls_match":       "url_matches",
+	"urls_matches":     "url_matches",
+	"domain_match":     "domain_matches",
+	"domains_match":    "domain_matches",
+	"domains_matches":  "domain_matches",
 }
 
 // commonActionTypos maps common action typos to suggestions.

--- a/internal/engine/policy.go
+++ b/internal/engine/policy.go
@@ -252,9 +252,24 @@ type Condition struct {
 	// If a session matches any of these, the rule does not apply.
 	SessionNotMatches []string `yaml:"session_not_matches"`
 
+	// AgentDepth matches on nested sub-agent depth.
+	AgentDepth *IntRangeCondition `yaml:"agent_depth,omitempty" json:"agent_depth,omitempty"`
+
+	// ToolParamMatches matches MCP tool input parameters by glob pattern.
+	// Keys are parameter names, values are glob patterns.
+	// Condition matches if any specified parameter value matches.
+	ToolParamMatches map[string]string `yaml:"tool_param_matches,omitempty" json:"tool_param_matches,omitempty"`
+
 	// Default, when true, makes this rule match all tool calls.
 	// Use as a catch-all at the end of a rules list.
 	Default bool `yaml:"default"`
+}
+
+// IntRangeCondition matches integer values using gte/lte/eq operators.
+type IntRangeCondition struct {
+	Gte *int `yaml:"gte,omitempty"`
+	Lte *int `yaml:"lte,omitempty"`
+	Eq  *int `yaml:"eq,omitempty"`
 }
 
 // IsEmpty returns true if no conditions are specified.
@@ -274,7 +289,9 @@ func (c Condition) IsEmpty() bool {
 		len(c.ResponseMatches) == 0 &&
 		len(c.ResponseNotMatches) == 0 &&
 		len(c.SessionMatches) == 0 &&
-		len(c.SessionNotMatches) == 0
+		len(c.SessionNotMatches) == 0 &&
+		c.AgentDepth == nil &&
+		len(c.ToolParamMatches) == 0
 }
 
 // StringOrSlice handles YAML fields that can be either a single string

--- a/internal/mcp/proxy.go
+++ b/internal/mcp/proxy.go
@@ -317,6 +317,7 @@ func (p *Proxy) handleToolsCall(ctx context.Context, req Request, rawLine []byte
 		Session:   "mcp-proxy",
 		Tool:      mappedTool,
 		Params:    requestData,
+		Input:     params.Arguments,
 		Timestamp: time.Now().UTC(),
 	}
 

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -345,6 +345,7 @@ type toolRequest struct {
 	Session string         `json:"session"`
 	RunID   string         `json:"run_id,omitempty"`
 	Params  map[string]any `json:"params"`
+	Input   map[string]any `json:"input,omitempty"`
 
 	// Response is the tool's output for response-side policy evaluation.
 	// The caller executes the tool and submits the output here for scanning
@@ -380,6 +381,7 @@ func (s *Server) handleToolCall(w http.ResponseWriter, r *http.Request) {
 		RunID:     req.RunID,
 		Tool:      toolName,
 		Params:    req.Params,
+		Input:     extractToolInput(toolName, req.Params, req.Input),
 		Timestamp: time.Now().UTC(),
 	}
 
@@ -629,6 +631,7 @@ func (s *Server) handlePreflight(w http.ResponseWriter, r *http.Request) {
 		Session:   req.Session,
 		Tool:      toolName,
 		Params:    req.Params,
+		Input:     extractToolInput(toolName, req.Params, req.Input),
 		Timestamp: time.Now().UTC(),
 	}
 
@@ -1466,6 +1469,25 @@ func generateToken(logger *slog.Logger) string {
 		panic("rampart: crypto/rand failed; refusing to start with insecure token")
 	}
 	return hex.EncodeToString(buf)
+}
+
+// extractToolInput returns the best-available input map for tool parameter
+// matching. For MCP-style requests, prefer nested argument objects; otherwise
+// fall back to the top-level params map.
+func extractToolInput(toolName string, params map[string]any, explicitInput map[string]any) map[string]any {
+	if len(explicitInput) > 0 {
+		return explicitInput
+	}
+	if args, ok := params["arguments"].(map[string]any); ok && len(args) > 0 {
+		return args
+	}
+	if input, ok := params["tool_input"].(map[string]any); ok && len(input) > 0 {
+		return input
+	}
+	if strings.HasPrefix(toolName, "mcp") {
+		return params
+	}
+	return params
 }
 
 // enrichParams adds derived fields to params for richer policy matching.


### PR DESCRIPTION
## New Conditions

### `agent_depth` — closes #71
Match sub-agent nesting depth (0=top-level, 1+=sub-agents).

```yaml
when:
  agent_depth:
    gte: 1
```

Reads RAMPART_AGENT_DEPTH env; increments for tool==agent in hook.

### `tool_param_matches`
Match MCP tool input params by glob.

```yaml
when:
  tool_param_matches:
    path: '**/.env*'
```

9 new test cases, all passing. Docs updated.