### PR TITLE
feat: prompt injection detection + actionable denial hints

### DIFF
--- a/cmd/rampart/cli/hook.go
+++ b/cmd/rampart/cli/hook.go
@@ -360,9 +360,14 @@ Cline setup: Use "rampart setup cline" to install hooks automatically.`,
 					_, _ = auditFile.Write(line)
 				}
 
+				explainCmd := "rampart policy explain '" + parsed.Tool + "'"
 				msg := "This tool call failed or was blocked by a security policy. " +
 					"Do not attempt alternative approaches or workarounds — " +
-					"if an operation is restricted, report it to the user and stop."
+					"if an operation is restricted, report it to the user and stop.\n\n" +
+					"To diagnose: run `" + explainCmd + "` to see which policy applies, " +
+					"or `rampart watch` to view the live audit log. " +
+					"To allow this operation, update the policy at ~/.rampart/policies/ — " +
+					"see https://rampart.sh/docs/exceptions for guidance."
 				out := hookOutput{
 					HookSpecificOutput: &hookDecision{
 						HookEventName:     "PostToolUseFailure",

--- a/policies/standard.yaml
+++ b/policies/standard.yaml
@@ -425,6 +425,35 @@ policies:
             - "eyJ[a-zA-Z0-9_-]+\\.eyJ[a-zA-Z0-9_-]+"
         message: "Sensitive credential detected in response"
 
+  - name: watch-prompt-injection
+    description: "Detect prompt injection attempts in tool responses — logs suspicious patterns for review"
+    match:
+      tool: ["fetch", "web_search", "read", "exec", "mcp"]
+    rules:
+        # High-confidence injection markers — log for review (action: watch, not deny, to avoid false positives)
+      - action: watch
+        when:
+          response_matches:
+            # Classic instruction override attempts
+            - "(?i)ignore (all |your |previous |prior )?instructions"
+            - "(?i)disregard (all |your |previous |prior )?(instructions|rules|guidelines)"
+            - "(?i)forget (all |your |previous |prior )?instructions"
+            # Role/persona hijack
+            - "(?i)you are now (a|an) "
+            - "(?i)your new (instructions|role|purpose|task) (is|are)"
+            - "(?i)your real instructions"
+            - "(?i)new persona:"
+            # System prompt injection — model-specific special tokens
+            - "(?i)<\\|im_start\\|>system"
+            - "(?i)<\\|system\\|>"
+            - "(?i)\\[SYSTEM\\]"
+            - "(?i)###\\s*(INSTRUCTIONS|SYSTEM|NEW PROMPT)###"
+            - "(?i)---BEGIN (SYSTEM |NEW )?(PROMPT|INSTRUCTIONS)---"
+            # Explicit exfiltration instructions embedded in content
+            - "(?i)(send|POST|exfiltrate|transmit) (this|the following|these|it) to (https?://|the server)"
+            - "(?i)leak the (following|contents|file)"
+        message: "Possible prompt injection detected in tool response — logged for review"
+
 # ---------------------------------------------------------------------------
 # APPROVAL EXAMPLES (uncomment and customize)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Two changes aimed at making Rampart something agents actively want to be behind.

## Prompt Injection Detection (`watch-prompt-injection` policy)

New policy added to `standard.yaml` that monitors tool responses for prompt injection patterns. Uses `action: watch` (not deny) to log without blocking legitimate content.

**Patterns covered:**
- Instruction override: `ignore previous instructions`, `disregard your rules`, `forget your instructions`
- Role hijack: `you are now a...`, `your new instructions are`, `new persona:`
- Model-specific injection tokens: `<|im_start|>system`, `[SYSTEM]`, `###INSTRUCTIONS###`, `---BEGIN SYSTEM PROMPT---`
- Exfiltration directives: `POST the following to https://...`, `leak the contents of`, `exfiltrate`

All 14 patterns are case-insensitive (`(?i)`). Tested against 11 true positives and 4 true negatives — no false positives on common legitimate phrasing.

**Why `watch` not `deny`:** Web pages can contain these phrases in legitimate contexts (articles about AI security, tutorials, etc.). Logging gives you the audit trail to investigate without breaking agent workflows.

## Actionable Denial Hints (PostToolUseFailure)

When an agent hits a blocked tool call, the `PostToolUseFailure` feedback now includes concrete next steps instead of just "stop and report":

```
To diagnose: run `rampart policy explain '<tool>'` to see which policy applies,
or `rampart watch` to view the live audit log.
To allow this operation, update the policy at ~/.rampart/policies/ —
see https://rampart.sh/docs/exceptions for guidance.
```

The agent can now surface these steps directly to the user. It goes from looking broken to looking helpful.