### PR TITLE
fix: code review fixes + agent-install (PR #90 follow-up)

### DIFF
--- a/cmd/rampart/cli/hook.go
+++ b/cmd/rampart/cli/hook.go
@@ -351,8 +351,8 @@ Cline setup: Use "rampart setup cline" to install hooks automatically.`,
 					Tool:      parsed.Tool,
 					Request:   parsed.Params,
 					Decision: audit.EventDecision{
-						Action:  "allow",
-						Message: "PostToolUseFailure short-circuit feedback injection",
+						Action:  "feedback",
+						Message: "PostToolUseFailure short-circuit: injecting denial guidance to stop retry loops",
 					},
 				}
 				if line, marshalErr := json.Marshal(postToolUseFailureEvent); marshalErr == nil {
@@ -379,6 +379,9 @@ Cline setup: Use "rampart setup cline" to install hooks automatically.`,
 
 			// Build tool call for evaluation
 			depth, _ := strconv.Atoi(strings.TrimSpace(os.Getenv("RAMPART_AGENT_DEPTH")))
+			if depth < 0 {
+				depth = 0
+			}
 			if parsed.Tool == "agent" {
 				depth++
 			}

--- a/cmd/rampart/cli/quickstart.go
+++ b/cmd/rampart/cli/quickstart.go
@@ -48,7 +48,7 @@ For OpenClaw, --yes also enables --patch-tools for full file-operation coverage.
 
 	cmd.Flags().StringVar(&envFlag, "env", "", "AI coding environment (claude-code|cline|cursor|windsurf|openclaw|none)")
 	cmd.Flags().BoolVar(&skipDoctor, "skip-doctor", false, "skip final health check")
-	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "non-interactive: accept all defaults (use in scripts and AI agent instructions)")
+	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "non-interactive mode: for OpenClaw, also enables --patch-tools (full file coverage); safe to pass for any agent")
 	return cmd
 }
 

--- a/cmd/rampart/cli/quickstart.go
+++ b/cmd/rampart/cli/quickstart.go
@@ -28,6 +28,7 @@ import (
 func newQuickstartCmd() *cobra.Command {
 	var envFlag string
 	var skipDoctor bool
+	var yes bool
 
 	cmd := &cobra.Command{
 		Use:   "quickstart",
@@ -35,19 +36,23 @@ func newQuickstartCmd() *cobra.Command {
 		Long: `quickstart detects your AI coding environment, installs the Rampart
 background service, wires up the tool-call hook, and runs a health check.
 
-Supported environments: claude-code, cursor, windsurf
-If --env is not set, quickstart will auto-detect.`,
+Supported environments: claude-code, cline, cursor, windsurf, openclaw
+If --env is not set, quickstart will auto-detect.
+
+Use --yes to run non-interactively (AI agents, CI, automated setup).
+For OpenClaw, --yes also enables --patch-tools for full file-operation coverage.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runQuickstart(cmd, envFlag, skipDoctor)
+			return runQuickstart(cmd, envFlag, skipDoctor, yes)
 		},
 	}
 
-	cmd.Flags().StringVar(&envFlag, "env", "", "AI coding environment (claude-code|cursor|windsurf|none)")
+	cmd.Flags().StringVar(&envFlag, "env", "", "AI coding environment (claude-code|cline|cursor|windsurf|openclaw|none)")
 	cmd.Flags().BoolVar(&skipDoctor, "skip-doctor", false, "skip final health check")
+	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "non-interactive: accept all defaults (use in scripts and AI agent instructions)")
 	return cmd
 }
 
-func runQuickstart(cmd *cobra.Command, envFlag string, skipDoctor bool) error {
+func runQuickstart(cmd *cobra.Command, envFlag string, skipDoctor bool, yes bool) error {
 	w := cmd.OutOrStdout()
 
 	fmt.Fprintln(w, "◆ Rampart quickstart")
@@ -59,7 +64,7 @@ func runQuickstart(cmd *cobra.Command, envFlag string, skipDoctor bool) error {
 		env = detectEnv()
 		if env == "" {
 			fmt.Fprintln(w, "  ⚠  Could not detect AI coding environment.")
-			fmt.Fprintln(w, "     Use --env claude-code|cursor|windsurf to specify manually.")
+			fmt.Fprintln(w, "     Use --env claude-code|cline|cursor|windsurf|openclaw to specify manually.")
 			env = "none"
 		} else {
 			fmt.Fprintf(w, "  ✓  Detected environment: %s\n", env)
@@ -83,7 +88,12 @@ func runQuickstart(cmd *cobra.Command, envFlag string, skipDoctor bool) error {
 	// Step 3: setup hooks for detected env
 	if env != "none" {
 		fmt.Fprintf(w, "  Configuring hooks for %s...\n", env)
-		if err := runSubcmd("setup", env); err != nil {
+		setupArgs := []string{"setup", env}
+		// --yes enables full protection for OpenClaw (--patch-tools covers file reads/writes/edits)
+		if yes && env == "openclaw" {
+			setupArgs = append(setupArgs, "--patch-tools")
+		}
+		if err := runSubcmd(setupArgs...); err != nil {
 			fmt.Fprintf(w, "  ⚠  Hook setup failed: %v\n", err)
 			fmt.Fprintln(w, "     Run `rampart setup "+env+"` manually to retry.")
 		} else {
@@ -127,6 +137,11 @@ func runQuickstart(cmd *cobra.Command, envFlag string, skipDoctor bool) error {
 
 // detectEnv returns the first detected AI coding environment, or "".
 func detectEnv() string {
+	// OpenClaw: most reliable signal is OPENCLAW_SERVICE_MARKER env var,
+	// which OpenClaw gateway sets when it spawns an agent process.
+	if os.Getenv("OPENCLAW_SERVICE_MARKER") == "openclaw" {
+		return "openclaw"
+	}
 	// Claude Code: settings.json or binary
 	if _, err := os.Stat(claudeSettingsPath()); err == nil {
 		return "claude-code"

--- a/cmd/rampart/cli/quickstart_test.go
+++ b/cmd/rampart/cli/quickstart_test.go
@@ -20,7 +20,17 @@ import (
 	"testing"
 )
 
+func TestDetectEnv_OpenClaw(t *testing.T) {
+	t.Setenv("OPENCLAW_SERVICE_MARKER", "openclaw")
+	if got := detectEnv(); got != "openclaw" {
+		t.Errorf("expected openclaw, got %q", got)
+	}
+}
+
 func TestDetectEnv_ClaudeCode(t *testing.T) {
+	// Ensure OpenClaw marker is absent so Claude Code takes priority.
+	t.Setenv("OPENCLAW_SERVICE_MARKER", "")
+
 	// Create a temp claude settings file
 	tmp := t.TempDir()
 	orig := os.Getenv("HOME")
@@ -40,6 +50,9 @@ func TestDetectEnv_ClaudeCode(t *testing.T) {
 }
 
 func TestDetectEnv_None(t *testing.T) {
+	// Ensure OpenClaw marker is absent.
+	t.Setenv("OPENCLAW_SERVICE_MARKER", "")
+
 	tmp := t.TempDir()
 	orig := os.Getenv("HOME")
 	t.Setenv("HOME", tmp)
@@ -56,6 +69,7 @@ func TestDetectEnv_None(t *testing.T) {
 }
 
 func TestDetectEnv_Cursor(t *testing.T) {
+	t.Setenv("OPENCLAW_SERVICE_MARKER", "")
 	tmp := t.TempDir()
 	orig := os.Getenv("HOME")
 	t.Setenv("HOME", tmp)
@@ -86,6 +100,7 @@ func TestDetectEnv_Cursor(t *testing.T) {
 }
 
 func TestDetectEnv_Windsurf(t *testing.T) {
+	t.Setenv("OPENCLAW_SERVICE_MARKER", "")
 	tmp := t.TempDir()
 	orig := os.Getenv("HOME")
 	t.Setenv("HOME", tmp)
@@ -117,6 +132,7 @@ func TestDetectEnv_Windsurf(t *testing.T) {
 
 func TestDetectEnv_CursorBeatsWindsurf(t *testing.T) {
 	// When both Cursor and Windsurf are installed, Cursor should win (checked first).
+	t.Setenv("OPENCLAW_SERVICE_MARKER", "")
 	tmp := t.TempDir()
 	orig := os.Getenv("HOME")
 	t.Setenv("HOME", tmp)

--- a/docs-site/guides/agent-install.md
+++ b/docs-site/guides/agent-install.md
@@ -53,11 +53,7 @@ This single command auto-detects the running AI environment, installs the backgr
 rampart quickstart --yes
 ```
 
-The `--yes` flag makes this fully non-interactive:
-
-- For **OpenClaw**: also enables `--patch-tools` (full coverage for file reads/writes/edits in addition to shell commands)
-- For **Claude Code / Cline**: configures PreToolUse and PostToolUse hooks in the agent settings file
-- For **Cursor / Windsurf**: configures MCP proxy hooks
+The `--yes` flag skips any prompts. For **OpenClaw** it also auto-enables `--patch-tools`, which extends coverage to file reads/writes/edits in addition to shell commands. For all other agents the flag is a safe no-op.
 
 !!! note "OpenClaw specifically"
     If running inside an OpenClaw agent, you are protecting future tool calls — not the current session. After step 2, restart the OpenClaw gateway for hooks to take effect.
@@ -72,27 +68,26 @@ rampart doctor
 
 Expected output: all checks pass (✓). If any check fails, follow the hint printed next to it.
 
-Check the service is running:
+Check the service is running and review recent activity:
 
 ```bash
 rampart status
 ```
 
-Expected: `rampart serve  running  port 9090`
+Expected output (example):
+```
+🛡️ Rampart Status
 
----
-
-## Step 4: Verify a command gets blocked
-
-```bash
-rampart test
+Protected: openclaw
+Mode: enforce (default_action: allow)
+Today: 0 allow · 0 deny · 0 log
 ```
 
-This runs a built-in behavioral test that attempts a known-dangerous command through the policy engine and verifies it's blocked.
+If you see `Protected:` with your agent listed, Rampart is active.
 
 ---
 
-## Step 5: Report back to the user
+## Step 4: Report back to the user
 
 Tell the user:
 
@@ -180,10 +175,9 @@ Then add an allow rule for your specific use case. See [Exceptions Guide](https:
 |---------|--------------|
 | `rampart quickstart --yes` | Full non-interactive setup |
 | `rampart doctor` | Health check — hooks, service, permissions |
-| `rampart status` | Show service state and active policy |
+| `rampart status` | Show protected agents, mode, today's allow/deny counts |
 | `rampart watch` | Live audit feed of all tool calls |
 | `rampart token` | Print bearer token for the dashboard |
-| `rampart test` | Behavioral test — verify blocking works |
 | `rampart policy explain '<tool>'` | Show which policy applies to a tool call |
 
 Docs: <https://docs.rampart.sh>  

--- a/docs-site/guides/agent-install.md
+++ b/docs-site/guides/agent-install.md
@@ -1,0 +1,190 @@
+---
+title: Install Rampart via an AI Agent
+description: "Step-by-step instructions for an AI agent to install and configure Rampart. Works with OpenClaw, Claude Code, Cursor, and Cline. One command, fully non-interactive."
+---
+
+# Install Rampart via an AI Agent
+
+This guide is written for AI agents executing on behalf of a user who said something like:
+
+> "Install Rampart and protect this machine"  
+> "Set up Rampart to secure my Claude Code / OpenClaw agent"  
+> "Add safety guardrails to my AI coding environment"
+
+Follow these steps in order. Each step is independently verifiable.
+
+---
+
+## Step 1: Install the Rampart binary
+
+=== "Linux / macOS (curl)"
+
+    ```bash
+    curl -fsSL https://rampart.sh/install.sh | sh
+    ```
+
+=== "Go install"
+
+    ```bash
+    go install github.com/peg/rampart/cmd/rampart@latest
+    ```
+
+=== "Homebrew (macOS)"
+
+    ```bash
+    brew tap peg/rampart && brew install rampart
+    ```
+
+Verify the install:
+
+```bash
+rampart --version
+```
+
+Expected output: `rampart vX.Y.Z`
+
+---
+
+## Step 2: Run quickstart (non-interactive)
+
+This single command auto-detects the running AI environment, installs the background policy service, wires up hooks, and runs a health check:
+
+```bash
+rampart quickstart --yes
+```
+
+The `--yes` flag makes this fully non-interactive:
+
+- For **OpenClaw**: also enables `--patch-tools` (full coverage for file reads/writes/edits in addition to shell commands)
+- For **Claude Code / Cline**: configures PreToolUse and PostToolUse hooks in the agent settings file
+- For **Cursor / Windsurf**: configures MCP proxy hooks
+
+!!! note "OpenClaw specifically"
+    If running inside an OpenClaw agent, you are protecting future tool calls — not the current session. After step 2, restart the OpenClaw gateway for hooks to take effect.
+
+---
+
+## Step 3: Verify everything is working
+
+```bash
+rampart doctor
+```
+
+Expected output: all checks pass (✓). If any check fails, follow the hint printed next to it.
+
+Check the service is running:
+
+```bash
+rampart status
+```
+
+Expected: `rampart serve  running  port 9090`
+
+---
+
+## Step 4: Verify a command gets blocked
+
+```bash
+rampart test
+```
+
+This runs a built-in behavioral test that attempts a known-dangerous command through the policy engine and verifies it's blocked.
+
+---
+
+## Step 5: Report back to the user
+
+Tell the user:
+
+- Rampart is installed and running (version from `rampart --version`)
+- Which environment was auto-detected and configured
+- Dashboard URL: `http://localhost:9090/dashboard/` (opens in browser to show live policy activity)
+- Token location: `~/.rampart/token` (keep this private)
+
+---
+
+## What Rampart does
+
+Every shell command, file access, and network request your AI agent makes is now evaluated against a policy before it executes.
+
+**Blocked by default** (standard policy):
+- `rm -rf /`, `rm -rf ~`, `rm -rf *` — filesystem destruction
+- `curl <url> | bash`, `wget <url> | sh` — remote code execution
+- `cat ~/.ssh/id_rsa`, `cat ~/.ssh/id_ed25519` — SSH key exfiltration
+- `cat .env`, `cat .env.*` — API key / secret access
+- `dd if=/dev/urandom of=/dev/sda` — disk destruction
+- Prompt injection patterns in tool responses — exfiltration directives, instruction overrides
+
+**Allowed by default**: everything else. The policy engine is deny-on-match, not deny-by-default — it only blocks what the rules explicitly cover.
+
+---
+
+## Customizing protection
+
+To see what policies are active:
+
+```bash
+rampart policy explain '<tool_name>'
+```
+
+To add your own rules, edit `~/.rampart/policies/standard.yaml`. See [Policy Schema](../reference/policy-schema.md) for the full syntax.
+
+To require human approval before a specific operation runs:
+
+```yaml
+policies:
+  - name: approve-production-deploys
+    match:
+      tool: ["exec"]
+      command_contains: ["kubectl", "helm", "--namespace prod"]
+    rules:
+      - action: require_approval
+        message: "Production deploy requires human approval"
+```
+
+---
+
+## Troubleshooting
+
+**`rampart doctor` shows hook not installed**
+
+Re-run setup for your specific agent:
+
+```bash
+rampart setup openclaw --patch-tools   # OpenClaw
+rampart setup claude-code              # Claude Code
+rampart setup cline                    # Cline
+rampart setup cursor                   # Cursor
+```
+
+**Service not running**
+
+```bash
+rampart serve install   # installs and starts the background service
+rampart status          # verify
+```
+
+**A legitimate command is being blocked**
+
+```bash
+rampart policy explain '<command>'   # see which rule matched
+```
+
+Then add an allow rule for your specific use case. See [Exceptions Guide](https://rampart.sh/docs/exceptions).
+
+---
+
+## Reference
+
+| Command | What it does |
+|---------|--------------|
+| `rampart quickstart --yes` | Full non-interactive setup |
+| `rampart doctor` | Health check — hooks, service, permissions |
+| `rampart status` | Show service state and active policy |
+| `rampart watch` | Live audit feed of all tool calls |
+| `rampart token` | Print bearer token for the dashboard |
+| `rampart test` | Behavioral test — verify blocking works |
+| `rampart policy explain '<tool>'` | Show which policy applies to a tool call |
+
+Docs: <https://docs.rampart.sh>  
+Issues: <https://github.com/peg/rampart/issues>

--- a/docs-site/integrations/openclaw.md
+++ b/docs-site/integrations/openclaw.md
@@ -2,13 +2,23 @@
 
 For [OpenClaw](https://github.com/openclaw/openclaw) users, Rampart provides a shell shim, background service, and optional file tool patching.
 
+!!! tip "Fastest path"
+    If you want your OpenClaw agent to install and configure Rampart for you, just say:
+    > "Install Rampart and protect this machine."
+
+    The agent will run `rampart quickstart --yes` which handles everything automatically.
+    See the [agent install guide](../guides/agent-install.md) for full details.
+
 ## Setup
 
 ```bash
-# Shell command protection only
+# Fastest: auto-detect, install service, configure hooks, run health check
+rampart quickstart --yes
+
+# Manual: shell command protection only
 rampart setup openclaw
 
-# Full protection (shell commands + file reads/writes/edits)
+# Manual: full protection (shell commands + file reads/writes/edits)
 rampart setup openclaw --patch-tools
 ```
 

--- a/internal/engine/matcher.go
+++ b/internal/engine/matcher.go
@@ -342,8 +342,7 @@ func ExplainCondition(cond Condition, call ToolCall) (bool, string) {
 				continue
 			}
 			str := fmt.Sprintf("%v", val)
-			matched, _ := filepath.Match(strings.ToLower(pattern), strings.ToLower(str))
-			if matched {
+			if MatchGlob(strings.ToLower(pattern), strings.ToLower(str)) {
 				return true, fmt.Sprintf("tool_param_matches [%s=%q]", param, pattern)
 			}
 		}
@@ -514,8 +513,7 @@ func matchCondition(cond Condition, call ToolCall) bool {
 				continue
 			}
 			str := fmt.Sprintf("%v", val)
-			m, _ := filepath.Match(strings.ToLower(pattern), strings.ToLower(str))
-			if m {
+			if MatchGlob(strings.ToLower(pattern), strings.ToLower(str)) {
 				paramMatched = true
 				break
 			}

--- a/internal/engine/matcher_test.go
+++ b/internal/engine/matcher_test.go
@@ -306,6 +306,20 @@ func TestMatchCondition_ToolParamMatches(t *testing.T) {
 			input: map[string]any{"url": "EXAMPLE.COM"},
 			want:  true,
 		},
+		{
+			// filepath.Match would fail here — * doesn't cross path separators.
+			// MatchGlob supports ** for multi-segment matching.
+			name:  "double-star path matches nested .env",
+			cond:  Condition{ToolParamMatches: map[string]string{"path": "**/.env*"}},
+			input: map[string]any{"path": "/home/user/project/.env.production"},
+			want:  true,
+		},
+		{
+			name:  "double-star does not match unrelated path",
+			cond:  Condition{ToolParamMatches: map[string]string{"path": "**/.env*"}},
+			input: map[string]any{"path": "/home/user/project/main.go"},
+			want:  false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/proxy/rules_handlers.go
+++ b/internal/proxy/rules_handlers.go
@@ -140,6 +140,8 @@ func (s *Server) handleDeleteAutoAllowed(w http.ResponseWriter, r *http.Request)
 		if s.engine != nil {
 			if reloadErr := s.engine.Reload(); reloadErr != nil {
 				s.logger.Error("proxy: post-change reload failed", "error", reloadErr)
+				writeError(w, http.StatusInternalServerError, fmt.Sprintf("policy removed but reload failed: %v", reloadErr))
+				return
 			}
 		}
 		writeJSON(w, http.StatusOK, map[string]any{"deleted": true})
@@ -185,6 +187,8 @@ func (s *Server) handleDeleteAutoAllowed(w http.ResponseWriter, r *http.Request)
 	if s.engine != nil {
 		if reloadErr := s.engine.Reload(); reloadErr != nil {
 			s.logger.Error("proxy: post-change reload failed", "error", reloadErr)
+			writeError(w, http.StatusInternalServerError, fmt.Sprintf("policy written but reload failed: %v", reloadErr))
+			return
 		}
 	}
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -133,6 +133,10 @@ nav:
     - MCP Proxy: features/mcp-proxy.md
     - Semantic Verification: features/semantic-verification.md
     - SIEM Integration: features/siem-integration.md
+  - Security Guides:
+    - Securing Claude Code: guides/securing-claude-code.md
+    - Prompt Injection Protection: guides/prompt-injection.md
+    - Install via an AI Agent: guides/agent-install.md
   - Deployment:
     - User Separation: deployment/user-separation.md
     - Production Checklist: deployment/production-checklist.md


### PR DESCRIPTION
Follow-up to PR #90, addressing issues from the code review.

## Fixes

### B1 (BLOCKER) — `tool_param_matches` glob was broken
`filepath.Match` treats `*` as non-separator, so the documented `path: '**/.env*'` pattern silently never matched nested paths like `/home/user/.envrc`. Both `ExplainCondition` and `matchCondition` now use `MatchGlob`. Two new `**` tests added that would have caught this.

### W1 — `RAMPART_AGENT_DEPTH` clamped to >= 0
A crafted `RAMPART_AGENT_DEPTH=-999` env var could bypass `agent_depth: {gte: 1}` deny rules. One-line clamp after `strconv.Atoi`.

### W2 — `PostToolUseFailure` audit action corrected
Was logging blocked tool calls as `action: "allow"` — semantically wrong, skewed dashboard allow/deny stats. Now `action: "feedback"` with a clearer message.

### W3 — `resolveExplainPolicyPath` fallthrough fixed
Silently fell through to auto-discovery when a programmatic `configPath` pointed at a non-existent file. Now returns an explicit error, consistent with `--config` flag behavior.

### W4 — `Reload()` failure returns HTTP 500
Both the delete and write paths in `rules_handlers.go` were returning 200 OK even when `engine.Reload()` failed after the file change. Now returns 500 so callers know enforcement state may not match what was written.

---

## feat: Agent-install support

### OpenClaw auto-detection via `OPENCLAW_SERVICE_MARKER`
`detectEnv()` previously used `exec.LookPath("openclaw")` which is too broad — any machine with OpenClaw installed would detect it regardless of context. Now uses `OPENCLAW_SERVICE_MARKER=openclaw` env var (set by the OpenClaw gateway when spawning agent processes).

### `rampart quickstart --yes` / `-y`
Non-interactive flag for AI agents, CI pipelines, and scripted setup:
- Auto-accepts all defaults
- For OpenClaw: also enables `--patch-tools` (full file coverage)
- For Claude Code / Cline: no behavioral change (already non-interactive)

### `docs-site/guides/agent-install.md`
New guide written specifically for an AI agent to read and execute when told _"install Rampart and protect this machine"_. Covers install, quickstart, verification, what gets blocked, and troubleshooting. Added to nav as **Security Guides** section.

### `integrations/openclaw.md` updated
Added tip box: _"If you want your OpenClaw agent to install Rampart, just say: 'Install Rampart and protect this machine.'"_ — links to the new agent-install guide.