### PR TITLE
fix: sweep warnings — .env.* policy coverage + agent-install cleanup

### DIFF
--- a/docs-site/guides/agent-install.md
+++ b/docs-site/guides/agent-install.md
@@ -53,10 +53,9 @@ This single command auto-detects the running AI environment, installs the backgr
 rampart quickstart --yes
 ```
 
-The `--yes` flag skips any prompts. For **OpenClaw** it also auto-enables `--patch-tools`, which extends coverage to file reads/writes/edits in addition to shell commands. For all other agents the flag is a safe no-op.
+The `--yes` flag skips any prompts. For **OpenClaw** it also auto-enables `--patch-tools` (full coverage for file reads/writes/edits in addition to shell commands). For all other agents the flag is a safe no-op.
 
-!!! note "OpenClaw specifically"
-    If running inside an OpenClaw agent, you are protecting future tool calls — not the current session. After step 2, restart the OpenClaw gateway for hooks to take effect.
+**OpenClaw note:** protection applies to future tool calls, not the current session. Restart the OpenClaw gateway after this step for hooks to take effect.
 
 ---
 

--- a/docs-site/guides/securing-claude-code.md
+++ b/docs-site/guides/securing-claude-code.md
@@ -42,7 +42,7 @@ rampart doctor
 | Tool type | Example | Policy coverage |
 |-----------|---------|-----------------|
 | `exec` | `rm -rf /`, `curl ... | bash` | Block destructive and remote execution patterns, allow safe commands, or require approval |
-| `read` | `cat ~/.ssh/id_rsa`, `cat .env` | Deny sensitive paths and secret files, log policy matches |
+| `read` | `cat ~/.ssh/id_rsa`, `cat .env`, `cat .env.local` | Deny sensitive paths and secret files, log policy matches |
 | `write` | Editing `/etc/*` or production config | Enforce path rules, require approval for high-risk targets |
 | `fetch` | Web content, API responses, MCP output | Monitor for prompt injection and suspicious exfiltration directives |
 

--- a/docs-site/integrations/claude-code.md
+++ b/docs-site/integrations/claude-code.md
@@ -27,7 +27,7 @@ The standard policy (`~/.rampart/policies/standard.yaml`) blocks:
 | `rm -rf /`, `rm -rf ~` | Destructive filesystem wipe |
 | `curl ... \| bash` | Remote code execution |
 | `cat ~/.ssh/id_rsa` | SSH private key exfiltration |
-| `cat .env` | API key / secret exposure |
+| `cat .env`, `cat .env.local`, `cat .env.production` | API key / secret exposure |
 | `dd if=/dev/urandom of=/dev/sda` | Disk destruction |
 | Credential patterns in responses | Data exfiltration detection |
 

--- a/policies/standard.yaml
+++ b/policies/standard.yaml
@@ -223,6 +223,7 @@ policies:
             - "**/.docker/config.json"
             # Token / secrets files
             - "**/.env"
+            - "**/.env.*"
             - "**/.envrc"
             - "**/.netrc"
             - "**/token*"
@@ -281,6 +282,7 @@ policies:
             - "**/.docker/config.json"
             # Token / secrets files
             - "cat **/.env"
+            - "cat **/.env.*"
             - "cat **/.envrc"
             - "cat **/.netrc"
             - "cat **/.git-credentials"
@@ -338,9 +340,10 @@ policies:
             - "**/.zlogout"
             - "**/.profile"
             - "**/.config/fish/**"
-            # direnv environment files (frequently hold API keys)
+            # direnv environment files and variants (frequently hold API keys)
             - "**/.envrc"
             - "**/.env"
+            - "**/.env.*"
         message: "Write to sensitive path blocked"
 
   - name: block-browser-data


### PR DESCRIPTION
Two items from the final staging sweep.

**W1 — agent-install.md OpenClaw note**
Collapsed the admonition box into inline prose. Same information, cleaner layout.

**W2 — .env.* credential coverage gap**
`block-credential-access`, `block-credential-commands`, and `block-sensitive-writes` only covered `**/.env` (exact). `.env.local`, `.env.production`, `.env.staging` etc. were not blocked.

Added `**/.env.*` patterns to all three rules. `.envrc` already had its own entry and is unaffected.

Updated docs tables in `integrations/claude-code.md` and `guides/securing-claude-code.md` to reflect actual coverage.