### PR TITLE
feat: help command grouping + rampart token rotate

### DIFF
--- a/cmd/rampart/cli/root.go
+++ b/cmd/rampart/cli/root.go
@@ -87,30 +87,92 @@ func NewRootCmd(ctx context.Context, outWriter, errWriter io.Writer) *cobra.Comm
 	cmd.PersistentFlags().BoolVar(&opts.verbose, "verbose", false, "Enable debug logging")
 	cmd.PersistentFlags().BoolVar(&showVersion, "version", false, "Print version information and exit")
 
-	cmd.AddCommand(newVersionCmd())
-	cmd.AddCommand(newInitCmd(opts))
-	cmd.AddCommand(newServeCmd(opts, nil))
-	cmd.AddCommand(newPolicyCmd(opts))
-	cmd.AddCommand(newAuditCmd(opts))
-	cmd.AddCommand(newReportCmd(opts))
-	cmd.AddCommand(newWatchCmd(opts))
-	cmd.AddCommand(newOpenClawCmd(opts))
-	cmd.AddCommand(newDaemonCmd(opts))
-	cmd.AddCommand(newApproveCmd(opts))
-	cmd.AddCommand(newDenyCmd(opts))
-	cmd.AddCommand(newPendingCmd(opts))
-	cmd.AddCommand(newWrapCmd(opts, nil))
-	cmd.AddCommand(newPreloadCmd(opts))
-	cmd.AddCommand(newMCPCmd(opts, nil))
-	cmd.AddCommand(newHookCmd(opts))
-	cmd.AddCommand(newLogCmd(opts))
-	cmd.AddCommand(newSetupCmd(opts))
-	cmd.AddCommand(newDoctorCmd())
-	cmd.AddCommand(newStatusCmd())
-	cmd.AddCommand(newTokenShowCmd())
-	cmd.AddCommand(newTestCmd(opts))
-	cmd.AddCommand(newQuickstartCmd())
-	cmd.AddCommand(newUpgradeCmd(opts))
+	const (
+		groupSetup     = "setup"
+		groupPolicy    = "policy"
+		groupRuntime   = "runtime"
+		groupApprovals = "approvals"
+		groupHooks     = "hooks"
+	)
+	cmd.AddGroup(
+		&cobra.Group{ID: groupSetup, Title: "Setup"},
+		&cobra.Group{ID: groupPolicy, Title: "Policy"},
+		&cobra.Group{ID: groupRuntime, Title: "Runtime"},
+		&cobra.Group{ID: groupApprovals, Title: "Approvals"},
+		&cobra.Group{ID: groupHooks, Title: "Hooks"},
+	)
+
+	versionCmd := newVersionCmd()
+	initCmd := newInitCmd(opts)
+	serveCmd := newServeCmd(opts, nil)
+	policyCmd := newPolicyCmd(opts)
+	auditCmd := newAuditCmd(opts)
+	reportCmd := newReportCmd(opts)
+	watchCmd := newWatchCmd(opts)
+	openClawCmd := newOpenClawCmd(opts)
+	daemonCmd := newDaemonCmd(opts)
+	approveCmd := newApproveCmd(opts)
+	denyCmd := newDenyCmd(opts)
+	pendingCmd := newPendingCmd(opts)
+	wrapCmd := newWrapCmd(opts, nil)
+	preloadCmd := newPreloadCmd(opts)
+	mcpCmd := newMCPCmd(opts, nil)
+	hookCmd := newHookCmd(opts)
+	logCmd := newLogCmd(opts)
+	setupCmd := newSetupCmd(opts)
+	doctorCmd := newDoctorCmd()
+	statusCmd := newStatusCmd()
+	tokenCmd := newTokenShowCmd()
+	testCmd := newTestCmd(opts)
+	quickstartCmd := newQuickstartCmd()
+	upgradeCmd := newUpgradeCmd(opts)
+
+	setupCmd.GroupID = groupSetup
+	quickstartCmd.GroupID = groupSetup
+	upgradeCmd.GroupID = groupSetup
+	doctorCmd.GroupID = groupSetup
+
+	policyCmd.GroupID = groupPolicy
+	testCmd.GroupID = groupPolicy
+	watchCmd.GroupID = groupPolicy
+
+	serveCmd.GroupID = groupRuntime
+	tokenCmd.GroupID = groupRuntime
+	statusCmd.GroupID = groupRuntime
+	logCmd.GroupID = groupRuntime
+
+	approveCmd.GroupID = groupApprovals
+	denyCmd.GroupID = groupApprovals
+	pendingCmd.GroupID = groupApprovals
+
+	hookCmd.GroupID = groupHooks
+	preloadCmd.GroupID = groupHooks
+	wrapCmd.GroupID = groupHooks
+
+	cmd.AddCommand(versionCmd)
+	cmd.AddCommand(initCmd)
+	cmd.AddCommand(serveCmd)
+	cmd.AddCommand(policyCmd)
+	cmd.AddCommand(auditCmd)
+	cmd.AddCommand(reportCmd)
+	cmd.AddCommand(watchCmd)
+	cmd.AddCommand(openClawCmd)
+	cmd.AddCommand(daemonCmd)
+	cmd.AddCommand(approveCmd)
+	cmd.AddCommand(denyCmd)
+	cmd.AddCommand(pendingCmd)
+	cmd.AddCommand(wrapCmd)
+	cmd.AddCommand(preloadCmd)
+	cmd.AddCommand(mcpCmd)
+	cmd.AddCommand(hookCmd)
+	cmd.AddCommand(logCmd)
+	cmd.AddCommand(setupCmd)
+	cmd.AddCommand(doctorCmd)
+	cmd.AddCommand(statusCmd)
+	cmd.AddCommand(tokenCmd)
+	cmd.AddCommand(testCmd)
+	cmd.AddCommand(quickstartCmd)
+	cmd.AddCommand(upgradeCmd)
 
 	return cmd
 }

--- a/cmd/rampart/cli/token_test.go
+++ b/cmd/rampart/cli/token_test.go
@@ -14,6 +14,12 @@
 package cli
 
 import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -32,4 +38,63 @@ func TestTokenShow_PrintsPersistedToken(t *testing.T) {
 	stdout, _, err = runCLI(t, "token", "show")
 	require.NoError(t, err)
 	assert.Equal(t, want, stdout)
+}
+
+func TestTokenRotateForce_GeneratesAndPersistsToken(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd := NewRootCmd(context.Background(), stdout, stderr)
+	cmd.SetArgs([]string{"token", "rotate", "--force"})
+
+	require.NoError(t, cmd.Execute())
+
+	got := stdout.String()
+	assert.Regexp(t, regexp.MustCompile(`^[a-f0-9]{64}\n$`), got)
+
+	data, err := os.ReadFile(filepath.Join(home, ".rampart", "token"))
+	require.NoError(t, err)
+	assert.Equal(t, strings.TrimSpace(got), string(data))
+}
+
+func TestTokenRotateConfirmNo_DoesNotOverwrite(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	require.NoError(t, persistToken("existing-token"))
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd := NewRootCmd(context.Background(), stdout, stderr)
+	cmd.SetArgs([]string{"token", "rotate"})
+	cmd.SetIn(bytes.NewBufferString("n\n"))
+
+	require.NoError(t, cmd.Execute())
+
+	assert.Equal(t, "Rotate token and overwrite ~/.rampart/token? [y/N]: ", stdout.String())
+	tok, err := readPersistedToken()
+	require.NoError(t, err)
+	assert.Equal(t, "existing-token", tok)
+}
+
+func TestTokenRotateConfirmYes_Overwrites(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	require.NoError(t, persistToken("old-token"))
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd := NewRootCmd(context.Background(), stdout, stderr)
+	cmd.SetArgs([]string{"token", "rotate"})
+	cmd.SetIn(bytes.NewBufferString("yes\n"))
+
+	require.NoError(t, cmd.Execute())
+
+	got := stdout.String()
+	assert.Regexp(t, regexp.MustCompile(`^Rotate token and overwrite ~/.rampart/token\? \[y/N\]: [a-f0-9]{64}\n$`), got)
+	tok, err := readPersistedToken()
+	require.NoError(t, err)
+	assert.Regexp(t, regexp.MustCompile(`^[a-f0-9]{64}$`), tok)
+	assert.NotEqual(t, "old-token", tok)
 }


### PR DESCRIPTION
Two small UX improvements for v0.4.8.

**Help grouping:** 20+ commands organized into sections via cobra `AddGroup()` — Setup, Policy, Runtime, Approvals, Hooks. Much cleaner `rampart --help` output.

**Token rotate:** `rampart token rotate` generates a new random token, writes to `~/.rampart/token`, prints it. `--force` skips the confirmation prompt. 4 tests.