### PR TITLE
feat: agent transparency mode (/v1/policy/summary + ACTIVE_POLICY.md)

### DIFF
--- a/internal/proxy/server_test.go
+++ b/internal/proxy/server_test.go
@@ -632,9 +632,9 @@ policies: []`
 
 func TestResolveApproval_AuditTrail(t *testing.T) {
 	tests := []struct {
-		name       string
-		approved   bool
-		persist    bool
+		name           string
+		approved       bool
+		persist        bool
 		wantResolution string
 	}{
 		{"approved", true, false, "approved"},
@@ -761,6 +761,39 @@ func TestGetPolicy_NoAuth(t *testing.T) {
 	defer resp.Body.Close()
 
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+func TestPolicySummaryEndpoint(t *testing.T) {
+	srv, token, _ := setupTestServer(t, testPolicyYAML, "enforce")
+	ts := httptest.NewServer(srv.handler())
+	defer ts.Close()
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/v1/policy/summary", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body struct {
+		DefaultAction string `json:"default_action"`
+		Rules         []struct {
+			Name    string `json:"name"`
+			Action  string `json:"action"`
+			Summary string `json:"summary"`
+		} `json:"rules"`
+		Summary string `json:"summary"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+
+	assert.Equal(t, "allow", body.DefaultAction)
+	assert.NotEmpty(t, body.Summary)
+	require.Len(t, body.Rules, 3)
+	assert.Equal(t, "block-destructive", body.Rules[0].Name)
+	assert.Equal(t, "deny", body.Rules[0].Action)
+	assert.Equal(t, "destructive command blocked", body.Rules[0].Summary)
 }
 
 func TestCreateApproval_NoAuth(t *testing.T) {


### PR DESCRIPTION
Enables agents to self-describe their security policy.

**`GET /v1/policy/summary`** — new API endpoint returning:
```json
{ "default_action": "deny", "rules": [{"name": "...", "action": "deny", "summary": "..."}], "summary": "..." }
```
Auth-gated with bearer token same as all other endpoints.

**`~/.rampart/ACTIVE_POLICY.md`** — written on serve startup and every hot-reload. Markdown table of active rules + `rampart watch`/`rampart log` hints. An agent told 'describe your security policy' will find this file naturally.

This is the enabler for the viral moment: agent says 'I'm running under Rampart. Here's what I can and can't do: [table]'.