### PR TITLE
feat: call_count rate limiting condition

### DIFF
--- a/cmd/rampart/cli/hook.go
+++ b/cmd/rampart/cli/hook.go
@@ -405,6 +405,7 @@ Cline setup: Use "rampart setup cline" to install hooks automatically.`,
 			if isPostToolUse {
 				decision = eng.EvaluateResponse(call, parsed.Response)
 			} else {
+				eng.IncrementCallCount(call.Tool, call.Timestamp)
 				decision = eng.Evaluate(call)
 			}
 

--- a/internal/engine/callcount_test.go
+++ b/internal/engine/callcount_test.go
@@ -1,0 +1,85 @@
+package engine
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCallCountBasic(t *testing.T) {
+	counter := NewSlidingWindowCounter()
+	call := ToolCall{Tool: "fetch"}
+	cond := Condition{
+		CallCount: &CallCountCondition{
+			Gte:    3,
+			Window: "1h",
+		},
+	}
+
+	now := time.Now().UTC()
+	counter.Increment("fetch", now.Add(-10*time.Minute))
+	if matchCondition(cond, call, counter) {
+		t.Fatal("expected no match at count=1")
+	}
+
+	counter.Increment("fetch", now.Add(-5*time.Minute))
+	if matchCondition(cond, call, counter) {
+		t.Fatal("expected no match at count=2")
+	}
+
+	counter.Increment("fetch", now.Add(-1*time.Minute))
+	if !matchCondition(cond, call, counter) {
+		t.Fatal("expected match at count=3")
+	}
+}
+
+func TestCallCountSliding(t *testing.T) {
+	counter := NewSlidingWindowCounter()
+	call := ToolCall{Tool: "fetch"}
+	cond := Condition{
+		CallCount: &CallCountCondition{
+			Gte:    2,
+			Window: "1h",
+		},
+	}
+
+	now := time.Now().UTC()
+	counter.Increment("fetch", now.Add(-2*time.Hour))
+	counter.Increment("fetch", now.Add(-45*time.Minute))
+	if matchCondition(cond, call, counter) {
+		t.Fatal("expected no match with only one call inside 1h window")
+	}
+
+	counter.Increment("fetch", now.Add(-5*time.Minute))
+	if !matchCondition(cond, call, counter) {
+		t.Fatal("expected match with two calls inside 1h window")
+	}
+}
+
+func TestCallCountToolFilter(t *testing.T) {
+	counter := NewSlidingWindowCounter()
+	call := ToolCall{Tool: "fetch"}
+	cond := Condition{
+		CallCount: &CallCountCondition{
+			Tool:   "web_search",
+			Gte:    2,
+			Window: "1h",
+		},
+	}
+
+	now := time.Now().UTC()
+	counter.Increment("fetch", now.Add(-1*time.Minute))
+	counter.Increment("fetch", now.Add(-30*time.Second))
+	if matchCondition(cond, call, counter) {
+		t.Fatal("expected no match when threshold is not met for specified tool")
+	}
+
+	counter.Increment("web_search", now.Add(-30*time.Minute))
+	if matchCondition(cond, call, counter) {
+		t.Fatal("expected no match at web_search count=1")
+	}
+
+	counter.Increment("web_search", now.Add(-10*time.Minute))
+	if !matchCondition(cond, call, counter) {
+		t.Fatal("expected match at web_search count=2")
+	}
+}

--- a/internal/engine/matcher_fuzz_test.go
+++ b/internal/engine/matcher_fuzz_test.go
@@ -9,7 +9,7 @@ func FuzzMatchCondition(f *testing.F) {
 	// Add seed corpus with various condition and ToolCall combinations
 	f.Add("exec", "test-agent", "ssh root@example.com", "/etc/passwd", "https://evil.com", "evil.com")
 	f.Add("read", "admin", "cat secret.txt", "/home/user/.ssh/id_rsa", "", "")
-	f.Add("fetch", "bot-*", "curl webhook.site", "", "https://webhook.site/abc123", "webhook.site") 
+	f.Add("fetch", "bot-*", "curl webhook.site", "", "https://webhook.site/abc123", "webhook.site")
 	f.Add("write", "user", "rm -rf /", "/tmp/dangerous", "", "")
 	f.Add("", "", "", "", "", "")
 
@@ -48,16 +48,16 @@ func FuzzMatchCondition(f *testing.F) {
 			{ResponseNotMatches: []string{"safe", "allowed"}},
 			{
 				// Complex condition with multiple fields
-				CommandMatches:    []string{"ssh *", "wget *"},
-				PathNotMatches:    []string{"/safe/*"},
-				URLMatches:        []string{"https://*"},
-				ResponseMatches:   []string{".*"},
+				CommandMatches:  []string{"ssh *", "wget *"},
+				PathNotMatches:  []string{"/safe/*"},
+				URLMatches:      []string{"https://*"},
+				ResponseMatches: []string{".*"},
 			},
 		}
 
 		for _, cond := range conditions {
 			// Test matchCondition - should never panic
-			result := matchCondition(cond, call)
+			result := matchCondition(cond, call, nil)
 			_ = result
 
 			// Test ExplainCondition - should never panic
@@ -73,7 +73,7 @@ func FuzzMatchCondition(f *testing.F) {
 		for _, pattern := range patterns {
 			result := MatchGlob(pattern, command)
 			_ = result
-			result = MatchGlob(pattern, path)  
+			result = MatchGlob(pattern, path)
 			_ = result
 			result = MatchGlob(pattern, url)
 			_ = result
@@ -91,14 +91,14 @@ func FuzzMatchGlob(f *testing.F) {
 	f.Add("/etc/**", "/etc/passwd")
 	f.Add("*curl*webhook*", "curl https://webhook.site/abc")
 	f.Add("***", "test")
-	
+
 	f.Fuzz(func(t *testing.T, pattern, name string) {
 		defer func() {
 			if r := recover(); r != nil {
 				t.Errorf("Panic in MatchGlob(%q, %q): %v", pattern, name, r)
 			}
 		}()
-		
+
 		result := MatchGlob(pattern, name)
 		_ = result // We don't care about the result, just that it doesn't panic
 	})

--- a/internal/engine/matcher_test.go
+++ b/internal/engine/matcher_test.go
@@ -119,7 +119,7 @@ func TestMatchCondition_PathTraversalBypass(t *testing.T) {
 				Tool:   "read",
 				Params: map[string]interface{}{"path": tt.path},
 			}
-			got := matchCondition(cond, call)
+			got := matchCondition(cond, call, nil)
 			if got != tt.want {
 				t.Errorf("matchCondition(path_matches=/etc/shadow, path=%q) = %v, want %v",
 					tt.path, got, tt.want)
@@ -146,7 +146,7 @@ func TestMatchCondition_PathTraversalBypass(t *testing.T) {
 				Tool:   "read",
 				Params: map[string]interface{}{"path": tt.path},
 			}
-			got := matchCondition(condSSH, call)
+			got := matchCondition(condSSH, call, nil)
 			if got != tt.want {
 				t.Errorf("matchCondition(path_matches=%s/.ssh/*, path=%q) = %v, want %v",
 					home, tt.path, got, tt.want)
@@ -196,7 +196,7 @@ func TestMatchCondition_CommandContains(t *testing.T) {
 				Tool:   "exec",
 				Params: map[string]interface{}{"command": tt.cmd},
 			}
-			got := matchCondition(cond, call)
+			got := matchCondition(cond, call, nil)
 			if got != tt.want {
 				t.Errorf("matchCondition(command_contains=%v, cmd=%q) = %v, want %v",
 					tt.contains, tt.cmd, got, tt.want)
@@ -261,7 +261,7 @@ func TestMatchCondition_AgentDepth(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			call := ToolCall{Tool: "agent", AgentDepth: tt.depth}
-			got := matchCondition(tt.cond, call)
+			got := matchCondition(tt.cond, call, nil)
 			if got != tt.want {
 				t.Fatalf("matchCondition(agent_depth, depth=%d) = %v, want %v", tt.depth, got, tt.want)
 			}
@@ -325,7 +325,7 @@ func TestMatchCondition_ToolParamMatches(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			call := ToolCall{Tool: "mcp", Input: tt.input}
-			got := matchCondition(tt.cond, call)
+			got := matchCondition(tt.cond, call, nil)
 			if got != tt.want {
 				t.Fatalf("matchCondition(tool_param_matches, input=%v) = %v, want %v", tt.input, got, tt.want)
 			}

--- a/internal/engine/persist.go
+++ b/internal/engine/persist.go
@@ -258,7 +258,17 @@ func sanitizeName(s string) string {
 func conditionsEqual(a, b Condition) bool {
 	return slicesEqual(a.CommandMatches, b.CommandMatches) &&
 		slicesEqual(a.PathMatches, b.PathMatches) &&
-		a.Default == b.Default
+		a.Default == b.Default &&
+		callCountEqual(a.CallCount, b.CallCount)
+}
+
+func callCountEqual(a, b *CallCountCondition) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return a.Tool == b.Tool &&
+		a.Gte == b.Gte &&
+		a.Window == b.Window
 }
 
 func slicesEqual(a, b []string) bool {
@@ -275,8 +285,8 @@ func slicesEqual(a, b []string) bool {
 
 // cleanRule is a minimal YAML representation that omits empty fields.
 type cleanRule struct {
-	Action string     `yaml:"action"`
-	When   cleanWhen  `yaml:"when"`
+	Action string    `yaml:"action"`
+	When   cleanWhen `yaml:"when"`
 }
 
 type cleanWhen struct {
@@ -286,9 +296,9 @@ type cleanWhen struct {
 }
 
 type cleanPolicy struct {
-	Name  string        `yaml:"name"`
-	Match cleanMatch    `yaml:"match"`
-	Rules []cleanRule   `yaml:"rules"`
+	Name  string      `yaml:"name"`
+	Match cleanMatch  `yaml:"match"`
+	Rules []cleanRule `yaml:"rules"`
 }
 
 type cleanMatch struct {

--- a/internal/engine/ratelimit.go
+++ b/internal/engine/ratelimit.go
@@ -1,0 +1,108 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package engine
+
+import (
+	"sync"
+	"time"
+)
+
+// CallCounter tracks per-tool call counts in a sliding time window.
+type CallCounter interface {
+	Increment(tool string, at time.Time)
+	Count(tool string, window time.Duration, now time.Time) int
+	Snapshot(window time.Duration, now time.Time) map[string]int
+}
+
+// SlidingWindowCounter is an in-memory per-tool sliding window counter.
+// It is safe for concurrent use.
+type SlidingWindowCounter struct {
+	mu    sync.Mutex
+	calls map[string][]time.Time
+}
+
+// NewSlidingWindowCounter creates a new empty counter.
+func NewSlidingWindowCounter() *SlidingWindowCounter {
+	return &SlidingWindowCounter{
+		calls: make(map[string][]time.Time),
+	}
+}
+
+// Increment records one tool invocation at time at.
+func (c *SlidingWindowCounter) Increment(tool string, at time.Time) {
+	if tool == "" {
+		return
+	}
+	if at.IsZero() {
+		at = time.Now().UTC()
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.calls[tool] = append(c.calls[tool], at)
+}
+
+// Count returns how many calls for tool occurred in the given sliding window.
+// Old entries outside the window are pruned on each check.
+func (c *SlidingWindowCounter) Count(tool string, window time.Duration, now time.Time) int {
+	if tool == "" || window <= 0 {
+		return 0
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	ts := c.pruneLocked(tool, window, now)
+	return len(ts)
+}
+
+// Snapshot returns current per-tool counts in the given sliding window.
+// Old entries outside the window are pruned for each tool on each check.
+func (c *SlidingWindowCounter) Snapshot(window time.Duration, now time.Time) map[string]int {
+	if window <= 0 {
+		return map[string]int{}
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	out := make(map[string]int, len(c.calls))
+	for tool := range c.calls {
+		ts := c.pruneLocked(tool, window, now)
+		if len(ts) > 0 {
+			out[tool] = len(ts)
+		}
+	}
+	return out
+}
+
+func (c *SlidingWindowCounter) pruneLocked(tool string, window time.Duration, now time.Time) []time.Time {
+	ts := c.calls[tool]
+	if len(ts) == 0 {
+		return nil
+	}
+
+	cutoff := now.Add(-window)
+	keepFrom := 0
+	for keepFrom < len(ts) && ts[keepFrom].Before(cutoff) {
+		keepFrom++
+	}
+
+	if keepFrom == len(ts) {
+		delete(c.calls, tool)
+		return nil
+	}
+	if keepFrom > 0 {
+		ts = append([]time.Time(nil), ts[keepFrom:]...)
+		c.calls[tool] = ts
+	}
+	return ts
+}

--- a/internal/proxy/server_test.go
+++ b/internal/proxy/server_test.go
@@ -632,9 +632,9 @@ policies: []`
 
 func TestResolveApproval_AuditTrail(t *testing.T) {
 	tests := []struct {
-		name       string
-		approved   bool
-		persist    bool
+		name           string
+		approved       bool
+		persist        bool
 		wantResolution string
 	}{
 		{"approved", true, false, "approved"},
@@ -738,6 +738,7 @@ func TestGetPolicy(t *testing.T) {
 			assert.NotNil(t, body["default_action"])
 			assert.NotNil(t, body["policy_count"])
 			assert.NotNil(t, body["rule_count"])
+			assert.NotNil(t, body["call_counts"])
 
 			// Verify counts are plausible.
 			policyCount, ok := body["policy_count"].(float64)
@@ -749,6 +750,36 @@ func TestGetPolicy(t *testing.T) {
 			assert.Greater(t, int(ruleCount), 0, "should have at least one rule")
 		})
 	}
+}
+
+func TestGetStatus(t *testing.T) {
+	srv, token, _ := setupTestServer(t, testPolicyYAML, "enforce")
+	ts := httptest.NewServer(srv.handler())
+	defer ts.Close()
+
+	// Simulate a few PreToolUse calls.
+	resp1 := postToolCall(t, ts, token, `{"agent":"main","session":"s1","params":{"command":"git status"}}`)
+	assert.Equal(t, http.StatusOK, resp1.StatusCode)
+	resp2 := postToolCall(t, ts, token, `{"agent":"main","session":"s1","params":{"command":"git log"}}`)
+	assert.Equal(t, http.StatusOK, resp2.StatusCode)
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/v1/status", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+
+	callCounts, ok := body["call_counts"].(map[string]any)
+	require.True(t, ok, "call_counts should be an object")
+	count, ok := callCounts["exec"].(float64)
+	require.True(t, ok, "exec count should be a number")
+	assert.GreaterOrEqual(t, int(count), 2)
 }
 
 func TestGetPolicy_NoAuth(t *testing.T) {

--- a/policies/standard.yaml
+++ b/policies/standard.yaml
@@ -399,6 +399,17 @@ policies:
             - "beeceptor.com"
         message: "Potential data exfiltration domain blocked"
 
+  - name: rate-limit-fetch
+    match:
+      tool: ["fetch", "web_search", "web_fetch", "browser"]
+    rules:
+      - action: require_approval
+        when:
+          call_count:
+            gte: 100
+            window: 1h
+        message: "High fetch volume — require approval to continue"
+
   - name: block-mcp-destructive
     match:
       tool: ["mcp-destructive"]


### PR DESCRIPTION
Adds sliding window rate limiting as a policy condition.

```yaml
- action: require_approval
  when:
    call_count:
      tool: fetch
      gte: 100
      window: 1h
```

- `internal/engine/ratelimit.go`: thread-safe in-memory sliding window (mutex + map of timestamps), pruned on each check
- Injected into Engine as dependency (not a global)
- Increments on every `PreToolUse` regardless of outcome
- `/v1/status` now exposes `call_counts` map
- Standard policy: `rate-limit-fetch` (require_approval at 100 calls/hour for fetch/browser tools)
- 3 tests: basic threshold, sliding expiry, per-tool filter