### PR TITLE
docs: v0.4.8 updates — call_count, token rotate, API summary, ACTIVE_POLICY.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ go install github.com/peg/rampart/cmd/rampart@latest
 ```
 
 > **Tip:** The curl installer drops the binary in `~/.local/bin` and runs `rampart quickstart` automatically.
-> Pin a version with `RAMPART_VERSION=v0.4.5 curl -fsSL https://rampart.sh/install | bash`.
+> Pin a version with `RAMPART_VERSION=v0.4.7 curl -fsSL https://rampart.sh/install | bash`.
 >
 > Run `rampart version` to confirm.
 
@@ -714,6 +714,11 @@ rampart audit search [--tool exec] [--decision deny]
 rampart pending
 rampart approve <id>
 rampart deny <id>
+
+# Token
+rampart token                                      # Print current bearer token
+rampart token rotate                               # Generate and persist a new bearer token
+rampart token rotate --force                       # Skip confirmation prompt and rotate immediately
 ```
 
 ---

--- a/docs-site/features/policy-engine.md
+++ b/docs-site/features/policy-engine.md
@@ -116,6 +116,19 @@ domain_matches:
   - "webhook.site"      # Exact domain match
 ```
 
+### `call_count` (sliding-window rate limiting)
+
+Use `call_count` to trigger rules once call volume reaches a threshold in a sliding window.
+Rampart increments this counter on every `PreToolUse`.
+
+```yaml
+when:
+  call_count:
+    tool: fetch    # optional, omit for all tools
+    gte: 100       # trigger threshold
+    window: 1h     # sliding window (1h, 30m, 10m, 5m, 1m)
+```
+
 ## Tool Types
 
 | Tool | Trigger | Available Matchers |

--- a/docs-site/guides/agent-install.md
+++ b/docs-site/guides/agent-install.md
@@ -164,7 +164,9 @@ rampart status          # verify
 rampart policy explain '<command>'   # see which rule matched
 ```
 
-Then add an allow rule for your specific use case. See [Exceptions Guide](https://rampart.sh/docs/exceptions).
+Then add an allow rule for your specific use case. See [Securing Claude Code](https://docs.rampart.sh/guides/securing-claude-code/).
+
+`rampart serve` also writes `~/.rampart/ACTIVE_POLICY.md`, a markdown table of active rules that agents can use for self-description.
 
 ---
 

--- a/docs-site/reference/architecture.md
+++ b/docs-site/reference/architecture.md
@@ -140,6 +140,7 @@ HTTP server for tool evaluation. Bearer token auth, localhost-only.
 |----------|---------|
 | `POST /v1/tool/{name}` | Evaluate and execute |
 | `POST /v1/preflight/{name}` | Dry-run check |
+| `GET /v1/policy/summary` | Auth required. Returns JSON with `default_action`, per-rule summaries, and a plain-English overall summary |
 | `GET /v1/approvals` | Pending approvals |
 | `POST /v1/approvals/{id}/resolve` | Approve/deny |
 | `GET /healthz` | Health check |

--- a/docs-site/reference/cli-commands.md
+++ b/docs-site/reference/cli-commands.md
@@ -9,6 +9,18 @@ Complete reference for all `rampart` commands.
 
 ## Agent Setup
 
+### `rampart quickstart`
+
+Auto-detects your environment, installs `rampart serve`, configures integration hooks, and runs a health check.
+
+```bash
+rampart quickstart                  # Interactive setup
+rampart quickstart --yes            # Non-interactive mode
+rampart quickstart -y               # Short form of --yes
+```
+
+`--yes` / `-y` skips prompts. For OpenClaw it also auto-enables `--patch-tools` for full file read/write/edit coverage. For all other agents it is a safe no-op.
+
 ### `rampart setup claude-code`
 
 Install native hooks into Claude Code.
@@ -280,4 +292,23 @@ Deny a pending command.
 
 ```bash
 rampart deny <id>
+```
+
+## Token
+
+### `rampart token`
+
+Print the current bearer token.
+
+```bash
+rampart token
+```
+
+### `rampart token rotate`
+
+Generate and persist a new bearer token.
+
+```bash
+rampart token rotate
+rampart token rotate --force
 ```

--- a/docs-site/reference/policy-schema.md
+++ b/docs-site/reference/policy-schema.md
@@ -189,6 +189,18 @@ when:
     url: "*webhook.site*"
 ```
 
+#### `call_count`
+
+Sliding-window rate limiting for tool calls. Rampart increments the counter on every `PreToolUse` event.
+
+```yaml
+when:
+  call_count:
+    tool: fetch    # optional, omit for all tools
+    gte: 100       # trigger threshold
+    window: 1h     # sliding window (1h, 30m, 10m, 5m, 1m)
+```
+
 ### Webhook Configuration
 
 When `action: webhook`:


### PR DESCRIPTION
Docs catch-up for v0.4.8 — all gaps identified by QA sweep.

**README:**
- Version pin `v0.4.5` → `v0.4.7`
- Add `rampart token rotate` to CLI section

**policy-engine.md + policy-schema.md:**
- Document `call_count` condition (sliding window rate limiting, `tool`/`gte`/`window` fields + YAML examples)

**cli-commands.md:**
- `rampart token rotate [--force]`
- `rampart quickstart --yes/-y` (non-interactive, auto-enables `--patch-tools` for OpenClaw)

**architecture.md:**
- `GET /v1/policy/summary` endpoint (auth required, returns `default_action` + per-rule summaries)

**agent-install.md:**
- Fix broken link (`rampart.sh/docs/exceptions` → `docs.rampart.sh/guides/securing-claude-code/`)
- Add note about `~/.rampart/ACTIVE_POLICY.md` written by `rampart serve`