### PR TITLE
fix: v0.4.10 — four post-release bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.10] - 2026-02-24
+
+### Fixed
+
+- **`rampart audit` subcommands crash with default path** — `tail`, `verify`, `stats`, `search`, and `replay` all failed with the default `--audit-dir` because `~` was never expanded. Fixed in `listAuditFiles` and `listAnchorFiles` helpers (covers all subcommands).
+- **`rampart bench` approval-gated coverage always 0%** — corpus entries with `expected_action: require_approval` were never included in coverage math. The 4 correctly-gated sudo/shred entries showed in decisions but were invisible to the coverage percentage. Both `deny` and `require_approval` expected entries now feed the coverage denominator. Coverage for privilege-escalation goes from 28% → 50%.
+- **`rampart bench` crashes with no args on installed binaries** — default corpus path `bench/corpus.yaml` was relative to CWD. Fixed by embedding the corpus in the binary. `rampart bench` now works anywhere; shows `Corpus: built-in`.
+- **`rampart doctor` lint error for `call_count`** — `call_count` was added to the engine in v0.4.8 but the linter's `validConditionFields` map was never updated. Any user with `standard.yaml` (which uses `call_count` in the rate-limit rule) saw a spurious lint error.
+- **`rampart status` undercounts blocking decisions** — `require_approval` and `webhook` decisions were silently dropped from today's event stats. Now counted alongside `deny`.
+- **`rampart policy generate` emits verbose null/empty fields** — generated YAML included `priority: 0`, `enabled: null`, `agent: ""`, and all-empty condition slices. Added `omitempty` to relevant struct fields; marshaling-only change, existing policy files parse identically.
+
 ## [0.4.9] - 2026-02-22
 
 ### Added

--- a/bench/embed.go
+++ b/bench/embed.go
@@ -1,0 +1,22 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package bench embeds the default benchmark corpus.
+package bench
+
+import _ "embed"
+
+// CorpusYAML is the built-in attack corpus bundled with the binary.
+//
+//go:embed corpus.yaml
+var CorpusYAML []byte

--- a/cmd/rampart/cli/audit.go
+++ b/cmd/rampart/cli/audit.go
@@ -329,6 +329,11 @@ func newAuditReplayCmd() *cobra.Command {
 }
 
 func listAuditFiles(auditDir string) ([]string, error) {
+	auditDir, err := expandHome(auditDir)
+	if err != nil {
+		return nil, fmt.Errorf("audit: expand audit dir: %w", err)
+	}
+	auditDir = filepath.Clean(auditDir)
 	entries, err := os.ReadDir(auditDir)
 	if err != nil {
 		return nil, fmt.Errorf("audit: read audit dir: %w", err)

--- a/cmd/rampart/cli/audit_helpers.go
+++ b/cmd/rampart/cli/audit_helpers.go
@@ -352,6 +352,11 @@ func verifyAnchors(auditDir string, hashesByID map[string]string) error {
 }
 
 func listAnchorFiles(auditDir string) ([]string, error) {
+	auditDir, err := expandHome(auditDir)
+	if err != nil {
+		return nil, fmt.Errorf("audit: expand audit dir: %w", err)
+	}
+	auditDir = filepath.Clean(auditDir)
 	entries, err := os.ReadDir(auditDir)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/cmd/rampart/cli/bench.go
+++ b/cmd/rampart/cli/bench.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/peg/rampart/bench"
 	"github.com/peg/rampart/internal/engine"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
@@ -112,8 +113,9 @@ type benchRunOptions struct {
 	PolicyPath string
 	CorpusPath string
 	Category   string
-	Verbose    bool
-	Strict     bool
+	Verbose             bool
+	Strict              bool
+	UseEmbeddedCorpus   bool
 }
 
 func newBenchCmd(_ *rootOptions) *cobra.Command {
@@ -132,11 +134,12 @@ func newBenchCmd(_ *rootOptions) *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			summary, err := runBench(benchRunOptions{
-				PolicyPath: policyPath,
-				CorpusPath: corpusPath,
-				Category:   category,
-				Verbose:    verbose,
-				Strict:     strict,
+				PolicyPath:          policyPath,
+				CorpusPath:          corpusPath,
+				Category:            category,
+				Verbose:             verbose,
+				Strict:              strict,
+				UseEmbeddedCorpus:   !cmd.Flags().Changed("corpus"),
 			})
 			if err != nil {
 				return err
@@ -177,18 +180,26 @@ func runBench(opts benchRunOptions) (benchSummary, error) {
 		return benchSummary{}, err
 	}
 
-	corpusPath, err := expandBenchPath(opts.CorpusPath)
-	if err != nil {
-		return benchSummary{}, err
-	}
-
 	store := engine.NewFileStore(policyPath)
 	eng, err := engine.New(store, nil)
 	if err != nil {
 		return benchSummary{}, fmt.Errorf("bench: load policy: %w", err)
 	}
 
-	entries, err := loadBenchCorpus(corpusPath)
+	var (
+		entries    []benchCorpusEntry
+		corpusPath string
+	)
+	if opts.UseEmbeddedCorpus {
+		corpusPath = "built-in"
+		entries, err = parseBenchCorpus(bench.CorpusYAML)
+	} else {
+		corpusPath, err = expandBenchPath(opts.CorpusPath)
+		if err != nil {
+			return benchSummary{}, err
+		}
+		entries, err = loadBenchCorpus(corpusPath)
+	}
 	if err != nil {
 		return benchSummary{}, err
 	}
@@ -520,7 +531,10 @@ func loadBenchCorpus(path string) ([]benchCorpusEntry, error) {
 	if err != nil {
 		return nil, fmt.Errorf("bench: read corpus: %w", err)
 	}
+	return parseBenchCorpus(data)
+}
 
+func parseBenchCorpus(data []byte) ([]benchCorpusEntry, error) {
 	var doc benchCorpusDocument
 	if err := yaml.Unmarshal(data, &doc); err != nil {
 		return nil, fmt.Errorf("bench: parse corpus YAML: %w", err)

--- a/cmd/rampart/cli/bench.go
+++ b/cmd/rampart/cli/bench.go
@@ -286,7 +286,7 @@ func runBench(opts benchRunOptions) (benchSummary, error) {
 			categoryStats.Allowed++
 		}
 
-		if entry.ExpectedAction == "deny" {
+		if entry.ExpectedAction == "deny" || entry.ExpectedAction == "require_approval" {
 			summary.DenyTotal++
 			categoryStats.DenyTotal++
 			switch actual {

--- a/cmd/rampart/cli/bench_test.go
+++ b/cmd/rampart/cli/bench_test.go
@@ -380,6 +380,48 @@ func TestCorpusFileHasCoverageAndSchema(t *testing.T) {
 	}
 }
 
+func TestBenchUsesEmbeddedCorpusWhenNoFlagSet(t *testing.T) {
+	// Verifies that 'rampart bench' with no --corpus flag uses the embedded
+	// built-in corpus rather than attempting to open bench/corpus.yaml from
+	// the current directory (which does not exist in an installed binary).
+	dir := t.TempDir()
+	policyPath := filepath.Join(dir, "policy.yaml")
+	policy := `
+version: "1"
+default_action: allow
+policies:
+  - name: deny-rm
+    match:
+      tool: ["exec"]
+    rules:
+      - action: deny
+        when:
+          command_matches: ["rm -rf /*"]
+`
+	if err := os.WriteFile(policyPath, []byte(policy), 0o644); err != nil {
+		t.Fatalf("write policy: %v", err)
+	}
+
+	// Change to temp dir so there is no bench/corpus.yaml on disk.
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	stdout, _, err := runCLI(t, "bench", "--policy", policyPath)
+	// Gaps are expected (exit 1); we just want no "no such file" error.
+	if err != nil && strings.Contains(err.Error(), "no such file or directory") {
+		t.Fatalf("bench used disk path instead of embedded corpus: %v", err)
+	}
+	if !strings.Contains(stdout, "built-in") {
+		t.Fatalf("expected 'built-in' in bench output, got:\n%s", stdout)
+	}
+}
+
 func TestLoadBenchCorpusRejectsInvalidExpectedAction(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "invalid-corpus.yaml")

--- a/cmd/rampart/cli/status.go
+++ b/cmd/rampart/cli/status.go
@@ -184,6 +184,8 @@ func todayEvents() (allow, deny, log int, lastDeny *audit.Event) {
 				if lastDeny == nil || ev.Timestamp.After(lastDeny.Timestamp) {
 					lastDeny = ev
 				}
+			case "require_approval", "webhook":
+				deny++
 			case "watch", "log":
 				log++
 			}

--- a/internal/engine/lint.go
+++ b/internal/engine/lint.go
@@ -91,6 +91,7 @@ var validConditionFields = map[string]bool{
 	"session_not_matches":  true,
 	"agent_depth":          true,
 	"tool_param_matches":   true,
+	"call_count":           true,
 	"default":              true,
 }
 

--- a/internal/engine/lint_test.go
+++ b/internal/engine/lint_test.go
@@ -124,6 +124,30 @@ policies:
 	}
 }
 
+func TestLint_CallCountConditionValid(t *testing.T) {
+	path := writeTempPolicy(t, `
+version: "1"
+default_action: allow
+policies:
+  - name: rate-limit
+    match:
+      tool: ["fetch"]
+    rules:
+      - action: require_approval
+        when:
+          call_count:
+            gte: 100
+            window: 1h
+        message: "High fetch volume"
+`)
+	result := LintPolicyFile(path)
+	for _, f := range result.Findings {
+		if f.Severity == LintError && strings.Contains(f.Message, "call_count") {
+			t.Errorf("call_count should be a valid condition field, got lint error: %s", f.Message)
+		}
+	}
+}
+
 func TestLint_EmptyConditions(t *testing.T) {
 	path := writeTempPolicy(t, `
 version: "1"

--- a/internal/engine/policy.go
+++ b/internal/engine/policy.go
@@ -55,11 +55,11 @@ type Policy struct {
 	// Priority controls evaluation order. Lower number = higher priority.
 	// Default: 100. When multiple policies match, deny always wins
 	// regardless of priority.
-	Priority int `yaml:"priority"`
+	Priority int `yaml:"priority,omitempty"`
 
 	// Enabled allows disabling a policy without removing it.
 	// Default: true.
-	Enabled *bool `yaml:"enabled"`
+	Enabled *bool `yaml:"enabled,omitempty"`
 
 	// Match defines which tool calls this policy applies to.
 	Match Match `yaml:"match"`
@@ -91,11 +91,11 @@ type Match struct {
 	// Agent is a glob pattern for agent identity.
 	// "*" matches all agents. "ops-*" matches "ops-deploy", "ops-monitor".
 	// Default: "*".
-	Agent string `yaml:"agent"`
+	Agent string `yaml:"agent,omitempty"`
 
 	// Session is a glob pattern for session identity (e.g. "myrepo/main").
 	// "*" matches all sessions. "" defaults to "*".
-	Session string `yaml:"session"`
+	Session string `yaml:"session,omitempty"`
 
 	// Tool is a glob pattern or list of tool names.
 	// "exec" matches only exec. "fs.*" matches "fs.read", "fs.write".
@@ -213,44 +213,44 @@ func (r Rule) ParseAction() (Action, error) {
 type Condition struct {
 	// CommandMatches is a list of glob patterns for exec commands.
 	// Any matching pattern triggers the rule.
-	CommandMatches []string `yaml:"command_matches"`
+	CommandMatches []string `yaml:"command_matches,omitempty"`
 
 	// CommandNotMatches excludes commands from matching.
 	// If a command matches any of these, the rule does not apply.
-	CommandNotMatches []string `yaml:"command_not_matches"`
+	CommandNotMatches []string `yaml:"command_not_matches,omitempty"`
 
 	// CommandContains is a list of literal substrings.
 	// The command must contain ALL specified substrings (AND logic within a single
 	// entry is not supported; use multiple entries for OR logic).
 	// Useful for patterns that glob can't express, e.g. process substitution
 	// with URLs: bash <(curl ...) where the / in URLs breaks glob * matching.
-	CommandContains []string `yaml:"command_contains"`
+	CommandContains []string `yaml:"command_contains,omitempty"`
 
 	// PathMatches is a list of glob patterns for file paths.
-	PathMatches []string `yaml:"path_matches"`
+	PathMatches []string `yaml:"path_matches,omitempty"`
 
 	// PathNotMatches excludes file paths from matching.
-	PathNotMatches []string `yaml:"path_not_matches"`
+	PathNotMatches []string `yaml:"path_not_matches,omitempty"`
 
 	// URLMatches is a list of glob patterns for URLs.
-	URLMatches []string `yaml:"url_matches"`
+	URLMatches []string `yaml:"url_matches,omitempty"`
 
 	// DomainMatches is a list of glob patterns for domains.
-	DomainMatches []string `yaml:"domain_matches"`
+	DomainMatches []string `yaml:"domain_matches,omitempty"`
 
 	// ResponseMatches is a list of regex patterns for tool response bodies.
-	ResponseMatches []string `yaml:"response_matches"`
+	ResponseMatches []string `yaml:"response_matches,omitempty"`
 
 	// ResponseNotMatches excludes response bodies from matching.
-	ResponseNotMatches []string `yaml:"response_not_matches"`
+	ResponseNotMatches []string `yaml:"response_not_matches,omitempty"`
 
 	// SessionMatches is a list of glob patterns for session identity.
 	// Any matching pattern triggers the rule.
-	SessionMatches []string `yaml:"session_matches"`
+	SessionMatches []string `yaml:"session_matches,omitempty"`
 
 	// SessionNotMatches excludes sessions from matching.
 	// If a session matches any of these, the rule does not apply.
-	SessionNotMatches []string `yaml:"session_not_matches"`
+	SessionNotMatches []string `yaml:"session_not_matches,omitempty"`
 
 	// AgentDepth matches on nested sub-agent depth.
 	AgentDepth *IntRangeCondition `yaml:"agent_depth,omitempty" json:"agent_depth,omitempty"`
@@ -266,7 +266,7 @@ type Condition struct {
 
 	// Default, when true, makes this rule match all tool calls.
 	// Use as a catch-all at the end of a rules list.
-	Default bool `yaml:"default"`
+	Default bool `yaml:"default,omitempty"`
 }
 
 // IntRangeCondition matches integer values using gte/lte/eq operators.


### PR DESCRIPTION
Four bugs found during hands-on testing on agent-01 and agent-02 after v0.4.9 shipped.

### 🔴 Fix 1: `rampart audit` subcommands crash with default path

`tail`, `verify`, `stats`, `search`, `replay` all passed raw `~/.rampart/audit` to `os.ReadDir` without expanding tilde. Fixed in `listAuditFiles` and `listAnchorFiles` helpers (single fix covers all 5 subcommands). Same class as the bench corpus path bug.

### 🔴 Fix 2: `rampart bench` approval-gated coverage always 0%

Corpus entries with `expected_action: require_approval` were never counted in `DenyTotal` or `ApprovalGated`. The 4 correctly-gated sudo/shred entries showed up in decisions but were invisible to coverage math. Fixed: both `deny` and `require_approval` expected entries now feed the coverage denominator.

### 🟡 Fix 3: `rampart status` undercounts blocking decisions

`require_approval` and `webhook` decisions were silently dropped from today's event stats. Now counted alongside `deny`.

### 🟡 Fix 4: `rampart policy generate` emits verbose null/empty fields

Generated YAML had `priority: 0`, `enabled: null`, `agent: ""`, and all empty `command_not_matches: []`, `path_matches: []` etc. Added `omitempty` to relevant struct fields. Marshaling-only change — existing policy files parse identically.