### PR TITLE
fix(upgrade): refresh policies even when already on latest version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.11] - 2026-02-24
+
+### Fixed
+
+- **`rampart upgrade` skipped policy refresh when already on latest** — the command returned early when the installed binary matched the latest release, bypassing the policy update step entirely. Users who upgraded binaries manually or were already on the latest version never received policy improvements from newer releases. Now always refreshes installed profiles unless `--no-policy-update` is set.
+
 ## [0.4.10] - 2026-02-24
 
 ### Fixed

--- a/cmd/rampart/cli/upgrade.go
+++ b/cmd/rampart/cli/upgrade.go
@@ -216,6 +216,11 @@ func newUpgradeCmdWithDeps(_ *rootOptions, deps *upgradeDeps) *cobra.Command {
 
 			if current != "" && compareSemver(current, target) >= 0 {
 				fmt.Fprintf(cmd.OutOrStdout(), "Already on latest (%s)\n", target)
+				if !skipPolicyUpdate {
+					if err := upgradeStandardPolicies(cmd.OutOrStdout(), dryRun); err != nil {
+						fmt.Fprintf(cmd.ErrOrStderr(), "⚠ policy update failed: %v\n", err)
+					}
+				}
 				return nil
 			}
 

--- a/cmd/rampart/cli/upgrade_test.go
+++ b/cmd/rampart/cli/upgrade_test.go
@@ -114,6 +114,48 @@ func TestNewUpgradeCmdAlreadyLatest(t *testing.T) {
 	}
 }
 
+func TestNewUpgradeCmdAlreadyLatestStillRefreshesPolicy(t *testing.T) {
+	// Regression test: when already on latest, upgrade should still refresh
+	// installed policy files from the embedded binary.
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	policyDir := filepath.Join(dir, ".rampart", "policies")
+	if err := os.MkdirAll(policyDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	standardPath := filepath.Join(policyDir, "standard.yaml")
+	if err := os.WriteFile(standardPath, []byte("old-stale-policy"), 0o644); err != nil {
+		t.Fatalf("write stale policy: %v", err)
+	}
+
+	deps := &upgradeDeps{
+		currentVersion: func(context.Context, commandRunner, func() (string, error)) (string, error) {
+			return "v1.2.3", nil
+		},
+		latestRelease: func(context.Context, *http.Client, string) (string, error) {
+			return "v1.2.3", nil
+		},
+	}
+
+	var out bytes.Buffer
+	cmd := newUpgradeCmdWithDeps(&rootOptions{}, deps)
+	cmd.SetOut(&out)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"--yes"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	got, err := os.ReadFile(standardPath)
+	if err != nil {
+		t.Fatalf("read policy: %v", err)
+	}
+	if string(got) == "old-stale-policy" {
+		t.Fatal("policy was not refreshed even though already on latest version")
+	}
+}
+
 func TestNewUpgradeCmdDryRun(t *testing.T) {
 	dir := t.TempDir()
 	exe := filepath.Join(dir, "rampart")


### PR DESCRIPTION
## Problem

`rampart upgrade` returned early when the binary was already on the latest version — skipping the policy refresh entirely. Users who:
- Upgraded manually (e.g. downloaded a binary, ran `go install`)
- Were already on the latest version when a new policy shipped

...never got policy improvements without knowing to run `rampart init --force` manually. This is exactly what happened when upgrading agent-01 and agent-02 to v0.4.10 — the binary updated but the installed `standard.yaml` stayed on v0.4.8 policy.

## Fix

Always run `upgradeStandardPolicies` before the early return, unless `--no-policy-update` is set. Same behavior as the normal upgrade path.

## Test

Adds `TestNewUpgradeCmdAlreadyLatestStillRefreshesPolicy` — sets up a stale policy file, runs upgrade with current == target, and asserts the file was refreshed from the embedded binary.