### PR TITLE
fix(serve): read and persist token across restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.12] - 2026-02-24
+
+### Fixed
+
+- **`rampart serve` generated a new random token on every restart** — the foreground serve path (including `--background`) only checked the `RAMPART_TOKEN` environment variable for the token; it never read `~/.rampart/token` and never wrote to it. Only the systemd/launchd install path called `resolveServiceToken`. Every restart broke existing tools and configs using the previous token. Now reads the persisted token before starting the proxy and writes it back after binding, consistent with the install path.
+
 ## [0.4.11] - 2026-02-24
 
 ### Fixed

--- a/cmd/rampart/cli/cli_test.go
+++ b/cmd/rampart/cli/cli_test.go
@@ -16,6 +16,8 @@ package cli
 import (
 	"bytes"
 	"context"
+	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -190,4 +192,81 @@ func runCLI(t *testing.T, args ...string) (string, string, error) {
 	err := cmd.Execute()
 
 	return strings.TrimSpace(stdout.String()), strings.TrimSpace(stderr.String()), err
+}
+
+func TestServeReadsAndPersistsToken(t *testing.T) {
+	// Regression test: rampart serve was generating a new random token on every
+	// start, ignoring ~/.rampart/token and never writing to it. The foreground
+	// serve path should read a persisted token and persist it after start.
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	configPath := filepath.Join(dir, "rampart.yaml")
+	content, err := policies.FS.ReadFile("standard.yaml")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(configPath, content, 0o644))
+
+	// Pre-write a known token to ~/.rampart/token.
+	rampartDir := filepath.Join(dir, ".rampart")
+	require.NoError(t, os.MkdirAll(rampartDir, 0o700))
+	knownToken := "deadbeef00112233deadbeef00112233"
+	tokenPath := filepath.Join(rampartDir, "token")
+	require.NoError(t, os.WriteFile(tokenPath, []byte(knownToken), 0o600))
+
+	// Find a free port so proxy starts (port>0 gate in serve.go).
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+	require.NoError(t, ln.Close())
+
+	signalCh := make(chan os.Signal, 1)
+	deps := &serveDeps{
+		notifyContext: func(parent context.Context, _ ...os.Signal) (context.Context, context.CancelFunc) {
+			ctx, cancel := context.WithCancel(parent)
+			go func() {
+				select {
+				case <-ctx.Done():
+				case <-signalCh:
+					cancel()
+				}
+			}()
+			return ctx, cancel
+		},
+	}
+
+	var stderr bytes.Buffer
+	cmd := newServeCmd(&rootOptions{configPath: configPath}, deps)
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&stderr)
+	cmd.SetContext(context.Background())
+	cmd.SetArgs([]string{"--port", fmt.Sprintf("%d", port)})
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- cmd.Execute() }()
+
+	time.Sleep(300 * time.Millisecond)
+	signalCh <- os.Interrupt
+
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("serve command did not shut down in time")
+	}
+
+	logs := stderr.String()
+
+	// Serve must log the persisted token, not a fresh random one.
+	if !strings.Contains(logs, knownToken) {
+		t.Fatalf("serve did not use persisted token from ~/.rampart/token.\nlogs:\n%s", logs)
+	}
+
+	// Token file must still contain the same value after serve writes it back.
+	written, err := os.ReadFile(tokenPath)
+	require.NoError(t, err)
+	if strings.TrimSpace(string(written)) != knownToken {
+		t.Fatalf("token file changed after serve; want %q got %q", knownToken, strings.TrimSpace(string(written)))
+	}
+
+	_ = os.RemoveAll(filepath.Join(".", "audit"))
 }

--- a/cmd/rampart/cli/serve.go
+++ b/cmd/rampart/cli/serve.go
@@ -274,8 +274,21 @@ func newServeCmd(opts *rootOptions, deps *serveDeps) *cobra.Command {
 				if approvalTimeout > 0 {
 					proxyOpts = append(proxyOpts, proxy.WithApprovalTimeout(approvalTimeout))
 				}
-				if envToken := os.Getenv("RAMPART_TOKEN"); envToken != "" {
-					proxyOpts = append(proxyOpts, proxy.WithToken(envToken))
+				// Resolve token: flag > env > persisted file > generate new.
+				// Mirrors serve install behaviour so the token survives restarts.
+				{
+					var tok string
+					switch {
+					case os.Getenv("RAMPART_TOKEN") != "":
+						tok = os.Getenv("RAMPART_TOKEN")
+					default:
+						if persisted, err := readPersistedToken(); err == nil && persisted != "" {
+							tok = persisted
+						}
+					}
+					if tok != "" {
+						proxyOpts = append(proxyOpts, proxy.WithToken(tok))
+					}
 				}
 				if resolveBaseURL != "" {
 					proxyOpts = append(proxyOpts, proxy.WithResolveBaseURL(resolveBaseURL))
@@ -321,6 +334,11 @@ func newServeCmd(opts *rootOptions, deps *serveDeps) *cobra.Command {
 				listenPort := listener.Addr().(*net.TCPAddr).Port
 				fmt.Fprintf(cmd.ErrOrStderr(), "serve: dashboard: http://localhost:%d/dashboard/\n", listenPort)
 				fmt.Fprintf(cmd.ErrOrStderr(), "serve: use the full token above to authenticate in the dashboard\n")
+				// Persist the token so it survives restarts.
+				if err := persistToken(token); err != nil {
+					fmt.Fprintf(cmd.ErrOrStderr(), "⚠ Warning: could not save token to ~/.rampart/token: %v\n", err)
+					fmt.Fprintf(cmd.ErrOrStderr(), "  Run: echo '%s' > ~/.rampart/token\n", token)
+				}
 
 				if metrics {
 					logger.Info("serve: metrics enabled on /metrics")


### PR DESCRIPTION
## Problem

`rampart serve --background` generated a fresh random token on every start. The foreground serve path only checked the `RAMPART_TOKEN` env var — it never read `~/.rampart/token` and never wrote to it. Only the systemd/launchd install path (`rampart serve install`) called `resolveServiceToken` which handles file persistence.

**Impact:** every `rampart serve stop && rampart serve --background` (e.g., after upgrade) broke all existing integrations using the old token — doctor token auth failed, curl to the API failed, watch/log commands couldn't auto-discover the token.

## Fix

Before creating the proxy server, resolve the token using priority: `RAMPART_TOKEN` env > `~/.rampart/token` > generate new. After the listener binds, persist the (possibly new) token to `~/.rampart/token`.

## Test

`TestServeReadsAndPersistsToken` — starts serve with a pre-written known token file, verifies the serve logs that exact token (not a fresh random one), and verifies the file still contains the same token after shutdown.