### PR TITLE
feat: audit:true for action:ask — require_approval becomes alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`ask.audit: true`** — `action: ask` rules can now set `ask.audit: true` to mirror pending approval state into `rampart serve` for dashboard and `rampart watch` visibility. Dashboard and watch show the item as pending while the native Claude Code prompt is active, then reflect the user's decision after PostToolUse.
+
+### Changed
+
+- **`require_approval` now uses native ask prompt** — Previously, `require_approval` blocked execution and waited for approval via the serve dashboard or `rampart approve` CLI. It now behaves as `action: ask` + `ask.audit: true`: the native Claude Code inline prompt fires immediately, and the decision is mirrored to serve (if running) for audit/observability. **If you rely on serve-gated headless approval in CI/non-interactive environments**, this changes your workflow — approval now requires a human at the Claude Code terminal. A dedicated `headless_only` flag for serve-gated approval without native prompt is planned for a future release.
+
 ## [0.6.5] - 2026-02-27
 
 ### Added

--- a/cmd/rampart/cli/hook.go
+++ b/cmd/rampart/cli/hook.go
@@ -387,6 +387,24 @@ Cline setup: Use "rampart setup cline" to install hooks automatically.`,
 			// Rampart. Inject additionalContext telling Claude to stop retrying rather than
 			// burning 3-5 turns on workarounds.
 			if parsed.HookEventName == "PostToolUseFailure" {
+				// If this failure corresponds to an ask+audit prompt denial, best-effort
+				// resolve the mirrored serve approval as denied for dashboard/watch sync.
+				if parsed.ToolUseID != "" && parsed.SessionID != "" && serveURL != "" && isServeRunning(serveURL) {
+					sessionMgr := session.NewManager(sessionStateDir(), parsed.SessionID, logger)
+					if ask, dismissErr := sessionMgr.DismissAsk(parsed.ToolUseID); dismissErr == nil && ask != nil && ask.Audit && ask.AuditApprovalID != "" {
+						approvalClient := &hookApprovalClient{
+							serveURL:       strings.TrimRight(serveURL, "/"),
+							token:          serveToken,
+							logger:         logger,
+							autoDiscovered: serveAutoDiscovered,
+							errWriter:      cmd.ErrOrStderr(),
+						}
+						resolveCtx, cancelResolve := context.WithTimeout(cmd.Context(), 400*time.Millisecond)
+						_ = approvalClient.resolveAskAuditCtx(resolveCtx, ask.AuditApprovalID, false, "hook-posttoolusefailure")
+						cancelResolve()
+					}
+				}
+
 				postToolUseFailureEvent := audit.Event{
 					ID:        audit.NewEventID(),
 					Timestamp: time.Now().UTC(),
@@ -495,7 +513,7 @@ Cline setup: Use "rampart setup cline" to install hooks automatically.`,
 			// The observation is best-effort — errors are logged but do not block the hook.
 			if parsed.HookEventName == "PostToolUse" && parsed.ToolUseID != "" && parsed.SessionID != "" {
 				sessionMgr := session.NewManager(sessionStateDir(), parsed.SessionID, logger)
-				record, obsErr := sessionMgr.ObserveApproval(parsed.ToolUseID)
+				ask, record, obsErr := sessionMgr.ObserveApprovalWithAsk(parsed.ToolUseID)
 				if obsErr != nil {
 					// Not found means this PostToolUse was not preceded by an ActionAsk —
 					// that is normal (most tool calls are allowed/denied, not asked).
@@ -512,6 +530,21 @@ Cline setup: Use "rampart setup cline" to install hooks automatically.`,
 						"pattern", record.Pattern,
 						"approval_count", record.ApprovalCount,
 					)
+
+					// Best-effort: if this ask was mirrored to serve, mark it approved so
+					// dashboard/watch pending state resolves with the user's decision.
+					if ask != nil && ask.Audit && ask.AuditApprovalID != "" && serveURL != "" && isServeRunning(serveURL) {
+						approvalClient := &hookApprovalClient{
+							serveURL:       strings.TrimRight(serveURL, "/"),
+							token:          serveToken,
+							logger:         logger,
+							autoDiscovered: serveAutoDiscovered,
+							errWriter:      cmd.ErrOrStderr(),
+						}
+						resolveCtx, cancelResolve := context.WithTimeout(cmd.Context(), 400*time.Millisecond)
+						_ = approvalClient.resolveAskAuditCtx(resolveCtx, ask.AuditApprovalID, true, "hook-posttooluse")
+						cancelResolve()
+					}
 				}
 			}
 
@@ -527,7 +560,29 @@ Cline setup: Use "rampart setup cline" to install hooks automatically.`,
 					return outputHookResult(cmd, format, hookBlock, true, decision.Message, cmdStr, decision.Suggestions...)
 				}
 				return outputHookResult(cmd, format, hookDeny, false, decision.Message, cmdStr, decision.Suggestions...)
-			case engine.ActionAsk:
+			case engine.ActionAsk, engine.ActionRequireApproval:
+				askAudit := decision.Audit || decision.Action == engine.ActionRequireApproval
+				auditApprovalID := ""
+				// For ask+audit, best-effort mirror pending state into serve if reachable.
+				if askAudit && serveURL != "" && isServeRunning(serveURL) {
+					approvalClient := &hookApprovalClient{
+						serveURL:       strings.TrimRight(serveURL, "/"),
+						token:          serveToken,
+						logger:         logger,
+						autoDiscovered: serveAutoDiscovered,
+						errWriter:      cmd.ErrOrStderr(),
+					}
+					command, _ := call.Params["command"].(string)
+					path := call.Path()
+					registerCtx, cancelRegister := context.WithTimeout(cmd.Context(), 400*time.Millisecond)
+					if approvalID, regErr := approvalClient.registerAskAuditCtx(registerCtx, call.Tool, command, call.Agent, path, call.RunID, decision.Message); regErr == nil {
+						auditApprovalID = approvalID
+					} else {
+						logger.Debug("hook: ask audit registration failed (best-effort)", "error", regErr)
+					}
+					cancelRegister()
+				}
+
 				// Write pending ask to session state so PostToolUse can correlate the outcome.
 				if parsed.SessionID != "" && parsed.ToolUseID != "" {
 					sessionMgr := session.NewManager(sessionStateDir(), parsed.SessionID, logger)
@@ -538,34 +593,13 @@ Cline setup: Use "rampart setup cline" to install hooks automatically.`,
 					if len(decision.MatchedPolicies) > 0 {
 						policyName = decision.MatchedPolicies[0]
 					}
-					if err := sessionMgr.RecordAsk(parsed.ToolUseID, call.Tool, cmdStr2, cmdStr2, policyName, decision.Message); err != nil {
+					if err := sessionMgr.RecordAskWithAudit(parsed.ToolUseID, call.Tool, cmdStr2, cmdStr2, policyName, decision.Message, askAudit, auditApprovalID); err != nil {
 						// NOTE: Use Debug, not Warn. Claude Code treats ANY stderr as a hook error
 						// for ask decisions. RecordAsk is best-effort anyway.
 						logger.Debug("hook: failed to record ask in session state", "error", err)
 					}
 				}
 				// Emit native ask prompt (Claude Code shows the 4-button dialog).
-				return outputHookResult(cmd, format, hookAsk, false, decision.Message, cmdStr)
-			case engine.ActionRequireApproval:
-				// Check if serve is actually running. The token file persists after serve stops,
-				// so we can't rely on its presence. A quick health check confirms serve is up.
-				// If serve isn't running, fall back to native ask prompts.
-				if serveURL != "" && isServeRunning(serveURL) {
-					approvalClient := &hookApprovalClient{
-						serveURL:       strings.TrimRight(serveURL, "/"),
-						token:          serveToken,
-						logger:         logger,
-						autoDiscovered: serveAutoDiscovered,
-						errWriter:      cmd.ErrOrStderr(),
-					}
-					command, _ := call.Params["command"].(string)
-					path := call.Path() // handles both "file_path" (Claude Code) and "path"
-					result := approvalClient.requestApprovalCtx(cmd.Context(), call.Tool, command, call.Agent, path, call.RunID, decision.Message, 5*time.Minute)
-					return outputHookResult(cmd, format, result, false, decision.Message, cmdStr)
-				}
-				// Serve not running — fall back to native ask prompt.
-				// This gives a better UX than blocking forever on a dashboard that isn't there.
-				logger.Debug("hook: serve not running, falling back to native ask for require_approval")
 				return outputHookResult(cmd, format, hookAsk, false, decision.Message, cmdStr)
 			default:
 				return outputHookResult(cmd, format, hookAllow, isPostToolUse, decision.Message, cmdStr)
@@ -741,7 +775,7 @@ type hookDecisionType int
 const (
 	hookAllow hookDecisionType = iota
 	hookDeny
-	hookAsk   // require_approval → Claude Code native prompt
+	hookAsk   // ask (and require_approval alias) → Claude Code native prompt
 	hookBlock // PostToolUse: block response from being shown to agent
 )
 
@@ -759,7 +793,7 @@ func outputHookResult(cmd *cobra.Command, format string, decision hookDecisionTy
 	// PermissionDecisionReason in the JSON response.
 	switch format {
 	case "cline":
-		// Cline has no "ask" — cancel on deny, block, and require_approval.
+		// Cline has no "ask" — cancel on deny, block, and ask.
 		cancel := decision == hookDeny || decision == hookAsk || decision == hookBlock
 		out := clineHookOutput{Cancel: cancel}
 		if decision == hookDeny || decision == hookBlock {

--- a/cmd/rampart/cli/hook_approval.go
+++ b/cmd/rampart/cli/hook_approval.go
@@ -230,6 +230,91 @@ func (c *hookApprovalClient) stderrWriter() io.Writer {
 	return os.Stderr
 }
 
+// registerAskAuditCtx creates a pending approval in serve for ask+audit
+// visibility, but does not wait for human resolution.
+func (c *hookApprovalClient) registerAskAuditCtx(ctx context.Context, tool, command, agent, path, runID, message string) (string, error) {
+	body := createApprovalRequest{
+		Tool:    tool,
+		Command: command,
+		Agent:   agent,
+		Path:    path,
+		Message: enrichApprovalMessage(message, command),
+		RunID:   runID,
+	}
+	data, err := json.Marshal(body)
+	if err != nil {
+		return "", err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", c.serveURL+"/v1/approvals", bytes.NewReader(data))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+c.token)
+
+	client := &http.Client{Timeout: 400 * time.Millisecond}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		var autoResp struct {
+			ID string `json:"id"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&autoResp); err != nil {
+			return "", err
+		}
+		return autoResp.ID, nil
+	}
+	if resp.StatusCode != http.StatusCreated {
+		return "", fmt.Errorf("create approval returned status %d", resp.StatusCode)
+	}
+
+	var created createApprovalResponse
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		return "", err
+	}
+	return created.ID, nil
+}
+
+// resolveAskAuditCtx marks a previously registered ask+audit approval as
+// approved or denied. Best-effort callers should ignore returned errors.
+func (c *hookApprovalClient) resolveAskAuditCtx(ctx context.Context, approvalID string, approved bool, resolvedBy string) error {
+	if strings.TrimSpace(approvalID) == "" {
+		return nil
+	}
+	if resolvedBy == "" {
+		resolvedBy = "hook"
+	}
+	body, err := json.Marshal(map[string]any{
+		"approved":    approved,
+		"resolved_by": resolvedBy,
+	})
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, "POST", c.serveURL+"/v1/approvals/"+url.PathEscape(approvalID)+"/resolve", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+c.token)
+
+	client := &http.Client{Timeout: 400 * time.Millisecond}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+	return fmt.Errorf("resolve approval returned status %d", resp.StatusCode)
+}
+
 func enrichApprovalMessage(message, toolInput string) string {
 	registryURL := detectPackageRegistryURL(toolInput)
 	if registryURL == "" {

--- a/cmd/rampart/cli/hook_ask_audit_test.go
+++ b/cmd/rampart/cli/hook_ask_audit_test.go
@@ -1,0 +1,223 @@
+package cli
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestHookActionAsk_NoAudit_DoesNotRegisterServeApproval(t *testing.T) {
+	dir := t.TempDir()
+	testSetHome(t, dir)
+
+	const policy = `version: "1"
+policies:
+  - name: test-ask-no-audit
+    match:
+      tool: ["exec"]
+    rules:
+      - action: ask
+        message: "approve this command?"
+`
+	configPath := filepath.Join(dir, "policy.yaml")
+	if err := os.WriteFile(configPath, []byte(policy), 0o644); err != nil {
+		t.Fatalf("write policy: %v", err)
+	}
+
+	var createCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/healthz":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"status":"ok"}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/approvals":
+			createCount.Add(1)
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "a1", "status": "pending"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	payload := map[string]any{
+		"hook_event_name": "PreToolUse",
+		"session_id":      "sess-audit-off-001",
+		"tool_use_id":     "toolu_audit_off_001",
+		"tool_name":       "Bash",
+		"tool_input":      map[string]any{"command": "sudo apt install git"},
+	}
+	stdinJSON, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	opts := &rootOptions{configPath: configPath}
+	stdout, _, hookErr := runHookWithStdin(t, opts, string(stdinJSON), "--mode", "enforce", "--serve-url", srv.URL)
+	if hookErr != nil {
+		t.Fatalf("hook RunE error: %v", hookErr)
+	}
+	if createCount.Load() != 0 {
+		t.Fatalf("expected no serve approval registration for ask without audit, got %d", createCount.Load())
+	}
+
+	var out hookOutput
+	if err := json.Unmarshal([]byte(stdout), &out); err != nil {
+		t.Fatalf("unmarshal hook output: %v (stdout=%q)", err, stdout)
+	}
+	if out.HookSpecificOutput == nil || out.HookSpecificOutput.PermissionDecision != "ask" {
+		t.Fatalf("expected permissionDecision=ask, got %+v", out.HookSpecificOutput)
+	}
+}
+
+func TestHookActionRequireApproval_AliasUsesNativeAskAndRegistersAudit(t *testing.T) {
+	dir := t.TempDir()
+	testSetHome(t, dir)
+
+	const policy = `version: "1"
+policies:
+  - name: test-require-approval-alias
+    match:
+      tool: ["exec"]
+    rules:
+      - action: require_approval
+        message: "approval required"
+`
+	configPath := filepath.Join(dir, "policy.yaml")
+	if err := os.WriteFile(configPath, []byte(policy), 0o644); err != nil {
+		t.Fatalf("write policy: %v", err)
+	}
+
+	var createCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/healthz":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"status":"ok"}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/approvals":
+			createCount.Add(1)
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "ap-alias-1", "status": "pending"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	payload := map[string]any{
+		"hook_event_name": "PreToolUse",
+		"session_id":      "sess-audit-on-001",
+		"tool_use_id":     "toolu_audit_on_001",
+		"tool_name":       "Bash",
+		"tool_input":      map[string]any{"command": "sudo apt install git"},
+	}
+	stdinJSON, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	opts := &rootOptions{configPath: configPath}
+	stdout, _, hookErr := runHookWithStdin(t, opts, string(stdinJSON), "--mode", "enforce", "--serve-url", srv.URL)
+	if hookErr != nil {
+		t.Fatalf("hook RunE error: %v", hookErr)
+	}
+	if createCount.Load() != 1 {
+		t.Fatalf("expected exactly 1 serve approval registration for require_approval alias, got %d", createCount.Load())
+	}
+
+	var out hookOutput
+	if err := json.Unmarshal([]byte(stdout), &out); err != nil {
+		t.Fatalf("unmarshal hook output: %v (stdout=%q)", err, stdout)
+	}
+	if out.HookSpecificOutput == nil || out.HookSpecificOutput.PermissionDecision != "ask" {
+		t.Fatalf("expected permissionDecision=ask, got %+v", out.HookSpecificOutput)
+	}
+	if !strings.Contains(out.HookSpecificOutput.PermissionDecisionReason, "approval required") {
+		t.Fatalf("expected ask reason to include message, got %q", out.HookSpecificOutput.PermissionDecisionReason)
+	}
+}
+
+func TestHookActionAskAudit_PostToolUse_ResolvesApproved(t *testing.T) {
+	dir := t.TempDir()
+	testSetHome(t, dir)
+
+	const policy = `version: "1"
+policies:
+  - name: test-ask-audit-on
+    match:
+      tool: ["exec"]
+    rules:
+      - action: ask
+        ask:
+          audit: true
+        message: "approve this command?"
+`
+	configPath := filepath.Join(dir, "policy.yaml")
+	if err := os.WriteFile(configPath, []byte(policy), 0o644); err != nil {
+		t.Fatalf("write policy: %v", err)
+	}
+
+	var createCount atomic.Int32
+	var resolveCount atomic.Int32
+	var lastResolveBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/healthz":
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/approvals":
+			createCount.Add(1)
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "ap-audit-1", "status": "pending"})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/approvals/ap-audit-1/resolve":
+			resolveCount.Add(1)
+			_ = json.NewDecoder(r.Body).Decode(&lastResolveBody)
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "ap-audit-1", "status": "approved"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	opts := &rootOptions{configPath: configPath}
+	prePayload := map[string]any{
+		"hook_event_name": "PreToolUse",
+		"session_id":      "sess-audit-approve-001",
+		"tool_use_id":     "toolu_audit_approve_001",
+		"tool_name":       "Bash",
+		"tool_input":      map[string]any{"command": "sudo apt install git"},
+	}
+	preJSON, _ := json.Marshal(prePayload)
+	if _, _, err := runHookWithStdin(t, opts, string(preJSON), "--mode", "enforce", "--serve-url", srv.URL); err != nil {
+		t.Fatalf("pre hook error: %v", err)
+	}
+	if createCount.Load() != 1 {
+		t.Fatalf("expected one create call, got %d", createCount.Load())
+	}
+
+	postPayload := map[string]any{
+		"hook_event_name": "PostToolUse",
+		"session_id":      "sess-audit-approve-001",
+		"tool_use_id":     "toolu_audit_approve_001",
+		"tool_name":       "Bash",
+		"tool_input":      map[string]any{"command": "sudo apt install git"},
+		"tool_response":   map[string]any{"stdout": "ok"},
+	}
+	postJSON, _ := json.Marshal(postPayload)
+	if _, _, err := runHookWithStdin(t, opts, string(postJSON), "--mode", "enforce", "--serve-url", srv.URL); err != nil {
+		t.Fatalf("post hook error: %v", err)
+	}
+	if resolveCount.Load() != 1 {
+		t.Fatalf("expected one resolve call, got %d", resolveCount.Load())
+	}
+	want := map[string]any{"approved": true, "resolved_by": "hook-posttooluse"}
+	if !reflect.DeepEqual(lastResolveBody, want) {
+		t.Fatalf("resolve body = %#v, want %#v", lastResolveBody, want)
+	}
+}

--- a/internal/engine/ask_test.go
+++ b/internal/engine/ask_test.go
@@ -84,6 +84,27 @@ func TestRuleParseAction_Ask(t *testing.T) {
 	}
 }
 
+func TestRuleAskAuditEnabled_RequireApprovalAlias(t *testing.T) {
+	r := Rule{Action: "require_approval"}
+	if !r.AskAuditEnabled() {
+		t.Fatal("expected require_approval to be treated as ask+audit")
+	}
+}
+
+func TestRuleAskAuditEnabled_AskExplicitAudit(t *testing.T) {
+	r := Rule{Action: "ask", Ask: AskActionConfig{Audit: true}}
+	if !r.AskAuditEnabled() {
+		t.Fatal("expected ask.audit=true to enable ask audit")
+	}
+}
+
+func TestRuleAskAuditEnabled_AskDefaultFalse(t *testing.T) {
+	r := Rule{Action: "ask"}
+	if r.AskAuditEnabled() {
+		t.Fatal("expected ask.audit to default to false")
+	}
+}
+
 // ── Policy evaluation with action: ask ───────────────────────────────────────
 
 func TestEvaluate_ActionAsk_MatchedRule(t *testing.T) {

--- a/internal/engine/decision.go
+++ b/internal/engine/decision.go
@@ -148,6 +148,12 @@ type Decision struct {
 	// Action is the final verdict: allow, deny, or log.
 	Action Action
 
+	// Audit is set for ask decisions when audit mirroring is enabled.
+	// This is true for:
+	// - action: ask with ask.audit: true
+	// - action: require_approval (alias for ask+audit)
+	Audit bool
+
 	// MatchedPolicies lists the names of all policies that matched
 	// the tool call. Useful for debugging and audit.
 	MatchedPolicies []string

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -107,6 +107,7 @@ func (e *Engine) Evaluate(call ToolCall) Decision {
 	var (
 		finalAction  = ActionAllow
 		finalMessage string
+		finalAudit   bool
 		matched      []string
 		anyRuleFired bool
 	)
@@ -146,6 +147,9 @@ func (e *Engine) Evaluate(call ToolCall) Decision {
 			if finalAction != ActionDeny && finalAction != ActionWebhook && finalAction != ActionRequireApproval {
 				finalAction = ActionRequireApproval
 				finalMessage = message
+				if rule != nil {
+					finalAudit = rule.AskAuditEnabled()
+				}
 			}
 		case ActionAsk:
 			// Ask wins over log and allow, but not deny, webhook, or require_approval.
@@ -154,15 +158,20 @@ func (e *Engine) Evaluate(call ToolCall) Decision {
 				finalAction != ActionRequireApproval && finalAction != ActionAsk {
 				finalAction = ActionAsk
 				finalMessage = message
+				if rule != nil {
+					finalAudit = rule.AskAuditEnabled()
+				}
 			}
 		case ActionWatch:
 			if finalAction == ActionAllow {
 				finalAction = ActionWatch
 				finalMessage = message
+				finalAudit = false
 			}
 		case ActionAllow:
 			if finalAction == ActionAllow && finalMessage == "" {
 				finalMessage = message
+				finalAudit = false
 			}
 		}
 	}
@@ -179,6 +188,7 @@ func (e *Engine) Evaluate(call ToolCall) Decision {
 
 	return Decision{
 		Action:          finalAction,
+		Audit:           finalAudit,
 		MatchedPolicies: matched,
 		Message:         finalMessage,
 		EvalDuration:    time.Since(start),

--- a/internal/engine/policy.go
+++ b/internal/engine/policy.go
@@ -125,6 +125,10 @@ type Rule struct {
 	// "require_approval", or "webhook".
 	Action string `yaml:"action"`
 
+	// Ask configures action: ask behavior.
+	// - audit: when true, mirror ask prompts to rampart serve (best-effort).
+	Ask AskActionConfig `yaml:"ask,omitempty" json:"ask,omitempty"`
+
 	// When defines the conditions under which this rule matches.
 	When Condition `yaml:"when"`
 
@@ -134,6 +138,11 @@ type Rule struct {
 
 	// Webhook configures the external webhook for action: webhook rules.
 	Webhook *WebhookActionConfig `yaml:"webhook,omitempty"`
+}
+
+// AskActionConfig defines optional behavior for action: ask rules.
+type AskActionConfig struct {
+	Audit bool `yaml:"audit" json:"audit"`
 }
 
 // WebhookActionConfig defines the webhook endpoint and behavior for
@@ -208,6 +217,21 @@ func (r Rule) ParseAction() (Action, error) {
 	default:
 		return ActionAllow, fmt.Errorf("engine: unknown action %q", r.Action)
 	}
+}
+
+// AskAuditEnabled reports whether this rule should be treated as ask+audit.
+//
+// action: require_approval is kept as a policy alias and is interpreted as
+// action: ask + ask.audit=true for hook-side behavior.
+func (r Rule) AskAuditEnabled() bool {
+	action := strings.ToLower(strings.TrimSpace(r.Action))
+	if action == "require_approval" {
+		return true
+	}
+	if action == "ask" {
+		return r.Ask.Audit
+	}
+	return false
 }
 
 // Condition defines when a rule matches. All specified fields must match

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -205,6 +205,11 @@ func (m *Manager) trimOldest(s *State) {
 // RecordAsk records a pending ask for the given toolUseID.
 // The entry is written to pending_asks[toolUseID] in the session state file.
 func (m *Manager) RecordAsk(toolUseID, tool, command, pattern, policyName, message string) error {
+	return m.RecordAskWithAudit(toolUseID, tool, command, pattern, policyName, message, false, "")
+}
+
+// RecordAskWithAudit records a pending ask and optional audit linkage metadata.
+func (m *Manager) RecordAskWithAudit(toolUseID, tool, command, pattern, policyName, message string, audit bool, auditApprovalID string) error {
 	path, err := m.statePath()
 	if err != nil {
 		return err
@@ -221,6 +226,8 @@ func (m *Manager) RecordAsk(toolUseID, tool, command, pattern, policyName, messa
 		AskedAt:            time.Now().UTC(),
 		PolicyName:         policyName,
 		DecisionMessage:    message,
+		Audit:              audit,
+		AuditApprovalID:    auditApprovalID,
 	}
 
 	if err := m.save(path, s); err != nil {
@@ -231,6 +238,8 @@ func (m *Manager) RecordAsk(toolUseID, tool, command, pattern, policyName, messa
 		"tool_use_id", toolUseID,
 		"tool", tool,
 		"pattern", pattern,
+		"audit", audit,
+		"audit_approval_id", auditApprovalID,
 	)
 	return nil
 }
@@ -239,18 +248,25 @@ func (m *Manager) RecordAsk(toolUseID, tool, command, pattern, policyName, messa
 // incrementing the approval count. Returns the updated ApprovalRecord.
 // Returns an error if toolUseID is not found in pending_asks.
 func (m *Manager) ObserveApproval(toolUseID string) (*ApprovalRecord, error) {
+	_, record, err := m.ObserveApprovalWithAsk(toolUseID)
+	return record, err
+}
+
+// ObserveApprovalWithAsk is like ObserveApproval, but also returns the pending
+// ask metadata that was observed and removed.
+func (m *Manager) ObserveApprovalWithAsk(toolUseID string) (*PendingAsk, *ApprovalRecord, error) {
 	path, err := m.statePath()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	s, err := m.load(path)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	ask, ok := s.PendingAsks[toolUseID]
 	if !ok {
-		return nil, fmt.Errorf("session: no pending ask for tool_use_id %q", toolUseID)
+		return nil, nil, fmt.Errorf("session: no pending ask for tool_use_id %q", toolUseID)
 	}
 
 	// Key for the approval record: "{tool}:{generalized_pattern}".
@@ -277,7 +293,7 @@ func (m *Manager) ObserveApproval(toolUseID string) (*ApprovalRecord, error) {
 	delete(s.PendingAsks, toolUseID)
 
 	if err := m.save(path, s); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	m.logger.Debug("session: observed approval",
 		"session_id", m.sessionID,
@@ -285,7 +301,33 @@ func (m *Manager) ObserveApproval(toolUseID string) (*ApprovalRecord, error) {
 		"pattern", ask.GeneralizedPattern,
 		"approval_count", record.ApprovalCount,
 	)
-	return &record, nil
+	askCopy := ask
+	return &askCopy, &record, nil
+}
+
+// DismissAsk removes a pending ask without recording an approval outcome.
+// This is used when a user denies the native ask prompt (PostToolUseFailure).
+func (m *Manager) DismissAsk(toolUseID string) (*PendingAsk, error) {
+	path, err := m.statePath()
+	if err != nil {
+		return nil, err
+	}
+	s, err := m.load(path)
+	if err != nil {
+		return nil, err
+	}
+
+	ask, ok := s.PendingAsks[toolUseID]
+	if !ok {
+		return nil, fmt.Errorf("session: no pending ask for tool_use_id %q", toolUseID)
+	}
+	delete(s.PendingAsks, toolUseID)
+
+	if err := m.save(path, s); err != nil {
+		return nil, err
+	}
+	askCopy := ask
+	return &askCopy, nil
 }
 
 // Cleanup removes session state files that have not been active within maxAge.

--- a/internal/session/state.go
+++ b/internal/session/state.go
@@ -26,11 +26,11 @@ import "time"
 // tracking state. It is serialised as JSON and written atomically to
 // ~/.rampart/session-state/{session_id}.json.
 type State struct {
-	SessionID        string                     `json:"session_id"`
-	CreatedAt        time.Time                  `json:"created_at"`
-	LastActive       time.Time                  `json:"last_active"`
-	PendingAsks      map[string]PendingAsk      `json:"pending_asks"`
-	SessionApprovals map[string]ApprovalRecord  `json:"session_approvals"`
+	SessionID        string                    `json:"session_id"`
+	CreatedAt        time.Time                 `json:"created_at"`
+	LastActive       time.Time                 `json:"last_active"`
+	PendingAsks      map[string]PendingAsk     `json:"pending_asks"`
+	SessionApprovals map[string]ApprovalRecord `json:"session_approvals"`
 }
 
 // PendingAsk records the details of a PreToolUse event that emitted an ask
@@ -42,6 +42,8 @@ type PendingAsk struct {
 	AskedAt            time.Time `json:"asked_at"`
 	PolicyName         string    `json:"policy_name,omitempty"`
 	DecisionMessage    string    `json:"decision_message,omitempty"`
+	Audit              bool      `json:"audit,omitempty"`
+	AuditApprovalID    string    `json:"audit_approval_id,omitempty"`
 }
 
 // ApprovalRecord tracks cumulative approvals for a generalised command pattern


### PR DESCRIPTION
## Summary

Implements the convergence design from #126. Adds `ask.audit` field to the policy schema so `action: ask` can optionally mirror its pending state into `rampart serve` for dashboard/watch visibility.

## What changed

### Policy schema
```yaml
rules:
  - action: ask
    ask:
      audit: true   # new — mirrors to serve/dashboard/watch
    when:
      command_matches: "sudo **"
```

### require_approval alias
`action: require_approval` is now an alias for `action: ask` + `ask.audit: true`. Zero breaking changes — all existing policies continue to work.

### Hook behavior
- PreToolUse: if `audit: true` and serve is reachable → best-effort register pending event (400ms timeout, non-blocking)
- Native Claude Code ask prompt fires regardless of serve state
- PostToolUse: best-effort resolve the mirrored approval (approved/denied) so watch/dashboard updates

### What this enables
- Dashboard and `rampart watch` show pending ask events in real time (observability)
- Decisions made via native Claude Code prompt are reflected in the audit trail
- Headless/CI users still get serve-gated approval via `require_approval`

## Files changed
- `internal/engine/policy.go` — `AskActionConfig`, `AskAuditEnabled()`
- `internal/engine/decision.go` — `Audit bool` on Decision
- `internal/engine/engine.go` — propagate audit flag to Decision
- `cmd/rampart/cli/hook.go` — register/resolve with serve on ask+audit
- `cmd/rampart/cli/hook_approval.go` — `registerAskAuditCtx`, `resolveAskAuditCtx`
- `internal/session/manager.go` — `ObserveApprovalWithAsk`, `DismissAsk`
- `cmd/rampart/cli/hook_ask_audit_test.go` — new tests

Closes #126