### PR TITLE
feat: headless_only flag — restores serve-blocking approval for CI workflows

### DIFF
--- a/cmd/rampart/cli/hook.go
+++ b/cmd/rampart/cli/hook.go
@@ -560,8 +560,28 @@ Cline setup: Use "rampart setup cline" to install hooks automatically.`,
 					return outputHookResult(cmd, format, hookBlock, true, decision.Message, cmdStr, decision.Suggestions...)
 				}
 				return outputHookResult(cmd, format, hookDeny, false, decision.Message, cmdStr, decision.Suggestions...)
-			case engine.ActionAsk, engine.ActionRequireApproval:
-				askAudit := decision.Audit || decision.Action == engine.ActionRequireApproval
+			case engine.ActionAsk:
+				if decision.HeadlessOnly {
+					if serveURL == "" || !isServeRunning(serveURL) {
+						return fmt.Errorf("hook: ask.headless_only requires rampart serve, but no serve instance is reachable at %s", serveURL)
+					}
+					approvalClient := &hookApprovalClient{
+						serveURL:       strings.TrimRight(serveURL, "/"),
+						token:          serveToken,
+						logger:         logger,
+						autoDiscovered: serveAutoDiscovered,
+						errWriter:      cmd.ErrOrStderr(),
+					}
+					command, _ := call.Params["command"].(string)
+					path := call.Path() // handles both "file_path" (Claude Code) and "path"
+					result := approvalClient.requestApprovalCtx(cmd.Context(), call.Tool, command, call.Agent, path, call.RunID, decision.Message, 5*time.Minute)
+					if result == hookAsk {
+						return fmt.Errorf("hook: ask.headless_only could not reach rampart serve approval flow; native ask fallback is disabled")
+					}
+					return outputHookResult(cmd, format, result, false, decision.Message, cmdStr)
+				}
+
+				askAudit := decision.Audit
 				auditApprovalID := ""
 				// For ask+audit, best-effort mirror pending state into serve if reachable.
 				if askAudit && serveURL != "" && isServeRunning(serveURL) {
@@ -596,6 +616,43 @@ Cline setup: Use "rampart setup cline" to install hooks automatically.`,
 					if err := sessionMgr.RecordAskWithAudit(parsed.ToolUseID, call.Tool, cmdStr2, cmdStr2, policyName, decision.Message, askAudit, auditApprovalID); err != nil {
 						// NOTE: Use Debug, not Warn. Claude Code treats ANY stderr as a hook error
 						// for ask decisions. RecordAsk is best-effort anyway.
+						logger.Debug("hook: failed to record ask in session state", "error", err)
+					}
+				}
+				// Emit native ask prompt (Claude Code shows the 4-button dialog).
+				return outputHookResult(cmd, format, hookAsk, false, decision.Message, cmdStr)
+			case engine.ActionRequireApproval:
+				askAudit := true
+				auditApprovalID := ""
+				// For ask+audit, best-effort mirror pending state into serve if reachable.
+				if askAudit && serveURL != "" && isServeRunning(serveURL) {
+					approvalClient := &hookApprovalClient{
+						serveURL:       strings.TrimRight(serveURL, "/"),
+						token:          serveToken,
+						logger:         logger,
+						autoDiscovered: serveAutoDiscovered,
+						errWriter:      cmd.ErrOrStderr(),
+					}
+					command, _ := call.Params["command"].(string)
+					path := call.Path()
+					registerCtx, cancelRegister := context.WithTimeout(cmd.Context(), 400*time.Millisecond)
+					if approvalID, regErr := approvalClient.registerAskAuditCtx(registerCtx, call.Tool, command, call.Agent, path, call.RunID, decision.Message); regErr == nil {
+						auditApprovalID = approvalID
+					} else {
+						logger.Debug("hook: ask audit registration failed (best-effort)", "error", regErr)
+					}
+					cancelRegister()
+				}
+
+				// Write pending ask to session state so PostToolUse can correlate the outcome.
+				if parsed.SessionID != "" && parsed.ToolUseID != "" {
+					sessionMgr := session.NewManager(sessionStateDir(), parsed.SessionID, logger)
+					cmdStr2 := extractCommand(call)
+					policyName := ""
+					if len(decision.MatchedPolicies) > 0 {
+						policyName = decision.MatchedPolicies[0]
+					}
+					if err := sessionMgr.RecordAskWithAudit(parsed.ToolUseID, call.Tool, cmdStr2, cmdStr2, policyName, decision.Message, askAudit, auditApprovalID); err != nil {
 						logger.Debug("hook: failed to record ask in session state", "error", err)
 					}
 				}

--- a/cmd/rampart/cli/hook_ask_test.go
+++ b/cmd/rampart/cli/hook_ask_test.go
@@ -16,9 +16,12 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -33,6 +36,18 @@ policies:
       tool: ["exec"]
     rules:
       - action: ask
+        message: "approve this command?"
+`
+
+const askHeadlessOnlyPolicy = `version: "1"
+policies:
+  - name: test-ask-headless-only
+    match:
+      tool: ["exec"]
+    rules:
+      - action: ask
+        ask:
+          headless_only: true
         message: "approve this command?"
 `
 
@@ -191,6 +206,139 @@ func TestHookActionAsk_WritesSessionState(t *testing.T) {
 	askMap, _ := ask.(map[string]any)
 	if askMap["tool"] != "exec" {
 		t.Errorf("pending_asks[%q].tool = %v, want exec", toolUseID, askMap["tool"])
+	}
+}
+
+func TestHookActionAsk_HeadlessOnly_DoesNotEmitPermissionDecisionAsk(t *testing.T) {
+	dir := t.TempDir()
+	testSetHome(t, dir)
+
+	configPath := filepath.Join(dir, "policy.yaml")
+	if err := os.WriteFile(configPath, []byte(askHeadlessOnlyPolicy), 0o644); err != nil {
+		t.Fatalf("write policy: %v", err)
+	}
+
+	var createCount atomic.Int32
+	var pollCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/healthz":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"status":"ok"}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/approvals":
+			createCount.Add(1)
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "ap-headless-1", "status": "pending"})
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/approvals/ap-headless-1":
+			pollCount.Add(1)
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "ap-headless-1", "status": "approved"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	payload := map[string]any{
+		"hook_event_name": "PreToolUse",
+		"session_id":      "sess-headless-001",
+		"tool_use_id":     "toolu_headless_001",
+		"tool_name":       "Bash",
+		"tool_input":      map[string]any{"command": "sudo apt install git"},
+	}
+	stdinJSON, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	opts := &rootOptions{configPath: configPath}
+	stdout, _, hookErr := runHookWithStdin(t, opts, string(stdinJSON), "--mode", "enforce", "--serve-url", srv.URL)
+	if hookErr != nil {
+		t.Fatalf("hook RunE error: %v", hookErr)
+	}
+	if createCount.Load() != 1 {
+		t.Fatalf("expected 1 approval create call, got %d", createCount.Load())
+	}
+	if pollCount.Load() == 0 {
+		t.Fatalf("expected poll calls, got %d", pollCount.Load())
+	}
+
+	var out hookOutput
+	if err := json.Unmarshal([]byte(stdout), &out); err != nil {
+		t.Fatalf("unmarshal hook output: %v (stdout=%q)", err, stdout)
+	}
+	if out.HookSpecificOutput == nil {
+		t.Fatal("expected non-nil HookSpecificOutput")
+	}
+	if out.HookSpecificOutput.PermissionDecision == "ask" {
+		t.Fatalf("expected headless_only flow not to emit permissionDecision=ask, got %+v", out.HookSpecificOutput)
+	}
+	if out.HookSpecificOutput.PermissionDecision != "allow" {
+		t.Fatalf("expected permissionDecision=allow after external approval, got %q", out.HookSpecificOutput.PermissionDecision)
+	}
+}
+
+func TestHookActionAsk_DefaultHeadlessOnlyFalse_DoesEmitPermissionDecisionAsk(t *testing.T) {
+	dir := t.TempDir()
+	testSetHome(t, dir)
+
+	configPath := filepath.Join(dir, "policy.yaml")
+	if err := os.WriteFile(configPath, []byte(askPolicy), 0o644); err != nil {
+		t.Fatalf("write policy: %v", err)
+	}
+
+	payload := map[string]any{
+		"hook_event_name": "PreToolUse",
+		"session_id":      "sess-ask-default-001",
+		"tool_use_id":     "toolu_ask_default_001",
+		"tool_name":       "Bash",
+		"tool_input":      map[string]any{"command": "sudo apt install git"},
+	}
+	stdinJSON, _ := json.Marshal(payload)
+
+	opts := &rootOptions{configPath: configPath}
+	stdout, _, hookErr := runHookWithStdin(t, opts, string(stdinJSON), "--mode", "enforce")
+	if hookErr != nil {
+		t.Fatalf("hook RunE error: %v", hookErr)
+	}
+
+	var out hookOutput
+	if err := json.Unmarshal([]byte(stdout), &out); err != nil {
+		t.Fatalf("unmarshal hook output: %v (stdout=%q)", err, stdout)
+	}
+	if out.HookSpecificOutput == nil {
+		t.Fatal("expected non-nil HookSpecificOutput")
+	}
+	if out.HookSpecificOutput.PermissionDecision != "ask" {
+		t.Fatalf("expected permissionDecision=ask, got %q", out.HookSpecificOutput.PermissionDecision)
+	}
+}
+
+func TestHookActionAsk_HeadlessOnly_NoServe_ReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	testSetHome(t, dir)
+
+	configPath := filepath.Join(dir, "policy.yaml")
+	if err := os.WriteFile(configPath, []byte(askHeadlessOnlyPolicy), 0o644); err != nil {
+		t.Fatalf("write policy: %v", err)
+	}
+
+	payload := map[string]any{
+		"hook_event_name": "PreToolUse",
+		"session_id":      "sess-headless-noserve-001",
+		"tool_use_id":     "toolu_headless_noserve_001",
+		"tool_name":       "Bash",
+		"tool_input":      map[string]any{"command": "sudo apt install git"},
+	}
+	stdinJSON, _ := json.Marshal(payload)
+
+	opts := &rootOptions{configPath: configPath}
+	_, _, hookErr := runHookWithStdin(t, opts, string(stdinJSON), "--mode", "enforce", "--serve-url", "http://127.0.0.1:1")
+	if hookErr == nil {
+		t.Fatal("expected error when ask.headless_only=true and serve is unreachable")
+	}
+	if !strings.Contains(hookErr.Error(), "ask.headless_only requires rampart serve") {
+		t.Fatalf("unexpected error: %v", hookErr)
 	}
 }
 

--- a/internal/engine/ask_test.go
+++ b/internal/engine/ask_test.go
@@ -105,6 +105,20 @@ func TestRuleAskAuditEnabled_AskDefaultFalse(t *testing.T) {
 	}
 }
 
+func TestRuleHeadlessOnlyEnabled_AskExplicit(t *testing.T) {
+	r := Rule{Action: "ask", Ask: AskActionConfig{HeadlessOnly: true}}
+	if !r.HeadlessOnlyEnabled() {
+		t.Fatal("expected ask.headless_only=true to enable headless-only mode")
+	}
+}
+
+func TestRuleHeadlessOnlyEnabled_RequireApprovalFalse(t *testing.T) {
+	r := Rule{Action: "require_approval", Ask: AskActionConfig{HeadlessOnly: true}}
+	if r.HeadlessOnlyEnabled() {
+		t.Fatal("expected require_approval not to enable headless-only mode")
+	}
+}
+
 // ── Policy evaluation with action: ask ───────────────────────────────────────
 
 func TestEvaluate_ActionAsk_MatchedRule(t *testing.T) {
@@ -136,6 +150,43 @@ policies:
 	}
 	if !strings.Contains(d.Message, "approve or deny") {
 		t.Errorf("expected message to contain 'approve or deny', got: %q", d.Message)
+	}
+	if d.HeadlessOnly {
+		t.Errorf("expected HeadlessOnly=false by default, got true")
+	}
+}
+
+func TestEvaluate_ActionAsk_HeadlessOnly(t *testing.T) {
+	e := setupEngine(t, `
+version: "1"
+default_action: deny
+policies:
+  - name: ask-sudo-headless
+    match:
+      agent: "claude-code"
+      tool: ["exec"]
+    rules:
+      - action: ask
+        ask:
+          headless_only: true
+        when:
+          command_matches: ["sudo *"]
+        message: "sudo command — approve or deny?"
+`)
+	call := ToolCall{
+		ID:    "test-ask-headless-001",
+		Agent: "claude-code",
+		Tool:  "exec",
+		Params: map[string]any{
+			"command": "sudo apt install git",
+		},
+	}
+	d := e.Evaluate(call)
+	if d.Action != ActionAsk {
+		t.Errorf("expected ActionAsk, got %s", d.Action)
+	}
+	if !d.HeadlessOnly {
+		t.Errorf("expected HeadlessOnly=true, got false")
 	}
 }
 

--- a/internal/engine/decision.go
+++ b/internal/engine/decision.go
@@ -154,6 +154,10 @@ type Decision struct {
 	// - action: require_approval (alias for ask+audit)
 	Audit bool
 
+	// HeadlessOnly is set for ask decisions when native prompts should be
+	// bypassed in favor of serve-backed blocking approval flow.
+	HeadlessOnly bool
+
 	// MatchedPolicies lists the names of all policies that matched
 	// the tool call. Useful for debugging and audit.
 	MatchedPolicies []string

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -105,11 +105,12 @@ func (e *Engine) Evaluate(call ToolCall) Decision {
 	// Deny wins. Then log. Then allow.
 	// If policies match scope but no rules fire, fall through to default action.
 	var (
-		finalAction  = ActionAllow
-		finalMessage string
-		finalAudit   bool
-		matched      []string
-		anyRuleFired bool
+		finalAction       = ActionAllow
+		finalMessage      string
+		finalAudit        bool
+		finalHeadlessOnly bool
+		matched           []string
+		anyRuleFired      bool
 	)
 
 	var finalWebhookConfig *WebhookActionConfig
@@ -149,6 +150,7 @@ func (e *Engine) Evaluate(call ToolCall) Decision {
 				finalMessage = message
 				if rule != nil {
 					finalAudit = rule.AskAuditEnabled()
+					finalHeadlessOnly = false
 				}
 			}
 		case ActionAsk:
@@ -160,6 +162,7 @@ func (e *Engine) Evaluate(call ToolCall) Decision {
 				finalMessage = message
 				if rule != nil {
 					finalAudit = rule.AskAuditEnabled()
+					finalHeadlessOnly = rule.HeadlessOnlyEnabled()
 				}
 			}
 		case ActionWatch:
@@ -167,11 +170,13 @@ func (e *Engine) Evaluate(call ToolCall) Decision {
 				finalAction = ActionWatch
 				finalMessage = message
 				finalAudit = false
+				finalHeadlessOnly = false
 			}
 		case ActionAllow:
 			if finalAction == ActionAllow && finalMessage == "" {
 				finalMessage = message
 				finalAudit = false
+				finalHeadlessOnly = false
 			}
 		}
 	}
@@ -189,6 +194,7 @@ func (e *Engine) Evaluate(call ToolCall) Decision {
 	return Decision{
 		Action:          finalAction,
 		Audit:           finalAudit,
+		HeadlessOnly:    finalHeadlessOnly,
 		MatchedPolicies: matched,
 		Message:         finalMessage,
 		EvalDuration:    time.Since(start),

--- a/internal/engine/policy.go
+++ b/internal/engine/policy.go
@@ -142,7 +142,8 @@ type Rule struct {
 
 // AskActionConfig defines optional behavior for action: ask rules.
 type AskActionConfig struct {
-	Audit bool `yaml:"audit" json:"audit"`
+	Audit        bool `yaml:"audit" json:"audit"`
+	HeadlessOnly bool `yaml:"headless_only" json:"headless_only"`
 }
 
 // WebhookActionConfig defines the webhook endpoint and behavior for
@@ -230,6 +231,16 @@ func (r Rule) AskAuditEnabled() bool {
 	}
 	if action == "ask" {
 		return r.Ask.Audit
+	}
+	return false
+}
+
+// HeadlessOnlyEnabled reports whether action: ask should bypass native prompts
+// and require serve-backed blocking approval flow.
+func (r Rule) HeadlessOnlyEnabled() bool {
+	action := strings.ToLower(strings.TrimSpace(r.Action))
+	if action == "ask" {
+		return r.Ask.HeadlessOnly
 	}
 	return false
 }

--- a/policies/standard.yaml
+++ b/policies/standard.yaml
@@ -18,6 +18,15 @@
 
 version: "1"
 default_action: allow
+
+# CI/headless approval — blocks until approved via dashboard (no native prompt)
+# - action: ask
+#   ask:
+#     audit: true
+#     headless_only: true
+#   when:
+#     command_matches: "kubectl apply **"
+
 policies:
   # Self-modification protection: agents cannot change their own constraints
   - name: block-self-modification


### PR DESCRIPTION
## Summary

Closes the behavioral gap introduced in v0.6.6 where `require_approval` stopped blocking for serve-gated approval. CI users who need a human to approve via dashboard before execution can now use `ask.headless_only: true`.

## Usage

```yaml
rules:
  - action: ask
    ask:
      audit: true
      headless_only: true   # blocks until serve approves — no native prompt
    when:
      command_matches: "kubectl apply **"
```

## Behavior

| Config | Interactive | Headless/CI |
|---|---|---|
| `action: ask` | Native prompt | Native prompt (no human present = times out) |
| `action: ask` + `audit: true` | Native prompt + serve visibility | Same |
| `action: ask` + `headless_only: true` | Blocks, waits for serve | Blocks, waits for serve ✅ |
| `action: require_approval` (alias) | Native prompt + serve visibility | Same (v0.6.6 behavior) |

If serve is unreachable and `headless_only: true`: hook returns a clear error exit, does not silently allow.

## Changes
- `internal/engine/policy.go` — `HeadlessOnly bool` on `AskActionConfig`
- `internal/engine/decision.go` — `HeadlessOnly bool` on `Decision`
- `internal/engine/engine.go` — propagate flag
- `cmd/rampart/cli/hook.go` — skip native ask, enter block-and-poll when HeadlessOnly
- `policies/standard.yaml` — commented CI usage example
- Tests: headless_only skips permissionDecision:ask, default ask emits it, headless+no serve → error