### PR TITLE
fix: require_approval migration safety net — CHANGELOG, lint warning, upgrade detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **`require_approval` now uses native ask prompt** — Previously, `require_approval` blocked execution and waited for approval via the serve dashboard or `rampart approve` CLI. It now behaves as `action: ask` + `ask.audit: true`: the native Claude Code inline prompt fires immediately, and the decision is mirrored to serve (if running) for audit/observability. **If you rely on serve-gated headless approval in CI/non-interactive environments**, this changes your workflow — approval now requires a human at the Claude Code terminal. A dedicated `headless_only` flag for serve-gated approval without native prompt is planned for a future release.
+- **`require_approval` now uses native Claude Code prompt** ⚠️ Breaking change for CI/headless users
+
+  `action: require_approval` no longer blocks execution waiting for dashboard approval. It now fires the native Claude Code inline permission prompt immediately (same as `action: ask` + `ask.audit: true`).
+
+  **If your CI pipeline relies on blocking approvals** (agent waits, human approves via dashboard), migrate your policy rules:
+
+  ```yaml
+  # Before (v0.6.5 and earlier)
+  - action: require_approval
+    when:
+      command_matches: "kubectl apply **"
+
+  # After (v0.6.6+) — preserves blocking behavior for CI
+  - action: ask
+    ask:
+      audit: true
+      headless_only: true
+    when:
+      command_matches: "kubectl apply **"
+  ```
+
+  Interactive users (Claude Code running in a terminal with a human present) are unaffected — the native prompt is faster and more convenient than opening a dashboard.
 
 ## [0.6.5] - 2026-02-27
 

--- a/cmd/rampart/cli/upgrade.go
+++ b/cmd/rampart/cli/upgrade.go
@@ -39,6 +39,7 @@ import (
 	"time"
 
 	"github.com/peg/rampart/internal/build"
+	"github.com/peg/rampart/internal/engine"
 	"github.com/peg/rampart/policies"
 	"github.com/spf13/cobra"
 )
@@ -222,6 +223,12 @@ func newUpgradeCmdWithDeps(_ *rootOptions, deps *upgradeDeps) *cobra.Command {
 					}
 				}
 				return nil
+			}
+
+			if compareSemver(target, "v0.6.6") >= 0 {
+				if err := maybeWarnRequireApprovalMigration(cmd.OutOrStdout(), cmd.ErrOrStderr(), cmd.InOrStdin(), assumeYes, resolved.userHomeDir); err != nil {
+					fmt.Fprintf(cmd.ErrOrStderr(), "⚠ migration policy scan failed: %v\n", err)
+				}
 			}
 
 			assetOS, assetArch, err := upgradePlatform(runtime.GOOS, runtime.GOARCH)
@@ -796,6 +803,99 @@ func confirmUpgrade(in io.Reader, out io.Writer, current, target string) (bool, 
 		return true, nil
 	}
 	return false, nil
+}
+
+type requireApprovalUsage struct {
+	FilePath   string
+	PolicyName string
+}
+
+func maybeWarnRequireApprovalMigration(out io.Writer, errOut io.Writer, in io.Reader, assumeYes bool, userHomeDir func() (string, error)) error {
+	usages, err := findRequireApprovalUsages(userHomeDir)
+	if err != nil {
+		return err
+	}
+	if len(usages) == 0 {
+		return nil
+	}
+
+	fmt.Fprintln(out, "⚠️  Migration notice for v0.6.6:")
+	fmt.Fprintln(out, "   Found policies using `action: require_approval`:")
+	for _, u := range usages {
+		fmt.Fprintf(out, "     - %s (policy: %q)\n", u.FilePath, u.PolicyName)
+	}
+	fmt.Fprintln(out, "")
+	fmt.Fprintln(out, "   In v0.6.6, require_approval now shows a native Claude Code prompt instead")
+	fmt.Fprintln(out, "   of blocking for dashboard approval. CI pipelines that rely on blocking")
+	fmt.Fprintln(out, "   approvals should migrate to: action: ask + ask.headless_only: true")
+	fmt.Fprintln(out, "")
+	fmt.Fprintln(out, "   See https://rampart.sh/docs/migration/v0.6.6 for full migration steps.")
+	fmt.Fprintln(out, "")
+
+	inFile, inIsFile := in.(*os.File)
+	if !assumeYes && inIsFile && isTerminal(inFile) {
+		fmt.Fprintln(out, "   Press Enter to continue with upgrade, or Ctrl+C to cancel.")
+		reader := bufio.NewReader(in)
+		if _, readErr := reader.ReadString('\n'); readErr != nil && !errors.Is(readErr, io.EOF) {
+			return fmt.Errorf("upgrade: read migration confirmation: %w", readErr)
+		}
+		return nil
+	}
+
+	if errOut != nil {
+		fmt.Fprintln(errOut, "   Non-interactive mode detected (or --yes set); continuing automatically.")
+	}
+	return nil
+}
+
+func findRequireApprovalUsages(userHomeDir func() (string, error)) ([]requireApprovalUsage, error) {
+	home, err := userHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("upgrade: resolve home directory: %w", err)
+	}
+	policyDir := filepath.Join(home, ".rampart", "policies")
+	entries, err := os.ReadDir(policyDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("upgrade: read policy dir: %w", err)
+	}
+
+	var findings []requireApprovalUsage
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		ext := strings.ToLower(filepath.Ext(e.Name()))
+		if ext != ".yaml" && ext != ".yml" {
+			continue
+		}
+		path := filepath.Join(policyDir, e.Name())
+		cfg, err := engine.NewFileStore(path).Load()
+		if err != nil {
+			// Keep upgrade resilient: unreadable/invalid files are skipped.
+			continue
+		}
+		for _, p := range cfg.Policies {
+			for _, r := range p.Rules {
+				if strings.EqualFold(strings.TrimSpace(r.Action), "require_approval") {
+					findings = append(findings, requireApprovalUsage{
+						FilePath:   "~" + strings.TrimPrefix(path, home),
+						PolicyName: p.Name,
+					})
+					break
+				}
+			}
+		}
+	}
+	sort.Slice(findings, func(i, j int) bool {
+		if findings[i].FilePath != findings[j].FilePath {
+			return findings[i].FilePath < findings[j].FilePath
+		}
+		return findings[i].PolicyName < findings[j].PolicyName
+	})
+	return findings, nil
 }
 
 // upgradeStandardPolicies refreshes built-in profile files in ~/.rampart/policies/.

--- a/cmd/rampart/cli/upgrade_test.go
+++ b/cmd/rampart/cli/upgrade_test.go
@@ -463,3 +463,88 @@ func TestUpgradeStandardPoliciesUpdatesBuiltIns(t *testing.T) {
 		t.Fatalf("missing updated summary line: %q", out.String())
 	}
 }
+
+func TestFindRequireApprovalUsages(t *testing.T) {
+	dir := t.TempDir()
+	testSetHome(t, dir)
+
+	policyDir := filepath.Join(dir, ".rampart", "policies")
+	if err := os.MkdirAll(policyDir, 0o755); err != nil {
+		t.Fatalf("mkdir policy dir: %v", err)
+	}
+	customPath := filepath.Join(policyDir, "custom.yaml")
+	if err := os.WriteFile(customPath, []byte(`
+version: "1"
+default_action: deny
+policies:
+  - name: approve-deploys
+    match:
+      tool: exec
+    rules:
+      - action: require_approval
+        when:
+          command_matches: ["kubectl apply **"]
+        message: "approve deploys"
+`), 0o644); err != nil {
+		t.Fatalf("write custom policy: %v", err)
+	}
+
+	usages, err := findRequireApprovalUsages(os.UserHomeDir)
+	if err != nil {
+		t.Fatalf("findRequireApprovalUsages: %v", err)
+	}
+	if len(usages) != 1 {
+		t.Fatalf("expected 1 usage, got %d: %#v", len(usages), usages)
+	}
+	if usages[0].FilePath != "~/.rampart/policies/custom.yaml" {
+		t.Fatalf("unexpected file path: %q", usages[0].FilePath)
+	}
+	if usages[0].PolicyName != "approve-deploys" {
+		t.Fatalf("unexpected policy name: %q", usages[0].PolicyName)
+	}
+}
+
+func TestMaybeWarnRequireApprovalMigration(t *testing.T) {
+	dir := t.TempDir()
+	testSetHome(t, dir)
+
+	policyDir := filepath.Join(dir, ".rampart", "policies")
+	if err := os.MkdirAll(policyDir, 0o755); err != nil {
+		t.Fatalf("mkdir policy dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(policyDir, "custom.yaml"), []byte(`
+version: "1"
+default_action: deny
+policies:
+  - name: approve-deploys
+    match:
+      tool: exec
+    rules:
+      - action: require_approval
+        when:
+          command_matches: ["kubectl apply **"]
+        message: "approve deploys"
+`), 0o644); err != nil {
+		t.Fatalf("write custom policy: %v", err)
+	}
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	if err := maybeWarnRequireApprovalMigration(&out, &errOut, strings.NewReader(""), true, os.UserHomeDir); err != nil {
+		t.Fatalf("maybeWarnRequireApprovalMigration: %v", err)
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "⚠️  Migration notice for v0.6.6:") {
+		t.Fatalf("missing migration header: %q", got)
+	}
+	if !strings.Contains(got, "~/.rampart/policies/custom.yaml (policy: \"approve-deploys\")") {
+		t.Fatalf("missing policy usage line: %q", got)
+	}
+	if !strings.Contains(got, "action: ask + ask.headless_only: true") {
+		t.Fatalf("missing migration target guidance: %q", got)
+	}
+	if !strings.Contains(errOut.String(), "continuing automatically") {
+		t.Fatalf("missing non-interactive continuation note: %q", errOut.String())
+	}
+}

--- a/internal/engine/lint.go
+++ b/internal/engine/lint.go
@@ -248,6 +248,18 @@ func lintRule(filename string, p Policy, ruleIdx int, r Rule, result *LintResult
 			Message:  fmt.Sprintf("policy %q rule %d: action \"log\" is deprecated — use \"watch\" instead (same behavior, clearer name)", p.Name, ruleIdx+1),
 		})
 	}
+	// Deprecation warning for action: require_approval (v0.6.6 migration path).
+	if actionLower == "require_approval" {
+		result.add(LintFinding{
+			File:     filename,
+			Severity: LintWarning,
+			Message: "action \"require_approval\" is deprecated as of v0.6.6 and will be removed in v1.0.\n" +
+				"  - For interactive use:  action: ask\n" +
+				"  - For interactive + audit logging: action: ask (with ask.audit: true)\n" +
+				"  - For CI/headless (blocking): action: ask (with ask.audit: true and ask.headless_only: true)\n" +
+				"  See: https://rampart.sh/docs/migration/v0.6.6",
+		})
+	}
 
 	// Agent-scoping warning for action: ask.
 	// The native Claude Code permission dialog only works for the claude-code agent.

--- a/internal/engine/lint_test.go
+++ b/internal/engine/lint_test.go
@@ -589,3 +589,32 @@ policies:
 		}
 	}
 }
+
+func TestLint_RequireApproval_DeprecationWarning(t *testing.T) {
+	path := writeTempPolicy(t, `
+version: "1"
+default_action: deny
+policies:
+  - name: approve-sudo
+    match:
+      tool: ["exec"]
+    rules:
+      - action: require_approval
+        when:
+          command_matches: ["sudo *"]
+        message: "sudo requires approval"
+`)
+	result := LintPolicyFile(path)
+	found := false
+	for _, f := range result.Findings {
+		if f.Severity == LintWarning &&
+			strings.Contains(f.Message, `action "require_approval" is deprecated as of v0.6.6`) &&
+			strings.Contains(f.Message, `ask.headless_only: true`) &&
+			strings.Contains(f.Message, `https://rampart.sh/docs/migration/v0.6.6`) {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected require_approval deprecation warning, findings: %v", result.Findings)
+	}
+}


### PR DESCRIPTION
Protects existing users who relied on `require_approval` serve-blocking when upgrading to v0.6.6.

## What's in this PR

### 1. Better CHANGELOG migration note
Before/after YAML, concrete explanation, no jargon. CI users can follow the steps.

### 2. `rampart policy lint` deprecation warning
When lint sees `action: require_approval`:
```
warning: action "require_approval" is deprecated as of v0.6.6 and will be removed in v1.0.
  For interactive use:            action: ask
  For interactive + audit log:    action: ask (with ask.audit: true)  
  For CI/headless (blocking):     action: ask (with ask.audit: true and ask.headless_only: true)
  See: https://rampart.sh/docs/migration/v0.6.6
```

### 3. Upgrade-time policy scan
`rampart upgrade` scans `~/.rampart/policies/` before upgrading. If `require_approval` rules are found:
```
⚠️  Migration notice for v0.6.6:
   Found policies using `action: require_approval`:
     - ~/.rampart/policies/custom.yaml (policy: approve-deploys)
   
   In v0.6.6, require_approval now shows a native Claude Code prompt
   instead of blocking for dashboard approval. CI pipelines should
   migrate to: action: ask + ask.headless_only: true
   
   Press Enter to continue, or Ctrl+C to cancel.
```
Auto-continues if non-interactive (no TTY or `--yes` flag).

## Tests
- lint_test.go: deprecation warning fires for require_approval rules
- upgrade_test.go: scan detects require_approval in policies, warning shown, auto-continue in CI mode