### PR TITLE
feat: add git-based policy sync (rampart policy sync)

### DIFF
--- a/cmd/rampart/cli/policy.go
+++ b/cmd/rampart/cli/policy.go
@@ -56,6 +56,7 @@ func newPolicyCmd(opts *rootOptions) *cobra.Command {
 	cmd.AddCommand(newPolicyListCmd(opts))
 	cmd.AddCommand(newPolicyFetchCmd(opts))
 	cmd.AddCommand(newPolicyRemoveCmd(opts))
+	cmd.AddCommand(newPolicySyncCmd(opts))
 
 	// `rampart policy test` is an alias for `rampart test` — same command,
 	// discoverable under the policy subcommand for users who expect it there.

--- a/cmd/rampart/cli/policy_sync.go
+++ b/cmd/rampart/cli/policy_sync.go
@@ -1,0 +1,370 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	policySyncStateFileName = "sync-state.json"
+	policySyncPolicyName    = "org-sync.yaml"
+)
+
+var (
+	policySyncLookPath = exec.LookPath
+	policySyncRunGit   = runPolicySyncGit
+	policySyncNow      = func() time.Time { return time.Now().UTC() }
+)
+
+type syncState struct {
+	GitURL        string    `json:"git_url,omitempty"`
+	LastCommitSHA string    `json:"last_commit_sha,omitempty"`
+	LastSyncTime  time.Time `json:"last_sync_time,omitempty"`
+}
+
+type syncResult struct {
+	CommitSHA     string
+	PolicyChanged bool
+	SyncedAt      time.Time
+}
+
+func newPolicySyncCmd(_ *rootOptions) *cobra.Command {
+	var (
+		watch    bool
+		interval time.Duration
+	)
+
+	cmd := &cobra.Command{
+		Use:   "sync <git-url>",
+		Short: "Sync policies from a git repository",
+		Long: `Sync a Rampart policy file from a public HTTPS git repository.
+
+Rampart checks for policy files in this order:
+  1. rampart.yaml
+  2. policy.yaml
+  3. .rampart/policy.yaml
+
+Synced policy is written to ~/.rampart/policies/org-sync.yaml and a state file
+is stored at ~/.rampart/sync-state.json.`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			url, err := resolvePolicySyncURL(args)
+			if err != nil {
+				return err
+			}
+
+			result, err := performPolicySync(cmd.Context(), url)
+			if err != nil {
+				return err
+			}
+
+			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "%s commit=%s policy_changed=%t\n", result.SyncedAt.Format(time.RFC3339), result.CommitSHA, result.PolicyChanged); err != nil {
+				return fmt.Errorf("policy: write sync output: %w", err)
+			}
+
+			if !watch {
+				return nil
+			}
+
+			if interval <= 0 {
+				return fmt.Errorf("policy: --interval must be greater than 0")
+			}
+
+			for {
+				select {
+				case <-cmd.Context().Done():
+					return nil
+				case <-time.After(interval):
+				}
+
+				result, err := performPolicySync(cmd.Context(), url)
+				if err != nil {
+					return err
+				}
+				if _, err := fmt.Fprintf(cmd.OutOrStdout(), "%s commit=%s policy_changed=%t\n", result.SyncedAt.Format(time.RFC3339), result.CommitSHA, result.PolicyChanged); err != nil {
+					return fmt.Errorf("policy: write sync output: %w", err)
+				}
+			}
+		},
+	}
+
+	cmd.Flags().BoolVar(&watch, "watch", false, "Poll for policy updates in the foreground")
+	cmd.Flags().DurationVar(&interval, "interval", 5*time.Minute, "Polling interval for --watch")
+
+	cmd.AddCommand(newPolicySyncStatusCmd())
+	cmd.AddCommand(newPolicySyncStopCmd())
+
+	return cmd
+}
+
+func newPolicySyncStatusCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Show policy sync status",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			state, err := loadPolicySyncState()
+			if err != nil {
+				return err
+			}
+
+			url := state.GitURL
+			if strings.TrimSpace(url) == "" {
+				url = "(not configured)"
+			}
+
+			lastSync := "(never)"
+			if !state.LastSyncTime.IsZero() {
+				lastSync = state.LastSyncTime.UTC().Format(time.RFC3339)
+			}
+
+			sha := state.LastCommitSHA
+			if strings.TrimSpace(sha) == "" {
+				sha = "(unknown)"
+			}
+
+			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Git URL: %s\nLast sync: %s\nLast commit: %s\n", url, lastSync, sha); err != nil {
+				return fmt.Errorf("policy: write sync status output: %w", err)
+			}
+			return nil
+		},
+	}
+}
+
+func newPolicySyncStopCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "stop",
+		Short: "Stop policy sync by removing configured URL",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			state, err := loadPolicySyncState()
+			if err != nil {
+				return err
+			}
+			state.GitURL = ""
+			if err := savePolicySyncState(state); err != nil {
+				return err
+			}
+			if _, err := fmt.Fprintln(cmd.OutOrStdout(), "Policy sync URL removed."); err != nil {
+				return fmt.Errorf("policy: write sync stop output: %w", err)
+			}
+			return nil
+		},
+	}
+}
+
+func resolvePolicySyncURL(args []string) (string, error) {
+	if len(args) > 0 {
+		url := strings.TrimSpace(args[0])
+		if err := validatePolicySyncURL(url); err != nil {
+			return "", err
+		}
+		return url, nil
+	}
+
+	state, err := loadPolicySyncState()
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(state.GitURL) == "" {
+		return "", fmt.Errorf("policy: git URL is required (use: rampart policy sync <https-url>)")
+	}
+	if err := validatePolicySyncURL(state.GitURL); err != nil {
+		return "", err
+	}
+	return state.GitURL, nil
+}
+
+func validatePolicySyncURL(url string) error {
+	if strings.TrimSpace(url) == "" {
+		return fmt.Errorf("policy: git URL cannot be empty")
+	}
+	if !strings.HasPrefix(strings.ToLower(url), "https://") {
+		return fmt.Errorf("policy: only HTTPS git URLs are supported")
+	}
+	return nil
+}
+
+func performPolicySync(ctx context.Context, url string) (syncResult, error) {
+	if _, err := policySyncLookPath("git"); err != nil {
+		return syncResult{}, fmt.Errorf("policy: git is required but was not found in PATH")
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return syncResult{}, fmt.Errorf("policy: resolve home directory: %w", err)
+	}
+
+	repoPath := filepath.Join(home, ".rampart", "sync-repo")
+	if err := syncRepo(ctx, url, repoPath); err != nil {
+		return syncResult{}, err
+	}
+
+	srcPolicyPath, err := findPolicySyncSource(repoPath)
+	if err != nil {
+		return syncResult{}, err
+	}
+	srcPolicyData, err := os.ReadFile(srcPolicyPath)
+	if err != nil {
+		return syncResult{}, fmt.Errorf("policy: read policy from repository: %w", err)
+	}
+
+	destPolicyPath := filepath.Join(home, ".rampart", "policies", policySyncPolicyName)
+	changed := true
+	if existing, err := os.ReadFile(destPolicyPath); err == nil {
+		changed = string(existing) != string(srcPolicyData)
+	} else if !os.IsNotExist(err) {
+		return syncResult{}, fmt.Errorf("policy: read existing synced policy: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(destPolicyPath), 0o755); err != nil {
+		return syncResult{}, fmt.Errorf("policy: create policy directory: %w", err)
+	}
+	if err := os.WriteFile(destPolicyPath, srcPolicyData, 0o600); err != nil {
+		return syncResult{}, fmt.Errorf("policy: write synced policy: %w", err)
+	}
+
+	sha, err := policySyncRunGit(ctx, "-C", repoPath, "rev-parse", "HEAD")
+	if err != nil {
+		return syncResult{}, err
+	}
+
+	now := policySyncNow()
+	state, err := loadPolicySyncState()
+	if err != nil {
+		return syncResult{}, err
+	}
+	state.GitURL = url
+	state.LastCommitSHA = strings.TrimSpace(sha)
+	state.LastSyncTime = now
+	if err := savePolicySyncState(state); err != nil {
+		return syncResult{}, err
+	}
+
+	return syncResult{CommitSHA: state.LastCommitSHA, PolicyChanged: changed, SyncedAt: now}, nil
+}
+
+func syncRepo(ctx context.Context, url, repoPath string) error {
+	gitDir := filepath.Join(repoPath, ".git")
+	if _, err := os.Stat(gitDir); err == nil {
+		remoteURL, err := policySyncRunGit(ctx, "-C", repoPath, "remote", "get-url", "origin")
+		if err != nil {
+			return err
+		}
+		if strings.TrimSpace(remoteURL) != url {
+			if err := os.RemoveAll(repoPath); err != nil {
+				return fmt.Errorf("policy: clear previous sync repository: %w", err)
+			}
+			return clonePolicyRepo(ctx, url, repoPath)
+		}
+		if _, err := policySyncRunGit(ctx, "-C", repoPath, "pull", "--ff-only"); err != nil {
+			return err
+		}
+		return nil
+	}
+	if err := os.RemoveAll(repoPath); err != nil {
+		return fmt.Errorf("policy: remove invalid sync repository: %w", err)
+	}
+	return clonePolicyRepo(ctx, url, repoPath)
+}
+
+func clonePolicyRepo(ctx context.Context, url, repoPath string) error {
+	if err := os.MkdirAll(filepath.Dir(repoPath), 0o755); err != nil {
+		return fmt.Errorf("policy: create sync repository directory: %w", err)
+	}
+	if _, err := policySyncRunGit(ctx, "clone", "--depth", "1", url, repoPath); err != nil {
+		return err
+	}
+	return nil
+}
+
+func findPolicySyncSource(repoPath string) (string, error) {
+	candidates := []string{
+		filepath.Join(repoPath, "rampart.yaml"),
+		filepath.Join(repoPath, "policy.yaml"),
+		filepath.Join(repoPath, ".rampart", "policy.yaml"),
+	}
+	for _, candidate := range candidates {
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("policy: no policy file found in repository (expected rampart.yaml, policy.yaml, or .rampart/policy.yaml)")
+}
+
+func runPolicySyncGit(ctx context.Context, args ...string) (string, error) {
+	out, err := exec.CommandContext(ctx, "git", args...).CombinedOutput()
+	if err != nil {
+		msg := strings.TrimSpace(string(out))
+		if msg == "" {
+			return "", fmt.Errorf("policy: git command failed: git %s: %w", strings.Join(args, " "), err)
+		}
+		return "", fmt.Errorf("policy: git command failed: git %s: %s", strings.Join(args, " "), msg)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func loadPolicySyncState() (syncState, error) {
+	path, err := policySyncStatePath()
+	if err != nil {
+		return syncState{}, fmt.Errorf("policy: resolve sync state path: %w", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return syncState{}, nil
+		}
+		return syncState{}, fmt.Errorf("policy: read sync state: %w", err)
+	}
+	var state syncState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return syncState{}, fmt.Errorf("policy: parse sync state: %w", err)
+	}
+	return state, nil
+}
+
+func savePolicySyncState(state syncState) error {
+	path, err := policySyncStatePath()
+	if err != nil {
+		return fmt.Errorf("policy: resolve sync state path: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("policy: create sync state directory: %w", err)
+	}
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("policy: encode sync state: %w", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("policy: write sync state: %w", err)
+	}
+	return nil
+}
+
+func policySyncStatePath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".rampart", policySyncStateFileName), nil
+}

--- a/cmd/rampart/cli/policy_sync_test.go
+++ b/cmd/rampart/cli/policy_sync_test.go
@@ -1,0 +1,212 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPolicySyncCopiesPolicyAndSavesState(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+
+	origLookPath := policySyncLookPath
+	origRunGit := policySyncRunGit
+	origNow := policySyncNow
+	t.Cleanup(func() {
+		policySyncLookPath = origLookPath
+		policySyncRunGit = origRunGit
+		policySyncNow = origNow
+	})
+
+	now := time.Date(2026, 2, 28, 15, 0, 0, 0, time.UTC)
+	policySyncNow = func() time.Time { return now }
+	policySyncLookPath = func(string) (string, error) { return "git", nil }
+
+	policySyncRunGit = func(_ context.Context, args ...string) (string, error) {
+		switch {
+		case len(args) >= 5 && args[0] == "clone":
+			repoPath := args[4]
+			if err := os.MkdirAll(repoPath, 0o755); err != nil {
+				return "", err
+			}
+			if err := os.MkdirAll(filepath.Join(repoPath, ".git"), 0o755); err != nil {
+				return "", err
+			}
+			return "", os.WriteFile(filepath.Join(repoPath, "rampart.yaml"), []byte("version: \"1\"\npolicies: []\n"), 0o644)
+		case len(args) >= 4 && args[0] == "-C" && args[2] == "rev-parse" && args[3] == "HEAD":
+			return "abc123", nil
+		case len(args) >= 5 && args[0] == "-C" && args[2] == "remote" && args[3] == "get-url":
+			return "https://example.com/org/policy.git", nil
+		case len(args) >= 4 && args[0] == "-C" && args[2] == "pull":
+			return "Already up to date.", nil
+		default:
+			return "", fmt.Errorf("unexpected git args: %v", args)
+		}
+	}
+
+	var out bytes.Buffer
+	root := NewRootCmd(context.Background(), &out, &bytes.Buffer{})
+	root.SetArgs([]string{"policy", "sync", "https://example.com/org/policy.git"})
+	require.NoError(t, root.Execute())
+
+	syncedPolicyPath := filepath.Join(home, ".rampart", "policies", policySyncPolicyName)
+	data, err := os.ReadFile(syncedPolicyPath)
+	require.NoError(t, err)
+	require.Contains(t, string(data), "version: \"1\"")
+
+	statePath := filepath.Join(home, ".rampart", policySyncStateFileName)
+	stateData, err := os.ReadFile(statePath)
+	require.NoError(t, err)
+	require.Contains(t, string(stateData), "https://example.com/org/policy.git")
+	require.Contains(t, string(stateData), "abc123")
+	require.Contains(t, string(stateData), now.Format(time.RFC3339))
+	require.Contains(t, out.String(), "commit=abc123")
+}
+
+func TestPolicySyncWatchPrintsChecks(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+
+	origLookPath := policySyncLookPath
+	origRunGit := policySyncRunGit
+	origNow := policySyncNow
+	t.Cleanup(func() {
+		policySyncLookPath = origLookPath
+		policySyncRunGit = origRunGit
+		policySyncNow = origNow
+	})
+
+	policySyncLookPath = func(string) (string, error) { return "git", nil }
+
+	baseTime := time.Date(2026, 2, 28, 16, 0, 0, 0, time.UTC)
+	calls := 0
+	policySyncNow = func() time.Time {
+		calls++
+		return baseTime.Add(time.Duration(calls) * time.Minute)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cloneCount := 0
+	policySyncRunGit = func(_ context.Context, args ...string) (string, error) {
+		switch {
+		case len(args) >= 5 && args[0] == "clone":
+			cloneCount++
+			repoPath := args[4]
+			if err := os.MkdirAll(repoPath, 0o755); err != nil {
+				return "", err
+			}
+			if err := os.MkdirAll(filepath.Join(repoPath, ".git"), 0o755); err != nil {
+				return "", err
+			}
+			return "", os.WriteFile(filepath.Join(repoPath, "rampart.yaml"), []byte("version: \"1\"\npolicies: []\n"), 0o644)
+		case len(args) >= 5 && args[0] == "-C" && args[2] == "remote" && args[3] == "get-url":
+			return "https://example.com/org/policy.git", nil
+		case len(args) >= 4 && args[0] == "-C" && args[2] == "pull":
+			return "Already up to date.", nil
+		case len(args) >= 4 && args[0] == "-C" && args[2] == "rev-parse" && args[3] == "HEAD":
+			if calls >= 2 {
+				cancel()
+			}
+			return "def456", nil
+		default:
+			return "", fmt.Errorf("unexpected git args: %v", args)
+		}
+	}
+
+	var out bytes.Buffer
+	root := NewRootCmd(ctx, &out, &bytes.Buffer{})
+	root.SetArgs([]string{"policy", "sync", "https://example.com/org/policy.git", "--watch", "--interval", "1ms"})
+	require.NoError(t, root.Execute())
+
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	require.GreaterOrEqual(t, len(lines), 2)
+	require.Contains(t, lines[0], "commit=def456")
+	require.Contains(t, lines[1], "commit=def456")
+	require.Equal(t, 1, cloneCount)
+}
+
+func TestPolicySyncStatusAndStop(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+	state := syncState{
+		GitURL:        "https://example.com/org/policy.git",
+		LastCommitSHA: "cafebabe",
+		LastSyncTime:  time.Date(2026, 2, 28, 12, 0, 0, 0, time.UTC),
+	}
+	require.NoError(t, savePolicySyncState(state))
+
+	var statusOut bytes.Buffer
+	root := NewRootCmd(context.Background(), &statusOut, &bytes.Buffer{})
+	root.SetArgs([]string{"policy", "sync", "status"})
+	require.NoError(t, root.Execute())
+	require.Contains(t, statusOut.String(), "https://example.com/org/policy.git")
+	require.Contains(t, statusOut.String(), "cafebabe")
+
+	var stopOut bytes.Buffer
+	root = NewRootCmd(context.Background(), &stopOut, &bytes.Buffer{})
+	root.SetArgs([]string{"policy", "sync", "stop"})
+	require.NoError(t, root.Execute())
+	require.Contains(t, stopOut.String(), "Policy sync URL removed")
+
+	updated, err := loadPolicySyncState()
+	require.NoError(t, err)
+	require.Empty(t, updated.GitURL)
+	require.Equal(t, "cafebabe", updated.LastCommitSHA)
+}
+
+func TestPolicySyncRejectsNonHTTPSURL(t *testing.T) {
+	_, err := resolvePolicySyncURL([]string{"http://example.com/org/policy.git"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "only HTTPS")
+}
+
+func TestPolicySyncErrorsWhenGitMissing(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+
+	origLookPath := policySyncLookPath
+	t.Cleanup(func() {
+		policySyncLookPath = origLookPath
+	})
+
+	policySyncLookPath = func(string) (string, error) {
+		return "", fmt.Errorf("not found")
+	}
+
+	_, err := performPolicySync(context.Background(), "https://example.com/org/policy.git")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "git is required")
+}
+
+func TestFindPolicySyncSourceOrder(t *testing.T) {
+	repo := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(repo, ".rampart"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "policy.yaml"), []byte("secondary"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(repo, ".rampart", "policy.yaml"), []byte("tertiary"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "rampart.yaml"), []byte("primary"), 0o644))
+
+	got, err := findPolicySyncSource(repo)
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(repo, "rampart.yaml"), got)
+}


### PR DESCRIPTION
## Summary
Adds `rampart policy sync <git-url>` for team policy distribution without requiring any server infrastructure. Teams commit their policy to a git repo; developers sync with one command.

## Changes
- `rampart policy sync <url>` — clone/pull a public HTTPS git repo, copy policy file to `~/.rampart/policies/org-sync.yaml`
- `rampart policy sync --watch` — foreground polling (default 5min interval, configurable)
- `rampart policy sync status` — show configured URL, last SHA, last sync time
- `rampart policy sync stop` — remove configured sync URL
- State persisted to `~/.rampart/sync-state.json`
- Uses system `git` via `os/exec` (no new deps)
- HTTPS-only enforcement
- Policy file discovery: `rampart.yaml` → `policy.yaml` → `.rampart/policy.yaml`

## Tests
5 new tests: copy+state persistence, watch polling, status/stop, non-HTTPS rejection, git-missing error.

Part of leaner v0.7.0 scope.