### PR TITLE
feat: add AIUC-1 compliance report (rampart report compliance)

### DIFF
--- a/cmd/rampart/cli/report.go
+++ b/cmd/rampart/cli/report.go
@@ -14,12 +14,14 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
+	"github.com/peg/rampart/internal/build"
 	"github.com/peg/rampart/internal/report"
 	"github.com/spf13/cobra"
 )
@@ -30,24 +32,32 @@ type reportOptions struct {
 	last     string
 }
 
+type complianceReportOptions struct {
+	auditDir string
+	since    string
+	until    string
+	format   string
+	output   string
+}
+
 // newReportCmd creates the `rampart report` command.
 func newReportCmd(opts *rootOptions) *cobra.Command {
 	reportOpts := &reportOptions{}
 
 	cmd := &cobra.Command{
 		Use:   "report",
-		Short: "Generate HTML audit report",
-		Long: `Generate a self-contained HTML audit report from JSONL audit files.
+		Short: "Generate reports from audit logs",
+		Long: `Generate reports from Rampart audit logs.
 
-The report includes event summaries, timelines, top denied commands, policy 
-triggers, and a searchable event log. The HTML is completely self-contained
-with inline CSS and JavaScript.
+By default this command generates a self-contained HTML report.
+Use 'rampart report compliance' to generate an AIUC-1 compliance report.
 
 Examples:
-  rampart report                                    # Last 24 hours
-  rampart report --last 7d                         # Last 7 days  
-  rampart report --output weekly.html --last 7d    # Custom output
-  rampart report --audit-dir /var/log/rampart      # Custom audit dir`,
+  rampart report                                    # HTML report for last 24h
+  rampart report --last 7d                         # HTML report for last 7 days
+  rampart report --output weekly.html --last 7d    # Custom HTML output path
+  rampart report compliance                        # AIUC-1 text report
+  rampart report compliance --format json          # AIUC-1 JSON report`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runReport(reportOpts)
 		},
@@ -64,7 +74,116 @@ Examples:
 	cmd.Flags().StringVar(&reportOpts.output, "output", "report.html", "Output HTML file path")
 	cmd.Flags().StringVar(&reportOpts.last, "last", "24h", "Time window (e.g., 24h, 7d, 30d)")
 
+	cmd.AddCommand(newReportComplianceCmd(opts, defaultAuditDir))
 	return cmd
+}
+
+func newReportComplianceCmd(rootOpts *rootOptions, defaultAuditDir string) *cobra.Command {
+	complianceOpts := &complianceReportOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "compliance",
+		Short: "Generate AIUC-1 compliance report",
+		Long: `Generate an AIUC-1 compliance evidence report from audit logs.
+
+Controls evaluated:
+  AIUC-1.1 Tool Call Authorization
+  AIUC-1.2 Audit Logging
+  AIUC-1.3 Human-in-the-Loop
+  AIUC-1.4 Data Exfiltration Prevention
+
+Examples:
+  rampart report compliance
+  rampart report compliance --since 2026-02-01 --until 2026-02-28
+  rampart report compliance --format json --output aiuc1-report.json`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runComplianceReport(cmd, rootOpts, complianceOpts)
+		},
+	}
+
+	cmd.Flags().StringVar(&complianceOpts.auditDir, "audit-dir", defaultAuditDir, "Directory containing audit JSONL files")
+	cmd.Flags().StringVar(&complianceOpts.since, "since", "", "Reporting period start date (YYYY-MM-DD, default: 30 days ago)")
+	cmd.Flags().StringVar(&complianceOpts.until, "until", "", "Reporting period end date (YYYY-MM-DD, default: now)")
+	cmd.Flags().StringVar(&complianceOpts.format, "format", "text", "Output format: text or json")
+	cmd.Flags().StringVar(&complianceOpts.output, "output", "", "Write report to file instead of stdout")
+
+	return cmd
+}
+
+func runComplianceReport(cmd *cobra.Command, rootOpts *rootOptions, opts *complianceReportOptions) error {
+	format := strings.ToLower(strings.TrimSpace(opts.format))
+	if format != "text" && format != "json" {
+		return fmt.Errorf("report: invalid --format %q (expected text or json)", opts.format)
+	}
+
+	now := time.Now().UTC()
+	since, err := parseReportDateStart(opts.since)
+	if err != nil {
+		return err
+	}
+	if since.IsZero() {
+		since = now.AddDate(0, 0, -30)
+	}
+
+	until, err := parseReportDateEnd(opts.until)
+	if err != nil {
+		return err
+	}
+	if until.IsZero() {
+		until = now
+	}
+	if since.After(until) {
+		return fmt.Errorf("report: --since must be before --until")
+	}
+
+	policyPath := resolveCompliancePolicyPath(cmd, rootOpts.configPath)
+
+	reportData, err := report.GenerateAIUC1Report(report.ComplianceOptions{
+		AuditDir:       opts.auditDir,
+		PolicyPath:     policyPath,
+		Since:          since,
+		Until:          until,
+		GeneratedAt:    now,
+		RampartVersion: build.Version,
+	})
+	if err != nil {
+		return err
+	}
+
+	var payload []byte
+	if format == "json" {
+		payload, err = json.MarshalIndent(reportData, "", "  ")
+		if err != nil {
+			return fmt.Errorf("report: marshal json: %w", err)
+		}
+		payload = append(payload, '\n')
+	} else {
+		payload = []byte(report.FormatAIUC1TextReport(reportData))
+	}
+
+	if strings.TrimSpace(opts.output) != "" {
+		if err := os.WriteFile(opts.output, payload, 0o644); err != nil {
+			return fmt.Errorf("report: write output file: %w", err)
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Wrote compliance report to %s\n", opts.output)
+		return nil
+	}
+
+	if _, err := cmd.OutOrStdout().Write(payload); err != nil {
+		return fmt.Errorf("report: write output: %w", err)
+	}
+	return nil
+}
+
+func resolveCompliancePolicyPath(cmd *cobra.Command, configPath string) string {
+	resolved, err := resolveExplainPolicyPath(cmd, configPath)
+	if err == nil {
+		return resolved
+	}
+	if strings.TrimSpace(configPath) != "" {
+		return configPath
+	}
+	return "rampart.yaml"
 }
 
 // runReport executes the report generation.
@@ -134,4 +253,29 @@ func parseDuration(s string) (time.Duration, error) {
 
 	// Use standard Go duration parsing for other formats
 	return time.ParseDuration(s)
+}
+
+func parseReportDateStart(raw string) (time.Time, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return time.Time{}, nil
+	}
+	parsed, err := time.Parse("2006-01-02", trimmed)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("report: invalid --since date %q (expected YYYY-MM-DD)", raw)
+	}
+	return parsed.UTC(), nil
+}
+
+func parseReportDateEnd(raw string) (time.Time, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return time.Time{}, nil
+	}
+	parsed, err := time.Parse("2006-01-02", trimmed)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("report: invalid --until date %q (expected YYYY-MM-DD)", raw)
+	}
+	parsed = parsed.UTC()
+	return parsed.Add(24*time.Hour - time.Nanosecond), nil
 }

--- a/internal/report/compliance.go
+++ b/internal/report/compliance.go
@@ -271,23 +271,31 @@ func (r *AIUC1Report) applyPolicyControlResult(policyPath string) {
 		return
 	}
 
+	// Note: evaluateSensitiveDenyCoverage uses keyword proximity heuristics,
+	// not semantic YAML parsing. Manual review of the policy file is recommended
+	// for full assurance that deny rules actually match the sensitive paths.
 	covered, found, missing := evaluateSensitiveDenyCoverage(string(data))
+	heuristicNote := "Note: coverage check is keyword proximity heuristic — manual policy review recommended for full assurance."
 	if covered {
 		r.Controls["AIUC-1.4"] = ComplianceControl{
-			Name:     "Data Exfiltration Prevention",
-			Status:   ControlStatusPass,
-			Evidence: []string{fmt.Sprintf("Sensitive deny coverage found for: %s", strings.Join(found, ", "))},
+			Name:   "Data Exfiltration Prevention",
+			Status: ControlStatusPass,
+			Evidence: []string{
+				fmt.Sprintf("Keyword proximity check passed for: %s", strings.Join(found, ", ")),
+				heuristicNote,
+			},
 		}
 		return
 	}
 
-	evidence := []string{"No deny coverage found for all required sensitive targets."}
+	evidence := []string{"Sensitive keyword proximity check did not find deny coverage for all required targets."}
 	if len(found) > 0 {
 		evidence = append(evidence, fmt.Sprintf("Found: %s", strings.Join(found, ", ")))
 	}
 	if len(missing) > 0 {
 		evidence = append(evidence, fmt.Sprintf("Missing: %s", strings.Join(missing, ", ")))
 	}
+	evidence = append(evidence, heuristicNote)
 	r.Controls["AIUC-1.4"] = ComplianceControl{
 		Name:     "Data Exfiltration Prevention",
 		Status:   ControlStatusWarn,

--- a/internal/report/compliance.go
+++ b/internal/report/compliance.go
@@ -1,0 +1,598 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package report
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/peg/rampart/internal/audit"
+)
+
+type ControlStatus string
+
+type ComplianceStatus string
+
+const (
+	ControlStatusPass ControlStatus = "PASS"
+	ControlStatusWarn ControlStatus = "WARN"
+	ControlStatusFail ControlStatus = "FAIL"
+
+	ComplianceStatusCompliant    ComplianceStatus = "COMPLIANT"
+	ComplianceStatusPartial      ComplianceStatus = "PARTIAL"
+	ComplianceStatusNonCompliant ComplianceStatus = "NON-COMPLIANT"
+)
+
+type CompliancePeriod struct {
+	Since time.Time `json:"since"`
+	Until time.Time `json:"until"`
+}
+
+type DecisionCounts struct {
+	Total int `json:"total"`
+	Allow int `json:"allow"`
+	Deny  int `json:"deny"`
+	Log   int `json:"log"`
+	Ask   int `json:"ask"`
+	Other int `json:"other"`
+}
+
+type ComplianceSummary struct {
+	DecisionCounts   DecisionCounts   `json:"decision_counts"`
+	ComplianceStatus ComplianceStatus `json:"compliance_status"`
+}
+
+type ComplianceControl struct {
+	Name     string        `json:"name"`
+	Status   ControlStatus `json:"status"`
+	Evidence []string      `json:"evidence"`
+}
+
+type AIUC1Report struct {
+	ReportID       string                       `json:"report_id"`
+	GeneratedAt    time.Time                    `json:"generated_at"`
+	Period         CompliancePeriod             `json:"period"`
+	RampartVersion string                       `json:"rampart_version"`
+	Standard       string                       `json:"standard"`
+	Summary        ComplianceSummary            `json:"summary"`
+	Controls       map[string]ComplianceControl `json:"controls"`
+}
+
+type ComplianceOptions struct {
+	AuditDir       string
+	PolicyPath     string
+	Since          time.Time
+	Until          time.Time
+	GeneratedAt    time.Time
+	RampartVersion string
+}
+
+func GenerateAIUC1Report(opts ComplianceOptions) (*AIUC1Report, error) {
+	generatedAt := opts.GeneratedAt.UTC()
+	if generatedAt.IsZero() {
+		generatedAt = time.Now().UTC()
+	}
+
+	since := opts.Since.UTC()
+	if since.IsZero() {
+		since = generatedAt.AddDate(0, 0, -30)
+	}
+	until := opts.Until.UTC()
+	if until.IsZero() {
+		until = generatedAt
+	}
+	if since.After(until) {
+		return nil, fmt.Errorf("report: period start must be before period end")
+	}
+
+	auditDir, err := expandHomePath(opts.AuditDir)
+	if err != nil {
+		return nil, fmt.Errorf("report: expand audit dir: %w", err)
+	}
+	if strings.TrimSpace(auditDir) == "" {
+		auditDir = "."
+	}
+
+	report := &AIUC1Report{
+		ReportID:    generateUUID4(),
+		GeneratedAt: generatedAt,
+		Period: CompliancePeriod{
+			Since: since,
+			Until: until,
+		},
+		RampartVersion: opts.RampartVersion,
+		Standard:       "AIUC-1",
+		Controls: map[string]ComplianceControl{
+			"AIUC-1.1": {Name: "Tool Call Authorization"},
+			"AIUC-1.2": {Name: "Audit Logging"},
+			"AIUC-1.3": {Name: "Human-in-the-Loop"},
+			"AIUC-1.4": {Name: "Data Exfiltration Prevention"},
+		},
+	}
+
+	auditFiles, listErr := listAuditJSONLFiles(auditDir)
+	if listErr != nil {
+		report.Controls["AIUC-1.1"] = ComplianceControl{
+			Name:   "Tool Call Authorization",
+			Status: ControlStatusFail,
+			Evidence: []string{
+				fmt.Sprintf("Could not read audit directory %q: %v", auditDir, listErr),
+			},
+		}
+		report.Controls["AIUC-1.2"] = ComplianceControl{
+			Name:   "Audit Logging",
+			Status: ControlStatusFail,
+			Evidence: []string{
+				"Audit chain could not be verified because audit logs are unavailable.",
+			},
+		}
+		report.Controls["AIUC-1.3"] = ComplianceControl{
+			Name:   "Human-in-the-Loop",
+			Status: ControlStatusWarn,
+			Evidence: []string{
+				"No audit events available for period; cannot confirm ask decisions.",
+			},
+		}
+	} else {
+		report.applyAuditControlResults(auditDir, auditFiles, since, until)
+	}
+
+	report.applyPolicyControlResult(opts.PolicyPath)
+	report.Summary.ComplianceStatus = deriveComplianceStatus(report.Controls)
+
+	return report, nil
+}
+
+func (r *AIUC1Report) applyAuditControlResults(auditDir string, auditFiles []string, since, until time.Time) {
+	if len(auditFiles) == 0 {
+		r.Controls["AIUC-1.1"] = ComplianceControl{
+			Name:   "Tool Call Authorization",
+			Status: ControlStatusFail,
+			Evidence: []string{
+				fmt.Sprintf("No audit log files found in %q.", auditDir),
+			},
+		}
+		r.Controls["AIUC-1.2"] = ComplianceControl{
+			Name:   "Audit Logging",
+			Status: ControlStatusFail,
+			Evidence: []string{
+				"Audit chain verification cannot run because no audit log files were found.",
+			},
+		}
+		r.Controls["AIUC-1.3"] = ComplianceControl{
+			Name:   "Human-in-the-Loop",
+			Status: ControlStatusWarn,
+			Evidence: []string{
+				"No audit events available in the reporting period.",
+			},
+		}
+		return
+	}
+
+	allEvents, hashesByID, chainErr := readAndVerifyAuditChain(auditFiles)
+	if chainErr != nil {
+		r.Controls["AIUC-1.2"] = ComplianceControl{
+			Name:     "Audit Logging",
+			Status:   ControlStatusFail,
+			Evidence: []string{fmt.Sprintf("Audit chain verification failed: %v", chainErr)},
+		}
+	} else {
+		anchorErr := verifyAnchorsInDir(auditDir, hashesByID)
+		if anchorErr != nil {
+			r.Controls["AIUC-1.2"] = ComplianceControl{
+				Name:     "Audit Logging",
+				Status:   ControlStatusFail,
+				Evidence: []string{fmt.Sprintf("Audit anchor verification failed: %v", anchorErr)},
+			}
+		} else {
+			r.Controls["AIUC-1.2"] = ComplianceControl{
+				Name:     "Audit Logging",
+				Status:   ControlStatusPass,
+				Evidence: []string{fmt.Sprintf("Verified %d events across %d audit files.", len(allEvents), len(auditFiles))},
+			}
+		}
+	}
+
+	periodEvents := filterEventsByPeriod(allEvents, since, until)
+	counts := computeDecisionCounts(periodEvents)
+	r.Summary.DecisionCounts = counts
+
+	if len(periodEvents) > 0 {
+		r.Controls["AIUC-1.1"] = ComplianceControl{
+			Name:     "Tool Call Authorization",
+			Status:   ControlStatusPass,
+			Evidence: []string{fmt.Sprintf("Found %d audited tool-call events in reporting period.", len(periodEvents))},
+		}
+	} else {
+		r.Controls["AIUC-1.1"] = ComplianceControl{
+			Name:   "Tool Call Authorization",
+			Status: ControlStatusWarn,
+			Evidence: []string{
+				"Audit log files exist, but no events were recorded in the reporting period.",
+			},
+		}
+	}
+
+	if counts.Ask > 0 {
+		r.Controls["AIUC-1.3"] = ComplianceControl{
+			Name:     "Human-in-the-Loop",
+			Status:   ControlStatusPass,
+			Evidence: []string{fmt.Sprintf("Found %d ask decisions in reporting period.", counts.Ask)},
+		}
+	} else {
+		r.Controls["AIUC-1.3"] = ComplianceControl{
+			Name:     "Human-in-the-Loop",
+			Status:   ControlStatusWarn,
+			Evidence: []string{"No ask decisions found in reporting period."},
+		}
+	}
+}
+
+func (r *AIUC1Report) applyPolicyControlResult(policyPath string) {
+	resolved, err := expandHomePath(policyPath)
+	if err != nil {
+		resolved = policyPath
+	}
+	trimmed := strings.TrimSpace(resolved)
+	if trimmed == "" {
+		r.Controls["AIUC-1.4"] = ComplianceControl{
+			Name:     "Data Exfiltration Prevention",
+			Status:   ControlStatusWarn,
+			Evidence: []string{"No policy file path provided; cannot verify sensitive deny rules."},
+		}
+		return
+	}
+
+	data, err := os.ReadFile(trimmed)
+	if err != nil {
+		r.Controls["AIUC-1.4"] = ComplianceControl{
+			Name:     "Data Exfiltration Prevention",
+			Status:   ControlStatusWarn,
+			Evidence: []string{fmt.Sprintf("Could not read policy file %q: %v", trimmed, err)},
+		}
+		return
+	}
+
+	covered, found, missing := evaluateSensitiveDenyCoverage(string(data))
+	if covered {
+		r.Controls["AIUC-1.4"] = ComplianceControl{
+			Name:     "Data Exfiltration Prevention",
+			Status:   ControlStatusPass,
+			Evidence: []string{fmt.Sprintf("Sensitive deny coverage found for: %s", strings.Join(found, ", "))},
+		}
+		return
+	}
+
+	evidence := []string{"No deny coverage found for all required sensitive targets."}
+	if len(found) > 0 {
+		evidence = append(evidence, fmt.Sprintf("Found: %s", strings.Join(found, ", ")))
+	}
+	if len(missing) > 0 {
+		evidence = append(evidence, fmt.Sprintf("Missing: %s", strings.Join(missing, ", ")))
+	}
+	r.Controls["AIUC-1.4"] = ComplianceControl{
+		Name:     "Data Exfiltration Prevention",
+		Status:   ControlStatusWarn,
+		Evidence: evidence,
+	}
+}
+
+func deriveComplianceStatus(controls map[string]ComplianceControl) ComplianceStatus {
+	hasWarn := false
+	for _, c := range controls {
+		switch c.Status {
+		case ControlStatusFail:
+			return ComplianceStatusNonCompliant
+		case ControlStatusWarn:
+			hasWarn = true
+		}
+	}
+	if hasWarn {
+		return ComplianceStatusPartial
+	}
+	return ComplianceStatusCompliant
+}
+
+func filterEventsByPeriod(events []audit.Event, since, until time.Time) []audit.Event {
+	filtered := make([]audit.Event, 0, len(events))
+	for _, evt := range events {
+		ts := evt.Timestamp.UTC()
+		if (ts.Equal(since) || ts.After(since)) && (ts.Equal(until) || ts.Before(until)) {
+			filtered = append(filtered, evt)
+		}
+	}
+	return filtered
+}
+
+func computeDecisionCounts(events []audit.Event) DecisionCounts {
+	counts := DecisionCounts{Total: len(events)}
+	for _, evt := range events {
+		switch strings.ToLower(strings.TrimSpace(evt.Decision.Action)) {
+		case "allow":
+			counts.Allow++
+		case "deny":
+			counts.Deny++
+		case "log", "watch":
+			counts.Log++
+		case "ask":
+			counts.Ask++
+		default:
+			counts.Other++
+		}
+	}
+	return counts
+}
+
+func readAndVerifyAuditChain(files []string) ([]audit.Event, map[string]string, error) {
+	allEvents := make([]audit.Event, 0)
+	hashesByID := map[string]string{}
+	prevHash := ""
+	eventCount := 0
+
+	for _, file := range files {
+		events, _, err := audit.ReadEventsFromOffset(file, 0)
+		if err != nil {
+			return nil, nil, fmt.Errorf("read events from %s: %w", filepath.Base(file), err)
+		}
+		for _, event := range events {
+			eventCount++
+			if eventCount == 1 && event.PrevHash != "" {
+				return nil, nil, fmt.Errorf("first event %s in %s has non-empty prev_hash", event.ID, filepath.Base(file))
+			}
+			if eventCount > 1 && event.PrevHash != prevHash {
+				return nil, nil, fmt.Errorf("event %s in %s has prev_hash mismatch", event.ID, filepath.Base(file))
+			}
+			ok, err := event.VerifyHash()
+			if err != nil {
+				return nil, nil, fmt.Errorf("verify hash for event %s in %s: %w", event.ID, filepath.Base(file), err)
+			}
+			if !ok {
+				return nil, nil, fmt.Errorf("event %s in %s failed hash verification", event.ID, filepath.Base(file))
+			}
+
+			prevHash = event.Hash
+			hashesByID[event.ID] = event.Hash
+			allEvents = append(allEvents, event)
+		}
+	}
+
+	return allEvents, hashesByID, nil
+}
+
+func verifyAnchorsInDir(auditDir string, hashesByID map[string]string) error {
+	anchors, err := listAnchorFiles(auditDir)
+	if err != nil {
+		return err
+	}
+	for _, anchorFile := range anchors {
+		data, err := os.ReadFile(anchorFile)
+		if err != nil {
+			return fmt.Errorf("read anchor file %s: %w", filepath.Base(anchorFile), err)
+		}
+
+		var anchor audit.ChainAnchor
+		if err := json.Unmarshal(data, &anchor); err != nil {
+			return fmt.Errorf("parse anchor file %s: %w", filepath.Base(anchorFile), err)
+		}
+		if strings.TrimSpace(anchor.EventID) == "" {
+			continue
+		}
+		hash, ok := hashesByID[anchor.EventID]
+		if !ok {
+			return fmt.Errorf("anchor event %s not found in chain", anchor.EventID)
+		}
+		if hash != anchor.Hash {
+			return fmt.Errorf("anchor hash mismatch at event %s", anchor.EventID)
+		}
+	}
+	return nil
+}
+
+func listAnchorFiles(auditDir string) ([]string, error) {
+	entries, err := os.ReadDir(auditDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read audit dir for anchors: %w", err)
+	}
+
+	files := make([]string, 0)
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if name == "audit-anchor.json" || strings.HasSuffix(name, ".anchor.json") {
+			files = append(files, filepath.Join(auditDir, name))
+		}
+	}
+	sort.Strings(files)
+	return files, nil
+}
+
+func listAuditJSONLFiles(auditDir string) ([]string, error) {
+	entries, err := os.ReadDir(auditDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	files := make([]string, 0)
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".jsonl") {
+			continue
+		}
+		files = append(files, filepath.Join(auditDir, entry.Name()))
+	}
+	sort.Strings(files)
+	return files, nil
+}
+
+func evaluateSensitiveDenyCoverage(policyText string) (bool, []string, []string) {
+	categories := []struct {
+		label    string
+		keywords []string
+	}{
+		{label: "/etc/shadow", keywords: []string{"/etc/shadow", "etc/shadow"}},
+		{label: "~/.ssh", keywords: []string{"~/.ssh", ".ssh/", ".ssh\\"}},
+		{label: ".env", keywords: []string{".env"}},
+		{label: "credentials", keywords: []string{"credentials"}},
+	}
+
+	lines := strings.Split(strings.ToLower(policyText), "\n")
+	denyLines := make([]int, 0)
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if strings.Contains(trimmed, "action:") && strings.Contains(trimmed, "deny") {
+			denyLines = append(denyLines, i)
+		}
+	}
+	if len(denyLines) == 0 {
+		missing := make([]string, 0, len(categories))
+		for _, cat := range categories {
+			missing = append(missing, cat.label)
+		}
+		return false, nil, missing
+	}
+
+	found := make([]string, 0)
+	missing := make([]string, 0)
+	for _, cat := range categories {
+		if hasDenyCoverageForCategory(lines, denyLines, cat.keywords) {
+			found = append(found, cat.label)
+		} else {
+			missing = append(missing, cat.label)
+		}
+	}
+
+	return len(missing) == 0, found, missing
+}
+
+func hasDenyCoverageForCategory(lines []string, denyLines []int, keywords []string) bool {
+	const window = 20
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		matchedKeyword := false
+		for _, kw := range keywords {
+			if strings.Contains(line, kw) {
+				matchedKeyword = true
+				break
+			}
+		}
+		if !matchedKeyword {
+			continue
+		}
+
+		for _, denyIdx := range denyLines {
+			if absInt(i-denyIdx) <= window {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func absInt(v int) int {
+	if v < 0 {
+		return -v
+	}
+	return v
+}
+
+func expandHomePath(path string) (string, error) {
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" {
+		return "", nil
+	}
+	if trimmed == "~" || strings.HasPrefix(trimmed, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		if trimmed == "~" {
+			return home, nil
+		}
+		return filepath.Join(home, strings.TrimPrefix(trimmed, "~/")), nil
+	}
+	return trimmed, nil
+}
+
+func generateUUID4() string {
+	buf := make([]byte, 16)
+	if _, err := rand.Read(buf); err != nil {
+		fallback := make([]byte, 16)
+		for i := range fallback {
+			fallback[i] = byte(i * 17)
+		}
+		buf = fallback
+	}
+
+	buf[6] = (buf[6] & 0x0f) | 0x40
+	buf[8] = (buf[8] & 0x3f) | 0x80
+
+	hexStr := hex.EncodeToString(buf)
+	return fmt.Sprintf("%s-%s-%s-%s-%s", hexStr[0:8], hexStr[8:12], hexStr[12:16], hexStr[16:20], hexStr[20:32])
+}
+
+func FormatAIUC1TextReport(report *AIUC1Report) string {
+	var b strings.Builder
+
+	_, _ = fmt.Fprintf(&b, "AIUC-1 Compliance Report\n")
+	_, _ = fmt.Fprintf(&b, "========================\n")
+	_, _ = fmt.Fprintf(&b, "Report ID: %s\n", report.ReportID)
+	_, _ = fmt.Fprintf(&b, "Generated: %s\n", report.GeneratedAt.Format(time.RFC3339))
+	_, _ = fmt.Fprintf(&b, "Period: %s to %s\n", report.Period.Since.Format(time.RFC3339), report.Period.Until.Format(time.RFC3339))
+	_, _ = fmt.Fprintf(&b, "Rampart Version: %s\n", report.RampartVersion)
+	_, _ = fmt.Fprintf(&b, "Standard: %s\n", report.Standard)
+	_, _ = fmt.Fprintf(&b, "Overall Status: %s\n\n", report.Summary.ComplianceStatus)
+
+	counts := report.Summary.DecisionCounts
+	_, _ = fmt.Fprintf(&b, "Decision Counts\n")
+	_, _ = fmt.Fprintf(&b, "---------------\n")
+	_, _ = fmt.Fprintf(&b, "Total: %d\n", counts.Total)
+	_, _ = fmt.Fprintf(&b, "Allow: %d\n", counts.Allow)
+	_, _ = fmt.Fprintf(&b, "Deny: %d\n", counts.Deny)
+	_, _ = fmt.Fprintf(&b, "Log: %d\n", counts.Log)
+	_, _ = fmt.Fprintf(&b, "Ask: %d\n", counts.Ask)
+	_, _ = fmt.Fprintf(&b, "Other: %d\n\n", counts.Other)
+
+	keys := []string{"AIUC-1.1", "AIUC-1.2", "AIUC-1.3", "AIUC-1.4"}
+	_, _ = fmt.Fprintf(&b, "Controls\n")
+	_, _ = fmt.Fprintf(&b, "--------\n")
+	for _, key := range keys {
+		control := report.Controls[key]
+		_, _ = fmt.Fprintf(&b, "%s %-4s %s\n", key, string(control.Status), control.Name)
+		for _, evidence := range control.Evidence {
+			_, _ = fmt.Fprintf(&b, "  - %s\n", evidence)
+		}
+	}
+
+	return b.String()
+}

--- a/internal/report/compliance_test.go
+++ b/internal/report/compliance_test.go
@@ -1,0 +1,296 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package report
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/peg/rampart/internal/audit"
+)
+
+func TestGenerateAIUC1Report_Compliant(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Date(2026, 2, 28, 12, 0, 0, 0, time.UTC)
+
+	events := makeEvents(t, now,
+		"allow",
+		"ask",
+		"deny",
+	)
+	writeAuditFile(t, dir, "audit-20260228.jsonl", events)
+
+	policyPath := filepath.Join(dir, "policy.yaml")
+	policy := `version: "1"
+policies:
+  - name: sensitive-deny
+    rules:
+      - action: deny
+        when:
+          path_matches: ["**/etc/shadow", "**/.ssh/**", "**/.env", "**/credentials/**"]
+`
+	if err := os.WriteFile(policyPath, []byte(policy), 0o644); err != nil {
+		t.Fatalf("write policy: %v", err)
+	}
+
+	rep, err := GenerateAIUC1Report(ComplianceOptions{
+		AuditDir:       dir,
+		PolicyPath:     policyPath,
+		Since:          now.Add(-24 * time.Hour),
+		Until:          now,
+		GeneratedAt:    now,
+		RampartVersion: "v1.2.3",
+	})
+	if err != nil {
+		t.Fatalf("GenerateAIUC1Report returned error: %v", err)
+	}
+
+	if rep.Standard != "AIUC-1" {
+		t.Fatalf("standard = %q, want AIUC-1", rep.Standard)
+	}
+	if rep.Summary.ComplianceStatus != ComplianceStatusCompliant {
+		t.Fatalf("status = %s, want %s", rep.Summary.ComplianceStatus, ComplianceStatusCompliant)
+	}
+	if rep.Summary.DecisionCounts.Total != 3 || rep.Summary.DecisionCounts.Ask != 1 {
+		t.Fatalf("unexpected decision counts: %+v", rep.Summary.DecisionCounts)
+	}
+	if rep.Controls["AIUC-1.1"].Status != ControlStatusPass {
+		t.Fatalf("AIUC-1.1 status = %s, want PASS", rep.Controls["AIUC-1.1"].Status)
+	}
+	if rep.Controls["AIUC-1.2"].Status != ControlStatusPass {
+		t.Fatalf("AIUC-1.2 status = %s, want PASS", rep.Controls["AIUC-1.2"].Status)
+	}
+	if rep.Controls["AIUC-1.3"].Status != ControlStatusPass {
+		t.Fatalf("AIUC-1.3 status = %s, want PASS", rep.Controls["AIUC-1.3"].Status)
+	}
+	if rep.Controls["AIUC-1.4"].Status != ControlStatusPass {
+		t.Fatalf("AIUC-1.4 status = %s, want PASS", rep.Controls["AIUC-1.4"].Status)
+	}
+}
+
+func TestGenerateAIUC1Report_NoAuditLogsNonCompliant(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Date(2026, 2, 28, 12, 0, 0, 0, time.UTC)
+
+	policyPath := filepath.Join(dir, "policy.yaml")
+	if err := os.WriteFile(policyPath, []byte("version: \"1\"\n"), 0o644); err != nil {
+		t.Fatalf("write policy: %v", err)
+	}
+
+	rep, err := GenerateAIUC1Report(ComplianceOptions{
+		AuditDir:    filepath.Join(dir, "missing"),
+		PolicyPath:  policyPath,
+		Since:       now.Add(-24 * time.Hour),
+		Until:       now,
+		GeneratedAt: now,
+	})
+	if err != nil {
+		t.Fatalf("GenerateAIUC1Report returned error: %v", err)
+	}
+
+	if rep.Controls["AIUC-1.1"].Status != ControlStatusFail {
+		t.Fatalf("AIUC-1.1 status = %s, want FAIL", rep.Controls["AIUC-1.1"].Status)
+	}
+	if rep.Controls["AIUC-1.2"].Status != ControlStatusFail {
+		t.Fatalf("AIUC-1.2 status = %s, want FAIL", rep.Controls["AIUC-1.2"].Status)
+	}
+	if rep.Summary.ComplianceStatus != ComplianceStatusNonCompliant {
+		t.Fatalf("status = %s, want %s", rep.Summary.ComplianceStatus, ComplianceStatusNonCompliant)
+	}
+}
+
+func TestGenerateAIUC1Report_ZeroEventsWarnsClearly(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Date(2026, 2, 28, 12, 0, 0, 0, time.UTC)
+
+	emptyLog := filepath.Join(dir, "audit-20260228.jsonl")
+	if err := os.WriteFile(emptyLog, nil, 0o644); err != nil {
+		t.Fatalf("write empty log: %v", err)
+	}
+
+	policyPath := filepath.Join(dir, "policy.yaml")
+	policy := `version: "1"
+policies:
+  - name: sensitive-deny
+    rules:
+      - action: deny
+        when:
+          path_matches: ["**/etc/shadow", "**/.ssh/**", "**/.env", "**/credentials/**"]
+`
+	if err := os.WriteFile(policyPath, []byte(policy), 0o644); err != nil {
+		t.Fatalf("write policy: %v", err)
+	}
+
+	rep, err := GenerateAIUC1Report(ComplianceOptions{
+		AuditDir:    dir,
+		PolicyPath:  policyPath,
+		Since:       now.Add(-24 * time.Hour),
+		Until:       now,
+		GeneratedAt: now,
+	})
+	if err != nil {
+		t.Fatalf("GenerateAIUC1Report returned error: %v", err)
+	}
+
+	if rep.Summary.DecisionCounts.Total != 0 {
+		t.Fatalf("total decisions = %d, want 0", rep.Summary.DecisionCounts.Total)
+	}
+	if rep.Controls["AIUC-1.1"].Status != ControlStatusWarn {
+		t.Fatalf("AIUC-1.1 status = %s, want WARN", rep.Controls["AIUC-1.1"].Status)
+	}
+	if rep.Controls["AIUC-1.2"].Status != ControlStatusPass {
+		t.Fatalf("AIUC-1.2 status = %s, want PASS", rep.Controls["AIUC-1.2"].Status)
+	}
+	if rep.Controls["AIUC-1.3"].Status != ControlStatusWarn {
+		t.Fatalf("AIUC-1.3 status = %s, want WARN", rep.Controls["AIUC-1.3"].Status)
+	}
+	if rep.Summary.ComplianceStatus != ComplianceStatusPartial {
+		t.Fatalf("status = %s, want %s", rep.Summary.ComplianceStatus, ComplianceStatusPartial)
+	}
+	if !strings.Contains(strings.Join(rep.Controls["AIUC-1.1"].Evidence, " | "), "no events") {
+		t.Fatalf("expected AIUC-1.1 evidence to explain no events: %v", rep.Controls["AIUC-1.1"].Evidence)
+	}
+}
+
+func TestGenerateAIUC1Report_PartialForMissingAskAndPolicyCoverage(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Date(2026, 2, 28, 12, 0, 0, 0, time.UTC)
+
+	events := makeEvents(t, now, "allow", "deny")
+	writeAuditFile(t, dir, "audit-20260228.jsonl", events)
+
+	policyPath := filepath.Join(dir, "policy.yaml")
+	policy := `version: "1"
+policies:
+  - name: not-sensitive
+    rules:
+      - action: deny
+        when:
+          cmd_matches: ["rm -rf /"]
+`
+	if err := os.WriteFile(policyPath, []byte(policy), 0o644); err != nil {
+		t.Fatalf("write policy: %v", err)
+	}
+
+	rep, err := GenerateAIUC1Report(ComplianceOptions{
+		AuditDir:    dir,
+		PolicyPath:  policyPath,
+		Since:       now.Add(-24 * time.Hour),
+		Until:       now,
+		GeneratedAt: now,
+	})
+	if err != nil {
+		t.Fatalf("GenerateAIUC1Report returned error: %v", err)
+	}
+
+	if rep.Summary.ComplianceStatus != ComplianceStatusPartial {
+		t.Fatalf("status = %s, want %s", rep.Summary.ComplianceStatus, ComplianceStatusPartial)
+	}
+	if rep.Controls["AIUC-1.3"].Status != ControlStatusWarn {
+		t.Fatalf("AIUC-1.3 status = %s, want WARN", rep.Controls["AIUC-1.3"].Status)
+	}
+	if rep.Controls["AIUC-1.4"].Status != ControlStatusWarn {
+		t.Fatalf("AIUC-1.4 status = %s, want WARN", rep.Controls["AIUC-1.4"].Status)
+	}
+}
+
+func TestGenerateAIUC1Report_FailsOnTamperedChain(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Date(2026, 2, 28, 12, 0, 0, 0, time.UTC)
+
+	events := makeEvents(t, now, "allow", "deny")
+	events[1].PrevHash = "sha256:tampered"
+	writeAuditFile(t, dir, "audit-20260228.jsonl", events)
+
+	policyPath := filepath.Join(dir, "policy.yaml")
+	policy := `version: "1"
+policies:
+  - name: sensitive-deny
+    rules:
+      - action: deny
+        when:
+          path_matches: ["**/etc/shadow", "**/.ssh/**", "**/.env", "**/credentials/**"]
+`
+	if err := os.WriteFile(policyPath, []byte(policy), 0o644); err != nil {
+		t.Fatalf("write policy: %v", err)
+	}
+
+	rep, err := GenerateAIUC1Report(ComplianceOptions{
+		AuditDir:    dir,
+		PolicyPath:  policyPath,
+		Since:       now.Add(-24 * time.Hour),
+		Until:       now,
+		GeneratedAt: now,
+	})
+	if err != nil {
+		t.Fatalf("GenerateAIUC1Report returned error: %v", err)
+	}
+
+	if rep.Controls["AIUC-1.2"].Status != ControlStatusFail {
+		t.Fatalf("AIUC-1.2 status = %s, want FAIL", rep.Controls["AIUC-1.2"].Status)
+	}
+	if rep.Summary.ComplianceStatus != ComplianceStatusNonCompliant {
+		t.Fatalf("status = %s, want %s", rep.Summary.ComplianceStatus, ComplianceStatusNonCompliant)
+	}
+}
+
+func makeEvents(t *testing.T, now time.Time, actions ...string) []audit.Event {
+	t.Helper()
+	events := make([]audit.Event, 0, len(actions))
+	prevHash := ""
+
+	for i, action := range actions {
+		e := audit.Event{
+			ID:        fmt.Sprintf("evt-%04d", i+1),
+			Timestamp: now.Add(time.Duration(-len(actions)+i) * time.Minute),
+			Agent:     "codex",
+			Session:   "session-1",
+			Tool:      "exec",
+			Request:   map[string]any{"command": "echo test"},
+			Decision: audit.EventDecision{
+				Action: action,
+			},
+			PrevHash: prevHash,
+		}
+		if err := e.ComputeHash(); err != nil {
+			t.Fatalf("compute hash: %v", err)
+		}
+		prevHash = e.Hash
+		events = append(events, e)
+	}
+
+	return events
+}
+
+func writeAuditFile(t *testing.T, dir, name string, events []audit.Event) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create audit file: %v", err)
+	}
+	defer f.Close()
+
+	enc := json.NewEncoder(f)
+	for _, event := range events {
+		if err := enc.Encode(event); err != nil {
+			t.Fatalf("encode event: %v", err)
+		}
+	}
+}

--- a/internal/report/compliance_test.go
+++ b/internal/report/compliance_test.go
@@ -278,6 +278,83 @@ func makeEvents(t *testing.T, now time.Time, actions ...string) []audit.Event {
 	return events
 }
 
+// makeEventsFrom continues a hash chain from a given starting prevHash.
+func makeEventsFrom(t *testing.T, now time.Time, startPrevHash string, startIdx int, actions ...string) []audit.Event {
+	t.Helper()
+	events := make([]audit.Event, 0, len(actions))
+	prevHash := startPrevHash
+
+	for i, action := range actions {
+		e := audit.Event{
+			ID:        fmt.Sprintf("evt-%04d", startIdx+i+1),
+			Timestamp: now.Add(time.Duration(i) * time.Minute),
+			Agent:     "codex",
+			Session:   "session-1",
+			Tool:      "exec",
+			Request:   map[string]any{"command": "echo test"},
+			Decision:  audit.EventDecision{Action: action},
+			PrevHash:  prevHash,
+		}
+		if err := e.ComputeHash(); err != nil {
+			t.Fatalf("compute hash: %v", err)
+		}
+		prevHash = e.Hash
+		events = append(events, e)
+	}
+	return events
+}
+
+func TestGenerateAIUC1Report_MultiFileChainVerification(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Date(2026, 2, 28, 10, 0, 0, 0, time.UTC)
+
+	// Write two separate audit files that form one continuous chain.
+	file1Events := makeEvents(t, now, "allow", "deny")
+	lastHash := file1Events[len(file1Events)-1].Hash
+	file2Events := makeEventsFrom(t, now.Add(10*time.Minute), lastHash, len(file1Events), "ask", "allow")
+
+	// Use names that sort correctly alphabetically so chain is processed in order.
+	writeAuditFile(t, dir, "audit-20260228-part1.jsonl", file1Events)
+	writeAuditFile(t, dir, "audit-20260228-part2.jsonl", file2Events)
+
+	policyPath := filepath.Join(dir, "policy.yaml")
+	policy := `version: "1"
+policies:
+  - name: sensitive-deny
+    rules:
+      - action: deny
+        when:
+          path_matches: ["**/etc/shadow", "**/.ssh/**", "**/.env", "**/credentials/**"]
+`
+	if err := os.WriteFile(policyPath, []byte(policy), 0o644); err != nil {
+		t.Fatalf("write policy: %v", err)
+	}
+
+	rep, err := GenerateAIUC1Report(ComplianceOptions{
+		AuditDir:    dir,
+		PolicyPath:  policyPath,
+		Since:       now.Add(-time.Hour),
+		Until:       now.Add(time.Hour),
+		GeneratedAt: now,
+	})
+	if err != nil {
+		t.Fatalf("GenerateAIUC1Report returned error: %v", err)
+	}
+
+	// Chain across two files should verify cleanly.
+	if rep.Controls["AIUC-1.2"].Status != ControlStatusPass {
+		t.Fatalf("AIUC-1.2 status = %s, want PASS — multi-file chain failed: %v",
+			rep.Controls["AIUC-1.2"].Status, rep.Controls["AIUC-1.2"].Evidence)
+	}
+	// ask event from file 2 should be counted.
+	if rep.Summary.DecisionCounts.Ask != 1 {
+		t.Fatalf("ask count = %d, want 1", rep.Summary.DecisionCounts.Ask)
+	}
+	if rep.Summary.DecisionCounts.Total != 4 {
+		t.Fatalf("total count = %d, want 4", rep.Summary.DecisionCounts.Total)
+	}
+}
+
 func writeAuditFile(t *testing.T, dir, name string, events []audit.Event) {
 	t.Helper()
 	path := filepath.Join(dir, name)


### PR DESCRIPTION
## Summary
Adds `rampart report compliance` — generates AIUC-1 compliance evidence reports from local audit logs. Makes Rampart the first OSS tool with AIUC-1 compliance reporting.

## Changes
- `rampart report compliance` — text or JSON report (`--format`, `--since`, `--until`, `--output`)
- Maps audit data to 4 AIUC-1 controls: Tool Call Authorization, Audit Logging, Human-in-the-Loop, Data Exfiltration Prevention
- Overall status: COMPLIANT / PARTIAL / NON-COMPLIANT
- Reuses existing audit chain verification for AIUC-1.2 evidence
- `internal/report/compliance.go` (598 lines) — pure library, no CLI deps
- Extends existing `rampart report` command (HTML report untouched)

## Tests
5 new tests covering: fully compliant, no audit logs (non-compliant), zero events (partial+warns), missing ask+policy coverage (partial), tampered chain (non-compliant).

Part of leaner v0.7.0 scope.