### PR TITLE
docs: add SECURITY.md vulnerability disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,47 +1,61 @@
 # Security Policy
 
+## Supported Versions
+
+| Version | Supported          |
+|---------|--------------------|
+| 0.7.x   | ✅ Current release |
+| 0.6.x   | ⚠️ Critical fixes only |
+| < 0.6   | ❌ No longer supported |
+
 ## Reporting a Vulnerability
 
 If you discover a security vulnerability in Rampart, please report it responsibly.
 
-**Email:** rampartsec@pm.me (or open a [private security advisory](https://github.com/peg/rampart/security/advisories/new) on GitHub)
+**Email:** [rampartsec@pm.me](mailto:rampartsec@pm.me)
 
-**Please include:**
+**What to include:**
 - Description of the vulnerability
 - Steps to reproduce
-- Impact assessment
-- Suggested fix (if any)
+- Affected version(s)
+- Impact assessment (what can an attacker do?)
+- Suggested fix (if you have one)
 
-**Response timeline:**
-- Acknowledgment within 48 hours
-- Initial assessment within 7 days
-- Fix or mitigation within 30 days for critical issues
+**What to expect:**
+- **Acknowledgment** within 48 hours
+- **Initial assessment** within 1 week
+- **Fix timeline** communicated within 2 weeks
+- **Coordinated disclosure** — we'll work with you on timing
+
+**Please do NOT:**
+- Open public GitHub issues for security vulnerabilities
+- Disclose publicly before we've had time to respond
+- Test against production systems you don't own
+
+## Security Design
+
+Rampart's threat model is documented in [`docs/THREAT-MODEL.md`](docs/THREAT-MODEL.md). Key design principles:
+
+- **Fail-open by default** — if Rampart crashes, commands execute normally (deliberate: fail-closed locks users out)
+- **Deny-wins evaluation** — any deny from any policy overrides all allows
+- **Local-first** — no data leaves the machine, no cloud dependency, no telemetry
+- **Hash-chained audit** — tamper-evident append-only trail with SIEM export
 
 ## Scope
 
-The following are in scope:
-- Policy engine bypass (tool call allowed when policy should deny)
-- Audit trail tampering that evades `rampart audit verify`
-- Authentication bypass on the proxy or daemon API
-- Remote code execution
-- Denial of service against the proxy/daemon
+The following are **in scope** for security reports:
+- Policy engine bypasses (commands that should be denied but aren't)
+- Audit trail integrity issues (undetected tampering)
+- Authentication bypass on the HTTP API
+- Privilege escalation through Rampart
+- Information disclosure through error messages or logs
 
-The following are **known limitations**, not vulnerabilities:
-- **Pattern evasion via obfuscation** (e.g., variable expansion `$CMD`, base64 encoding). Rampart matches against the literal command string. For common shell wrappers (`bash -c`, `sh -c`), the standard policy includes explicit patterns. For obfuscation, combine with [semantic verification](https://github.com/peg/rampart-verify).
-- **Proxy bypass** when the agent has direct shell access and isn't using daemon mode. The proxy is voluntary; use daemon mode with OpenClaw for enforced evaluation.
-- **Agent modifying policy files** when it has write access to the filesystem. Restrict file permissions or use daemon mode.
-- **Shim token extraction** when using `rampart wrap`. The proxy auth token is embedded in the shim script and readable by the wrapped agent. Use `rampart hook` (Claude Code native integration) for stronger isolation — no token is exposed.
-- **Fail-open on proxy unavailability** when using `rampart wrap`. If the proxy process dies, the shim allows commands through rather than blocking the agent entirely. This is a deliberate design tradeoff — fail-closed would brick the agent.
-- **Interpreter-based execution** (e.g., `python3 -c "os.system('rm -rf /')"`) bypasses shell-level interception. The hook integration catches this for agents that route all tool calls through the hook system.
-- **Audit trail rewrite** by anyone with filesystem write access. The hash chain detects partial tampering but not a complete rewrite. No external trust anchor is used.
+The following are **out of scope:**
+- Denial of service against `rampart serve` (rate limiting is a known gap)
+- Attacks requiring pre-existing root/admin access
+- Social engineering
+- Issues in dependencies (report upstream, but let us know)
 
-## Supported Versions
+## Bug Bounty
 
-| Version | Supported |
-|---------|-----------|
-| latest main | ✅ |
-| < v1.0.0 | Pre-release, best-effort |
-
-## Threat Model
-
-See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full threat model, including honest discussion of what Rampart does and doesn't protect against.
+We don't currently have a formal bug bounty program. Significant findings will be credited in the changelog and release notes (with your permission).


### PR DESCRIPTION
Adds a SECURITY.md file per GitHub's security policy standard.

- Supported versions table
- Reporting process: rampartsec@pm.me
- Response timeline: 48h ack → 1w assessment → 2w fix
- In/out scope definition
- Security design principles summary