### PR TITLE
fix: deduplicate policy test subcommand in help output

### DIFF
--- a/cmd/rampart/cli/policy.go
+++ b/cmd/rampart/cli/policy.go
@@ -49,7 +49,6 @@ func newPolicyCmd(opts *rootOptions) *cobra.Command {
 	}
 
 	cmd.AddCommand(newPolicyCheckCmd(opts))
-	cmd.AddCommand(newPolicyTestCmd(opts))
 	cmd.AddCommand(newPolicyExplainCmd(opts))
 	cmd.AddCommand(newPolicyLintCmd())
 	cmd.AddCommand(newPolicyGenerateCmd(opts))

--- a/cmd/rampart/cli/policy_test.go
+++ b/cmd/rampart/cli/policy_test.go
@@ -139,6 +139,19 @@ policies: []
 	}
 }
 
+func TestPolicyCmd_HasSingleTestSubcommand(t *testing.T) {
+	cmd := newPolicyCmd(&rootOptions{})
+	count := 0
+	for _, sub := range cmd.Commands() {
+		if sub.Name() == "test" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly 1 test subcommand, got %d", count)
+	}
+}
+
 func TestResolveExplainPolicyPath_ExplicitConfig(t *testing.T) {
 	dir := t.TempDir()
 	p := filepath.Join(dir, "custom.yaml")


### PR DESCRIPTION
The 'test' subcommand appeared twice in `rampart policy --help` output.

- Removed duplicate registration in policy.go
- Added regression test
- Verified: `rampart policy --help | grep test` now returns exactly 1 match