### PR TITLE
fix: restore CLI unit tests with proper naming

### DIFF
--- a/cmd/rampart/cli/cli_unit2_test.go
+++ b/cmd/rampart/cli/cli_unit2_test.go
@@ -1,0 +1,300 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/peg/rampart/internal/audit"
+	"github.com/spf13/cobra"
+)
+
+// --- parseSinceDuration (audit_helpers.go) ---
+
+func TestParseSinceDuration(t *testing.T) {
+	tests := []struct {
+		input   string
+		wantErr bool
+		desc    string
+	}{
+		{"", false, "empty"},
+		{"1h", false, "1h"},
+		{"2d", false, "2 days"},
+		{"1d12h", false, "1 day 12 hours"},
+		{"3d", false, "3 days"},
+		{"d", true, "bare d"},
+		{"xd", true, "invalid day value"},
+		{"notaduration", true, "invalid"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			_, err := parseSinceDuration(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseSinceDuration(%q) err=%v, wantErr=%v", tt.input, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// --- matchesAuditFilters (audit_helpers.go) ---
+
+func TestMatchesAuditFilters(t *testing.T) {
+	evt := audit.Event{Tool: "exec", Agent: "claude", Decision: audit.EventDecision{Action: "allow"}}
+	tests := []struct {
+		tool, agent, decision string
+		want                  bool
+	}{
+		{"", "", "", true},
+		{"exec", "", "", true},
+		{"read", "", "", false},
+		{"", "claude", "", true},
+		{"", "other", "", false},
+		{"", "", "allow", true},
+		{"", "", "deny", false},
+		{"exec", "claude", "allow", true},
+	}
+	for _, tt := range tests {
+		if got := matchesAuditFilters(evt, tt.tool, tt.agent, tt.decision); got != tt.want {
+			t.Errorf("matchesAuditFilters(tool=%q,agent=%q,dec=%q) = %v, want %v", tt.tool, tt.agent, tt.decision, got, tt.want)
+		}
+	}
+}
+
+// --- eventMatchesQuery (audit_helpers.go) ---
+
+func TestEventMatchesQuery(t *testing.T) {
+	evt := audit.Event{
+		Tool:     "exec",
+		Agent:    "claude",
+		Decision: audit.EventDecision{Action: "allow", Message: "policy matched"},
+		Request:  map[string]any{"command": "ls -la"},
+	}
+	tests := []struct {
+		query string
+		want  bool
+	}{
+		{"", true},
+		{"exec", true},
+		{"claude", true},
+		{"policy", true},
+		{"ls", true},
+		{"nonexistent", false},
+	}
+	for _, tt := range tests {
+		if got := eventMatchesQuery(evt, tt.query); got != tt.want {
+			t.Errorf("eventMatchesQuery(query=%q) = %v, want %v", tt.query, got, tt.want)
+		}
+	}
+}
+
+// --- extractPrimaryRequestValue (audit_helpers.go) ---
+
+func TestExtractPrimaryRequestValue(t *testing.T) {
+	tests := []struct {
+		name string
+		req  map[string]any
+		want string
+	}{
+		{"command", map[string]any{"command": "ls"}, "ls"},
+		{"path", map[string]any{"path": "/etc/passwd"}, "/etc/passwd"},
+		{"file_path", map[string]any{"file_path": "/tmp/x"}, "/tmp/x"},
+		{"empty", map[string]any{}, ""},
+		{"nil", nil, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractPrimaryRequestValue(tt.req)
+			if got != tt.want {
+				t.Errorf("extractPrimaryRequestValue() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// --- resolveTestPolicyPath (test_cmd.go) ---
+
+func TestResolveTestPolicyPath(t *testing.T) {
+	t.Run("existing file", func(t *testing.T) {
+		dir := t.TempDir()
+		p := filepath.Join(dir, "rampart.yaml")
+		os.WriteFile(p, []byte("version: 1"), 0o644)
+
+		got, cleanup, err := resolveTestPolicyPath(p)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer cleanup()
+		if got != p {
+			t.Errorf("expected %s, got %s", p, got)
+		}
+	})
+
+	t.Run("fallback to embedded", func(t *testing.T) {
+		// Use a non-existent path so it falls through
+		got, cleanup, err := resolveTestPolicyPath("/nonexistent/rampart.yaml")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer cleanup()
+		if got == "" {
+			t.Error("expected non-empty path")
+		}
+	})
+}
+
+// --- createShellShim (wrap.go) ---
+
+func TestCreateShellShim_Coverage(t *testing.T) {
+	path, err := createShellShim("http://localhost:8080", "tok123", "enforce", "/bin/bash")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer os.Remove(path)
+	defer os.Remove(path + ".tok")
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat shim: %v", err)
+	}
+	if info.Size() == 0 {
+		t.Error("shim file is empty")
+	}
+
+	// Verify token file permissions (Unix only — Windows doesn't have Unix-style perms)
+	if runtime.GOOS != "windows" {
+		tokInfo, err := os.Stat(path + ".tok")
+		if err != nil {
+			t.Fatalf("stat token file: %v", err)
+		}
+		if tokInfo.Mode().Perm() != 0o600 {
+			t.Errorf("token file perms = %o, want 600", tokInfo.Mode().Perm())
+		}
+	}
+}
+
+// --- formatDenyMessage / formatApprovalRequiredMessage (color.go) ---
+
+func TestFormatDenyMessage(t *testing.T) {
+	msg := formatDenyMessage("rm -rf /", "too dangerous", nil)
+	if msg == "" {
+		t.Error("expected non-empty message")
+	}
+}
+
+func TestFormatApprovalRequiredMessage(t *testing.T) {
+	msg := formatApprovalRequiredMessage("sudo reboot", "needs approval")
+	if msg == "" {
+		t.Error("expected non-empty message")
+	}
+}
+
+// --- verifyAnchors (audit_helpers.go) ---
+
+func TestVerifyAnchors_NoAnchors(t *testing.T) {
+	dir := t.TempDir()
+	err := verifyAnchors(dir, map[string]string{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// --- filterEventsBySince (audit_helpers.go) ---
+
+func TestFilterEventsBySince(t *testing.T) {
+	t.Run("empty since", func(t *testing.T) {
+		events := []audit.Event{{Tool: "exec"}}
+		filtered, label, err := filterEventsBySince(events, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if label != "all time" {
+			t.Errorf("expected 'all time', got %q", label)
+		}
+		if len(filtered) != 1 {
+			t.Errorf("expected 1 event, got %d", len(filtered))
+		}
+	})
+
+	t.Run("invalid duration", func(t *testing.T) {
+		_, _, err := filterEventsBySince(nil, "invalid")
+		if err == nil {
+			t.Error("expected error for invalid duration")
+		}
+	})
+}
+
+// --- newPolicyLintCmd (lint.go) via cobra execution ---
+
+func TestNewPolicyLintCmd_FileNotFound(t *testing.T) {
+	cmd := newPolicyLintCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"/nonexistent/policy.yaml"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Error("expected error for missing file")
+	}
+}
+
+func TestNewPolicyLintCmd_ValidFile(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "policy.yaml")
+	os.WriteFile(p, []byte("version: \"1\"\ndefault_action: deny\nrules:\n  - action: allow\n    when:\n      tool: exec\n"), 0o644)
+
+	var out bytes.Buffer
+	cmd := newPolicyLintCmd()
+	cmd.SetOut(&out)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{p})
+	// This may call os.Exit(1), but we're just testing the path
+	_ = cmd.Execute()
+}
+
+// --- newLogCmd paths (log.go) ---
+
+func TestNewLogCmd(t *testing.T) {
+	cmd := &cobra.Command{Use: "root"}
+	logCmd := newLogCmd(&rootOptions{})
+	cmd.AddCommand(logCmd)
+
+	// Test with empty audit dir
+	dir := t.TempDir()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetContext(context.Background())
+	cmd.SetArgs([]string{"log", "--audit-dir", dir})
+	err := cmd.Execute()
+	// Empty dir should be OK (no events)
+	if err != nil {
+		t.Logf("log cmd error (may be expected): %v", err)
+	}
+}
+
+// --- doctorVersionCheck (doctor.go) ---
+
+func TestDoctorVersionCheck(t *testing.T) {
+	var buf bytes.Buffer
+	// With dev build version, should return 0 immediately
+	issues := doctorVersionCheck(&buf, false, nil)
+	if issues < 0 {
+		t.Errorf("unexpected negative issues: %d", issues)
+	}
+}
+
+// --- doctorHooks (doctor.go) ---
+
+func TestDoctorHooks(t *testing.T) {
+	var results []checkResult
+	emit := func(name, status, msg string) {
+		results = append(results, checkResult{Name: name, Status: status, Message: msg})
+	}
+	// Should not panic even if no hooks configured
+	issues := doctorHooks(emit)
+	if issues < 0 {
+		t.Errorf("unexpected negative issues: %d", issues)
+	}
+}

--- a/cmd/rampart/cli/cli_unit3_test.go
+++ b/cmd/rampart/cli/cli_unit3_test.go
@@ -1,0 +1,274 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/peg/rampart/internal/audit"
+)
+
+// --- newInitCmd (init.go) ---
+
+func TestNewInitCmd_AlreadyExists(t *testing.T) {
+	dir := t.TempDir()
+	testSetHome(t, dir)
+	p := filepath.Join(dir, "rampart.yaml")
+	os.WriteFile(p, []byte("existing"), 0o644)
+
+	stdout := &bytes.Buffer{}
+	root := NewRootCmd(context.Background(), stdout, &bytes.Buffer{})
+	root.SetArgs([]string{"init", "--config", p})
+	err := root.Execute()
+	// Should succeed now - init creates policies even if config exists
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+	// Config should be unchanged
+	data, _ := os.ReadFile(p)
+	if string(data) != "existing" {
+		t.Errorf("config was modified, expected 'existing' got %q", string(data))
+	}
+}
+
+func TestNewInitCmd_Force(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "rampart.yaml")
+	os.WriteFile(p, []byte("existing"), 0o644)
+
+	var out bytes.Buffer
+	root := NewRootCmd(context.Background(), &out, &bytes.Buffer{})
+	root.SetArgs([]string{"init", "--config", p, "--force"})
+	err := root.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNewInitCmd_NewFile(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "rampart.yaml")
+
+	var out bytes.Buffer
+	root := NewRootCmd(context.Background(), &out, &bytes.Buffer{})
+	root.SetArgs([]string{"init", "--config", p})
+	err := root.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := os.Stat(p); err != nil {
+		t.Error("expected config file to be created")
+	}
+}
+
+func TestNewInitCmd_WithProfile(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "rampart.yaml")
+
+	var out bytes.Buffer
+	root := NewRootCmd(context.Background(), &out, &bytes.Buffer{})
+	root.SetArgs([]string{"init", "--config", p, "--profile", "standard"})
+	err := root.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNewInitCmd_DetectEnv(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "rampart.yaml")
+
+	var out bytes.Buffer
+	root := NewRootCmd(context.Background(), &out, &bytes.Buffer{})
+	root.SetArgs([]string{"init", "--config", p, "--detect"})
+	err := root.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// --- newPolicyTestCmd (test_cmd.go / policy.go) ---
+
+func TestPolicyTestCmd_Basic(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "rampart.yaml")
+	os.WriteFile(p, []byte(`version: "1"
+default_action: deny
+rules:
+  - action: allow
+    when:
+      tool: exec
+      command: "echo *"
+`), 0o644)
+
+	var out bytes.Buffer
+	root := NewRootCmd(context.Background(), &out, &bytes.Buffer{})
+	root.SetArgs([]string{"policy", "test", "--config", p, "exec", "echo hello"})
+	err := root.Execute()
+	_ = err // may or may not error depending on result formatting
+}
+
+// --- followAuditFile with data (audit.go) ---
+
+func TestFollowAuditFile_WithEvents(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "audit.jsonl")
+
+	event := map[string]any{
+		"id": "evt1", "ts": time.Now().UTC().Format(time.RFC3339),
+		"tool": "exec", "agent": "claude",
+		"decision": map[string]any{"action": "allow", "matched_policies": []string{"default"}, "evaluation_time_us": 10},
+	}
+	data, _ := json.Marshal(event)
+	os.WriteFile(f, append(data, '\n'), 0o644)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := testCobraCmd(ctx)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- followAuditFile(cmd, dir, f, true)
+	}()
+
+	// Write a new event after a brief delay
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		f2, _ := os.OpenFile(f, os.O_APPEND|os.O_WRONLY, 0o644)
+		event2 := map[string]any{
+			"id": "evt2", "ts": time.Now().UTC().Format(time.RFC3339),
+			"tool": "read", "agent": "claude",
+			"decision": map[string]any{"action": "allow", "matched_policies": []string{"p"}, "evaluation_time_us": 5},
+		}
+		d, _ := json.Marshal(event2)
+		f2.Write(append(d, '\n'))
+		f2.Close()
+		time.Sleep(600 * time.Millisecond)
+		cancel()
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		cancel()
+		t.Fatal("followAuditFile did not return")
+	}
+}
+
+// --- runReport success path (report.go) ---
+
+func TestRunReport_WithEvents(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create events within the last 24h
+	events := []audit.Event{
+		{
+			ID:        "evt1",
+			Timestamp: time.Now().Add(-1 * time.Hour),
+			Tool:      "exec",
+			Agent:     "claude",
+			Decision:  audit.EventDecision{Action: "allow", MatchedPolicies: []string{"default"}},
+			Request:   map[string]any{"command": "ls"},
+		},
+		{
+			ID:        "evt2",
+			Timestamp: time.Now().Add(-30 * time.Minute),
+			Tool:      "read",
+			Agent:     "claude",
+			Decision:  audit.EventDecision{Action: "deny", Message: "blocked"},
+			Request:   map[string]any{"path": "/etc/shadow"},
+		},
+	}
+
+	// Write events to a JSONL file
+	today := time.Now().UTC().Format("2006-01-02")
+	f, _ := os.Create(filepath.Join(dir, "audit-"+today+".jsonl"))
+	enc := json.NewEncoder(f)
+	for _, e := range events {
+		enc.Encode(e)
+	}
+	f.Close()
+
+	outFile := filepath.Join(dir, "report.html")
+	err := runReport(&reportOptions{
+		last:     "24h",
+		auditDir: dir,
+		output:   outFile,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify report was created
+	info, err := os.Stat(outFile)
+	if err != nil {
+		t.Fatalf("report not created: %v", err)
+	}
+	if info.Size() == 0 {
+		t.Error("report file is empty")
+	}
+}
+
+// --- preload command arg validation ---
+
+func TestNewPreloadCmd_NoArgs(t *testing.T) {
+	var out bytes.Buffer
+	root := NewRootCmd(context.Background(), &out, &bytes.Buffer{})
+	root.SetArgs([]string{"preload"})
+	err := root.Execute()
+	if err == nil {
+		t.Error("expected error for missing command")
+	}
+}
+
+// --- hook command missing stdin ---
+
+func TestNewHookCmd_NoStdin(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "rampart.yaml")
+	os.WriteFile(p, []byte(`version: "1"
+default_action: allow
+`), 0o644)
+
+	var out, errBuf bytes.Buffer
+	root := NewRootCmd(context.Background(), &out, &errBuf)
+	root.SetArgs([]string{"hook", "--config", p})
+
+	// Redirect stdin to empty
+	oldStdin := os.Stdin
+	r, w, _ := os.Pipe()
+	w.Close()
+	os.Stdin = r
+	defer func() { os.Stdin = oldStdin }()
+
+	err := root.Execute()
+	_ = err // may error on stdin read
+}
+
+// --- version command ---
+
+func TestVersionCmd(t *testing.T) {
+	var out bytes.Buffer
+	root := NewRootCmd(context.Background(), &out, &bytes.Buffer{})
+	root.SetArgs([]string{"version"})
+	err := root.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// --- status command ---
+
+func TestStatusCmd_NoServer(t *testing.T) {
+	var out bytes.Buffer
+	root := NewRootCmd(context.Background(), &out, &bytes.Buffer{})
+	root.SetArgs([]string{"status", "--addr", "http://127.0.0.1:1"})
+	// Should fail connecting
+	_ = root.Execute()
+}

--- a/cmd/rampart/cli/cli_unit_test.go
+++ b/cmd/rampart/cli/cli_unit_test.go
@@ -1,0 +1,461 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// --- ExitCode (root.go) ---
+
+type exitCodeErr struct {
+	code int
+	msg  string
+}
+
+func (e *exitCodeErr) Error() string    { return e.msg }
+func (e *exitCodeErr) ExitCode() int    { return e.code }
+
+func TestExitCode(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{"nil", nil, 0},
+		{"plain error", fmt.Errorf("boom"), 1},
+		{"exit code 42", &exitCodeErr{42, "custom"}, 42},
+		{"exit code 0 fallback", &exitCodeErr{0, "zero"}, 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ExitCode(tt.err); got != tt.want {
+				t.Errorf("ExitCode() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+// --- extractToolResponse (hook.go) ---
+
+func TestExtractToolResponse(t *testing.T) {
+	tests := []struct {
+		name string
+		resp map[string]any
+		want string
+	}{
+		{"stdout only", map[string]any{"stdout": "hello"}, "hello"},
+		{"stdout+stderr", map[string]any{"stdout": "out", "stderr": "err"}, "out\nerr"},
+		{"content", map[string]any{"content": "body"}, "body"},
+		{"output", map[string]any{"output": "data"}, "data"},
+		{"fallback to other keys", map[string]any{"result": "val"}, "val"},
+		{"empty strings ignored", map[string]any{"stdout": "", "result": "ok"}, "ok"},
+		{"non-string ignored", map[string]any{"count": 42}, ""},
+		{"empty map", map[string]any{}, ""},
+		{"priority order", map[string]any{"stdout": "a", "content": "b"}, "a\nb"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractToolResponse(tt.resp)
+			if got != tt.want {
+				t.Errorf("extractToolResponse() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// --- isPreloadRuntimeReady (preload.go) ---
+
+func TestIsPreloadRuntimeReady(t *testing.T) {
+	t.Run("healthy", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/healthz" {
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer srv.Close()
+		if !isPreloadRuntimeReady(context.Background(), srv.URL) {
+			t.Error("expected true for healthy server")
+		}
+	})
+
+	t.Run("unhealthy", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}))
+		defer srv.Close()
+		if isPreloadRuntimeReady(context.Background(), srv.URL) {
+			t.Error("expected false for unhealthy server")
+		}
+	})
+
+	t.Run("unreachable", func(t *testing.T) {
+		if isPreloadRuntimeReady(context.Background(), "http://127.0.0.1:1") {
+			t.Error("expected false for unreachable server")
+		}
+	})
+}
+
+// --- waitForProxyReady (wrap.go) ---
+
+func TestWaitForProxyReady(t *testing.T) {
+	t.Run("immediately ready", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+		if err := waitForProxyReady(context.Background(), srv.URL); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("context cancelled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		err := waitForProxyReady(ctx, "http://127.0.0.1:1")
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("timeout", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}))
+		defer srv.Close()
+		err := waitForProxyReady(context.Background(), srv.URL)
+		if err == nil || !strings.Contains(err.Error(), "timeout") {
+			t.Fatalf("expected timeout error, got: %v", err)
+		}
+	})
+}
+
+// --- resolveApproval (approve.go) ---
+
+func testCobraCmd(ctx context.Context) *cobra.Command {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetContext(ctx)
+	return cmd
+}
+
+func TestResolveApproval(t *testing.T) {
+	t.Run("no token", func(t *testing.T) {
+		testSetHome(t, t.TempDir()) // Avoid picking up real ~/.rampart/token
+		t.Setenv("RAMPART_TOKEN", "")
+		cmd := testCobraCmd(context.Background())
+		err := resolveApproval(cmd, "http://localhost", "", "abc12345678", true)
+		if err == nil || !strings.Contains(err.Error(), "token required") {
+			t.Fatalf("expected token error, got: %v", err)
+		}
+	})
+
+	t.Run("success approved", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost {
+				t.Errorf("expected POST, got %s", r.Method)
+			}
+			if !strings.Contains(r.URL.Path, "/v1/approvals/") {
+				t.Errorf("unexpected path: %s", r.URL.Path)
+			}
+			auth := r.Header.Get("Authorization")
+			if auth != "Bearer testtoken" {
+				t.Errorf("unexpected auth: %s", auth)
+			}
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		cmd := testCobraCmd(context.Background())
+		err := resolveApproval(cmd, srv.URL, "testtoken", "abc12345678", true)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("server error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprint(w, "internal error")
+		}))
+		defer srv.Close()
+
+		cmd := testCobraCmd(context.Background())
+		err := resolveApproval(cmd, srv.URL, "testtoken", "abc12345678", false)
+		if err == nil || !strings.Contains(err.Error(), "500") {
+			t.Fatalf("expected 500 error, got: %v", err)
+		}
+	})
+}
+
+// --- listPending (approve.go) ---
+
+func TestListPending(t *testing.T) {
+	t.Run("no token", func(t *testing.T) {
+		testSetHome(t, t.TempDir()) // Avoid picking up real ~/.rampart/token
+		t.Setenv("RAMPART_TOKEN", "")
+		cmd := testCobraCmd(context.Background())
+		err := listPending(cmd, "http://localhost", "")
+		if err == nil || !strings.Contains(err.Error(), "token required") {
+			t.Fatalf("expected token error, got: %v", err)
+		}
+	})
+
+	t.Run("no approvals", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			json.NewEncoder(w).Encode(map[string]any{"approvals": []any{}})
+		}))
+		defer srv.Close()
+
+		cmd := testCobraCmd(context.Background())
+		err := listPending(cmd, srv.URL, "tok")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("with approvals", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			json.NewEncoder(w).Encode(map[string]any{
+				"approvals": []map[string]any{
+					{
+						"id":         "abcdef1234567890",
+						"tool":       "exec",
+						"command":    "rm -rf /",
+						"agent":      "claude",
+						"message":    "dangerous",
+						"status":     "pending",
+						"created_at": time.Now().Format(time.RFC3339),
+						"expires_at": time.Now().Add(5 * time.Minute).Format(time.RFC3339),
+					},
+				},
+			})
+		}))
+		defer srv.Close()
+
+		cmd := testCobraCmd(context.Background())
+		err := listPending(cmd, srv.URL, "tok")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+// --- initializeMCPConnection / getToolsList (mcp_scan.go) ---
+
+func TestInitializeMCPConnection(t *testing.T) {
+	// Create a pipe pair simulating a child process
+	pr, pw := io.Pipe()
+	stdinR, stdinW := io.Pipe()
+
+	// Mock server: read request, write response
+	go func() {
+		buf := make([]byte, 4096)
+		n, _ := stdinR.Read(buf)
+		_ = n // consume the initialize request
+
+		// Write initialize response
+		resp := `{"jsonrpc":"2.0","id":"1","result":{"protocolVersion":"2024-11-05"}}` + "\n"
+		pw.Write([]byte(resp))
+	}()
+
+	err := initializeMCPConnection(stdinW, pr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGetToolsList(t *testing.T) {
+	pr, pw := io.Pipe()
+	stdinR, stdinW := io.Pipe()
+
+	go func() {
+		buf := make([]byte, 4096)
+		stdinR.Read(buf)
+
+		resp := map[string]any{
+			"jsonrpc": "2.0",
+			"id":      "2",
+			"result": map[string]any{
+				"tools": []map[string]any{
+					{"name": "read_file", "description": "Read a file"},
+					{"name": "write_file", "description": "Write a file"},
+				},
+			},
+		}
+		data, _ := json.Marshal(resp)
+		pw.Write(append(data, '\n'))
+	}()
+
+	tools, err := getToolsList(stdinW, pr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tools) != 2 {
+		t.Fatalf("expected 2 tools, got %d", len(tools))
+	}
+	if tools[0].Name != "read_file" {
+		t.Errorf("expected read_file, got %s", tools[0].Name)
+	}
+}
+
+func TestGetToolsList_NoResponse(t *testing.T) {
+	// Use a bytes.Reader that returns EOF immediately
+	emptyReader := bytes.NewReader(nil)
+
+	// stdinW that discards writes
+	stdinW := &nopWriteCloser{io.Discard}
+
+	_, err := getToolsList(stdinW, emptyReader)
+	if err == nil {
+		t.Fatal("expected error for no response")
+	}
+}
+
+type nopWriteCloser struct{ io.Writer }
+
+func (n *nopWriteCloser) Close() error { return nil }
+
+// --- loadLogEvents (log.go) ---
+
+func TestLoadLogEvents(t *testing.T) {
+	t.Run("empty dir", func(t *testing.T) {
+		dir := t.TempDir()
+		events, err := loadLogEvents(dir, false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(events) != 0 {
+			t.Errorf("expected 0 events, got %d", len(events))
+		}
+	})
+
+	t.Run("today only no files", func(t *testing.T) {
+		dir := t.TempDir()
+		events, err := loadLogEvents(dir, true)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(events) != 0 {
+			t.Errorf("expected 0 events, got %d", len(events))
+		}
+	})
+
+	t.Run("today with file", func(t *testing.T) {
+		dir := t.TempDir()
+		today := time.Now().UTC().Format("2006-01-02")
+		event := map[string]any{
+			"id": "evt1", "ts": time.Now().UTC().Format(time.RFC3339),
+			"tool": "exec", "agent": "claude",
+			"decision": map[string]any{"action": "allow", "matched_policies": []string{"default"}, "evaluation_time_us": 10},
+		}
+		data, _ := json.Marshal(event)
+		os.WriteFile(filepath.Join(dir, "audit-"+today+".jsonl"), append(data, '\n'), 0o644)
+
+		events, err := loadLogEvents(dir, true)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(events) != 1 {
+			t.Errorf("expected 1 event, got %d", len(events))
+		}
+	})
+
+	t.Run("latest file", func(t *testing.T) {
+		dir := t.TempDir()
+		event := map[string]any{
+			"id": "evt1", "ts": time.Now().UTC().Format(time.RFC3339),
+			"tool": "exec", "agent": "claude",
+			"decision": map[string]any{"action": "allow", "matched_policies": []string{"default"}, "evaluation_time_us": 10},
+		}
+		data, _ := json.Marshal(event)
+		os.WriteFile(filepath.Join(dir, "audit-2025-01-01.jsonl"), append(data, '\n'), 0o644)
+
+		events, err := loadLogEvents(dir, false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(events) != 1 {
+			t.Errorf("expected 1 event, got %d", len(events))
+		}
+	})
+}
+
+// --- writeJSONEvents / writePrettyEvents (log.go) ---
+
+// --- runReport (report.go) ---
+
+func TestRunReport(t *testing.T) {
+	t.Run("invalid duration", func(t *testing.T) {
+		err := runReport(&reportOptions{last: "invalid"})
+		if err == nil || !strings.Contains(err.Error(), "invalid duration") {
+			t.Fatalf("expected invalid duration error, got: %v", err)
+		}
+	})
+
+	t.Run("empty audit dir", func(t *testing.T) {
+		dir := t.TempDir()
+		err := runReport(&reportOptions{
+			last:     "24h",
+			auditDir: dir,
+			output:   filepath.Join(dir, "report.html"),
+		})
+		if err == nil || !strings.Contains(err.Error(), "no audit events") {
+			t.Fatalf("expected no events error, got: %v", err)
+		}
+	})
+}
+
+// --- followAuditFile (audit.go) ---
+
+func TestFollowAuditFile_ContextCancel(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "audit.jsonl")
+	os.WriteFile(f, []byte{}, 0o644)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := testCobraCmd(ctx)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- followAuditFile(cmd, dir, f, true)
+	}()
+
+	// Cancel immediately
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("followAuditFile did not return after context cancel")
+	}
+}
+
+// --- patchOpenClawTools (setup.go) ---
+
+func TestPatchOpenClawTools(t *testing.T) {
+	dir := t.TempDir()
+	toolFile := filepath.Join(dir, "read.js")
+	os.WriteFile(toolFile, []byte("original content"), 0o644)
+
+	cmd := testCobraCmd(context.Background())
+	err := patchOpenClawTools(cmd, "http://localhost:8080", "testtoken")
+	_ = err
+}


### PR DESCRIPTION
## Mea Culpa

The `coverage_boost{,2,3}_test.go` files I deleted in PR #167 weren't just coverage inflation — they contained **real behavioral tests** for CLI functions:

- `ExitCode` (root.go)
- `extractToolResponse` (hook.go)
- `waitForProxyReady` (wrap.go)
- `resolveApproval`, `listPending` (approve.go)
- `initializeMCPConnection`, `getToolsList` (mcp_scan.go)
- `loadLogEvents` (log.go)
- `runReport` (report.go)
- `followAuditFile` (audit.go)
- `patchOpenClawTools` (setup.go)
- ...and more

The **naming** was misleading, but the tests were legitimate. Restored with proper names: `cli_unit{,2,3}_test.go`.

All 1,035 lines restored. Tests passing on all platforms.