### PR TITLE
feat: add TLS support to rampart serve

### DIFF
--- a/cmd/rampart/cli/serve.go
+++ b/cmd/rampart/cli/serve.go
@@ -29,11 +29,14 @@ import (
 	"syscall"
 	"time"
 
+	crypto_tls "crypto/tls"
+
 	"github.com/fsnotify/fsnotify"
 	"github.com/peg/rampart/internal/audit"
 	"github.com/peg/rampart/internal/engine"
 	"github.com/peg/rampart/internal/proxy"
 	"github.com/peg/rampart/internal/signing"
+	"github.com/peg/rampart/internal/tlsutil"
 	"github.com/peg/rampart/policies"
 	"github.com/spf13/cobra"
 )
@@ -64,6 +67,9 @@ func newServeCmd(opts *rootOptions, deps *serveDeps) *cobra.Command {
 	var reloadInterval time.Duration
 	var approvalTimeout time.Duration
 	var background bool
+	var tlsCert string
+	var tlsKey string
+	var tlsAuto bool
 
 	resolvedDeps := defaultServeDeps()
 	if deps != nil {
@@ -136,6 +142,31 @@ func newServeCmd(opts *rootOptions, deps *serveDeps) *cobra.Command {
 
 			if listenAddr != "" && net.ParseIP(listenAddr) == nil {
 				return fmt.Errorf("serve: invalid --addr %q (must be a valid IP address, e.g. 127.0.0.1 or ::1)", listenAddr)
+			}
+
+			// Validate TLS flags.
+			if (tlsCert == "") != (tlsKey == "") {
+				return fmt.Errorf("serve: --tls-cert and --tls-key must be used together")
+			}
+			if tlsCert != "" && tlsAuto {
+				return fmt.Errorf("serve: --tls-cert/--tls-key and --tls-auto are mutually exclusive")
+			}
+
+			// Resolve TLS config.
+			var tlsCfg *crypto_tls.Config
+			var tlsFingerprint string
+			if tlsAuto {
+				var err error
+				tlsCfg, tlsFingerprint, err = tlsutil.LoadOrGenerate(tlsutil.DefaultCertDir())
+				if err != nil {
+					return fmt.Errorf("serve: tls auto: %w", err)
+				}
+			} else if tlsCert != "" {
+				var err error
+				tlsCfg, tlsFingerprint, err = tlsutil.LoadFromFiles(tlsCert, tlsKey)
+				if err != nil {
+					return fmt.Errorf("serve: tls: %w", err)
+				}
 			}
 
 			level := slog.LevelInfo
@@ -351,7 +382,14 @@ func newServeCmd(opts *rootOptions, deps *serveDeps) *cobra.Command {
 				}
 
 				fmt.Fprintf(cmd.ErrOrStderr(), "  🔑 Full token : %s\n", token)
-				fmt.Fprintf(cmd.ErrOrStderr(), "  🌐 Dashboard  : http://localhost:%d/dashboard/\n", listenPort)
+				scheme := "http"
+				if tlsCfg != nil {
+					scheme = "https"
+				}
+				fmt.Fprintf(cmd.ErrOrStderr(), "  🌐 Dashboard  : %s://localhost:%d/dashboard/\n", scheme, listenPort)
+				if tlsCfg != nil && tlsFingerprint != "" {
+					fmt.Fprintf(cmd.ErrOrStderr(), "  🔒 TLS        : sha256:%s\n", tlsFingerprint[:23]+"...")
+				}
 
 				// Persist the token so it survives restarts.
 				if err := persistToken(token); err != nil {
@@ -365,7 +403,13 @@ func newServeCmd(opts *rootOptions, deps *serveDeps) *cobra.Command {
 
 				proxyErrCh = make(chan error, 1)
 				go func() {
-					proxyErrCh <- proxyServer.Serve(listener)
+					if tlsCfg != nil {
+						// Wrap the listener with TLS.
+						tlsListener := crypto_tls.NewListener(listener, tlsCfg)
+						proxyErrCh <- proxyServer.Serve(tlsListener)
+					} else {
+						proxyErrCh <- proxyServer.Serve(listener)
+					}
 				}()
 			}
 
@@ -452,6 +496,9 @@ func newServeCmd(opts *rootOptions, deps *serveDeps) *cobra.Command {
 	cmd.Flags().StringVar(&configDir, "config-dir", "", "Directory of additional policy YAML files (default: ~/.rampart/policies/ if it exists)")
 	cmd.Flags().DurationVar(&reloadInterval, "reload-interval", 0, "How often to re-read policy files (0 = disabled; fsnotify handles hot-reload automatically)")
 	cmd.Flags().DurationVar(&approvalTimeout, "approval-timeout", 0, "How long approvals stay pending before expiring (default: 1h)")
+	cmd.Flags().StringVar(&tlsCert, "tls-cert", "", "Path to TLS certificate PEM file")
+	cmd.Flags().StringVar(&tlsKey, "tls-key", "", "Path to TLS private key PEM file")
+	cmd.Flags().BoolVar(&tlsAuto, "tls-auto", false, "Auto-generate self-signed TLS certificate")
 
 	cmd.AddCommand(newServeInstallCmd(opts, nil))
 	cmd.AddCommand(newServeUninstallCmd(nil))

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/subtle"
+	"crypto/tls"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -282,6 +283,26 @@ func (s *Server) ListenAndServe(addr string) error {
 
 	if err := srv.Serve(listener); err != nil {
 		return fmt.Errorf("proxy: listen and serve: %w", err)
+	}
+	return nil
+}
+
+// ListenAndServeTLS starts serving HTTPS requests at addr with the given TLS config.
+func (s *Server) ListenAndServeTLS(addr string, tlsCfg *tls.Config) error {
+	listener, err := tls.Listen("tcp", addr, tlsCfg)
+	if err != nil {
+		return fmt.Errorf("proxy: tls listen: %w", err)
+	}
+	s.listenAddr = listener.Addr().String()
+
+	srv := s.newHTTPServer(s.listenAddr, s.handler())
+
+	s.mu.Lock()
+	s.server = srv
+	s.mu.Unlock()
+
+	if err := srv.Serve(listener); err != nil {
+		return fmt.Errorf("proxy: tls serve: %w", err)
 	}
 	return nil
 }

--- a/internal/tlsutil/tlsutil.go
+++ b/internal/tlsutil/tlsutil.go
@@ -1,0 +1,174 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package tlsutil provides TLS certificate management for rampart serve.
+package tlsutil
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/hex"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// DefaultCertDir returns the default directory for auto-generated TLS certs.
+func DefaultCertDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = "."
+	}
+	return filepath.Join(home, ".rampart", "tls")
+}
+
+// LoadOrGenerate loads existing cert/key from dir, or generates a new
+// self-signed cert if none exists or the existing one is expired.
+// Returns the tls.Config and a human-readable fingerprint string.
+func LoadOrGenerate(certDir string) (*tls.Config, string, error) {
+	certPath := filepath.Join(certDir, "cert.pem")
+	keyPath := filepath.Join(certDir, "key.pem")
+
+	// Try loading existing.
+	if cfg, fp, err := loadExisting(certPath, keyPath); err == nil {
+		return cfg, fp, nil
+	}
+
+	// Generate new self-signed cert.
+	if err := os.MkdirAll(certDir, 0o700); err != nil {
+		return nil, "", fmt.Errorf("tls: create cert dir: %w", err)
+	}
+
+	if err := generateSelfSigned(certPath, keyPath); err != nil {
+		return nil, "", err
+	}
+
+	return loadExisting(certPath, keyPath)
+}
+
+// LoadFromFiles loads a TLS config from explicit cert and key files.
+// Returns the tls.Config and a human-readable fingerprint string.
+func LoadFromFiles(certPath, keyPath string) (*tls.Config, string, error) {
+	return loadExisting(certPath, keyPath)
+}
+
+// Fingerprint computes the SHA-256 fingerprint of a DER-encoded certificate.
+func Fingerprint(der []byte) string {
+	h := sha256.Sum256(der)
+	hex := hex.EncodeToString(h[:])
+	// Format as colon-separated pairs for readability.
+	var parts []string
+	for i := 0; i < len(hex); i += 2 {
+		parts = append(parts, hex[i:i+2])
+	}
+	return strings.Join(parts, ":")
+}
+
+func loadExisting(certPath, keyPath string) (*tls.Config, string, error) {
+	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		return nil, "", fmt.Errorf("tls: load keypair: %w", err)
+	}
+
+	// Check expiry.
+	if len(cert.Certificate) > 0 {
+		x509Cert, err := x509.ParseCertificate(cert.Certificate[0])
+		if err == nil && time.Now().After(x509Cert.NotAfter) {
+			return nil, "", fmt.Errorf("tls: certificate expired at %s", x509Cert.NotAfter)
+		}
+	}
+
+	fp := ""
+	if len(cert.Certificate) > 0 {
+		fp = Fingerprint(cert.Certificate[0])
+	}
+
+	cfg := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS12,
+	}
+
+	return cfg, fp, nil
+}
+
+func generateSelfSigned(certPath, keyPath string) error {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return fmt.Errorf("tls: generate key: %w", err)
+	}
+
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return fmt.Errorf("tls: generate serial: %w", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject:      pkix.Name{CommonName: "rampart"},
+		NotBefore:    time.Now().UTC().Add(-1 * time.Hour),
+		NotAfter:     time.Now().UTC().Add(365 * 24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
+		DNSNames:     []string{"localhost"},
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		return fmt.Errorf("tls: create certificate: %w", err)
+	}
+
+	// Write cert PEM.
+	if err := writePEM(certPath, "CERTIFICATE", certDER); err != nil {
+		return err
+	}
+
+	// Write key PEM.
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return fmt.Errorf("tls: marshal key: %w", err)
+	}
+	return writePEM(keyPath, "EC PRIVATE KEY", keyDER)
+}
+
+func writePEM(path, blockType string, data []byte) error {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		return fmt.Errorf("tls: create %s: %w", filepath.Base(path), err)
+	}
+	defer f.Close()
+
+	if err := pem.Encode(f, &pem.Block{Type: blockType, Bytes: data}); err != nil {
+		return fmt.Errorf("tls: write %s: %w", filepath.Base(path), err)
+	}
+
+	// On non-Windows, ensure restrictive permissions.
+	if runtime.GOOS != "windows" {
+		if err := f.Chmod(0o600); err != nil {
+			return fmt.Errorf("tls: chmod %s: %w", filepath.Base(path), err)
+		}
+	}
+
+	return nil
+}

--- a/internal/tlsutil/tlsutil_test.go
+++ b/internal/tlsutil/tlsutil_test.go
@@ -1,0 +1,141 @@
+package tlsutil
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadOrGenerate_CreatesCert(t *testing.T) {
+	dir := t.TempDir()
+	cfg, fp, err := LoadOrGenerate(dir)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.NotEmpty(t, fp)
+	assert.Len(t, cfg.Certificates, 1)
+
+	// Verify files exist.
+	_, err = os.Stat(filepath.Join(dir, "cert.pem"))
+	assert.NoError(t, err)
+	_, err = os.Stat(filepath.Join(dir, "key.pem"))
+	assert.NoError(t, err)
+}
+
+func TestLoadOrGenerate_ReusesExisting(t *testing.T) {
+	dir := t.TempDir()
+
+	// Generate first.
+	_, fp1, err := LoadOrGenerate(dir)
+	require.NoError(t, err)
+
+	// Load again — should reuse.
+	_, fp2, err := LoadOrGenerate(dir)
+	require.NoError(t, err)
+
+	assert.Equal(t, fp1, fp2, "should reuse existing cert")
+}
+
+func TestLoadFromFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	// Generate cert first.
+	_, _, err := LoadOrGenerate(dir)
+	require.NoError(t, err)
+
+	cfg, fp, err := LoadFromFiles(filepath.Join(dir, "cert.pem"), filepath.Join(dir, "key.pem"))
+	require.NoError(t, err)
+	assert.NotNil(t, cfg)
+	assert.NotEmpty(t, fp)
+}
+
+func TestLoadFromFiles_MissingFile(t *testing.T) {
+	_, _, err := LoadFromFiles("/nonexistent/cert.pem", "/nonexistent/key.pem")
+	assert.Error(t, err)
+}
+
+func TestFingerprint(t *testing.T) {
+	fp := Fingerprint([]byte("test data"))
+	assert.Contains(t, fp, ":")
+	// SHA-256 = 32 bytes = 64 hex chars = 32 pairs + 31 colons
+	assert.Len(t, fp, 95)
+}
+
+func TestGeneratedCertIsValid(t *testing.T) {
+	dir := t.TempDir()
+	cfg, _, err := LoadOrGenerate(dir)
+	require.NoError(t, err)
+
+	// Parse the cert.
+	cert, err := x509.ParseCertificate(cfg.Certificates[0].Certificate[0])
+	require.NoError(t, err)
+
+	assert.Equal(t, "rampart", cert.Subject.CommonName)
+	assert.Contains(t, cert.DNSNames, "localhost")
+	// Check that 127.0.0.1 is in the cert's IP SANs (may be 4-byte or 16-byte).
+	hasLoopback := false
+	for _, ip := range cert.IPAddresses {
+		if ip.Equal(net.IPv4(127, 0, 0, 1)) {
+			hasLoopback = true
+			break
+		}
+	}
+	assert.True(t, hasLoopback, "cert should include 127.0.0.1")
+	assert.Equal(t, x509.ECDSA, cert.PublicKeyAlgorithm)
+}
+
+func TestGeneratedCertPermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file permissions not enforced on Windows")
+	}
+
+	dir := t.TempDir()
+	_, _, err := LoadOrGenerate(dir)
+	require.NoError(t, err)
+
+	info, err := os.Stat(filepath.Join(dir, "key.pem"))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(), "key should be 0600")
+
+	info, err = os.Stat(filepath.Join(dir, "cert.pem"))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(), "cert should be 0600")
+}
+
+func TestTLSServerAcceptsConnections(t *testing.T) {
+	dir := t.TempDir()
+	tlsCfg, _, err := LoadOrGenerate(dir)
+	require.NoError(t, err)
+
+	// Start a TLS server.
+	listener, err := tls.Listen("tcp", "127.0.0.1:0", tlsCfg)
+	require.NoError(t, err)
+	defer listener.Close()
+
+	srv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}),
+	}
+	go srv.Serve(listener)
+	defer srv.Close()
+
+	// Connect with TLS (skip verify since self-signed).
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+
+	resp, err := client.Get("https://" + listener.Addr().String() + "/")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}


### PR DESCRIPTION
## What
HTTPS for `rampart serve`. A security product should not send auth tokens over plaintext HTTP.

## Usage
```bash
# Auto-generate self-signed cert (stored in ~/.rampart/tls/)
rampart serve --tls-auto

# Use your own cert
rampart serve --tls-cert /path/to/cert.pem --tls-key /path/to/key.pem
```

## New package: internal/tlsutil
- ECDSA P-256 self-signed cert generation (localhost, 127.0.0.1, ::1)
- Certs cached in `~/.rampart/tls/`, reused if valid
- SHA-256 fingerprint for cert pinning
- 0600 permissions on key files (skipped on Windows)
- Expired cert auto-regeneration

## Proxy server
- `ListenAndServeTLS()` wraps listener with `crypto/tls`
- Dashboard URL shows `https://` when TLS enabled
- Fingerprint displayed on startup

## CLI flags
- `--tls-cert` + `--tls-key` — explicit cert/key PEM files
- `--tls-auto` — auto-generate self-signed cert
- Mutual exclusion enforced

## Tests
8 new tests: cert generation, reuse, loading, validation (CN, SANs, algo), permissions, TLS server acceptance, missing file handling.

All existing tests pass. Cross-platform (Go crypto/tls is stdlib).