### PR TITLE
feat: add Docker image and CI workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.github
+*.md
+!README.md
+LICENSE
+docs-site/
+.rampart/
+.vscode/
+.idea/
+*.test
+coverage.out

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,44 @@
+name: Docker
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ghcr.io/peg/rampart
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ github.ref == format('refs/tags/{0}', github.event.repository.default_branch) || true }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# Build stage
+FROM golang:1.24-bookworm AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /rampart ./cmd/rampart
+
+# Runtime stage — distroless for minimal attack surface
+FROM gcr.io/distroless/static-debian12:nonroot
+COPY --from=build /rampart /rampart
+USER nonroot:nonroot
+EXPOSE 9090
+ENTRYPOINT ["/rampart"]
+CMD ["serve", "--bind", "0.0.0.0:9090"]

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -1,0 +1,27 @@
+# Example: Rampart as a sidecar proxy for an AI agent
+#
+# Usage:
+#   1. Put your policies in ./policies/
+#   2. docker compose up
+#   3. Configure your agent: RAMPART_API=http://localhost:9090
+
+services:
+  rampart:
+    image: ghcr.io/peg/rampart:latest
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./policies:/home/nonroot/.rampart/policies:ro
+      - rampart-audit:/home/nonroot/.rampart/audit
+    restart: unless-stopped
+
+  # Example agent — replace with your own
+  # agent:
+  #   image: your-agent:latest
+  #   environment:
+  #     RAMPART_API: http://rampart:9090
+  #   depends_on:
+  #     - rampart
+
+volumes:
+  rampart-audit:


### PR DESCRIPTION
## What
Container image for running Rampart as a sidecar proxy.

## Contents
- **Dockerfile** — Multi-stage build, distroless runtime, nonroot user, `serve` as default CMD
- **GitHub Actions** (`.github/workflows/docker.yml`) — Multi-arch (amd64+arm64), pushes to GHCR on version tags
- **docker-compose.example.yml** — Sidecar pattern with policy volume mount and persistent audit
- **.dockerignore** — Lean build context

## Usage
```bash
# Run directly
docker run -v ./policies:/home/nonroot/.rampart/policies:ro ghcr.io/peg/rampart:latest

# Or use the compose example
docker compose up
```

## Image details
- Base: `gcr.io/distroless/static-debian12:nonroot` (minimal attack surface)
- Static binary: `CGO_ENABLED=0 -trimpath -ldflags='-s -w'`
- Tags: `0.7.3`, `0.7`, `latest`
- Platforms: linux/amd64, linux/arm64