### PR TITLE
fix: wait for session cleanup goroutine to prevent TempDir race on macOS

### DIFF
--- a/cmd/rampart/cli/hook.go
+++ b/cmd/rampart/cli/hook.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/peg/rampart/internal/audit"
@@ -285,10 +286,14 @@ Cline setup: Use "rampart setup cline" to install hooks automatically.`,
 			// Cleanup stale session state files in the background (best-effort).
 			// This runs once per hook invocation; typically fires every few seconds
 			// during active sessions, which is sufficient to keep the directory clean.
+			var cleanupWg sync.WaitGroup
+			cleanupWg.Add(1)
 			go func() {
+				defer cleanupWg.Done()
 				mgr := session.NewManager(sessionStateDir(), "", logger)
 				_ = mgr.Cleanup(24 * time.Hour)
 			}()
+			defer cleanupWg.Wait()
 
 			// Load policies
 			policyPath, cleanupPolicy, err := resolveWrapPolicyPath(opts.configPath)


### PR DESCRIPTION
## Problem

`TestPostToolUseFailure_NoReasonForUnknownCommand` fails on macOS CI with:

```
TempDir RemoveAll cleanup: unlinkat .../TestPostToolUseFailure_NoReasonForUnknownCommand/.rampart: directory not empty
```

## Root Cause

The hook command fires a background goroutine for session-state cleanup (line ~289 in hook.go). This goroutine creates files in `$HOME/.rampart/session-state/`. In tests, `$HOME` points to `t.TempDir()`.

The goroutine can outlive the test function — when Go's TempDir cleanup runs `RemoveAll`, the goroutine is still writing to the directory. On macOS (APFS), this manifests as a race condition that causes the test to fail.

Passes on Linux and Windows because the timing is different (cleanup completes before RemoveAll).

## Fix

Use `sync.WaitGroup` + `defer cleanupWg.Wait()` to ensure the background goroutine finishes before the command returns. This is correct for production too — we shouldn't exit while still writing to disk.

## Testing

- `go test -run TestPostToolUseFailure -count=3 -v ./cmd/rampart/cli/` — passes
- Full suite `go test ./...` — all green

Unblocks PR #179.