### PR TITLE
docs: update docs site for v0.7.4 features

### DIFF
--- a/docs-site/getting-started/installation.md
+++ b/docs-site/getting-started/installation.md
@@ -77,7 +77,7 @@ sudo mv rampart /usr/local/bin/
 Multi-arch container image (amd64 + arm64), built on distroless for minimal attack surface:
 
 ```bash
-docker run ghcr.io/peg/rampart:latest serve --bind 0.0.0.0:9090
+docker run ghcr.io/peg/rampart:latest serve --addr 0.0.0.0 --port 9090
 ```
 
 Or use with docker-compose:
@@ -91,7 +91,7 @@ services:
     volumes:
       - ./policies:/policies:ro
       - rampart-audit:/audit
-    command: ["serve", "--bind", "0.0.0.0:9090", "--config", "/policies/rampart.yaml", "--audit-dir", "/audit"]
+    command: ["serve", "--addr", "0.0.0.0", "--port", "9090", "--config", "/policies/rampart.yaml", "--audit-dir", "/audit"]
 
 volumes:
   rampart-audit:

--- a/docs-site/getting-started/installation.md
+++ b/docs-site/getting-started/installation.md
@@ -80,7 +80,7 @@ Multi-arch container image (amd64 + arm64), built on distroless for minimal atta
 docker run ghcr.io/peg/rampart:latest serve --addr 0.0.0.0 --port 9090
 ```
 
-Or use with docker-compose:
+Or use with docker-compose. First, create a policy file (e.g. `mkdir policies && rampart init > policies/rampart.yaml`):
 
 ```yaml
 services:
@@ -97,7 +97,7 @@ volumes:
   rampart-audit:
 ```
 
-Available tags: `latest`, `0.7.4`, `0.7`. Images are published on [GitHub Container Registry](https://github.com/peg/rampart/pkgs/container/rampart).
+Available tags: `latest`, `0.7.4`, `0.7`. At release time, `latest` points to `0.7.4`. Pin to a specific version tag for reproducibility. Images are published on [GitHub Container Registry](https://github.com/peg/rampart/pkgs/container/rampart).
 
 ## Build from Source
 

--- a/docs-site/getting-started/installation.md
+++ b/docs-site/getting-started/installation.md
@@ -72,6 +72,33 @@ unzip rampart_*_darwin_arm64.zip
 sudo mv rampart /usr/local/bin/
 ```
 
+## Docker
+
+Multi-arch container image (amd64 + arm64), built on distroless for minimal attack surface:
+
+```bash
+docker run ghcr.io/peg/rampart:latest serve --bind 0.0.0.0:9090
+```
+
+Or use with docker-compose:
+
+```yaml
+services:
+  rampart:
+    image: ghcr.io/peg/rampart:latest
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./policies:/policies:ro
+      - rampart-audit:/audit
+    command: ["serve", "--bind", "0.0.0.0:9090", "--config", "/policies/rampart.yaml", "--audit-dir", "/audit"]
+
+volumes:
+  rampart-audit:
+```
+
+Available tags: `latest`, `0.7.4`, `0.7`. Images are published on [GitHub Container Registry](https://github.com/peg/rampart/pkgs/container/rampart).
+
 ## Build from Source
 
 ```bash

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -181,7 +181,7 @@ verify -> outcomes.approval
 | **Cursor** | MCP proxy | `rampart mcp --` |
 | **Claude Desktop** | MCP proxy | `rampart mcp --` |
 | **Codex CLI** | LD_PRELOAD | `rampart setup codex` |
-| **OpenClaw** | Shim + preload | `rampart setup openclaw` |
+| **OpenClaw** | Multi-layer | `rampart setup openclaw` |
 | **Any CLI agent** | Shell wrapper | `rampart wrap --` |
 | **Python agents** | HTTP API / SDK | `localhost:9090` |
 
@@ -190,7 +190,7 @@ verify -> outcomes.approval
 ## What's New in v0.7.4
 
 - **`rampart init --from-audit`** — Generate policy YAML from your audit logs. Observe what your agent does, then generate rules to match. [Learn more →](reference/cli-commands.md#rampart-init---from-audit)
-- **Temporal allows** — `rampart allow "docker *" --for 1h` creates rules that expire automatically. `--once` for single-use exceptions. [Learn more →](reference/cli-commands.md#rampart-allow)
+- **Temporal allows** — `rampart allow "docker *" --for 1h` creates rules that expire automatically. `--once` for single-use rules (consumed after first match, removed manually). [Learn more →](reference/cli-commands.md#rampart-allow)
 - **TLS on `rampart serve`** — `--tls-auto` generates a self-signed cert, or bring your own with `--tls-cert`/`--tls-key`. [Learn more →](reference/cli-commands.md#rampart-serve)
 - **Docker image** — `docker run ghcr.io/peg/rampart:latest` — multi-arch distroless container. [Installation →](getting-started/installation.md#docker)
 - **`rampart setup codex`** — One-command persistent wrapper for Codex CLI via LD_PRELOAD. [Learn more →](integrations/codex-cli.md)

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -180,9 +180,17 @@ verify -> outcomes.approval
 | **Cline** | Native hooks | `rampart setup cline` |
 | **Cursor** | MCP proxy | `rampart mcp --` |
 | **Claude Desktop** | MCP proxy | `rampart mcp --` |
-| **Codex CLI** | LD_PRELOAD | `rampart preload --` |
-| **OpenClaw** | Shim + service | `rampart setup openclaw` |
+| **Codex CLI** | LD_PRELOAD | `rampart setup codex` |
+| **OpenClaw** | Shim + preload | `rampart setup openclaw` |
 | **Any CLI agent** | Shell wrapper | `rampart wrap --` |
 | **Python agents** | HTTP API / SDK | `localhost:9090` |
 
 [:octicons-arrow-right-24: See all integration guides](integrations/index.md)
+
+## What's New in v0.7.4
+
+- **`rampart init --from-audit`** — Generate policy YAML from your audit logs. Observe what your agent does, then generate rules to match. [Learn more →](reference/cli-commands.md#rampart-init---from-audit)
+- **Temporal allows** — `rampart allow "docker *" --for 1h` creates rules that expire automatically. `--once` for single-use exceptions. [Learn more →](reference/cli-commands.md#rampart-allow)
+- **TLS on `rampart serve`** — `--tls-auto` generates a self-signed cert, or bring your own with `--tls-cert`/`--tls-key`. [Learn more →](reference/cli-commands.md#rampart-serve)
+- **Docker image** — `docker run ghcr.io/peg/rampart:latest` — multi-arch distroless container. [Installation →](getting-started/installation.md#docker)
+- **`rampart setup codex`** — One-command persistent wrapper for Codex CLI via LD_PRELOAD. [Learn more →](integrations/codex-cli.md)

--- a/docs-site/integrations/codex-cli.md
+++ b/docs-site/integrations/codex-cli.md
@@ -5,15 +5,21 @@ description: "Secure Codex CLI with Rampart using LD_PRELOAD syscall interceptio
 
 # Codex CLI
 
-Codex CLI doesn't have a hook system or `$SHELL` support. Rampart uses **LD_PRELOAD** to intercept exec syscalls at the OS level — the universal fallback.
+Codex CLI doesn't have a native hook system. Rampart uses **LD_PRELOAD** to intercept exec syscalls at the OS level — covering Codex and every process it spawns.
 
 ## Setup
 
 ```bash
+# Recommended: install persistent wrapper
+rampart setup codex
+
+# Alternative: wrap a single session
 rampart preload -- codex
 ```
 
-That's it. Every command Codex tries to execute goes through Rampart first.
+`rampart setup codex` installs a wrapper script at `~/.local/bin/codex` that transparently runs the real Codex binary through `rampart preload`. Once installed, every `codex` invocation is automatically protected — no need to remember to add `rampart preload --` each time.
+
+To remove the wrapper: `rampart setup codex --remove`.
 
 ## How It Works
 

--- a/docs-site/integrations/index.md
+++ b/docs-site/integrations/index.md
@@ -16,7 +16,7 @@ Rampart works with every major AI agent through multiple integration methods. Ch
 | **MCP Proxy** | Transparent proxy for MCP tool calls | Claude Desktop, Cursor |
 | **LD_PRELOAD** | Intercepts exec syscalls at the OS level | Codex CLI, any process |
 | **HTTP API** | RESTful endpoint for custom integrations | Python agents, custom code |
-| **Shim + Service** | Shell shim + background daemon | OpenClaw |
+| **Shim + Service** | Shell shim + file tool patching + LD_PRELOAD for sub-agents | OpenClaw |
 | **WebSocket Daemon** | WebSocket integration for real-time agents | OpenClaw (alternative) |
 
 ## require_approval Behavior

--- a/docs-site/integrations/index.md
+++ b/docs-site/integrations/index.md
@@ -41,7 +41,7 @@ When a policy action is `require_approval`, behavior varies by integration:
 | [Cline](cline.md) | Native hooks | `rampart setup cline` | All |
 | [Cursor](cursor.md) | MCP proxy | `rampart mcp --` | All |
 | [Claude Desktop](claude-desktop.md) | MCP proxy | `rampart mcp --` | All |
-| [Codex CLI](codex-cli.md) | LD_PRELOAD | `rampart preload --` | Linux, macOS |
+| [Codex CLI](codex-cli.md) | LD_PRELOAD | `rampart setup codex` | Linux, macOS |
 | [OpenClaw](openclaw.md) | Shim + service | `rampart setup openclaw` | Linux, macOS |
 | [Python Agents](python-agents.md) | HTTP API | `rampart serve` | All |
 | [Any CLI Agent](any-cli-agent.md) | Shell wrapper | `rampart wrap --` | Linux, macOS |
@@ -88,7 +88,7 @@ or any MCP-compatible client"
 q -> wrap: "Any CLI agent
 with \$SHELL support"
 q -> preload: "Any CLI agent
-without \$SHELL (e.g. Codex)"
+without \$SHELL or native hooks"
 q -> api: "Custom / Python agent
 or CI pipeline"
 ```

--- a/docs-site/integrations/openclaw.md
+++ b/docs-site/integrations/openclaw.md
@@ -7,6 +7,9 @@ description: "Protect OpenClaw agents and their sub-agents (Codex, Claude Code) 
 
 For [OpenClaw](https://github.com/openclaw/openclaw) users, Rampart provides multiple layers of protection: a shell shim for OpenClaw's exec tool, LD_PRELOAD interception for sub-agents, and optional file tool patching.
 
+!!! info "Version requirement"
+    Requires OpenClaw 2026.2.x or later.
+
 !!! tip "Fastest path"
     If you want your OpenClaw agent to install and configure Rampart for you, just say:
     > "Install Rampart and protect this machine."
@@ -62,7 +65,7 @@ rampart preload -- <agent-command>
 | Codex CLI commands | ✅ `rampart setup codex` | LD_PRELOAD — all child processes |
 | Claude Code commands | ✅ `rampart setup claude-code` | Native hooks |
 | Other sub-agent commands | ✅ `rampart preload --` | LD_PRELOAD — universal |
-| HTTP fetch (`web_fetch` tool) | ⚠️ Not intercepted | Uses Node.js HTTP internals, not exec. Use `fetch` tool policies or OS-level firewall rules |
+| HTTP fetch (`web_fetch` tool) | ⚠️ Not intercepted | Uses Node.js HTTP internals, not exec. Block via `rampart block --tool fetch '*'` or OS-level firewall rules |
 | Browser automation | ⚠️ Not intercepted | Runs in a separate browser process |
 
 ## How It Works
@@ -77,7 +80,7 @@ OpenClaw Gateway
 
 **Shell shim**: A bash script at `~/.local/bin/rampart-shim` that intercepts every `bash -c "command"` call, sends it to Rampart's policy server, and blocks if denied. Configured via `env.vars.SHELL` in OpenClaw's config.
 
-**LD_PRELOAD**: `librampart.so` hooks `execve`, `execvp`, `system()`, `popen()`, and `posix_spawn()` at the C library level. Inherited by all child processes automatically. Cannot be bypassed by choosing a different shell.
+**LD_PRELOAD**: `librampart.so` hooks `execve`, `execvp`, `execvpe`, `system()`, `popen()`, and `posix_spawn()` at the C library level. Inherited by all child processes automatically. Cannot be bypassed by choosing a different shell.
 
 **File tool patches**: Injects a policy check into OpenClaw's internal read/write/edit/grep tool implementations. Same fail-open behavior.
 
@@ -93,19 +96,19 @@ OpenClaw Gateway
 
 ## Configuration
 
-After running `rampart setup openclaw`, add the shim to your OpenClaw config:
+After running `rampart setup openclaw`, add the shim to your OpenClaw config (replace the path with your actual home directory — run `echo ~/.local/bin/rampart-shim` to get it):
 
 ```json
 {
   "env": {
     "vars": {
-      "SHELL": "/home/you/.local/bin/rampart-shim"
+      "SHELL": "/home/youruser/.local/bin/rampart-shim"
     }
   }
 }
 ```
 
-Then restart the OpenClaw gateway.
+Then restart the gateway: `openclaw gateway restart`.
 
 ## Monitor
 
@@ -124,6 +127,5 @@ rampart setup codex --remove      # Remove Codex wrapper
 
 Policies and audit logs in `~/.rampart/` are preserved.
 
-## Compatibility
-
-Requires OpenClaw 2026.2.x or later. The `--patch-tools` option targets specific internal file paths and is tested against each OpenClaw release — if an upgrade changes the target code, the patch script logs warnings for each failed injection point and continues. File tools that couldn't be patched will be unprotected (fail-open) without a hard error, so check the output of `rampart setup openclaw --patch-tools` after upgrades.
+!!! note "Patch verification"
+    `--patch-tools` targets specific internal file paths. If an upgrade changes the code, the patch script logs warnings for each failed injection point and continues — file tools that couldn't be patched will be unprotected (fail-open). Always check the output of `rampart setup openclaw --patch-tools` after upgrades.

--- a/docs-site/integrations/openclaw.md
+++ b/docs-site/integrations/openclaw.md
@@ -1,11 +1,11 @@
 ---
 title: Securing OpenClaw
-description: "Protect OpenClaw agents with Rampart guardrails for shell commands and file access. Use --patch-tools for full coverage and audit every risky action."
+description: "Protect OpenClaw agents and their sub-agents (Codex, Claude Code) with Rampart. Full exec coverage via LD_PRELOAD, file tool patching, and audit logging."
 ---
 
 # OpenClaw
 
-For [OpenClaw](https://github.com/openclaw/openclaw) users, Rampart provides a shell shim, background service, and optional file tool patching.
+For [OpenClaw](https://github.com/openclaw/openclaw) users, Rampart provides multiple layers of protection: a shell shim for OpenClaw's own exec tool, LD_PRELOAD interception for sub-agents, and optional file tool patching.
 
 !!! tip "Fastest path"
     If you want your OpenClaw agent to install and configure Rampart for you, just say:
@@ -33,38 +33,75 @@ Or use the interactive wizard, which will ask about file tool patching:
 rampart setup
 ```
 
-## What Gets Protected
+### Protecting Sub-Agents
 
-| Tool | Without `--patch-tools` | With `--patch-tools` |
-|------|------------------------|---------------------|
-| Shell commands (`exec`) | ✅ Protected | ✅ Protected |
-| File reads | ❌ Not checked | ✅ Protected |
-| File writes | ❌ Not checked | ✅ Protected |
-| File edits | ❌ Not checked | ✅ Protected |
-| Grep | ❌ Not checked | ✅ Protected |
+OpenClaw can spawn sub-agents like Codex CLI and Claude Code. These run commands through their own shell — **not** through OpenClaw's exec tool — so the shell shim alone won't catch them.
 
-We recommend `--patch-tools` for full coverage, especially if your policies include file access rules (e.g., blocking reads of `.env`, SSH keys, credentials).
+For Codex CLI, install the Rampart wrapper:
+
+```bash
+rampart setup codex
+```
+
+This creates a wrapper at `~/.local/bin/codex` that uses LD_PRELOAD to intercept every exec syscall from Codex and all its child processes. See the [Codex CLI integration guide](codex-cli.md) for details.
+
+For Claude Code, install native hooks:
+
+```bash
+rampart setup claude-code
+```
+
+See the [Claude Code integration guide](claude-code.md) for details.
+
+## Coverage
+
+| What | How it's protected | Setup |
+|------|--------------------|-------|
+| OpenClaw shell commands (`exec` tool) | Shell shim | `rampart setup openclaw` |
+| File reads/writes/edits/grep | Tool patching | `rampart setup openclaw --patch-tools` |
+| Codex CLI commands | LD_PRELOAD wrapper | `rampart setup codex` |
+| Claude Code commands | Native hooks | `rampart setup claude-code` |
+| Any other sub-agent | LD_PRELOAD | `rampart preload -- <agent>` |
+
+!!! note "Sub-agent coverage is not automatic"
+    `rampart setup openclaw` only protects OpenClaw's own exec tool. Each sub-agent needs its own setup. This is because sub-agents spawn their own shell processes directly, bypassing OpenClaw's tool layer.
 
 ## How It Works
 
 ```
-OpenClaw
-  └─ exec tool  → Shell Shim → rampart serve → Policy Engine → Audit
-  └─ file tools → Patched JS → rampart serve → Policy Engine → Audit
+OpenClaw Gateway
+  ├─ exec tool      → Shell Shim → rampart serve → Policy Engine → Audit
+  ├─ file tools     → Patched JS → rampart serve → Policy Engine → Audit
+  ├─ Codex CLI      → LD_PRELOAD → rampart serve → Policy Engine → Audit
+  └─ Claude Code    → Native Hook → Policy Engine → Audit
 ```
 
-**Shell shim**: A small bash script that intercepts every command OpenClaw runs, sends it to the Rampart policy server, and blocks if denied. Fail-open — if Rampart is unreachable, commands pass through.
+**Shell shim**: A bash script at `~/.local/bin/rampart-shim` that intercepts `$SHELL -c "command"` calls. OpenClaw is configured to use this as its shell. Sends each command to the Rampart policy server before execution. Fail-open — if Rampart is unreachable, commands pass through.
 
 **File tool patches**: Injects a policy check into OpenClaw's internal read/write/edit/grep tool implementations. Same fail-open behavior.
 
-**require_approval behavior**: When a policy action is `require_approval`, the daemon creates a pending approval and sends webhook notifications (if configured) to alert humans. The shim blocks execution until the approval is resolved via `rampart approve <id>` or the API.
+**LD_PRELOAD (sub-agents)**: The `librampart.so` library hooks exec-family syscalls (`execve`, `execvp`, `system`, `popen`, `posix_spawn`) at the C library level. Every child process inherits the preload, so the entire process tree is covered. Cannot be bypassed by changing `$SHELL` or calling `/bin/bash` directly.
+
+**require_approval behavior**: When a policy action is `require_approval`, the shim or preload library blocks execution and polls until the approval is resolved via `rampart approve <id>`, the dashboard, or the API.
 
 !!! warning "File patches require re-running after OpenClaw upgrades"
     `--patch-tools` modifies files in `node_modules`. After upgrading OpenClaw, run `rampart setup openclaw --patch-tools --force` to re-apply.
 
-## Compatibility
+## Configuration
 
-Supports recent OpenClaw versions with pi-coding-agent.
+After running `rampart setup openclaw`, configure OpenClaw to use the shim as its shell. In `~/.openclaw/openclaw.json`:
+
+```json
+{
+  "env": {
+    "vars": {
+      "SHELL": "/home/YOUR_USER/.local/bin/rampart-shim"
+    }
+  }
+}
+```
+
+Then restart the OpenClaw gateway.
 
 ## Monitor
 
@@ -78,6 +115,7 @@ rampart log --deny  # Recent denies
 
 ```bash
 rampart setup openclaw --remove
+rampart setup codex --remove          # If installed
 ```
 
-This stops the background service, removes the shim, and restores any patched file tools from backups. Your policies and audit logs in `~/.rampart/` are preserved.
+This stops the background service, removes the shim and wrappers, and restores any patched file tools from backups. Your policies and audit logs in `~/.rampart/` are preserved.

--- a/docs-site/integrations/openclaw.md
+++ b/docs-site/integrations/openclaw.md
@@ -62,8 +62,8 @@ rampart preload -- <agent-command>
 | Codex CLI commands | ✅ `rampart setup codex` | LD_PRELOAD — all child processes |
 | Claude Code commands | ✅ `rampart setup claude-code` | Native hooks |
 | Other sub-agent commands | ✅ `rampart preload --` | LD_PRELOAD — universal |
-| HTTP fetch (`web_fetch` tool) | ⚠️ Not intercepted | Use network policies if needed |
-| Browser automation | ⚠️ Not intercepted | — |
+| HTTP fetch (`web_fetch` tool) | ⚠️ Not intercepted | Uses Node.js HTTP internals, not exec. Use `fetch` tool policies or OS-level firewall rules |
+| Browser automation | ⚠️ Not intercepted | Runs in a separate browser process |
 
 ## How It Works
 
@@ -121,3 +121,7 @@ rampart setup codex --remove      # Remove Codex wrapper
 ```
 
 Policies and audit logs in `~/.rampart/` are preserved.
+
+## Compatibility
+
+Requires OpenClaw 2026.2.x or later. The `--patch-tools` option targets specific internal file paths and is tested against each OpenClaw release — if an upgrade changes the target code, the patch script will exit with an error and file tools will revert to unprotected (fail-open).

--- a/docs-site/integrations/openclaw.md
+++ b/docs-site/integrations/openclaw.md
@@ -45,7 +45,7 @@ rampart setup codex
 
 This creates a wrapper at `~/.local/bin/codex` that transparently routes every command through Rampart's policy engine. The wrapper inherits to all child processes — no configuration needed per sub-agent.
 
-For Claude Code, use `rampart setup claude-code` which installs native hooks.
+For Claude Code, use `rampart setup claude-code` which adds hooks to `~/.claude/settings.json`.
 
 For any other CLI agent, use `rampart preload`:
 
@@ -126,4 +126,4 @@ Policies and audit logs in `~/.rampart/` are preserved.
 
 ## Compatibility
 
-Requires OpenClaw 2026.2.x or later. The `--patch-tools` option targets specific internal file paths and is tested against each OpenClaw release — if an upgrade changes the target code, the patch script will exit with an error and file tools will revert to unprotected (fail-open).
+Requires OpenClaw 2026.2.x or later. The `--patch-tools` option targets specific internal file paths and is tested against each OpenClaw release — if an upgrade changes the target code, the patch script logs warnings for each failed injection point and continues. File tools that couldn't be patched will be unprotected (fail-open) without a hard error, so check the output of `rampart setup openclaw --patch-tools` after upgrades.

--- a/docs-site/integrations/openclaw.md
+++ b/docs-site/integrations/openclaw.md
@@ -1,11 +1,11 @@
 ---
 title: Securing OpenClaw
-description: "Protect OpenClaw agents and their sub-agents (Codex, Claude Code) with Rampart. Full exec coverage via LD_PRELOAD, file tool patching, and audit logging."
+description: "Protect OpenClaw agents and their sub-agents (Codex, Claude Code) with Rampart. Shell shim, LD_PRELOAD, and file tool patching for full coverage."
 ---
 
 # OpenClaw
 
-For [OpenClaw](https://github.com/openclaw/openclaw) users, Rampart provides multiple layers of protection: a shell shim for OpenClaw's own exec tool, LD_PRELOAD interception for sub-agents, and optional file tool patching.
+For [OpenClaw](https://github.com/openclaw/openclaw) users, Rampart provides multiple layers of protection: a shell shim for OpenClaw's exec tool, LD_PRELOAD interception for sub-agents, and optional file tool patching.
 
 !!! tip "Fastest path"
     If you want your OpenClaw agent to install and configure Rampart for you, just say:
@@ -23,79 +23,81 @@ rampart quickstart --yes
 # Manual: shell command protection only
 rampart setup openclaw
 
-# Manual: full protection (shell commands + file reads/writes/edits)
+# Manual: full protection (shell commands + file tools)
 rampart setup openclaw --patch-tools
 ```
 
-Or use the interactive wizard, which will ask about file tool patching:
+Or use the interactive wizard:
 
 ```bash
 rampart setup
 ```
 
-### Protecting Sub-Agents
+## Protecting Sub-Agents
 
-OpenClaw can spawn sub-agents like Codex CLI and Claude Code. These run commands through their own shell — **not** through OpenClaw's exec tool — so the shell shim alone won't catch them.
+OpenClaw can spawn sub-agents like Codex CLI and Claude Code. These agents execute commands through their own shell processes, **not** through OpenClaw's exec tool — so the shell shim alone doesn't catch them.
 
-For Codex CLI, install the Rampart wrapper:
+Use `rampart setup codex` to install a wrapper that intercepts all Codex commands via LD_PRELOAD:
 
 ```bash
 rampart setup codex
 ```
 
-This creates a wrapper at `~/.local/bin/codex` that uses LD_PRELOAD to intercept every exec syscall from Codex and all its child processes. See the [Codex CLI integration guide](codex-cli.md) for details.
+This creates a wrapper at `~/.local/bin/codex` that transparently routes every command through Rampart's policy engine. The wrapper inherits to all child processes — no configuration needed per sub-agent.
 
-For Claude Code, install native hooks:
+For Claude Code, use `rampart setup claude-code` which installs native hooks.
+
+For any other CLI agent, use `rampart preload`:
 
 ```bash
-rampart setup claude-code
+rampart preload -- <agent-command>
 ```
 
-See the [Claude Code integration guide](claude-code.md) for details.
+## Coverage Matrix
 
-## Coverage
-
-| What | How it's protected | Setup |
-|------|--------------------|-------|
-| OpenClaw shell commands (`exec` tool) | Shell shim | `rampart setup openclaw` |
-| File reads/writes/edits/grep | Tool patching | `rampart setup openclaw --patch-tools` |
-| Codex CLI commands | LD_PRELOAD wrapper | `rampart setup codex` |
-| Claude Code commands | Native hooks | `rampart setup claude-code` |
-| Any other sub-agent | LD_PRELOAD | `rampart preload -- <agent>` |
-
-!!! note "Sub-agent coverage is not automatic"
-    `rampart setup openclaw` only protects OpenClaw's own exec tool. Each sub-agent needs its own setup. This is because sub-agents spawn their own shell processes directly, bypassing OpenClaw's tool layer.
+| What | Protected by | Notes |
+|------|-------------|-------|
+| OpenClaw shell commands (`exec` tool) | ✅ Shell shim | Via `$SHELL` env var |
+| File reads/writes/edits/grep | ✅ `--patch-tools` | Re-run after OpenClaw upgrades |
+| Codex CLI commands | ✅ `rampart setup codex` | LD_PRELOAD — all child processes |
+| Claude Code commands | ✅ `rampart setup claude-code` | Native hooks |
+| Other sub-agent commands | ✅ `rampart preload --` | LD_PRELOAD — universal |
+| HTTP fetch (`web_fetch` tool) | ⚠️ Not intercepted | Use network policies if needed |
+| Browser automation | ⚠️ Not intercepted | — |
 
 ## How It Works
 
 ```
 OpenClaw Gateway
-  ├─ exec tool      → Shell Shim → rampart serve → Policy Engine → Audit
-  ├─ file tools     → Patched JS → rampart serve → Policy Engine → Audit
-  ├─ Codex CLI      → LD_PRELOAD → rampart serve → Policy Engine → Audit
-  └─ Claude Code    → Native Hook → Policy Engine → Audit
+  ├─ exec tool → Shell Shim → rampart serve → Policy Engine → allow/deny
+  ├─ file tools → Patched JS → rampart serve → Policy Engine → allow/deny
+  ├─ Codex CLI → librampart.so (LD_PRELOAD) → Policy Engine → allow/deny
+  └─ Claude Code → Native hooks → Policy Engine → allow/deny
 ```
 
-**Shell shim**: A bash script at `~/.local/bin/rampart-shim` that intercepts `$SHELL -c "command"` calls. OpenClaw is configured to use this as its shell. Sends each command to the Rampart policy server before execution. Fail-open — if Rampart is unreachable, commands pass through.
+**Shell shim**: A bash script at `~/.local/bin/rampart-shim` that intercepts every `bash -c "command"` call, sends it to Rampart's policy server, and blocks if denied. Configured via `env.vars.SHELL` in OpenClaw's config.
+
+**LD_PRELOAD**: `librampart.so` hooks `execve`, `execvp`, `system()`, `popen()`, and `posix_spawn()` at the C library level. Inherited by all child processes automatically. Cannot be bypassed by choosing a different shell.
 
 **File tool patches**: Injects a policy check into OpenClaw's internal read/write/edit/grep tool implementations. Same fail-open behavior.
 
-**LD_PRELOAD (sub-agents)**: The `librampart.so` library hooks exec-family syscalls (`execve`, `execvp`, `system`, `popen`, `posix_spawn`) at the C library level. Every child process inherits the preload, so the entire process tree is covered. Cannot be bypassed by changing `$SHELL` or calling `/bin/bash` directly.
-
-**require_approval behavior**: When a policy action is `require_approval`, the shim or preload library blocks execution and polls until the approval is resolved via `rampart approve <id>`, the dashboard, or the API.
+**Fail-open**: All interception layers fail open — if Rampart is unreachable, commands pass through. This is deliberate ([design philosophy](../reference/threat-model.md)).
 
 !!! warning "File patches require re-running after OpenClaw upgrades"
-    `--patch-tools` modifies files in `node_modules`. After upgrading OpenClaw, run `rampart setup openclaw --patch-tools --force` to re-apply.
+    `--patch-tools` modifies files in `node_modules`. After upgrading OpenClaw (`npm install -g openclaw`), run:
+    ```bash
+    rampart setup openclaw --patch-tools --force
+    ```
 
 ## Configuration
 
-After running `rampart setup openclaw`, configure OpenClaw to use the shim as its shell. In `~/.openclaw/openclaw.json`:
+After running `rampart setup openclaw`, add the shim to your OpenClaw config:
 
 ```json
 {
   "env": {
     "vars": {
-      "SHELL": "/home/YOUR_USER/.local/bin/rampart-shim"
+      "SHELL": "/home/you/.local/bin/rampart-shim"
     }
   }
 }
@@ -114,8 +116,8 @@ rampart log --deny  # Recent denies
 ## Uninstall
 
 ```bash
-rampart setup openclaw --remove
-rampart setup codex --remove          # If installed
+rampart setup openclaw --remove   # Remove shim, service, restore patched tools
+rampart setup codex --remove      # Remove Codex wrapper
 ```
 
-This stops the background service, removes the shim and wrappers, and restores any patched file tools from backups. Your policies and audit logs in `~/.rampart/` are preserved.
+Policies and audit logs in `~/.rampart/` are preserved.

--- a/docs-site/integrations/openclaw.md
+++ b/docs-site/integrations/openclaw.md
@@ -83,6 +83,8 @@ OpenClaw Gateway
 
 **Fail-open**: All interception layers fail open — if Rampart is unreachable, commands pass through. This is deliberate ([design philosophy](../reference/threat-model.md)).
 
+**require_approval**: When a policy uses `action: require_approval`, the shim blocks execution and creates a pending approval. If webhooks are configured, Rampart sends notifications (Discord, Slack, etc.) to alert humans. The command stays blocked until resolved via `rampart approve <id>`, `rampart deny <id>`, or the HTTP API.
+
 !!! warning "File patches require re-running after OpenClaw upgrades"
     `--patch-tools` modifies files in `node_modules`. After upgrading OpenClaw (`npm install -g openclaw`), run:
     ```bash

--- a/docs-site/reference/cli-commands.md
+++ b/docs-site/reference/cli-commands.md
@@ -155,7 +155,7 @@ rampart init --detect                 # Auto-detect environment
 
 ### `rampart init --from-audit`
 
-Generate policy YAML from audit logs. The "learn mode → enforce mode" pattern: observe what your agent does, then generate rules that match.
+Generate policy YAML from audit logs — the "learn mode → enforce mode" workflow. Observe what your agent does, then generate rules that match.
 
 ```bash
 rampart init --from-audit ~/.rampart/audit/audit.jsonl          # Generate from audit log

--- a/docs-site/reference/cli-commands.md
+++ b/docs-site/reference/cli-commands.md
@@ -39,6 +39,7 @@ Install native hooks into Cline.
 
 ```bash
 rampart setup cline           # Install hooks
+rampart setup cline --force   # Overwrite existing hooks
 rampart setup cline --remove  # Remove hooks
 ```
 
@@ -97,6 +98,7 @@ rampart serve --port 8080              # Custom port
 rampart serve --config policy.yaml     # Custom policy
 rampart serve --syslog localhost:514   # With syslog output
 rampart serve --cef                    # With CEF file output
+rampart serve --syslog localhost:514 --cef  # CEF to syslog
 rampart serve --tls-auto               # HTTPS with auto-generated self-signed cert
 rampart serve --tls-cert c.pem --tls-key k.pem  # HTTPS with your own cert
 ```

--- a/docs-site/reference/cli-commands.md
+++ b/docs-site/reference/cli-commands.md
@@ -23,12 +23,15 @@ rampart quickstart -y               # Short form of --yes
 
 ### `rampart setup claude-code`
 
-Install native hooks into Claude Code.
+Install native hooks into Claude Code. Uses Claude Code's native hook system (`hooks.toml`) — no LD_PRELOAD or shim needed.
 
 ```bash
 rampart setup claude-code           # Install hooks
+rampart setup claude-code --force   # Overwrite existing hooks
 rampart setup claude-code --remove  # Remove hooks
 ```
+
+Hooks are installed into Claude Code's config directory and intercept tool calls at the `PreToolUse` and `PostToolUse` lifecycle points. Both exec and file operations are covered natively — no `--patch-tools` equivalent needed.
 
 ### `rampart setup cline`
 

--- a/docs-site/reference/cli-commands.md
+++ b/docs-site/reference/cli-commands.md
@@ -23,7 +23,7 @@ rampart quickstart -y               # Short form of --yes
 
 ### `rampart setup claude-code`
 
-Install native hooks into Claude Code. Uses Claude Code's native hook system (`hooks.toml`) — no LD_PRELOAD or shim needed.
+Install native hooks into Claude Code. Adds a `PreToolUse` hook to `~/.claude/settings.json` — no LD_PRELOAD or shim needed.
 
 ```bash
 rampart setup claude-code           # Install hooks
@@ -31,7 +31,7 @@ rampart setup claude-code --force   # Overwrite existing hooks
 rampart setup claude-code --remove  # Remove hooks
 ```
 
-Hooks are installed into Claude Code's config directory and intercept tool calls at the `PreToolUse` and `PostToolUse` lifecycle points. Both exec and file operations are covered natively — no `--patch-tools` equivalent needed.
+Hooks are written to `~/.claude/settings.json` and intercept tool calls at the `PreToolUse` lifecycle point. A `PostToolUseFailure` hook is also registered for audit logging. Both exec and file operations are covered natively — no `--patch-tools` equivalent needed.
 
 ### `rampart setup cline`
 
@@ -167,7 +167,6 @@ rampart init --from-audit ~/.rampart/audit/audit.jsonl          # Generate from 
 rampart init --from-audit ~/.rampart/audit/ --since 24h         # Last 24 hours only
 rampart init --from-audit ~/.rampart/audit/ --dry-run           # Preview without writing
 rampart init --from-audit ~/.rampart/audit/ --output policy.yaml  # Custom output path
-rampart init --from-audit ~/.rampart/audit/ --merge             # Merge with existing policy
 ```
 
 Only allowed events are used for rule generation — denied events represent behavior you don't want to codify.
@@ -297,7 +296,7 @@ rampart allow "docker *" --for 1h             # Expires after 1 hour
 rampart allow "npm publish" --once             # Single-use — removed after first match
 ```
 
-`--for` accepts Go duration strings (`1h`, `30m`, `24h`, `2h30m`). The rule is skipped during evaluation once expired and cleaned up lazily. `--once` rules are removed immediately after their first match.
+`--for` accepts Go duration strings (`1h`, `30m`, `24h`, `2h30m`). Expired rules are skipped during evaluation (the `expires_at` timestamp is checked before matching). `--once` rules are flagged as consumed after their first match. In both cases the rules remain in the YAML file until manually removed via `rampart rules remove`.
 
 ### `rampart block`
 

--- a/docs-site/reference/cli-commands.md
+++ b/docs-site/reference/cli-commands.md
@@ -44,9 +44,26 @@ rampart setup cline --remove  # Remove hooks
 Install shell shim and background service for OpenClaw.
 
 ```bash
-rampart setup openclaw                # Install shim + service
-rampart setup openclaw --remove       # Remove shim + service
+rampart setup openclaw                    # Install shim + service
+rampart setup openclaw --patch-tools      # Full coverage (shell + file tools)
+rampart setup openclaw --force            # Overwrite existing config
+rampart setup openclaw --remove           # Remove shim + service
 ```
+
+!!! warning "Re-run after OpenClaw upgrades"
+    `--patch-tools` modifies files in `node_modules`. After upgrading OpenClaw, run `rampart setup openclaw --patch-tools --force` to re-apply.
+
+### `rampart setup codex`
+
+Install a wrapper script that intercepts all Codex CLI tool calls via LD_PRELOAD.
+
+```bash
+rampart setup codex                   # Install wrapper
+rampart setup codex --force           # Overwrite existing wrapper
+rampart setup codex --remove          # Remove wrapper
+```
+
+The wrapper is installed at `~/.local/bin/codex` and transparently wraps the real Codex binary. Every command Codex executes — including from sub-agents — goes through Rampart's policy engine.
 
 ### `rampart setup` (interactive)
 
@@ -77,8 +94,11 @@ rampart serve --port 8080              # Custom port
 rampart serve --config policy.yaml     # Custom policy
 rampart serve --syslog localhost:514   # With syslog output
 rampart serve --cef                    # With CEF file output
-rampart serve --syslog localhost:514 --cef  # CEF to syslog
+rampart serve --tls-auto               # HTTPS with auto-generated self-signed cert
+rampart serve --tls-cert c.pem --tls-key k.pem  # HTTPS with your own cert
 ```
+
+`--tls-auto` generates a self-signed ECDSA P-256 certificate (1-year validity) and stores it in `~/.rampart/tls/`. The SHA-256 fingerprint is printed on startup for verification. `--tls-cert` and `--tls-key` must be used together and are mutually exclusive with `--tls-auto`.
 
 ### `rampart wrap`
 
@@ -132,6 +152,20 @@ rampart init --profile paranoid       # Paranoid profile
 rampart init --profile yolo           # Yolo profile
 rampart init --detect                 # Auto-detect environment
 ```
+
+### `rampart init --from-audit`
+
+Generate policy YAML from audit logs. The "learn mode → enforce mode" pattern: observe what your agent does, then generate rules that match.
+
+```bash
+rampart init --from-audit ~/.rampart/audit/audit.jsonl          # Generate from audit log
+rampart init --from-audit ~/.rampart/audit/ --since 24h         # Last 24 hours only
+rampart init --from-audit ~/.rampart/audit/ --dry-run           # Preview without writing
+rampart init --from-audit ~/.rampart/audit/ --output policy.yaml  # Custom output path
+rampart init --from-audit ~/.rampart/audit/ --merge             # Merge with existing policy
+```
+
+Only allowed events are used for rule generation — denied events represent behavior you don't want to codify.
 
 ## Diagnostics
 
@@ -254,7 +288,11 @@ rampart allow "/tmp/**" --tool read            # Explicit tool type
 rampart allow "docker build *" --global        # Write to global policy
 rampart allow "pytest *" --project             # Write to project policy
 rampart allow "git push *" --yes               # Skip confirmation
+rampart allow "docker *" --for 1h             # Expires after 1 hour
+rampart allow "npm publish" --once             # Single-use — removed after first match
 ```
+
+`--for` accepts Go duration strings (`1h`, `30m`, `24h`, `2h30m`). The rule is skipped during evaluation once expired and cleaned up lazily. `--once` rules are removed immediately after their first match.
 
 ### `rampart block`
 

--- a/docs-site/reference/cli-commands.md
+++ b/docs-site/reference/cli-commands.md
@@ -31,7 +31,7 @@ rampart setup claude-code --force   # Overwrite existing hooks
 rampart setup claude-code --remove  # Remove hooks
 ```
 
-Hooks are written to `~/.claude/settings.json` and intercept tool calls at the `PreToolUse` lifecycle point. A `PostToolUseFailure` hook is also registered for audit logging. Both exec and file operations are covered natively — no `--patch-tools` equivalent needed.
+Hooks are written to `~/.claude/settings.json` and intercept tool calls at the `PreToolUse` lifecycle point. A `PostToolUseFailure` hook is also registered to prevent Claude Code from repeatedly retrying denied operations. Both exec and file operations are covered natively — no `--patch-tools` equivalent needed.
 
 ### `rampart setup cline`
 
@@ -55,7 +55,7 @@ rampart setup openclaw --remove           # Remove shim + service
 ```
 
 !!! warning "Re-run after OpenClaw upgrades"
-    `--patch-tools` modifies files in `node_modules`. After upgrading OpenClaw, run `rampart setup openclaw --patch-tools --force` to re-apply.
+    `--patch-tools` modifies files in `node_modules`. After upgrading OpenClaw (`npm install -g openclaw`), run `rampart setup openclaw --patch-tools --force` to re-apply.
 
 ### `rampart setup codex`
 
@@ -67,7 +67,7 @@ rampart setup codex --force           # Overwrite existing wrapper
 rampart setup codex --remove          # Remove wrapper
 ```
 
-The wrapper is installed at `~/.local/bin/codex` and transparently wraps the real Codex binary. Every command Codex executes — including from sub-agents — goes through Rampart's policy engine.
+The wrapper is installed at `~/.local/bin/codex` and transparently wraps the real Codex binary. Every command Codex executes — and every child process it spawns — goes through Rampart's policy engine via LD_PRELOAD inheritance.
 
 ### `rampart setup` (interactive)
 
@@ -93,17 +93,21 @@ echo '{"tool_name":"Bash","tool_input":{"command":"rm -rf /"}}' | rampart hook
 Start the HTTP policy proxy.
 
 ```bash
-rampart serve                          # Default (port 9090)
-rampart serve --port 8080              # Custom port
-rampart serve --config policy.yaml     # Custom policy
-rampart serve --syslog localhost:514   # With syslog output
-rampart serve --cef                    # With CEF file output
-rampart serve --syslog localhost:514 --cef  # CEF to syslog
-rampart serve --tls-auto               # HTTPS with auto-generated self-signed cert
-rampart serve --tls-cert c.pem --tls-key k.pem  # HTTPS with your own cert
+rampart serve                              # Default (port 9090, all interfaces)
+rampart serve --addr 127.0.0.1             # Bind to localhost only
+rampart serve --port 8080                  # Custom port
+rampart serve --config policy.yaml         # Custom policy
+rampart serve --audit-dir /var/log/rampart # Custom audit log directory
+rampart serve --syslog localhost:514       # With syslog output
+rampart serve --cef                        # With CEF file output
+rampart serve --syslog localhost:514 --cef # CEF to syslog
+rampart serve --tls-auto                   # HTTPS with auto-generated self-signed cert
+rampart serve --tls-cert cert.pem --tls-key key.pem  # HTTPS with your own cert
 ```
 
-`--tls-auto` generates a self-signed ECDSA P-256 certificate (1-year validity) and stores it in `~/.rampart/tls/`. The SHA-256 fingerprint is printed on startup for verification. `--tls-cert` and `--tls-key` must be used together and are mutually exclusive with `--tls-auto`.
+`--addr` takes a bare IP address (e.g. `127.0.0.1`, `0.0.0.0`, `::1`). Defaults to all interfaces if omitted — use `--addr 127.0.0.1` for localhost-only access. `--audit-dir` sets the directory for audit log output (defaults to `~/.rampart/audit/`).
+
+`--tls-auto` generates a self-signed ECDSA P-256 certificate (1-year validity) and stores it in `~/.rampart/tls/`. A truncated SHA-256 fingerprint is printed on startup. `--tls-cert` and `--tls-key` must be used together and are mutually exclusive with `--tls-auto`.
 
 ### `rampart wrap`
 
@@ -160,7 +164,7 @@ rampart init --detect                 # Auto-detect environment
 
 ### `rampart init --from-audit`
 
-Generate policy YAML from audit logs — the "learn mode → enforce mode" workflow. Observe what your agent does, then generate rules that match.
+Generate policy YAML from audit logs. Observe what your agent does in monitor mode, then generate allow rules to match the observed behavior.
 
 ```bash
 rampart init --from-audit ~/.rampart/audit/audit.jsonl          # Generate from audit log
@@ -292,11 +296,11 @@ rampart allow "/tmp/**" --tool read            # Explicit tool type
 rampart allow "docker build *" --global        # Write to global policy
 rampart allow "pytest *" --project             # Write to project policy
 rampart allow "git push *" --yes               # Skip confirmation
-rampart allow "docker *" --for 1h             # Expires after 1 hour
-rampart allow "npm publish" --once             # Single-use — removed after first match
+rampart allow "docker *" --for 1h              # Expires after 1 hour
+rampart allow "npm publish" --once             # Single-use — consumed after first match
 ```
 
-`--for` accepts Go duration strings (`1h`, `30m`, `24h`, `2h30m`). Expired rules are skipped during evaluation (the `expires_at` timestamp is checked before matching). `--once` rules are flagged as consumed after their first match. In both cases the rules remain in the YAML file until manually removed via `rampart rules remove`.
+`--for` accepts Go duration strings (`1h`, `30m`, `24h`, `2h30m`). Expired rules are skipped during evaluation (the `expires_at` timestamp is checked before matching). `--once` marks the rule as consumed in audit metadata after its first match, but the rule continues to be evaluated and the YAML is not automatically modified. In both cases, use `rampart rules remove` to clean up expired or consumed rules.
 
 ### `rampart block`
 

--- a/docs-site/reference/threat-model.md
+++ b/docs-site/reference/threat-model.md
@@ -241,8 +241,8 @@ v0.7.4 introduced temporal allows (`--for`, `--once`). Expired rules are **skipp
 
 **Security implications:**
 - Expired rules exist in the YAML but are inert — the engine checks `expires_at` before matching
-- `--once` rules are flagged as consumed in decision metadata after their first match, but remain in the YAML
-- Automatic cleanup is not yet implemented — use `rampart rules remove` to clean up expired/consumed rules
+- `--once` rules record consumption in decision metadata after their first match, but the proxy does not call `RemoveRule` — the rule continues to match on subsequent evaluations. This is a known gap; true single-use enforcement requires wiring `Decision.ConsumedOnce` to `persist.RemoveRule` in the proxy layer
+- Automatic cleanup is not yet implemented — use `rampart rules remove` to manually clean up expired or consumed rules
 - Clock skew: expiry is evaluated against the system clock. If the system clock is set backwards, an expired rule could become active again. Use NTP.
 
 ## Self-Modification Protection

--- a/docs-site/reference/threat-model.md
+++ b/docs-site/reference/threat-model.md
@@ -143,7 +143,7 @@ These limits protect against both accidental performance degradation and malicio
 As of v0.7.4, `rampart serve` supports TLS via `--tls-auto` (self-signed ECDSA P-256) or `--tls-cert`/`--tls-key` (bring your own). On localhost, plaintext is still acceptable; for remote or team deployments, enable TLS.
 
 **Notes:**
-- Default bind is `127.0.0.1` (localhost only) — TLS is optional for local use
+- Default bind is all interfaces (`--addr` defaults to `""`). Use `--addr 127.0.0.1` to restrict to localhost
 - `--tls-auto` generates a self-signed cert stored in `~/.rampart/tls/` (1-year validity)
 - The SHA-256 fingerprint is printed on startup for manual verification
 - For production, use proper certs via `--tls-cert`/`--tls-key` or a reverse proxy
@@ -237,11 +237,12 @@ The HTTP API uses a single bearer token for both tool call evaluation and admini
 
 ### 13. Temporal Allow Expiry
 
-v0.7.4 introduced temporal allows (`--for`, `--once`). Expired rules are **skipped during evaluation** and cleaned up lazily — they are not removed from the policy file immediately on expiry.
+v0.7.4 introduced temporal allows (`--for`, `--once`). Expired rules are **skipped during evaluation** but remain in the policy YAML until manually removed.
 
 **Security implications:**
-- Between expiry and cleanup, the rule exists in the YAML but is inert (evaluation checks `expires_at` before matching)
-- `--once` rules are removed immediately after their first match
+- Expired rules exist in the YAML but are inert — the engine checks `expires_at` before matching
+- `--once` rules are flagged as consumed in decision metadata after their first match, but remain in the YAML
+- Automatic cleanup is not yet implemented — use `rampart rules remove` to clean up expired/consumed rules
 - Clock skew: expiry is evaluated against the system clock. If the system clock is set backwards, an expired rule could become active again. Use NTP.
 
 ## Self-Modification Protection

--- a/docs-site/reference/threat-model.md
+++ b/docs-site/reference/threat-model.md
@@ -1,6 +1,6 @@
 # Threat Model
 
-> Last reviewed: 2026-03-03 | Applies to: v0.7.2
+> Last reviewed: 2026-03-03 | Applies to: v0.7.4
 
 Rampart is a policy engine for AI agents — not a sandbox, not a hypervisor, not a full isolation boundary. This document describes what Rampart protects against, what it doesn't, and why.
 

--- a/docs-site/reference/threat-model.md
+++ b/docs-site/reference/threat-model.md
@@ -157,15 +157,6 @@ Pending approvals are stored in memory and lost on service restart. If `rampart 
 - Service restarts are rare during active sessions
 - Persistent approval storage is planned for a future release
 
-### 13. Temporal Allow Expiry
-
-v0.7.4 introduced temporal allows (`--for`, `--once`). Expired rules are **skipped during evaluation** and cleaned up lazily — they are not removed from the policy file immediately on expiry.
-
-**Security implications:**
-- Between expiry and cleanup, the rule exists in the YAML but is inert (evaluation checks `expires_at` before matching)
-- `--once` rules are removed immediately after their first match
-- Clock skew: expiry is evaluated against the system clock. If the system clock is set backwards, an expired rule could become active again. Use NTP.
-
 ### 10. Project Policy Trust
 
 Project-local `.rampart/policy.yaml` files are loaded automatically when present. A malicious repository could include a permissive project policy.
@@ -243,6 +234,15 @@ The HTTP API uses a single bearer token for both tool call evaluation and admini
 - Splitting eval and admin tokens is tracked in [#180](https://github.com/peg/rampart/issues/180)
 
 **Current status:** This is a known gap in same-user deployments. The fix (separate eval and admin tokens) is designed and will ship in a future release with zero user friction — both tokens auto-generate and the shim only receives the eval token.
+
+### 13. Temporal Allow Expiry
+
+v0.7.4 introduced temporal allows (`--for`, `--once`). Expired rules are **skipped during evaluation** and cleaned up lazily — they are not removed from the policy file immediately on expiry.
+
+**Security implications:**
+- Between expiry and cleanup, the rule exists in the YAML but is inert (evaluation checks `expires_at` before matching)
+- `--once` rules are removed immediately after their first match
+- Clock skew: expiry is evaluated against the system clock. If the system clock is set backwards, an expired rule could become active again. Use NTP.
 
 ## Self-Modification Protection
 

--- a/docs-site/reference/threat-model.md
+++ b/docs-site/reference/threat-model.md
@@ -138,14 +138,15 @@ Rampart imposes limits on regex patterns used for response matching to prevent R
 
 These limits protect against both accidental performance degradation and malicious patterns. They prevent policy authors from creating DoS conditions, and prevent attackers from injecting malicious regex patterns via webhook-driven policy updates. Patterns exceeding these limits are rejected at policy load time with clear error messages.
 
-### 8. No TLS on HTTP API
+### 8. TLS on HTTP API
 
-`rampart serve` communicates over plaintext HTTP. On localhost this is acceptable; for remote or team deployments, this means policy decisions transit unencrypted.
+As of v0.7.4, `rampart serve` supports TLS via `--tls-auto` (self-signed ECDSA P-256) or `--tls-cert`/`--tls-key` (bring your own). On localhost, plaintext is still acceptable; for remote or team deployments, enable TLS.
 
-**Mitigations:**
-- Default bind is `127.0.0.1` (localhost only)
-- For remote access, use a reverse proxy with TLS or SSH tunnel
-- TLS support for `rampart serve` is planned for a future release
+**Notes:**
+- Default bind is `127.0.0.1` (localhost only) — TLS is optional for local use
+- `--tls-auto` generates a self-signed cert stored in `~/.rampart/tls/` (1-year validity)
+- The SHA-256 fingerprint is printed on startup for manual verification
+- For production, use proper certs via `--tls-cert`/`--tls-key` or a reverse proxy
 
 ### 9. In-Memory Approval Store
 
@@ -155,6 +156,15 @@ Pending approvals are stored in memory and lost on service restart. If `rampart 
 - Approvals typically resolve within seconds (human clicks approve/deny)
 - Service restarts are rare during active sessions
 - Persistent approval storage is planned for a future release
+
+### 13. Temporal Allow Expiry
+
+v0.7.4 introduced temporal allows (`--for`, `--once`). Expired rules are **skipped during evaluation** and cleaned up lazily — they are not removed from the policy file immediately on expiry.
+
+**Security implications:**
+- Between expiry and cleanup, the rule exists in the YAML but is inert (evaluation checks `expires_at` before matching)
+- `--once` rules are removed immediately after their first match
+- Clock skew: expiry is evaluated against the system clock. If the system clock is set backwards, an expired rule could become active again. Use NTP.
 
 ### 10. Project Policy Trust
 
@@ -183,6 +193,7 @@ Project-local `.rampart/policy.yaml` files are loaded automatically when present
 | `rampart wrap` | ✅ | ❌ | ❌ | ✅ LD_PRELOAD |
 | `rampart preload` | ✅ | ❌ | ❌ | ✅ LD_PRELOAD |
 | `rampart setup openclaw --patch-tools` | ✅ (shim) | ✅ (patched) | ❌ | ❌ |
+| `rampart setup codex` | ✅ (LD_PRELOAD) | ❌ | ❌ | ✅ LD_PRELOAD |
 | HTTP proxy | ✅ | ✅ | ✅ | ❌ |
 | MCP proxy | ✅ | ✅ | ✅ | ❌ |
 

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -241,8 +241,8 @@ v0.7.4 introduced temporal allows (`--for`, `--once`). Expired rules are **skipp
 
 **Security implications:**
 - Expired rules exist in the YAML but are inert — the engine checks `expires_at` before matching
-- `--once` rules are flagged as consumed in decision metadata after their first match, but remain in the YAML
-- Automatic cleanup is not yet implemented — use `rampart rules remove` to clean up expired/consumed rules
+- `--once` rules record consumption in decision metadata after their first match, but the proxy does not call `RemoveRule` — the rule continues to match on subsequent evaluations. This is a known gap; true single-use enforcement requires wiring `Decision.ConsumedOnce` to `persist.RemoveRule` in the proxy layer
+- Automatic cleanup is not yet implemented — use `rampart rules remove` to manually clean up expired or consumed rules
 - Clock skew: expiry is evaluated against the system clock. If the system clock is set backwards, an expired rule could become active again. Use NTP.
 
 ## Self-Modification Protection

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -143,7 +143,7 @@ These limits protect against both accidental performance degradation and malicio
 As of v0.7.4, `rampart serve` supports TLS via `--tls-auto` (self-signed ECDSA P-256) or `--tls-cert`/`--tls-key` (bring your own). On localhost, plaintext is still acceptable; for remote or team deployments, enable TLS.
 
 **Notes:**
-- Default bind is `127.0.0.1` (localhost only) — TLS is optional for local use
+- Default bind is all interfaces (`--addr` defaults to `""`). Use `--addr 127.0.0.1` to restrict to localhost
 - `--tls-auto` generates a self-signed cert stored in `~/.rampart/tls/` (1-year validity)
 - The SHA-256 fingerprint is printed on startup for manual verification
 - For production, use proper certs via `--tls-cert`/`--tls-key` or a reverse proxy
@@ -237,11 +237,12 @@ The HTTP API uses a single bearer token for both tool call evaluation and admini
 
 ### 13. Temporal Allow Expiry
 
-v0.7.4 introduced temporal allows (`--for`, `--once`). Expired rules are **skipped during evaluation** and cleaned up lazily — they are not removed from the policy file immediately on expiry.
+v0.7.4 introduced temporal allows (`--for`, `--once`). Expired rules are **skipped during evaluation** but remain in the policy YAML until manually removed.
 
 **Security implications:**
-- Between expiry and cleanup, the rule exists in the YAML but is inert (evaluation checks `expires_at` before matching)
-- `--once` rules are removed immediately after their first match
+- Expired rules exist in the YAML but are inert — the engine checks `expires_at` before matching
+- `--once` rules are flagged as consumed in decision metadata after their first match, but remain in the YAML
+- Automatic cleanup is not yet implemented — use `rampart rules remove` to clean up expired/consumed rules
 - Clock skew: expiry is evaluated against the system clock. If the system clock is set backwards, an expired rule could become active again. Use NTP.
 
 ## Self-Modification Protection

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -1,6 +1,6 @@
 # Threat Model
 
-> Last reviewed: 2026-03-03 | Applies to: v0.7.2
+> Last reviewed: 2026-03-03 | Applies to: v0.7.4
 
 Rampart is a policy engine for AI agents — not a sandbox, not a hypervisor, not a full isolation boundary. This document describes what Rampart protects against, what it doesn't, and why.
 

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -157,15 +157,6 @@ Pending approvals are stored in memory and lost on service restart. If `rampart 
 - Service restarts are rare during active sessions
 - Persistent approval storage is planned for a future release
 
-### 13. Temporal Allow Expiry
-
-v0.7.4 introduced temporal allows (`--for`, `--once`). Expired rules are **skipped during evaluation** and cleaned up lazily — they are not removed from the policy file immediately on expiry.
-
-**Security implications:**
-- Between expiry and cleanup, the rule exists in the YAML but is inert (evaluation checks `expires_at` before matching)
-- `--once` rules are removed immediately after their first match
-- Clock skew: expiry is evaluated against the system clock. If the system clock is set backwards, an expired rule could become active again. Use NTP.
-
 ### 10. Project Policy Trust
 
 Project-local `.rampart/policy.yaml` files are loaded automatically when present. A malicious repository could include a permissive project policy.
@@ -243,6 +234,15 @@ The HTTP API uses a single bearer token for both tool call evaluation and admini
 - Splitting eval and admin tokens is tracked in [#180](https://github.com/peg/rampart/issues/180)
 
 **Current status:** This is a known gap in same-user deployments. The fix (separate eval and admin tokens) is designed and will ship in a future release with zero user friction — both tokens auto-generate and the shim only receives the eval token.
+
+### 13. Temporal Allow Expiry
+
+v0.7.4 introduced temporal allows (`--for`, `--once`). Expired rules are **skipped during evaluation** and cleaned up lazily — they are not removed from the policy file immediately on expiry.
+
+**Security implications:**
+- Between expiry and cleanup, the rule exists in the YAML but is inert (evaluation checks `expires_at` before matching)
+- `--once` rules are removed immediately after their first match
+- Clock skew: expiry is evaluated against the system clock. If the system clock is set backwards, an expired rule could become active again. Use NTP.
 
 ## Self-Modification Protection
 

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -138,14 +138,15 @@ Rampart imposes limits on regex patterns used for response matching to prevent R
 
 These limits protect against both accidental performance degradation and malicious patterns. They prevent policy authors from creating DoS conditions, and prevent attackers from injecting malicious regex patterns via webhook-driven policy updates. Patterns exceeding these limits are rejected at policy load time with clear error messages.
 
-### 8. No TLS on HTTP API
+### 8. TLS on HTTP API
 
-`rampart serve` communicates over plaintext HTTP. On localhost this is acceptable; for remote or team deployments, this means policy decisions transit unencrypted.
+As of v0.7.4, `rampart serve` supports TLS via `--tls-auto` (self-signed ECDSA P-256) or `--tls-cert`/`--tls-key` (bring your own). On localhost, plaintext is still acceptable; for remote or team deployments, enable TLS.
 
-**Mitigations:**
-- Default bind is `127.0.0.1` (localhost only)
-- For remote access, use a reverse proxy with TLS or SSH tunnel
-- TLS support for `rampart serve` is planned for a future release
+**Notes:**
+- Default bind is `127.0.0.1` (localhost only) — TLS is optional for local use
+- `--tls-auto` generates a self-signed cert stored in `~/.rampart/tls/` (1-year validity)
+- The SHA-256 fingerprint is printed on startup for manual verification
+- For production, use proper certs via `--tls-cert`/`--tls-key` or a reverse proxy
 
 ### 9. In-Memory Approval Store
 
@@ -155,6 +156,15 @@ Pending approvals are stored in memory and lost on service restart. If `rampart 
 - Approvals typically resolve within seconds (human clicks approve/deny)
 - Service restarts are rare during active sessions
 - Persistent approval storage is planned for a future release
+
+### 13. Temporal Allow Expiry
+
+v0.7.4 introduced temporal allows (`--for`, `--once`). Expired rules are **skipped during evaluation** and cleaned up lazily — they are not removed from the policy file immediately on expiry.
+
+**Security implications:**
+- Between expiry and cleanup, the rule exists in the YAML but is inert (evaluation checks `expires_at` before matching)
+- `--once` rules are removed immediately after their first match
+- Clock skew: expiry is evaluated against the system clock. If the system clock is set backwards, an expired rule could become active again. Use NTP.
 
 ### 10. Project Policy Trust
 
@@ -183,6 +193,7 @@ Project-local `.rampart/policy.yaml` files are loaded automatically when present
 | `rampart wrap` | ✅ | ❌ | ❌ | ✅ LD_PRELOAD |
 | `rampart preload` | ✅ | ❌ | ❌ | ✅ LD_PRELOAD |
 | `rampart setup openclaw --patch-tools` | ✅ (shim) | ✅ (patched) | ❌ | ❌ |
+| `rampart setup codex` | ✅ (LD_PRELOAD) | ❌ | ❌ | ✅ LD_PRELOAD |
 | HTTP proxy | ✅ | ✅ | ✅ | ❌ |
 | MCP proxy | ✅ | ✅ | ✅ | ❌ |
 


### PR DESCRIPTION
## What changed

Docs audit found multiple gaps after the v0.7.4 release. This brings everything up to date.

### New content
- **CLI commands reference**: `init --from-audit`, `serve --tls-*`, `setup codex`, `allow --for/--once`
- **Installation page**: Docker section with GHCR image + docker-compose example
- **Homepage**: "What's New in v0.7.4" section

### Updated content
- **OpenClaw integration**: Rewritten with sub-agent coverage matrix, LD_PRELOAD explanation, `setup codex`/`setup claude-code` instructions, coverage table
- **Codex CLI integration**: Added `rampart setup codex` as recommended setup (persistent wrapper)
- **Integration index**: Updated OpenClaw description
- **Threat model**: Version reference updated to v0.7.4

### Files changed
- `docs-site/reference/cli-commands.md`
- `docs-site/getting-started/installation.md`
- `docs-site/integrations/openclaw.md`
- `docs-site/integrations/codex-cli.md`
- `docs-site/integrations/index.md`
- `docs-site/index.md`
- `docs-site/reference/threat-model.md`
- `docs/THREAT-MODEL.md`