### PR TITLE
site: fix bugs, copy, and UX from professional review

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -893,8 +893,10 @@
         <div class="section-label">Architecture</div>
         <h2 class="section-title">How it fits into your stack</h2>
         <p class="section-desc">Rampart sits between your agent and the OS. Every tool call passes through the policy engine before it executes.</p>
-        <div style="max-width:780px; margin:0 auto; background:var(--surface); border:1px solid var(--border); border-radius:12px; padding:32px; text-align:center;">
-            <img src="architecture.svg" alt="Rampart architecture diagram showing agent tool calls flowing through the policy engine" style="max-width:100%; height:auto; border-radius:8px;" loading="lazy">
+    </div>
+    <div style="max-width:1200px; margin:0 auto; padding:0 24px;">
+        <div style="background:var(--surface); border:1px solid var(--border); border-radius:12px; padding:24px; text-align:center; overflow-x:auto;">
+            <img src="architecture.svg" alt="Rampart architecture diagram showing agent tool calls flowing through the policy engine" style="max-width:100%; min-width:900px; height:auto; border-radius:8px;" loading="lazy">
         </div>
     </div>
 </section>


### PR DESCRIPTION
## Summary

Professional copywriter + front-end dev reviewed rampart.sh. This PR fixes everything they found.

### CSS Bugs Fixed
- `--text-dim` was **never defined** but used 9+ times — all FAQ answer text was rendering with broken/fallback color
- `var(--accent)20` is invalid CSS (can't append hex to var ref) — box-shadow silently dropped on install cards
- Missing `-webkit-backdrop-filter` — nav blur didn't work in Safari
- `Inter` font referenced but never loaded — now correctly uses `Archivo` (the font we actually load)
- FAQ section used hardcoded `#30363d` instead of `var(--border)`

### Copy Fixes
- **Removed 'No daemon'** — `rampart serve` IS a service, the docs install it, and the FAQ acknowledges it can crash. This was the #1 risk for an HN launch.
- **Replaced 'Enterprise-ready'** with 'SIEM-compatible audit' — defensible, specific, not aspirational
- **Moved 'seatbelt not a cage'** from buried FAQ to features section intro — it's the most quotable line on the site
- Added TLS to the SIEM feature card (new in v0.7.4)

### UX/Accessibility
- Nav logo is now a link (was a `<span>` — clicking did nothing)
- **Swapped hero CTAs**: Install is primary (filled), GitHub is secondary (ghost)
- Added `twitter:title/description/image` meta tags
- Added `aria-label` to copy buttons
- Added `@media (prefers-reduced-motion)` for terminal animation

### Enhancements
- **Animated terminal**: rows fade in with staggered delays (8-second sequence)
- GitHub star count cached in localStorage (1hr TTL, prevents rate limiting)
- Moved inline `switchTab` script to bottom script block
- **New FAQ: 'Can my agent bypass Rampart?'** — proactively addresses glob evasion, recommends allowlist mode
- **New FAQ: 'Can I require human approval?'** — surfaces `require_approval` feature

### Not in this PR (future work)
- YAML policy example on page
- Architecture diagram section
- `rampart init --from-audit` onboarding story
- Response-side credential scanning callout
- Video demo