### PR TITLE
fix: remove fabricated AIUC-1 control identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Double webhook for `ask` decisions**: the immediate webhook notification now skips `ask` decisions (same as `require_approval`), so the webhook fires once — after the approval is created — with full approval metadata.
 - **`rampart init` partial output**: when a config or policy file already exists, the output now includes a `--force` hint so users know how to overwrite.
 - **Standard policy lint**: `rampart doctor` now shows 1 lint warning instead of 17. All `require_approval` entries in `policies/standard.yaml` migrated to `action: ask`; the ask-agent-scope check downgraded from warning to info (deny fallback for non-Claude Code agents is intentional).
-- **`rampart report compliance` output**: AIUC-1 explanation header and per-control remediation hints added to text format. JSON output unchanged.
+- **`rampart report compliance` output**: Report explanation header and per-control remediation hints added to text format. JSON output unchanged.
 - **Install script**: post-install CTA updated to `rampart quickstart` (both `install.sh` and `install.ps1`).
 
 ### Added
@@ -41,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`rampart policy list`** — Browse community policies from the built-in registry (`registry/registry.json`). Results cached for 1 hour; use `--refresh` to force update.
 - **`rampart policy fetch <name>`** — Download and install a community policy with sha256 verification. Supports `--force` and `--dry-run`.
 - **`rampart policy remove <name>`** — Remove an installed community policy (built-in profiles protected).
-- **`rampart report compliance`** — AIUC-1 compliance report generated from local audit logs. Maps decisions to four controls (Tool Call Authorization, Audit Logging, Human-in-the-Loop, Data Exfiltration Prevention). Outputs `COMPLIANT`, `PARTIAL`, or `NON-COMPLIANT` with per-control evidence. Supports `--since`, `--until`, `--format json`, and `--output`.
+- **`rampart report compliance`** — security posture report generated from local audit logs. Maps decisions to four controls (Tool Call Authorization, Audit Logging, Human-in-the-Loop, Data Exfiltration Prevention). Outputs `PASS`, `PARTIAL`, or `FAIL` with per-control evidence. Supports `--since`, `--until`, `--format json`, and `--output`.
 - **Community policy registry** — `registry/` directory in the main repo serves as the policy registry. Initial policies: `research-agent` (read-only web/file analysis) and `mcp-server` (MCP context with exec/credential guards).
 
 ### Known Limitations

--- a/README.md
+++ b/README.md
@@ -854,7 +854,7 @@ rampart policy sync status                         # Show current sync state
 rampart policy sync stop                           # Stop a running --watch process
 
 # Compliance reporting
-rampart report compliance                          # AIUC-1 compliance report (text)
+rampart report compliance                          # Security posture report (text)
 rampart report compliance --format json            # JSON output for CI/tooling
 rampart report compliance --since 2026-01-01       # Scoped to date range
 rampart report compliance --output report.json     # Write to file

--- a/cmd/rampart/cli/report.go
+++ b/cmd/rampart/cli/report.go
@@ -50,14 +50,14 @@ func newReportCmd(opts *rootOptions) *cobra.Command {
 		Long: `Generate reports from Rampart audit logs.
 
 By default this command generates a self-contained HTML report.
-Use 'rampart report compliance' to generate an AIUC-1 compliance report.
+Use 'rampart report compliance' to generate a security posture report.
 
 Examples:
   rampart report                                    # HTML report for last 24h
   rampart report --last 7d                         # HTML report for last 7 days
   rampart report --output weekly.html --last 7d    # Custom HTML output path
-  rampart report compliance                        # AIUC-1 text report
-  rampart report compliance --format json          # AIUC-1 JSON report`,
+  rampart report compliance                        # Security posture text report
+  rampart report compliance --format json          # Security posture JSON report`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runReport(reportOpts)
 		},
@@ -83,26 +83,26 @@ func newReportComplianceCmd(rootOpts *rootOptions, defaultAuditDir string) *cobr
 
 	cmd := &cobra.Command{
 		Use:   "compliance",
-		Short: "Generate AIUC-1 compliance report",
-		Long: `Generate an AIUC-1 compliance evidence report from audit logs.
+		Short: "Generate security posture report",
+		Long: `Generate a security posture report from audit logs.
 
-AIUC-1 (AI Unified Controls v1) is the first compliance standard for AI agent
-operations. This report provides evidence that Rampart is enforcing the required
-controls and can be shared with auditors or security teams.
+This report evaluates how well your Rampart deployment enforces key
+agent security controls. It can be shared with security teams as
+supporting evidence for compliance efforts.
 
 Controls evaluated:
-  AIUC-1.1 Tool Call Authorization  — All tool calls evaluated against policy
-  AIUC-1.2 Audit Logging            — Tamper-evident audit chain maintained
-  AIUC-1.3 Human-in-the-Loop        — Sensitive ops require human approval
-  AIUC-1.4 Data Exfiltration Prev.  — Credential/sensitive path access blocked
+  RC-1 Tool Call Authorization  — All tool calls evaluated against policy
+  RC-2 Audit Logging            — Tamper-evident audit chain maintained
+  RC-3 Human-in-the-Loop        — Sensitive ops require human approval
+  RC-4 Data Exfiltration Prev.  — Credential/sensitive path access blocked
 
-Note: a fresh installation with no audit history will show NON-COMPLIANT.
+Note: a fresh installation with no audit history will show FAIL.
 Run Rampart with an agent to generate audit logs, then re-run this report.
 
 Examples:
   rampart report compliance
   rampart report compliance --since 2026-02-01 --until 2026-02-28
-  rampart report compliance --format json --output aiuc1-report.json`,
+  rampart report compliance --format json --output posture-report.json`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runComplianceReport(cmd, rootOpts, complianceOpts)
 		},
@@ -145,7 +145,7 @@ func runComplianceReport(cmd *cobra.Command, rootOpts *rootOptions, opts *compli
 
 	policyPath := resolveCompliancePolicyPath(cmd, rootOpts.configPath)
 
-	reportData, err := report.GenerateAIUC1Report(report.ComplianceOptions{
+	reportData, err := report.GeneratePostureReport(report.ComplianceOptions{
 		AuditDir:       opts.auditDir,
 		PolicyPath:     policyPath,
 		Since:          since,
@@ -165,7 +165,7 @@ func runComplianceReport(cmd *cobra.Command, rootOpts *rootOptions, opts *compli
 		}
 		payload = append(payload, '\n')
 	} else {
-		payload = []byte(report.FormatAIUC1TextReport(reportData))
+		payload = []byte(report.FormatPostureTextReport(reportData))
 	}
 
 	if strings.TrimSpace(opts.output) != "" {

--- a/docs-site/guides/compliance.md
+++ b/docs-site/guides/compliance.md
@@ -1,24 +1,23 @@
 ---
-title: AIUC-1 Compliance Reporting
-description: Generate evidence-based compliance reports for the AI Unified Controls v1 standard.
+title: Security Posture Report
 ---
 
-# AIUC-1 Compliance Reporting
+# Security Posture Report
 
-`rampart report compliance` generates a compliance evidence report for the [AIUC-1 standard](https://aiuc-1.com) — the first compliance framework for AI agent operations.
+`rampart report compliance` generates a security posture report that evaluates how well your Rampart deployment enforces key agent security controls.
 
-## What is AIUC-1?
+## What it checks
 
-AIUC-1 (AI Unified Controls v1) defines four controls for demonstrating that AI agents operate under human oversight:
+The report evaluates four areas of Rampart's enforcement:
 
 | Control | Name | What it checks |
 |---------|------|----------------|
-| AIUC-1.1 | Tool Call Authorization | All tool calls are evaluated against policy before executing |
-| AIUC-1.2 | Audit Logging | A tamper-evident audit chain is maintained |
-| AIUC-1.3 | Human-in-the-Loop | Sensitive operations require human approval |
-| AIUC-1.4 | Data Exfiltration Prevention | Credential and sensitive path access is blocked |
+| RC-1 | Tool Call Authorization | All tool calls are evaluated against policy before executing |
+| RC-2 | Audit Logging | A tamper-evident audit chain is maintained |
+| RC-3 | Human-in-the-Loop | Sensitive operations require human approval |
+| RC-4 | Data Exfiltration Prevention | Credential and sensitive path access is blocked |
 
-ElevenLabs became the first AIUC-1 certified organization in February 2026. Audit firms offering AIUC-1 assessments include 360 Advanced and Schellman.
+These are Rampart's own controls — they are not part of an external compliance standard. If your organization needs to comply with frameworks like [AIUC-1](https://aiuc-1.com), [SOC 2](https://www.aicpa.org/soc2), or [NIST AI RMF](https://www.nist.gov/artificial-intelligence/risk-management-framework), this report can serve as supporting evidence but does not constitute certification.
 
 ## Generating a report
 
@@ -26,50 +25,55 @@ ElevenLabs became the first AIUC-1 certified organization in February 2026. Audi
 rampart report compliance
 ```
 
-Example output (fresh install with audit logs):
+Example output (with audit logs):
 
 ```
-AIUC-1 Compliance Report
-========================
-Report ID:  3a1e1cc1-09b5-4641-b502-3ef8b1f9fc29
-Generated:  2026-02-28T22:08:48Z
-Period:     2026-01-29 to 2026-02-28
-Version:    v0.7.0
-Standard:   AIUC-1
-Status:     COMPLIANT
+Rampart Security Posture Report
+================================
+This report evaluates how well your Rampart deployment enforces key
+agent security controls.
+Learn more: https://docs.rampart.sh/guides/compliance/
+
+Report ID: 3a1e1cc1-09b5-4641-b502-3ef8b1f9fc29
+Generated: 2026-02-28T22:08:48Z
+Period: 2026-01-29 to 2026-02-28
+Rampart Version: v0.7.5
+Standard: Rampart Security Posture
+Overall Status: PASS
 
 Decision Counts
 ---------------
-Total:  1,247
-Allow:  1,089  (87%)
-Deny:   143    (11%)
-Ask:    15     (1%)
+Total: 1,247
+Allow: 1,089 (87%)
+Deny: 143 (11%)
+Ask: 15 (1%)
 
 Controls
 --------
-AIUC-1.1 PASS Tool Call Authorization
-  - 1,247 tool calls evaluated against policy
-  - 0 tool calls bypassed policy evaluation
+RC-1 PASS Tool Call Authorization
+ - 1,247 tool calls evaluated against policy
+ - 0 tool calls bypassed policy evaluation
 
-AIUC-1.2 PASS Audit Logging
-  - Audit chain verified: 1,247 events, 0 hash mismatches
+RC-2 PASS Audit Logging
+ - Audit chain verified: 1,247 events, 0 hash mismatches
 
-AIUC-1.3 PASS Human-in-the-Loop
-  - 15 ask decisions recorded in reporting period
+RC-3 PASS Human-in-the-Loop
+ - 15 ask decisions recorded in reporting period
 
-AIUC-1.4 PASS Data Exfiltration Prevention
-  - Policy covers: /etc/shadow, ~/.ssh/*, *.env, ~/.aws/credentials
+RC-4 PASS Data Exfiltration Prevention
+ - Policy covers: /etc/shadow, ~/.ssh/*, *.env, ~/.aws/credentials
 ```
 
 ## Status levels
 
 | Status | Meaning |
 |--------|---------|
-| `COMPLIANT` | All four controls pass |
-| `PARTIAL` | Some controls pass, some warn |
-| `NON-COMPLIANT` | One or more controls fail |
+| PASS | All four controls pass |
+| PARTIAL | Some controls pass, some warn |
+| FAIL | One or more controls fail |
 
-> **Note:** A fresh installation with no audit history will show `NON-COMPLIANT`. This is expected — run Rampart with an agent to generate audit logs, then re-run the report.
+!!! note
+    A fresh installation with no audit history will show FAIL. This is expected — run Rampart with an agent to generate audit logs, then re-run the report.
 
 ## Date ranges
 
@@ -88,38 +92,39 @@ For CI pipelines or tooling integrations:
 
 ```bash
 rampart report compliance --format json
-rampart report compliance --format json --output aiuc1-report.json
+rampart report compliance --format json --output posture-report.json
 ```
 
-JSON output includes the full evidence array per control, suitable for sharing with auditors.
+JSON output includes the full evidence array per control, suitable for internal audits or sharing with security teams.
 
 ## What each control evaluates
 
-### AIUC-1.1 — Tool Call Authorization
+### RC-1 — Tool Call Authorization
 
 Checks that Rampart is actively evaluating tool calls. Passes if:
-- Audit logs exist with `allow` or `deny` decisions
+- Audit logs exist with allow or deny decisions
 - No evidence of policy bypass
 
-### AIUC-1.2 — Audit Logging
+### RC-2 — Audit Logging
 
 Verifies the tamper-evident hash chain in audit logs. Each event's hash covers the previous event's hash — if any event is modified or deleted, chain verification fails.
 
-### AIUC-1.3 — Human-in-the-Loop
+### RC-3 — Human-in-the-Loop
 
 Checks that `ask` decisions exist in the audit log during the period. Passes if at least one human approval was requested.
 
-> If all sensitive operations are auto-denied rather than asking for approval, this control will warn. Consider using `action: ask` for borderline operations.
+If all sensitive operations are auto-denied rather than asking for approval, this control will warn. Consider using `action: ask` for borderline operations.
 
-### AIUC-1.4 — Data Exfiltration Prevention
+### RC-4 — Data Exfiltration Prevention
 
 Checks that the active policy contains rules blocking access to credential paths (`/etc/shadow`, `~/.ssh/*`, `*.env`, `~/.aws/credentials`, etc.).
 
-> This check uses keyword proximity heuristics on the policy file. It is labeled as a heuristic in the output — manual review by an auditor is recommended for full assurance.
+This check uses keyword proximity heuristics on the policy file — manual review of your policy is recommended for full assurance.
 
-## Sharing with auditors
+## Sharing with security teams
 
 The JSON report includes:
+
 - Report ID (UUID for tracking)
 - Generation timestamp and Rampart version
 - Audit period and decision counts
@@ -129,14 +134,24 @@ The JSON report includes:
 Export and share:
 
 ```bash
-rampart report compliance --format json --output aiuc1-$(date +%Y-%m-%d).json
+rampart report compliance --format json --output posture-$(date +%Y-%m-%d).json
 ```
 
-## Achieving COMPLIANT status
+## Improving your posture
 
-1. **AIUC-1.1**: Ensure Rampart hooks are installed and active (`rampart doctor`)
-2. **AIUC-1.2**: Ensure audit logging is enabled (on by default)
-3. **AIUC-1.3**: Use `action: ask` for sensitive operations instead of always-deny
-4. **AIUC-1.4**: Use `rampart init --profile standard` or ensure your policy covers credential paths
+1. **RC-1**: Ensure Rampart hooks are installed and active (`rampart doctor`)
+2. **RC-2**: Ensure audit logging is enabled (on by default)
+3. **RC-3**: Use `action: ask` for sensitive operations instead of always-deny
+4. **RC-4**: Use `rampart init --profile standard` or ensure your policy covers credential paths
 
-Run `rampart doctor` to verify your setup before generating a compliance report.
+Run `rampart doctor` to verify your setup before generating a report.
+
+## Relationship to compliance frameworks
+
+Rampart's security posture report is designed to provide evidence that can support compliance with external frameworks:
+
+- **[AIUC-1](https://aiuc-1.com)**: Tool call authorization, audit logging, and human oversight align with AIUC-1's security and accountability principles
+- **SOC 2**: Tamper-evident audit chain and access controls support Trust Services Criteria
+- **NIST AI RMF**: Policy enforcement and monitoring support the Govern and Measure functions
+
+However, Rampart does not certify compliance with any external standard. Compliance determinations require assessment by qualified auditors against the full requirements of each framework.

--- a/docs-site/reference/cli-commands.md
+++ b/docs-site/reference/cli-commands.md
@@ -93,7 +93,7 @@ echo '{"tool_name":"Bash","tool_input":{"command":"rm -rf /"}}' | rampart hook
 Start the HTTP policy proxy.
 
 ```bash
-rampart serve                              # Default (port 9090, all interfaces)
+rampart serve                              # Default (port 9090, localhost only)
 rampart serve --addr 127.0.0.1             # Bind to localhost only
 rampart serve --port 8080                  # Custom port
 rampart serve --config policy.yaml         # Custom policy
@@ -105,7 +105,7 @@ rampart serve --tls-auto                   # HTTPS with auto-generated self-sign
 rampart serve --tls-cert cert.pem --tls-key key.pem  # HTTPS with your own cert
 ```
 
-`--addr` takes a bare IP address (e.g. `127.0.0.1`, `0.0.0.0`, `::1`). Defaults to all interfaces if omitted — use `--addr 127.0.0.1` for localhost-only access. `--audit-dir` sets the directory for audit log output (defaults to `~/.rampart/audit/`).
+`--addr` takes a bare IP address (e.g. `127.0.0.1`, `0.0.0.0`, `::1`). Defaults to `127.0.0.1` (localhost only) — use `--addr 0.0.0.0` to listen on all interfaces. `--audit-dir` sets the directory for audit log output (defaults to `~/.rampart/audit/`).
 
 `--tls-auto` generates a self-signed ECDSA P-256 certificate (1-year validity) and stores it in `~/.rampart/tls/`. A truncated SHA-256 fingerprint is printed on startup. `--tls-cert` and `--tls-key` must be used together and are mutually exclusive with `--tls-auto`.
 

--- a/docs/guides/compliance.md
+++ b/docs/guides/compliance.md
@@ -1,24 +1,23 @@
 ---
-title: AIUC-1 Compliance Reporting
-description: Generate evidence-based compliance reports for the AI Unified Controls v1 standard.
+title: Security Posture Report
 ---
 
-# AIUC-1 Compliance Reporting
+# Security Posture Report
 
-`rampart report compliance` generates a compliance evidence report for the [AIUC-1 standard](https://aiuc-1.com) — the first compliance framework for AI agent operations.
+`rampart report compliance` generates a security posture report that evaluates how well your Rampart deployment enforces key agent security controls.
 
-## What is AIUC-1?
+## What it checks
 
-AIUC-1 (AI Unified Controls v1) defines four controls for demonstrating that AI agents operate under human oversight:
+The report evaluates four areas of Rampart's enforcement:
 
 | Control | Name | What it checks |
 |---------|------|----------------|
-| AIUC-1.1 | Tool Call Authorization | All tool calls are evaluated against policy before executing |
-| AIUC-1.2 | Audit Logging | A tamper-evident audit chain is maintained |
-| AIUC-1.3 | Human-in-the-Loop | Sensitive operations require human approval |
-| AIUC-1.4 | Data Exfiltration Prevention | Credential and sensitive path access is blocked |
+| RC-1 | Tool Call Authorization | All tool calls are evaluated against policy before executing |
+| RC-2 | Audit Logging | A tamper-evident audit chain is maintained |
+| RC-3 | Human-in-the-Loop | Sensitive operations require human approval |
+| RC-4 | Data Exfiltration Prevention | Credential and sensitive path access is blocked |
 
-ElevenLabs became the first AIUC-1 certified organization in February 2026. Audit firms offering AIUC-1 assessments include 360 Advanced and Schellman.
+These are Rampart's own controls — they are not part of an external compliance standard. If your organization needs to comply with frameworks like [AIUC-1](https://aiuc-1.com), [SOC 2](https://www.aicpa.org/soc2), or [NIST AI RMF](https://www.nist.gov/artificial-intelligence/risk-management-framework), this report can serve as supporting evidence but does not constitute certification.
 
 ## Generating a report
 
@@ -26,50 +25,55 @@ ElevenLabs became the first AIUC-1 certified organization in February 2026. Audi
 rampart report compliance
 ```
 
-Example output (fresh install with audit logs):
+Example output (with audit logs):
 
 ```
-AIUC-1 Compliance Report
-========================
-Report ID:  3a1e1cc1-09b5-4641-b502-3ef8b1f9fc29
-Generated:  2026-02-28T22:08:48Z
-Period:     2026-01-29 to 2026-02-28
-Version:    v0.7.0
-Standard:   AIUC-1
-Status:     COMPLIANT
+Rampart Security Posture Report
+================================
+This report evaluates how well your Rampart deployment enforces key
+agent security controls.
+Learn more: https://docs.rampart.sh/guides/compliance/
+
+Report ID: 3a1e1cc1-09b5-4641-b502-3ef8b1f9fc29
+Generated: 2026-02-28T22:08:48Z
+Period: 2026-01-29 to 2026-02-28
+Rampart Version: v0.7.5
+Standard: Rampart Security Posture
+Overall Status: PASS
 
 Decision Counts
 ---------------
-Total:  1,247
-Allow:  1,089  (87%)
-Deny:   143    (11%)
-Ask:    15     (1%)
+Total: 1,247
+Allow: 1,089 (87%)
+Deny: 143 (11%)
+Ask: 15 (1%)
 
 Controls
 --------
-AIUC-1.1 PASS Tool Call Authorization
-  - 1,247 tool calls evaluated against policy
-  - 0 tool calls bypassed policy evaluation
+RC-1 PASS Tool Call Authorization
+ - 1,247 tool calls evaluated against policy
+ - 0 tool calls bypassed policy evaluation
 
-AIUC-1.2 PASS Audit Logging
-  - Audit chain verified: 1,247 events, 0 hash mismatches
+RC-2 PASS Audit Logging
+ - Audit chain verified: 1,247 events, 0 hash mismatches
 
-AIUC-1.3 PASS Human-in-the-Loop
-  - 15 ask decisions recorded in reporting period
+RC-3 PASS Human-in-the-Loop
+ - 15 ask decisions recorded in reporting period
 
-AIUC-1.4 PASS Data Exfiltration Prevention
-  - Policy covers: /etc/shadow, ~/.ssh/*, *.env, ~/.aws/credentials
+RC-4 PASS Data Exfiltration Prevention
+ - Policy covers: /etc/shadow, ~/.ssh/*, *.env, ~/.aws/credentials
 ```
 
 ## Status levels
 
 | Status | Meaning |
 |--------|---------|
-| `COMPLIANT` | All four controls pass |
-| `PARTIAL` | Some controls pass, some warn |
-| `NON-COMPLIANT` | One or more controls fail |
+| PASS | All four controls pass |
+| PARTIAL | Some controls pass, some warn |
+| FAIL | One or more controls fail |
 
-> **Note:** A fresh installation with no audit history will show `NON-COMPLIANT`. This is expected — run Rampart with an agent to generate audit logs, then re-run the report.
+!!! note
+    A fresh installation with no audit history will show FAIL. This is expected — run Rampart with an agent to generate audit logs, then re-run the report.
 
 ## Date ranges
 
@@ -88,38 +92,39 @@ For CI pipelines or tooling integrations:
 
 ```bash
 rampart report compliance --format json
-rampart report compliance --format json --output aiuc1-report.json
+rampart report compliance --format json --output posture-report.json
 ```
 
-JSON output includes the full evidence array per control, suitable for sharing with auditors.
+JSON output includes the full evidence array per control, suitable for internal audits or sharing with security teams.
 
 ## What each control evaluates
 
-### AIUC-1.1 — Tool Call Authorization
+### RC-1 — Tool Call Authorization
 
 Checks that Rampart is actively evaluating tool calls. Passes if:
-- Audit logs exist with `allow` or `deny` decisions
+- Audit logs exist with allow or deny decisions
 - No evidence of policy bypass
 
-### AIUC-1.2 — Audit Logging
+### RC-2 — Audit Logging
 
 Verifies the tamper-evident hash chain in audit logs. Each event's hash covers the previous event's hash — if any event is modified or deleted, chain verification fails.
 
-### AIUC-1.3 — Human-in-the-Loop
+### RC-3 — Human-in-the-Loop
 
 Checks that `ask` decisions exist in the audit log during the period. Passes if at least one human approval was requested.
 
-> If all sensitive operations are auto-denied rather than asking for approval, this control will warn. Consider using `action: ask` for borderline operations.
+If all sensitive operations are auto-denied rather than asking for approval, this control will warn. Consider using `action: ask` for borderline operations.
 
-### AIUC-1.4 — Data Exfiltration Prevention
+### RC-4 — Data Exfiltration Prevention
 
 Checks that the active policy contains rules blocking access to credential paths (`/etc/shadow`, `~/.ssh/*`, `*.env`, `~/.aws/credentials`, etc.).
 
-> This check uses keyword proximity heuristics on the policy file. It is labeled as a heuristic in the output — manual review by an auditor is recommended for full assurance.
+This check uses keyword proximity heuristics on the policy file — manual review of your policy is recommended for full assurance.
 
-## Sharing with auditors
+## Sharing with security teams
 
 The JSON report includes:
+
 - Report ID (UUID for tracking)
 - Generation timestamp and Rampart version
 - Audit period and decision counts
@@ -129,14 +134,24 @@ The JSON report includes:
 Export and share:
 
 ```bash
-rampart report compliance --format json --output aiuc1-$(date +%Y-%m-%d).json
+rampart report compliance --format json --output posture-$(date +%Y-%m-%d).json
 ```
 
-## Achieving COMPLIANT status
+## Improving your posture
 
-1. **AIUC-1.1**: Ensure Rampart hooks are installed and active (`rampart doctor`)
-2. **AIUC-1.2**: Ensure audit logging is enabled (on by default)
-3. **AIUC-1.3**: Use `action: ask` for sensitive operations instead of always-deny
-4. **AIUC-1.4**: Use `rampart init --profile standard` or ensure your policy covers credential paths
+1. **RC-1**: Ensure Rampart hooks are installed and active (`rampart doctor`)
+2. **RC-2**: Ensure audit logging is enabled (on by default)
+3. **RC-3**: Use `action: ask` for sensitive operations instead of always-deny
+4. **RC-4**: Use `rampart init --profile standard` or ensure your policy covers credential paths
 
-Run `rampart doctor` to verify your setup before generating a compliance report.
+Run `rampart doctor` to verify your setup before generating a report.
+
+## Relationship to compliance frameworks
+
+Rampart's security posture report is designed to provide evidence that can support compliance with external frameworks:
+
+- **[AIUC-1](https://aiuc-1.com)**: Tool call authorization, audit logging, and human oversight align with AIUC-1's security and accountability principles
+- **SOC 2**: Tamper-evident audit chain and access controls support Trust Services Criteria
+- **NIST AI RMF**: Policy enforcement and monitoring support the Govern and Measure functions
+
+However, Rampart does not certify compliance with any external standard. Compliance determinations require assessment by qualified auditors against the full requirements of each framework.

--- a/internal/report/compliance.go
+++ b/internal/report/compliance.go
@@ -36,9 +36,9 @@ const (
 	ControlStatusWarn ControlStatus = "WARN"
 	ControlStatusFail ControlStatus = "FAIL"
 
-	ComplianceStatusCompliant    ComplianceStatus = "COMPLIANT"
+	ComplianceStatusCompliant    ComplianceStatus = "PASS"
 	ComplianceStatusPartial      ComplianceStatus = "PARTIAL"
-	ComplianceStatusNonCompliant ComplianceStatus = "NON-COMPLIANT"
+	ComplianceStatusNonCompliant ComplianceStatus = "FAIL"
 )
 
 type CompliancePeriod struct {
@@ -66,7 +66,7 @@ type ComplianceControl struct {
 	Evidence []string      `json:"evidence"`
 }
 
-type AIUC1Report struct {
+type PostureReport struct {
 	ReportID       string                       `json:"report_id"`
 	GeneratedAt    time.Time                    `json:"generated_at"`
 	Period         CompliancePeriod             `json:"period"`
@@ -85,7 +85,7 @@ type ComplianceOptions struct {
 	RampartVersion string
 }
 
-func GenerateAIUC1Report(opts ComplianceOptions) (*AIUC1Report, error) {
+func GeneratePostureReport(opts ComplianceOptions) (*PostureReport, error) {
 	generatedAt := opts.GeneratedAt.UTC()
 	if generatedAt.IsZero() {
 		generatedAt = time.Now().UTC()
@@ -111,7 +111,7 @@ func GenerateAIUC1Report(opts ComplianceOptions) (*AIUC1Report, error) {
 		auditDir = "."
 	}
 
-	report := &AIUC1Report{
+	report := &PostureReport{
 		ReportID:    generateUUID4(),
 		GeneratedAt: generatedAt,
 		Period: CompliancePeriod{
@@ -119,32 +119,32 @@ func GenerateAIUC1Report(opts ComplianceOptions) (*AIUC1Report, error) {
 			Until: until,
 		},
 		RampartVersion: opts.RampartVersion,
-		Standard:       "AIUC-1",
+		Standard:       "Rampart Security Posture",
 		Controls: map[string]ComplianceControl{
-			"AIUC-1.1": {Name: "Tool Call Authorization"},
-			"AIUC-1.2": {Name: "Audit Logging"},
-			"AIUC-1.3": {Name: "Human-in-the-Loop"},
-			"AIUC-1.4": {Name: "Data Exfiltration Prevention"},
+			"RC-1": {Name: "Tool Call Authorization"},
+			"RC-2": {Name: "Audit Logging"},
+			"RC-3": {Name: "Human-in-the-Loop"},
+			"RC-4": {Name: "Data Exfiltration Prevention"},
 		},
 	}
 
 	auditFiles, listErr := listAuditJSONLFiles(auditDir)
 	if listErr != nil {
-		report.Controls["AIUC-1.1"] = ComplianceControl{
+		report.Controls["RC-1"] = ComplianceControl{
 			Name:   "Tool Call Authorization",
 			Status: ControlStatusFail,
 			Evidence: []string{
 				fmt.Sprintf("Could not read audit directory %q: %v", auditDir, listErr),
 			},
 		}
-		report.Controls["AIUC-1.2"] = ComplianceControl{
+		report.Controls["RC-2"] = ComplianceControl{
 			Name:   "Audit Logging",
 			Status: ControlStatusFail,
 			Evidence: []string{
 				"Audit chain could not be verified because audit logs are unavailable.",
 			},
 		}
-		report.Controls["AIUC-1.3"] = ComplianceControl{
+		report.Controls["RC-3"] = ComplianceControl{
 			Name:   "Human-in-the-Loop",
 			Status: ControlStatusWarn,
 			Evidence: []string{
@@ -161,23 +161,23 @@ func GenerateAIUC1Report(opts ComplianceOptions) (*AIUC1Report, error) {
 	return report, nil
 }
 
-func (r *AIUC1Report) applyAuditControlResults(auditDir string, auditFiles []string, since, until time.Time) {
+func (r *PostureReport) applyAuditControlResults(auditDir string, auditFiles []string, since, until time.Time) {
 	if len(auditFiles) == 0 {
-		r.Controls["AIUC-1.1"] = ComplianceControl{
+		r.Controls["RC-1"] = ComplianceControl{
 			Name:   "Tool Call Authorization",
 			Status: ControlStatusFail,
 			Evidence: []string{
 				fmt.Sprintf("No audit log files found in %q.", auditDir),
 			},
 		}
-		r.Controls["AIUC-1.2"] = ComplianceControl{
+		r.Controls["RC-2"] = ComplianceControl{
 			Name:   "Audit Logging",
 			Status: ControlStatusFail,
 			Evidence: []string{
 				"Audit chain verification cannot run because no audit log files were found.",
 			},
 		}
-		r.Controls["AIUC-1.3"] = ComplianceControl{
+		r.Controls["RC-3"] = ComplianceControl{
 			Name:   "Human-in-the-Loop",
 			Status: ControlStatusWarn,
 			Evidence: []string{
@@ -189,7 +189,7 @@ func (r *AIUC1Report) applyAuditControlResults(auditDir string, auditFiles []str
 
 	allEvents, hashesByID, chainErr := readAndVerifyAuditChain(auditFiles)
 	if chainErr != nil {
-		r.Controls["AIUC-1.2"] = ComplianceControl{
+		r.Controls["RC-2"] = ComplianceControl{
 			Name:     "Audit Logging",
 			Status:   ControlStatusFail,
 			Evidence: []string{fmt.Sprintf("Audit chain verification failed: %v", chainErr)},
@@ -197,13 +197,13 @@ func (r *AIUC1Report) applyAuditControlResults(auditDir string, auditFiles []str
 	} else {
 		anchorErr := verifyAnchorsInDir(auditDir, hashesByID)
 		if anchorErr != nil {
-			r.Controls["AIUC-1.2"] = ComplianceControl{
+			r.Controls["RC-2"] = ComplianceControl{
 				Name:     "Audit Logging",
 				Status:   ControlStatusFail,
 				Evidence: []string{fmt.Sprintf("Audit anchor verification failed: %v", anchorErr)},
 			}
 		} else {
-			r.Controls["AIUC-1.2"] = ComplianceControl{
+			r.Controls["RC-2"] = ComplianceControl{
 				Name:     "Audit Logging",
 				Status:   ControlStatusPass,
 				Evidence: []string{fmt.Sprintf("Verified %d events across %d audit files.", len(allEvents), len(auditFiles))},
@@ -216,13 +216,13 @@ func (r *AIUC1Report) applyAuditControlResults(auditDir string, auditFiles []str
 	r.Summary.DecisionCounts = counts
 
 	if len(periodEvents) > 0 {
-		r.Controls["AIUC-1.1"] = ComplianceControl{
+		r.Controls["RC-1"] = ComplianceControl{
 			Name:     "Tool Call Authorization",
 			Status:   ControlStatusPass,
 			Evidence: []string{fmt.Sprintf("Found %d audited tool-call events in reporting period.", len(periodEvents))},
 		}
 	} else {
-		r.Controls["AIUC-1.1"] = ComplianceControl{
+		r.Controls["RC-1"] = ComplianceControl{
 			Name:   "Tool Call Authorization",
 			Status: ControlStatusWarn,
 			Evidence: []string{
@@ -232,13 +232,13 @@ func (r *AIUC1Report) applyAuditControlResults(auditDir string, auditFiles []str
 	}
 
 	if counts.Ask > 0 {
-		r.Controls["AIUC-1.3"] = ComplianceControl{
+		r.Controls["RC-3"] = ComplianceControl{
 			Name:     "Human-in-the-Loop",
 			Status:   ControlStatusPass,
 			Evidence: []string{fmt.Sprintf("Found %d ask decisions in reporting period.", counts.Ask)},
 		}
 	} else {
-		r.Controls["AIUC-1.3"] = ComplianceControl{
+		r.Controls["RC-3"] = ComplianceControl{
 			Name:     "Human-in-the-Loop",
 			Status:   ControlStatusWarn,
 			Evidence: []string{"No ask decisions found in reporting period."},
@@ -246,14 +246,14 @@ func (r *AIUC1Report) applyAuditControlResults(auditDir string, auditFiles []str
 	}
 }
 
-func (r *AIUC1Report) applyPolicyControlResult(policyPath string) {
+func (r *PostureReport) applyPolicyControlResult(policyPath string) {
 	resolved, err := expandHomePath(policyPath)
 	if err != nil {
 		resolved = policyPath
 	}
 	trimmed := strings.TrimSpace(resolved)
 	if trimmed == "" {
-		r.Controls["AIUC-1.4"] = ComplianceControl{
+		r.Controls["RC-4"] = ComplianceControl{
 			Name:     "Data Exfiltration Prevention",
 			Status:   ControlStatusWarn,
 			Evidence: []string{"No policy file path provided; cannot verify sensitive deny rules."},
@@ -264,7 +264,7 @@ func (r *AIUC1Report) applyPolicyControlResult(policyPath string) {
 	const maxPolicyBytes = 10 << 20 // 10 MiB
 	fi, err := os.Stat(trimmed)
 	if err != nil {
-		r.Controls["AIUC-1.4"] = ComplianceControl{
+		r.Controls["RC-4"] = ComplianceControl{
 			Name:     "Data Exfiltration Prevention",
 			Status:   ControlStatusWarn,
 			Evidence: []string{fmt.Sprintf("Could not read policy file %q: %v", trimmed, err)},
@@ -272,7 +272,7 @@ func (r *AIUC1Report) applyPolicyControlResult(policyPath string) {
 		return
 	}
 	if !fi.Mode().IsRegular() {
-		r.Controls["AIUC-1.4"] = ComplianceControl{
+		r.Controls["RC-4"] = ComplianceControl{
 			Name:     "Data Exfiltration Prevention",
 			Status:   ControlStatusWarn,
 			Evidence: []string{fmt.Sprintf("Policy path %q is not a regular file", trimmed)},
@@ -280,7 +280,7 @@ func (r *AIUC1Report) applyPolicyControlResult(policyPath string) {
 		return
 	}
 	if fi.Size() > maxPolicyBytes {
-		r.Controls["AIUC-1.4"] = ComplianceControl{
+		r.Controls["RC-4"] = ComplianceControl{
 			Name:     "Data Exfiltration Prevention",
 			Status:   ControlStatusWarn,
 			Evidence: []string{fmt.Sprintf("Policy file %q exceeds 10 MiB size limit", trimmed)},
@@ -289,7 +289,7 @@ func (r *AIUC1Report) applyPolicyControlResult(policyPath string) {
 	}
 	data, err := os.ReadFile(trimmed)
 	if err != nil {
-		r.Controls["AIUC-1.4"] = ComplianceControl{
+		r.Controls["RC-4"] = ComplianceControl{
 			Name:     "Data Exfiltration Prevention",
 			Status:   ControlStatusWarn,
 			Evidence: []string{fmt.Sprintf("Could not read policy file %q: %v", trimmed, err)},
@@ -303,7 +303,7 @@ func (r *AIUC1Report) applyPolicyControlResult(policyPath string) {
 	covered, found, missing := evaluateSensitiveDenyCoverage(string(data))
 	heuristicNote := "Note: coverage check is keyword proximity heuristic — manual policy review recommended for full assurance."
 	if covered {
-		r.Controls["AIUC-1.4"] = ComplianceControl{
+		r.Controls["RC-4"] = ComplianceControl{
 			Name:   "Data Exfiltration Prevention",
 			Status: ControlStatusPass,
 			Evidence: []string{
@@ -322,7 +322,7 @@ func (r *AIUC1Report) applyPolicyControlResult(policyPath string) {
 		evidence = append(evidence, fmt.Sprintf("Missing: %s", strings.Join(missing, ", ")))
 	}
 	evidence = append(evidence, heuristicNote)
-	r.Controls["AIUC-1.4"] = ComplianceControl{
+	r.Controls["RC-4"] = ComplianceControl{
 		Name:     "Data Exfiltration Prevention",
 		Status:   ControlStatusWarn,
 		Evidence: evidence,
@@ -595,14 +595,14 @@ func generateUUID4() string {
 	return fmt.Sprintf("%s-%s-%s-%s-%s", hexStr[0:8], hexStr[8:12], hexStr[12:16], hexStr[16:20], hexStr[20:32])
 }
 
-func FormatAIUC1TextReport(report *AIUC1Report) string {
+func FormatPostureTextReport(report *PostureReport) string {
 	var b strings.Builder
 
-	_, _ = fmt.Fprintf(&b, "AIUC-1 Compliance Report\n")
-	_, _ = fmt.Fprintf(&b, "========================\n")
-	_, _ = fmt.Fprintf(&b, "AIUC-1 (AI Unified Controls v1) is a compliance standard for AI agent\n")
-	_, _ = fmt.Fprintf(&b, "operations. This report provides evidence of Rampart's enforcement.\n")
-	_, _ = fmt.Fprintf(&b, "Learn more: https://rampart.sh/docs/guides/compliance\n\n")
+	_, _ = fmt.Fprintf(&b, "Rampart Security Posture Report\n")
+	_, _ = fmt.Fprintf(&b, "================================\n")
+	_, _ = fmt.Fprintf(&b, "This report evaluates how well your Rampart deployment enforces key\n")
+	_, _ = fmt.Fprintf(&b, "agent security controls.\n")
+	_, _ = fmt.Fprintf(&b, "Learn more: https://docs.rampart.sh/guides/compliance/\n\n")
 	_, _ = fmt.Fprintf(&b, "Report ID: %s\n", report.ReportID)
 	_, _ = fmt.Fprintf(&b, "Generated: %s\n", report.GeneratedAt.Format(time.RFC3339))
 	_, _ = fmt.Fprintf(&b, "Period: %s to %s\n", report.Period.Since.Format(time.RFC3339), report.Period.Until.Format(time.RFC3339))
@@ -620,7 +620,7 @@ func FormatAIUC1TextReport(report *AIUC1Report) string {
 	_, _ = fmt.Fprintf(&b, "Ask: %d\n", counts.Ask)
 	_, _ = fmt.Fprintf(&b, "Other: %d\n\n", counts.Other)
 
-	keys := []string{"AIUC-1.1", "AIUC-1.2", "AIUC-1.3", "AIUC-1.4"}
+	keys := []string{"RC-1", "RC-2", "RC-3", "RC-4"}
 	_, _ = fmt.Fprintf(&b, "Controls\n")
 	_, _ = fmt.Fprintf(&b, "--------\n")
 	for _, key := range keys {
@@ -633,17 +633,17 @@ func FormatAIUC1TextReport(report *AIUC1Report) string {
 
 	// Remediation hints for non-compliant controls.
 	var remediations []string
-	if c, ok := report.Controls["AIUC-1.1"]; ok && c.Status != ControlStatusPass {
-		remediations = append(remediations, "AIUC-1.1: Run 'rampart doctor' to verify hooks are installed, then use an AI agent to generate audit events.")
+	if c, ok := report.Controls["RC-1"]; ok && c.Status != ControlStatusPass {
+		remediations = append(remediations, "RC-1: Run 'rampart doctor' to verify hooks are installed, then use an AI agent to generate audit events.")
 	}
-	if c, ok := report.Controls["AIUC-1.2"]; ok && c.Status == ControlStatusFail {
-		remediations = append(remediations, "AIUC-1.2: Run 'rampart audit verify' to inspect chain integrity. Old or manually-edited audit files can cause hash mismatches.")
+	if c, ok := report.Controls["RC-2"]; ok && c.Status == ControlStatusFail {
+		remediations = append(remediations, "RC-2: Run 'rampart audit verify' to inspect chain integrity. Old or manually-edited audit files can cause hash mismatches.")
 	}
-	if c, ok := report.Controls["AIUC-1.3"]; ok && c.Status != ControlStatusPass {
-		remediations = append(remediations, "AIUC-1.3: Use 'action: ask' (not 'action: deny') for sensitive operations so human approval events appear in the audit log.")
+	if c, ok := report.Controls["RC-3"]; ok && c.Status != ControlStatusPass {
+		remediations = append(remediations, "RC-3: Use 'action: ask' (not 'action: deny') for sensitive operations so human approval events appear in the audit log.")
 	}
-	if c, ok := report.Controls["AIUC-1.4"]; ok && c.Status != ControlStatusPass {
-		remediations = append(remediations, "AIUC-1.4: Run 'rampart init --profile standard --force' to ensure credential-blocking rules are active.")
+	if c, ok := report.Controls["RC-4"]; ok && c.Status != ControlStatusPass {
+		remediations = append(remediations, "RC-4: Run 'rampart init --profile standard --force' to ensure credential-blocking rules are active.")
 	}
 	if len(remediations) > 0 {
 		_, _ = fmt.Fprintf(&b, "\nRemediation\n")

--- a/internal/report/compliance_test.go
+++ b/internal/report/compliance_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/peg/rampart/internal/audit"
 )
 
-func TestGenerateAIUC1Report_Compliant(t *testing.T) {
+func TestGeneratePostureReport_Compliant(t *testing.T) {
 	dir := t.TempDir()
 	now := time.Date(2026, 2, 28, 12, 0, 0, 0, time.UTC)
 
@@ -49,7 +49,7 @@ policies:
 		t.Fatalf("write policy: %v", err)
 	}
 
-	rep, err := GenerateAIUC1Report(ComplianceOptions{
+	rep, err := GeneratePostureReport(ComplianceOptions{
 		AuditDir:       dir,
 		PolicyPath:     policyPath,
 		Since:          now.Add(-24 * time.Hour),
@@ -58,11 +58,11 @@ policies:
 		RampartVersion: "v1.2.3",
 	})
 	if err != nil {
-		t.Fatalf("GenerateAIUC1Report returned error: %v", err)
+		t.Fatalf("GeneratePostureReport returned error: %v", err)
 	}
 
-	if rep.Standard != "AIUC-1" {
-		t.Fatalf("standard = %q, want AIUC-1", rep.Standard)
+	if rep.Standard != "Rampart Security Posture" {
+		t.Fatalf("standard = %q, want Rampart Security Posture", rep.Standard)
 	}
 	if rep.Summary.ComplianceStatus != ComplianceStatusCompliant {
 		t.Fatalf("status = %s, want %s", rep.Summary.ComplianceStatus, ComplianceStatusCompliant)
@@ -70,21 +70,21 @@ policies:
 	if rep.Summary.DecisionCounts.Total != 3 || rep.Summary.DecisionCounts.Ask != 1 {
 		t.Fatalf("unexpected decision counts: %+v", rep.Summary.DecisionCounts)
 	}
-	if rep.Controls["AIUC-1.1"].Status != ControlStatusPass {
-		t.Fatalf("AIUC-1.1 status = %s, want PASS", rep.Controls["AIUC-1.1"].Status)
+	if rep.Controls["RC-1"].Status != ControlStatusPass {
+		t.Fatalf("RC-1 status = %s, want PASS", rep.Controls["RC-1"].Status)
 	}
-	if rep.Controls["AIUC-1.2"].Status != ControlStatusPass {
-		t.Fatalf("AIUC-1.2 status = %s, want PASS", rep.Controls["AIUC-1.2"].Status)
+	if rep.Controls["RC-2"].Status != ControlStatusPass {
+		t.Fatalf("RC-2 status = %s, want PASS", rep.Controls["RC-2"].Status)
 	}
-	if rep.Controls["AIUC-1.3"].Status != ControlStatusPass {
-		t.Fatalf("AIUC-1.3 status = %s, want PASS", rep.Controls["AIUC-1.3"].Status)
+	if rep.Controls["RC-3"].Status != ControlStatusPass {
+		t.Fatalf("RC-3 status = %s, want PASS", rep.Controls["RC-3"].Status)
 	}
-	if rep.Controls["AIUC-1.4"].Status != ControlStatusPass {
-		t.Fatalf("AIUC-1.4 status = %s, want PASS", rep.Controls["AIUC-1.4"].Status)
+	if rep.Controls["RC-4"].Status != ControlStatusPass {
+		t.Fatalf("RC-4 status = %s, want PASS", rep.Controls["RC-4"].Status)
 	}
 }
 
-func TestGenerateAIUC1Report_NoAuditLogsNonCompliant(t *testing.T) {
+func TestGeneratePostureReport_NoAuditLogsNonCompliant(t *testing.T) {
 	dir := t.TempDir()
 	now := time.Date(2026, 2, 28, 12, 0, 0, 0, time.UTC)
 
@@ -93,7 +93,7 @@ func TestGenerateAIUC1Report_NoAuditLogsNonCompliant(t *testing.T) {
 		t.Fatalf("write policy: %v", err)
 	}
 
-	rep, err := GenerateAIUC1Report(ComplianceOptions{
+	rep, err := GeneratePostureReport(ComplianceOptions{
 		AuditDir:    filepath.Join(dir, "missing"),
 		PolicyPath:  policyPath,
 		Since:       now.Add(-24 * time.Hour),
@@ -101,21 +101,21 @@ func TestGenerateAIUC1Report_NoAuditLogsNonCompliant(t *testing.T) {
 		GeneratedAt: now,
 	})
 	if err != nil {
-		t.Fatalf("GenerateAIUC1Report returned error: %v", err)
+		t.Fatalf("GeneratePostureReport returned error: %v", err)
 	}
 
-	if rep.Controls["AIUC-1.1"].Status != ControlStatusFail {
-		t.Fatalf("AIUC-1.1 status = %s, want FAIL", rep.Controls["AIUC-1.1"].Status)
+	if rep.Controls["RC-1"].Status != ControlStatusFail {
+		t.Fatalf("RC-1 status = %s, want FAIL", rep.Controls["RC-1"].Status)
 	}
-	if rep.Controls["AIUC-1.2"].Status != ControlStatusFail {
-		t.Fatalf("AIUC-1.2 status = %s, want FAIL", rep.Controls["AIUC-1.2"].Status)
+	if rep.Controls["RC-2"].Status != ControlStatusFail {
+		t.Fatalf("RC-2 status = %s, want FAIL", rep.Controls["RC-2"].Status)
 	}
 	if rep.Summary.ComplianceStatus != ComplianceStatusNonCompliant {
 		t.Fatalf("status = %s, want %s", rep.Summary.ComplianceStatus, ComplianceStatusNonCompliant)
 	}
 }
 
-func TestGenerateAIUC1Report_ZeroEventsWarnsClearly(t *testing.T) {
+func TestGeneratePostureReport_ZeroEventsWarnsClearly(t *testing.T) {
 	dir := t.TempDir()
 	now := time.Date(2026, 2, 28, 12, 0, 0, 0, time.UTC)
 
@@ -137,7 +137,7 @@ policies:
 		t.Fatalf("write policy: %v", err)
 	}
 
-	rep, err := GenerateAIUC1Report(ComplianceOptions{
+	rep, err := GeneratePostureReport(ComplianceOptions{
 		AuditDir:    dir,
 		PolicyPath:  policyPath,
 		Since:       now.Add(-24 * time.Hour),
@@ -145,30 +145,30 @@ policies:
 		GeneratedAt: now,
 	})
 	if err != nil {
-		t.Fatalf("GenerateAIUC1Report returned error: %v", err)
+		t.Fatalf("GeneratePostureReport returned error: %v", err)
 	}
 
 	if rep.Summary.DecisionCounts.Total != 0 {
 		t.Fatalf("total decisions = %d, want 0", rep.Summary.DecisionCounts.Total)
 	}
-	if rep.Controls["AIUC-1.1"].Status != ControlStatusWarn {
-		t.Fatalf("AIUC-1.1 status = %s, want WARN", rep.Controls["AIUC-1.1"].Status)
+	if rep.Controls["RC-1"].Status != ControlStatusWarn {
+		t.Fatalf("RC-1 status = %s, want WARN", rep.Controls["RC-1"].Status)
 	}
-	if rep.Controls["AIUC-1.2"].Status != ControlStatusPass {
-		t.Fatalf("AIUC-1.2 status = %s, want PASS", rep.Controls["AIUC-1.2"].Status)
+	if rep.Controls["RC-2"].Status != ControlStatusPass {
+		t.Fatalf("RC-2 status = %s, want PASS", rep.Controls["RC-2"].Status)
 	}
-	if rep.Controls["AIUC-1.3"].Status != ControlStatusWarn {
-		t.Fatalf("AIUC-1.3 status = %s, want WARN", rep.Controls["AIUC-1.3"].Status)
+	if rep.Controls["RC-3"].Status != ControlStatusWarn {
+		t.Fatalf("RC-3 status = %s, want WARN", rep.Controls["RC-3"].Status)
 	}
 	if rep.Summary.ComplianceStatus != ComplianceStatusPartial {
 		t.Fatalf("status = %s, want %s", rep.Summary.ComplianceStatus, ComplianceStatusPartial)
 	}
-	if !strings.Contains(strings.Join(rep.Controls["AIUC-1.1"].Evidence, " | "), "no events") {
-		t.Fatalf("expected AIUC-1.1 evidence to explain no events: %v", rep.Controls["AIUC-1.1"].Evidence)
+	if !strings.Contains(strings.Join(rep.Controls["RC-1"].Evidence, " | "), "no events") {
+		t.Fatalf("expected RC-1 evidence to explain no events: %v", rep.Controls["RC-1"].Evidence)
 	}
 }
 
-func TestGenerateAIUC1Report_PartialForMissingAskAndPolicyCoverage(t *testing.T) {
+func TestGeneratePostureReport_PartialForMissingAskAndPolicyCoverage(t *testing.T) {
 	dir := t.TempDir()
 	now := time.Date(2026, 2, 28, 12, 0, 0, 0, time.UTC)
 
@@ -188,7 +188,7 @@ policies:
 		t.Fatalf("write policy: %v", err)
 	}
 
-	rep, err := GenerateAIUC1Report(ComplianceOptions{
+	rep, err := GeneratePostureReport(ComplianceOptions{
 		AuditDir:    dir,
 		PolicyPath:  policyPath,
 		Since:       now.Add(-24 * time.Hour),
@@ -196,21 +196,21 @@ policies:
 		GeneratedAt: now,
 	})
 	if err != nil {
-		t.Fatalf("GenerateAIUC1Report returned error: %v", err)
+		t.Fatalf("GeneratePostureReport returned error: %v", err)
 	}
 
 	if rep.Summary.ComplianceStatus != ComplianceStatusPartial {
 		t.Fatalf("status = %s, want %s", rep.Summary.ComplianceStatus, ComplianceStatusPartial)
 	}
-	if rep.Controls["AIUC-1.3"].Status != ControlStatusWarn {
-		t.Fatalf("AIUC-1.3 status = %s, want WARN", rep.Controls["AIUC-1.3"].Status)
+	if rep.Controls["RC-3"].Status != ControlStatusWarn {
+		t.Fatalf("RC-3 status = %s, want WARN", rep.Controls["RC-3"].Status)
 	}
-	if rep.Controls["AIUC-1.4"].Status != ControlStatusWarn {
-		t.Fatalf("AIUC-1.4 status = %s, want WARN", rep.Controls["AIUC-1.4"].Status)
+	if rep.Controls["RC-4"].Status != ControlStatusWarn {
+		t.Fatalf("RC-4 status = %s, want WARN", rep.Controls["RC-4"].Status)
 	}
 }
 
-func TestGenerateAIUC1Report_FailsOnTamperedChain(t *testing.T) {
+func TestGeneratePostureReport_FailsOnTamperedChain(t *testing.T) {
 	dir := t.TempDir()
 	now := time.Date(2026, 2, 28, 12, 0, 0, 0, time.UTC)
 
@@ -231,7 +231,7 @@ policies:
 		t.Fatalf("write policy: %v", err)
 	}
 
-	rep, err := GenerateAIUC1Report(ComplianceOptions{
+	rep, err := GeneratePostureReport(ComplianceOptions{
 		AuditDir:    dir,
 		PolicyPath:  policyPath,
 		Since:       now.Add(-24 * time.Hour),
@@ -239,11 +239,11 @@ policies:
 		GeneratedAt: now,
 	})
 	if err != nil {
-		t.Fatalf("GenerateAIUC1Report returned error: %v", err)
+		t.Fatalf("GeneratePostureReport returned error: %v", err)
 	}
 
-	if rep.Controls["AIUC-1.2"].Status != ControlStatusFail {
-		t.Fatalf("AIUC-1.2 status = %s, want FAIL", rep.Controls["AIUC-1.2"].Status)
+	if rep.Controls["RC-2"].Status != ControlStatusFail {
+		t.Fatalf("RC-2 status = %s, want FAIL", rep.Controls["RC-2"].Status)
 	}
 	if rep.Summary.ComplianceStatus != ComplianceStatusNonCompliant {
 		t.Fatalf("status = %s, want %s", rep.Summary.ComplianceStatus, ComplianceStatusNonCompliant)
@@ -304,7 +304,7 @@ func makeEventsFrom(t *testing.T, now time.Time, startPrevHash string, startIdx 
 	return events
 }
 
-func TestGenerateAIUC1Report_MultiFileChainVerification(t *testing.T) {
+func TestGeneratePostureReport_MultiFileChainVerification(t *testing.T) {
 	dir := t.TempDir()
 	now := time.Date(2026, 2, 28, 10, 0, 0, 0, time.UTC)
 
@@ -330,7 +330,7 @@ policies:
 		t.Fatalf("write policy: %v", err)
 	}
 
-	rep, err := GenerateAIUC1Report(ComplianceOptions{
+	rep, err := GeneratePostureReport(ComplianceOptions{
 		AuditDir:    dir,
 		PolicyPath:  policyPath,
 		Since:       now.Add(-time.Hour),
@@ -338,13 +338,13 @@ policies:
 		GeneratedAt: now,
 	})
 	if err != nil {
-		t.Fatalf("GenerateAIUC1Report returned error: %v", err)
+		t.Fatalf("GeneratePostureReport returned error: %v", err)
 	}
 
 	// Chain across two files should verify cleanly.
-	if rep.Controls["AIUC-1.2"].Status != ControlStatusPass {
-		t.Fatalf("AIUC-1.2 status = %s, want PASS — multi-file chain failed: %v",
-			rep.Controls["AIUC-1.2"].Status, rep.Controls["AIUC-1.2"].Evidence)
+	if rep.Controls["RC-2"].Status != ControlStatusPass {
+		t.Fatalf("RC-2 status = %s, want PASS — multi-file chain failed: %v",
+			rep.Controls["RC-2"].Status, rep.Controls["RC-2"].Evidence)
 	}
 	// ask event from file 2 should be counted.
 	if rep.Summary.DecisionCounts.Ask != 1 {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -149,7 +149,7 @@ nav:
   - Team & Compliance:
     - Policy Registry: guides/policy-registry.md
     - Policy Sync: guides/policy-sync.md
-    - Compliance Reporting: guides/compliance.md
+    - Security Posture Report: guides/compliance.md
   - Migration:
     - Migrating to v0.6.6: migration/v0.6.6.md
   - Deployment:


### PR DESCRIPTION
## Problem

The compliance report presented four Rampart-specific checks as official AIUC-1 control identifiers (`AIUC-1.1` through `AIUC-1.4`). The real AIUC-1 standard has 50+ controls across 6 principles — these identifiers were fabricated.

The docs page also name-dropped ElevenLabs, 360 Advanced, and Schellman in a way that implied association with Rampart.

## Fix

- Renamed control IDs to `RC-1` through `RC-4` (Rampart Controls)
- Renamed Go types: `AIUC1Report` → `PostureReport`, etc.
- Rewrote compliance docs as 'Security Posture Report' with honest framing
- Removed third-party name-dropping
- Added 'Relationship to compliance frameworks' section (AIUC-1, SOC 2, NIST AI RMF as supporting evidence, not certification)
- Fixed `--addr` default docs (now `127.0.0.1`, was 'all interfaces')

## Testing
All 22 test packages pass.