### PR TITLE
feat: overhaul quickstart with multi-agent detection and policy suggestions

### DIFF
--- a/.github/workflows/community-policy-ci.yml
+++ b/.github/workflows/community-policy-ci.yml
@@ -57,9 +57,16 @@ jobs:
           done
 
       - name: Bench policies
+        if: contains(github.event.pull_request.changed_files_url, 'policies/community') || github.event_name == 'workflow_dispatch'
         run: |
-          for file in policies/community/*.yaml; do
-            [ "$(basename "$file")" = "README.md" ] && continue
+          # Only bench when community policy YAML files are actually changed.
+          changed=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- 'policies/community/*.yaml' || true)
+          if [ -z "$changed" ]; then
+            echo "No community policy YAML changes — skipping bench"
+            exit 0
+          fi
+          for file in $changed; do
+            [ ! -f "$file" ] && continue
             echo "Benchmarking $file..."
             ./rampart bench --policy "$file" --min-coverage 60
           done
@@ -69,10 +76,14 @@ jobs:
 
       - name: Check registry.json is up to date
         run: |
-          if ! git diff --quiet registry/registry.json; then
+          # Compare everything except updated_at (which uses time.Now()).
+          jq 'del(.updated_at)' registry/registry.json > /tmp/before.json
+          go run scripts/generate-registry.go
+          jq 'del(.updated_at)' registry/registry.json > /tmp/after.json
+          if ! diff -q /tmp/before.json /tmp/after.json > /dev/null 2>&1; then
             echo "ERROR: registry/registry.json is out of date."
             echo "Run 'go run scripts/generate-registry.go' and commit the result."
-            git diff registry/registry.json
+            diff /tmp/before.json /tmp/after.json || true
             exit 1
           fi
           echo "✓ registry.json is up to date"

--- a/cmd/rampart/cli/quickstart.go
+++ b/cmd/rampart/cli/quickstart.go
@@ -16,6 +16,7 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"os/exec"
@@ -23,177 +24,433 @@ import (
 	"strings"
 	"time"
 
+	"github.com/peg/rampart/internal/detect"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
+type quickstartAgent struct {
+	Key      string
+	Name     string
+	HasSetup bool
+	SetupCmd string
+	WrapCmd  string
+}
+
+func quickstartAgents() []quickstartAgent {
+	return []quickstartAgent{
+		{Key: "claude-code", Name: "Claude Code", HasSetup: true, SetupCmd: "claude-code"},
+		{Key: "codex", Name: "Codex CLI", HasSetup: true, SetupCmd: "codex"},
+		{Key: "cline", Name: "Cline", HasSetup: true, SetupCmd: "cline"},
+		{Key: "openclaw", Name: "OpenClaw", HasSetup: true, SetupCmd: "openclaw"},
+		{Key: "cursor", Name: "Cursor", HasSetup: false, WrapCmd: "rampart wrap -- cursor"},
+		{Key: "aider", Name: "Aider", HasSetup: false, WrapCmd: "rampart wrap -- aider"},
+		{Key: "windsurf", Name: "Windsurf", HasSetup: false, WrapCmd: "rampart wrap -- windsurf"},
+		{Key: "copilot", Name: "GitHub Copilot CLI", HasSetup: false, WrapCmd: "rampart wrap -- gh-copilot"},
+	}
+}
+
 func newQuickstartCmd() *cobra.Command {
-	var envFlag string
+	var agentsFlag string
+	var envAlias string
+	var profile string
 	var skipDoctor bool
 	var yes bool
 
 	cmd := &cobra.Command{
 		Use:   "quickstart",
-		Short: "One-shot setup: install serve, configure hooks, verify",
-		Long: `quickstart detects your AI coding environment, installs the Rampart
-background service, wires up the tool-call hook, and runs a health check.
+		Short: "One-shot setup: install service, configure agent hooks, verify",
+		Long: `quickstart scans your environment, installs Rampart service, wires up detected
+AI agents, installs a policy profile, and runs a health summary.
 
-Supported environments: claude-code, cline, openclaw
-If --env is not set, quickstart will auto-detect.
+Supported setup agents: claude-code, codex, cline, openclaw
+Detected unsupported agents receive wrap guidance.
 
 Use --yes to run non-interactively (AI agents, CI, automated setup).
 For OpenClaw, --yes also enables --patch-tools for full file-operation coverage.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runQuickstart(cmd, envFlag, skipDoctor, yes)
+			return runQuickstart(cmd, agentsFlag, envAlias, profile, skipDoctor, yes)
 		},
 	}
 
-	cmd.Flags().StringVar(&envFlag, "env", "", "AI coding environment (claude-code|cline|openclaw|none)")
-	cmd.Flags().BoolVar(&skipDoctor, "skip-doctor", false, "skip final health check")
+	cmd.Flags().StringVar(&agentsFlag, "agents", "", "Comma-separated agents to configure (claude-code,codex,cline,openclaw,cursor,aider,windsurf,copilot,none)")
+	cmd.Flags().StringVar(&envAlias, "env", "", "(deprecated) single agent alias for --agents")
+	_ = cmd.Flags().MarkHidden("env")
+	cmd.Flags().StringVar(&profile, "profile", "", "Policy profile for initialization (default: standard)")
+	cmd.Flags().BoolVar(&skipDoctor, "skip-doctor", false, "skip final health check summary")
 	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "non-interactive mode: for OpenClaw, also enables --patch-tools (full file coverage); safe to pass for any agent")
 	return cmd
 }
 
-func runQuickstart(cmd *cobra.Command, envFlag string, skipDoctor bool, yes bool) error {
+func runQuickstart(cmd *cobra.Command, agentsFlag, envAlias, profile string, skipDoctor, yes bool) error {
 	w := cmd.OutOrStdout()
 
 	fmt.Fprintln(w, "◆ Rampart quickstart")
 	fmt.Fprintln(w)
-
-	// Step 1: detect environment
-	env := envFlag
-	if env == "" {
-		env = detectEnv()
-		if env == "" {
-			fmt.Fprintln(w, "  ⚠  Could not detect AI coding environment.")
-			fmt.Fprintln(w, "     Use --env claude-code|cline|openclaw to specify manually.")
-			env = "none"
-		} else {
-			fmt.Fprintf(w, "  ✓  Detected environment: %s\n", env)
-		}
-	}
+	fmt.Fprintln(w, "  Scanning environment...")
 	fmt.Fprintln(w)
 
-	// Step 2: install/start serve
+	result, err := detect.Environment()
+	if err != nil {
+		return fmt.Errorf("environment detection failed: %w", err)
+	}
+
+	printDetectedAgents(w, result)
+	fmt.Fprintln(w)
+	printDetectedTools(w, result)
+	fmt.Fprintln(w)
+
+	selectedAgents, err := selectQuickstartAgents(result, agentsFlag, envAlias)
+	if err != nil {
+		return err
+	}
+
 	fmt.Fprintln(w, "  Installing Rampart service...")
 	if err := runSubcmd("serve", "install"); err != nil {
-		// If already installed, that's fine — check if it's reachable.
 		if !quickstartServeRunning() {
-			return fmt.Errorf("serve install failed: %w", err)
+			return formatServeInstallError(err)
 		}
-		fmt.Fprintln(w, "  ✓  Service already installed and running")
+		fmt.Fprintln(w, "  ✓ Service already running on 127.0.0.1:9090")
 	} else {
-		fmt.Fprintln(w, "  ✓  Service installed and started")
+		fmt.Fprintln(w, "  ✓ Service running on 127.0.0.1:9090")
 	}
 	fmt.Fprintln(w)
 
-	// Step 3: setup hooks for detected env
-	if env != "none" {
-		hooksAlreadyConfigured := quickstartHooksConfigured(env)
-		fmt.Fprintf(w, "  Configuring hooks for %s...\n", env)
-		setupArgs := []string{"setup", env}
-		// --yes enables full protection for OpenClaw (--patch-tools covers file reads/writes/edits)
-		if yes && env == "openclaw" {
-			setupArgs = append(setupArgs, "--patch-tools")
-		}
-		if err := runSubcmd(setupArgs...); err != nil {
-			fmt.Fprintf(w, "  ⚠  Hook setup failed: %v\n", err)
-			fmt.Fprintln(w, "     Run `rampart setup "+env+"` manually to retry.")
-		} else {
-			if hooksAlreadyConfigured {
-				fmt.Fprintln(w, "  ✓  Hooks already configured (pass --force to reconfigure)")
-			} else {
-				fmt.Fprintln(w, "  ✓  Hooks configured")
+	fmt.Fprintln(w, "  Configuring hooks...")
+	hooksConfigured := 0
+	for _, agent := range selectedAgents {
+		if agent.HasSetup {
+			hooksAlreadyConfigured := quickstartHooksConfigured(agent.SetupCmd)
+			setupArgs := []string{"setup", agent.SetupCmd}
+			if yes && agent.SetupCmd == "openclaw" {
+				setupArgs = append(setupArgs, "--patch-tools")
 			}
+			if err := runSubcmd(setupArgs...); err != nil {
+				fmt.Fprintf(w, "  ⚠ %s: setup failed (%v)\n", agent.Name, err)
+				fmt.Fprintf(w, "    → Retry with: rampart setup %s\n", agent.SetupCmd)
+				continue
+			}
+			hooksConfigured++
+			if hooksAlreadyConfigured {
+				fmt.Fprintf(w, "  ✓ %s: hooks already configured\n", agent.Name)
+			} else {
+				fmt.Fprintf(w, "  ✓ %s: hooks installed\n", agent.Name)
+			}
+			continue
 		}
-		fmt.Fprintln(w)
+
+		fmt.Fprintf(w, "  ⚠ %s detected but setup not yet supported\n", agent.Name)
+		fmt.Fprintf(w, "    → Use: %s\n", agent.WrapCmd)
+	}
+	if len(selectedAgents) == 0 {
+		fmt.Fprintln(w, "  ⚠ No agents selected for setup")
+	}
+	fmt.Fprintln(w)
+
+	selectedProfile := strings.TrimSpace(profile)
+	if selectedProfile == "" {
+		selectedProfile = "standard"
 	}
 
-	// Step 4: ensure a policy is installed
-	if !hasInstalledPolicy() {
-		if err := runSubcmd("init", "--profile", "standard"); err != nil {
-			return fmt.Errorf("policy init failed: %w", err)
+	fmt.Fprintln(w, "  Installing policies...")
+	if !hasInstalledPolicy() || strings.TrimSpace(profile) != "" {
+		if err := runSubcmd("init", "--profile", selectedProfile); err != nil {
+			return fmt.Errorf("policy init failed for profile %q: %w", selectedProfile, err)
 		}
-		fmt.Fprintln(w, "  ✓  Policy initialized with standard profile")
-		fmt.Fprintln(w)
+		fmt.Fprintf(w, "  ✓ %s profile installed\n", selectedProfile)
+	} else {
+		fmt.Fprintln(w, "  ✓ Existing policy profile detected")
 	}
 
-	// Step 5: doctor
+	suggested := suggestedPolicies(result, installedPolicyNames())
+	if len(suggested) > 0 {
+		fmt.Fprintf(w, "  💡 Suggested: %s (based on detected tools)\n", strings.Join(suggested, ", "))
+		fmt.Fprintf(w, "    → Install with: rampart policy install %s\n", strings.Join(suggested, " "))
+	}
+	fmt.Fprintln(w)
+
 	if !skipDoctor {
 		fmt.Fprintln(w, "  Running health check...")
-		fmt.Fprintln(w)
-		_ = runSubcmd("doctor")
+		if quickstartServeRunning() {
+			fmt.Fprintln(w, "  ✓ Service reachable")
+		} else {
+			fmt.Fprintln(w, "  ⚠ Service unreachable (try: rampart serve)")
+		}
+
+		if hooksConfigured == 0 {
+			fmt.Fprintln(w, "  ⚠ Hooks configured for 0 agents")
+		} else {
+			fmt.Fprintf(w, "  ✓ Hooks configured for %d agents\n", hooksConfigured)
+		}
+
+		profiles, rules := installedPolicyStats()
+		if profiles == 0 {
+			fmt.Fprintln(w, "  ⚠ No active policy profiles found")
+		} else {
+			noun := "profiles"
+			if profiles == 1 {
+				noun = "profile"
+			}
+			fmt.Fprintf(w, "  ✓ %d policy %s active (%d rules)\n", profiles, noun, rules)
+		}
 		fmt.Fprintln(w)
 	}
 
-	// Step 6: summary
 	fmt.Fprintln(w, "◆ You're protected.")
 	fmt.Fprintln(w)
 
-	// Try to show dashboard URL
 	svcURL := quickstartServiceURL()
-	if svcURL != "" {
-		dashURL := strings.TrimSuffix(svcURL, "/") + "/dashboard/"
-		fmt.Fprintf(w, "  Dashboard: %s\n", dashURL)
-	}
+	dashURL := strings.TrimSuffix(svcURL, "/") + "/dashboard/"
+	fmt.Fprintf(w, "  Dashboard:  %s\n", dashURL)
 
 	if tok, err := readPersistedToken(); err == nil && tok != "" {
 		masked := tok
 		if len(tok) > 8 {
 			masked = tok[:8] + "..."
 		}
-		fmt.Fprintf(w, "  Token:     %s  (full token in ~/.rampart/token)\n", masked)
+		fmt.Fprintf(w, "  Token:      %s  (full token in ~/.rampart/token)\n", masked)
 	}
 	fmt.Fprintln(w)
-	fmt.Fprintln(w, "  Tip: export RAMPART_SESSION=my-project to tag audit events with a project name.")
-	fmt.Fprintln(w, "  Docs: https://docs.rampart.sh")
+	fmt.Fprintln(w, "  Next steps:")
+	fmt.Fprintln(w, "    • Run your agent normally — Rampart intercepts tool calls automatically")
+	fmt.Fprintln(w, "    • rampart watch        — see decisions in real time")
+	fmt.Fprintln(w, "    • rampart policy list  — browse available policies")
+	fmt.Fprintln(w, "    • Docs: https://docs.rampart.sh")
 
 	return nil
 }
 
-// detectEnv returns the first detected AI coding environment, or "".
-func detectEnv() string {
-	// OpenClaw: most reliable signal is OPENCLAW_SERVICE_MARKER env var,
-	// which OpenClaw gateway sets when it spawns an agent process.
-	if os.Getenv("OPENCLAW_SERVICE_MARKER") == "openclaw" {
-		return "openclaw"
+func selectQuickstartAgents(result *detect.DetectResult, agentsFlag, envAlias string) ([]quickstartAgent, error) {
+	override := strings.TrimSpace(agentsFlag)
+	if override == "" {
+		override = strings.TrimSpace(envAlias)
 	}
-	// Cline: explicit runtime env is a strong signal.
-	if os.Getenv("CLINE_ACTIVE") != "" || os.Getenv("CLINE_SESSION") != "" {
-		return "cline"
+
+	selectedKeys, err := parseAgentOverride(override)
+	if err != nil {
+		return nil, err
 	}
-	// Cline: detect VS Code extension installs in local/remote environments.
-	if home, err := os.UserHomeDir(); err == nil && home != "" {
-		clineGlobs := []string{
-			filepath.Join(home, ".vscode", "extensions", "saoud-m.vscode-claude-dev-*"),
-			filepath.Join(home, ".vscode", "extensions", "cline-*"),
-			filepath.Join(home, ".vscode-server", "extensions", "saoud-m.vscode-claude-dev-*"),
-			filepath.Join(home, ".vscode-server", "extensions", "cline-*"),
+
+	agents := quickstartAgents()
+	if len(selectedKeys) > 0 {
+		keySet := make(map[string]struct{}, len(selectedKeys))
+		for _, key := range selectedKeys {
+			keySet[key] = struct{}{}
 		}
-		for _, pattern := range clineGlobs {
-			matches, globErr := filepath.Glob(pattern)
-			if globErr == nil && len(matches) > 0 {
-				return "cline"
+		selected := make([]quickstartAgent, 0, len(selectedKeys))
+		for _, a := range agents {
+			if _, ok := keySet[a.Key]; ok {
+				selected = append(selected, a)
 			}
 		}
+		return selected, nil
 	}
-	// Claude Code: settings.json or binary
-	if _, err := os.Stat(claudeSettingsPath()); err == nil {
-		return "claude-code"
+
+	selected := make([]quickstartAgent, 0, len(agents))
+	for _, a := range agents {
+		if isAgentDetected(result, a.Key) {
+			selected = append(selected, a)
+		}
 	}
-	if _, err := exec.LookPath("claude"); err == nil {
-		return "claude-code"
-	}
-	return ""
+	return selected, nil
 }
 
-func claudeSettingsPath() string {
-	home, _ := os.UserHomeDir()
-	return home + "/.claude/settings.json"
+func parseAgentOverride(raw string) ([]string, error) {
+	raw = strings.TrimSpace(strings.ToLower(raw))
+	if raw == "" {
+		return nil, nil
+	}
+
+	parts := strings.Split(raw, ",")
+	aliases := map[string]string{
+		"codex-cli":          "codex",
+		"github-copilot-cli": "copilot",
+		"gh-copilot":         "copilot",
+	}
+	valid := map[string]struct{}{}
+	for _, a := range quickstartAgents() {
+		valid[a.Key] = struct{}{}
+	}
+
+	seen := map[string]struct{}{}
+	selected := make([]string, 0, len(parts))
+	for _, part := range parts {
+		key := strings.TrimSpace(part)
+		if key == "" {
+			continue
+		}
+		if key == "none" {
+			if len(parts) > 1 {
+				return nil, fmt.Errorf("--agents none cannot be combined with other values")
+			}
+			return []string{}, nil
+		}
+		if canonical, ok := aliases[key]; ok {
+			key = canonical
+		}
+		if _, ok := valid[key]; !ok {
+			return nil, fmt.Errorf("invalid agent %q in --agents", key)
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		selected = append(selected, key)
+	}
+	return selected, nil
+}
+
+func printDetectedAgents(w io.Writer, result *detect.DetectResult) {
+	fmt.Fprintln(w, "  AI Agents:")
+	for _, agent := range quickstartAgents() {
+		status := "✗"
+		if isAgentDetected(result, agent.Key) {
+			status = "✓"
+		}
+		fmt.Fprintf(w, "    %s %s\n", status, agent.Name)
+	}
+}
+
+func printDetectedTools(w io.Writer, result *detect.DetectResult) {
+	fmt.Fprintln(w, "  Dev Tools:")
+	fmt.Fprintf(w, "    %s kubectl    %s docker    %s node/npm\n", mark(result.HasKubectl), mark(result.HasDocker), mark(result.HasNode || result.HasNpm))
+	fmt.Fprintf(w, "    %s python     %s git       %s terraform\n", mark(result.HasPython || result.HasPip), mark(result.HasGit), mark(result.HasTerraform))
+	fmt.Fprintf(w, "    %s go         %s rust      %s aws-cli\n", mark(result.HasGo), mark(result.HasRust), mark(result.HasAWSCLI || result.AWSCredentials))
+}
+
+func mark(ok bool) string {
+	if ok {
+		return "✓"
+	}
+	return "✗"
+}
+
+func isAgentDetected(result *detect.DetectResult, key string) bool {
+	switch key {
+	case "claude-code":
+		return result.ClaudeCode
+	case "codex":
+		return result.HasCodex
+	case "cline":
+		return result.HasCline
+	case "openclaw":
+		return result.HasOpenClaw
+	case "cursor":
+		return result.HasCursor
+	case "aider":
+		return result.HasAider
+	case "windsurf":
+		return result.HasWindsurf
+	case "copilot":
+		return result.HasCopilot
+	default:
+		return false
+	}
+}
+
+func formatServeInstallError(err error) error {
+	return fmt.Errorf("serve install failed: %w\n  check permissions for service installation\n  try: sudo rampart serve install\n  or run manually in foreground: rampart serve", err)
+}
+
+func suggestedPolicies(result *detect.DetectResult, installed map[string]bool) []string {
+	suggestions := make([]string, 0, 5)
+	add := func(name string, cond bool) {
+		if !cond || installed[name] {
+			return
+		}
+		for _, existing := range suggestions {
+			if existing == name {
+				return
+			}
+		}
+		suggestions = append(suggestions, name)
+	}
+
+	add("kubernetes", result.HasKubectl)
+	add("docker", result.HasDocker)
+	add("terraform", result.HasTerraform)
+	add("node-python", result.HasNode || result.HasNpm || result.HasPython || result.HasPip)
+	add("aws-cli", result.HasAWSCLI || result.AWSCredentials)
+	return suggestions
+}
+
+func installedPolicyNames() map[string]bool {
+	names := map[string]bool{}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return names
+	}
+	policyDir := filepath.Join(home, ".rampart", "policies")
+	entries, err := os.ReadDir(policyDir)
+	if err != nil {
+		return names
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := strings.ToLower(e.Name())
+		if name == "custom.yaml" {
+			continue
+		}
+		if strings.HasSuffix(name, ".yaml") {
+			names[strings.TrimSuffix(name, ".yaml")] = true
+			continue
+		}
+		if strings.HasSuffix(name, ".yml") {
+			names[strings.TrimSuffix(name, ".yml")] = true
+		}
+	}
+	return names
+}
+
+func installedPolicyStats() (int, int) {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return 0, 0
+	}
+	policyDir := filepath.Join(home, ".rampart", "policies")
+	entries, err := os.ReadDir(policyDir)
+	if err != nil {
+		return 0, 0
+	}
+
+	profiles := 0
+	totalRules := 0
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := strings.ToLower(e.Name())
+		if name == "custom.yaml" || (!strings.HasSuffix(name, ".yaml") && !strings.HasSuffix(name, ".yml")) {
+			continue
+		}
+		profiles++
+
+		data, err := os.ReadFile(filepath.Join(policyDir, e.Name()))
+		if err != nil {
+			continue
+		}
+		var parsed struct {
+			Policies []struct {
+				Rules []any `yaml:"rules"`
+			} `yaml:"policies"`
+			Rules []any `yaml:"rules"`
+		}
+		if err := yaml.Unmarshal(data, &parsed); err != nil {
+			continue
+		}
+		totalRules += len(parsed.Rules)
+		for _, p := range parsed.Policies {
+			totalRules += len(p.Rules)
+		}
+	}
+	return profiles, totalRules
 }
 
 // quickstartServiceURL returns the base URL for the Rampart service.
 func quickstartServiceURL() string {
-	return fmt.Sprintf("http://localhost:%d", defaultServePort)
+	return fmt.Sprintf("http://127.0.0.1:%d", defaultServePort)
 }
 
 // quickstartServeRunning checks whether the Rampart service is reachable.
@@ -270,6 +527,19 @@ func quickstartHooksConfigured(env string) bool {
 			return false
 		}
 		return hasRampartHook(settings)
+	case "cline":
+		pre := filepath.Join(home, "Documents", "Cline", "Hooks", "PreToolUse", "rampart-policy")
+		post := filepath.Join(home, "Documents", "Cline", "Hooks", "PostToolUse", "rampart-audit")
+		_, preErr := os.Stat(pre)
+		_, postErr := os.Stat(post)
+		return preErr == nil && postErr == nil
+	case "codex":
+		wrapper := filepath.Join(home, ".local", "bin", "codex")
+		data, err := os.ReadFile(wrapper)
+		if err != nil {
+			return false
+		}
+		return containsRampartPreload(string(data))
 	default:
 		return false
 	}

--- a/cmd/rampart/cli/quickstart_test.go
+++ b/cmd/rampart/cli/quickstart_test.go
@@ -17,125 +17,152 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
+
+	"github.com/peg/rampart/internal/detect"
 )
 
-func TestDetectEnv_OpenClaw(t *testing.T) {
+func TestDetectEnv_MultiAgentDetection(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PATH shim binaries in this test are Unix-only")
+	}
+
+	home := t.TempDir()
+	testSetHome(t, home)
+	t.Setenv("CLINE_ACTIVE", "1")
 	t.Setenv("OPENCLAW_SERVICE_MARKER", "openclaw")
-	if got := detectEnv(); got != "openclaw" {
-		t.Errorf("expected openclaw, got %q", got)
-	}
-}
 
-func TestDetectEnv_ClaudeCode(t *testing.T) {
-	// Ensure OpenClaw marker is absent so Claude Code takes priority.
-	t.Setenv("OPENCLAW_SERVICE_MARKER", "")
-	t.Setenv("CLINE_ACTIVE", "")
-	t.Setenv("CLINE_SESSION", "")
-
-	// Create a temp claude settings file
-	tmp := t.TempDir()
-	testSetHome(t, tmp)
-
-	if err := os.MkdirAll(filepath.Join(tmp, ".claude"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(home, ".cursor"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(tmp, ".claude", "settings.json"), []byte("{}"), 0o644); err != nil {
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".claude", "settings.json"), []byte("{}"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
-	if got := detectEnv(); got != "claude-code" {
-		t.Errorf("expected claude-code, got %q", got)
+	binDir := t.TempDir()
+	writeTestExecutable(t, filepath.Join(binDir, "codex"))
+	t.Setenv("PATH", binDir)
+
+	got, err := detect.Environment()
+	if err != nil {
+		t.Fatalf("detect.Environment() error = %v", err)
+	}
+	if !got.ClaudeCode || !got.HasCodex || !got.HasCline || !got.HasOpenClaw || !got.HasCursor {
+		t.Fatalf("expected multi-agent detection, got %+v", got)
 	}
 }
 
-func TestDetectEnv_None(t *testing.T) {
-	// Ensure OpenClaw marker is absent.
-	t.Setenv("OPENCLAW_SERVICE_MARKER", "")
-	t.Setenv("CLINE_ACTIVE", "")
-	t.Setenv("CLINE_SESSION", "")
+func TestQuickstartSelectAgents_DefaultAllDetected(t *testing.T) {
+	result := &detect.DetectResult{ClaudeCode: true, HasCodex: true, HasCursor: true}
 
-	tmp := t.TempDir()
-	testSetHome(t, tmp)
-
-	// Ensure 'claude' binary is not in PATH for this test.
-	origPath := os.Getenv("PATH")
-	t.Setenv("PATH", "")
-	defer os.Setenv("PATH", origPath)
-
-	if got := detectEnv(); got != "" {
-		t.Errorf("expected empty, got %q", got)
+	selected, err := selectQuickstartAgents(result, "", "")
+	if err != nil {
+		t.Fatalf("selectQuickstartAgents error = %v", err)
+	}
+	if len(selected) != 3 {
+		t.Fatalf("expected 3 selected agents, got %d", len(selected))
+	}
+	if selected[0].Key != "claude-code" || selected[1].Key != "codex" || selected[2].Key != "cursor" {
+		t.Fatalf("unexpected selected order: %+v", selected)
 	}
 }
 
-func TestDetectEnv_ClineFromEnv(t *testing.T) {
-	t.Setenv("OPENCLAW_SERVICE_MARKER", "")
-	t.Setenv("CLINE_ACTIVE", "1")
-	t.Setenv("CLINE_SESSION", "")
+func TestQuickstartSelectAgents_AgentsFlagOverride(t *testing.T) {
+	result := &detect.DetectResult{ClaudeCode: true}
 
-	if got := detectEnv(); got != "cline" {
-		t.Errorf("expected cline, got %q", got)
+	selected, err := selectQuickstartAgents(result, "codex,cursor", "")
+	if err != nil {
+		t.Fatalf("selectQuickstartAgents error = %v", err)
+	}
+	if len(selected) != 2 {
+		t.Fatalf("expected 2 selected agents, got %d", len(selected))
+	}
+	if selected[0].Key != "codex" || selected[1].Key != "cursor" {
+		t.Fatalf("unexpected selected agents: %+v", selected)
 	}
 }
 
-func TestDetectEnv_ClineFromExtensionDir(t *testing.T) {
-	t.Setenv("OPENCLAW_SERVICE_MARKER", "")
-	t.Setenv("CLINE_ACTIVE", "")
-	t.Setenv("CLINE_SESSION", "")
+func TestQuickstartSelectAgents_EnvAliasOverride(t *testing.T) {
+	result := &detect.DetectResult{}
 
-	tmp := t.TempDir()
-	testSetHome(t, tmp)
-
-	if err := os.MkdirAll(filepath.Join(tmp, ".vscode", "extensions", "cline-1.0.0"), 0o755); err != nil {
-		t.Fatal(err)
+	selected, err := selectQuickstartAgents(result, "", "openclaw")
+	if err != nil {
+		t.Fatalf("selectQuickstartAgents error = %v", err)
 	}
-
-	if got := detectEnv(); got != "cline" {
-		t.Errorf("expected cline, got %q", got)
+	if len(selected) != 1 || selected[0].Key != "openclaw" {
+		t.Fatalf("unexpected selected agents: %+v", selected)
 	}
 }
 
-func TestDetectEnv_ClinePreferredOverClaudeCode(t *testing.T) {
-	t.Setenv("OPENCLAW_SERVICE_MARKER", "")
-	t.Setenv("CLINE_ACTIVE", "1")
-	t.Setenv("CLINE_SESSION", "")
-
-	tmp := t.TempDir()
-	testSetHome(t, tmp)
-
-	if err := os.MkdirAll(filepath.Join(tmp, ".claude"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(tmp, ".claude", "settings.json"), []byte("{}"), 0o644); err != nil {
-		t.Fatal(err)
+func TestQuickstartSuggestedPolicies(t *testing.T) {
+	result := &detect.DetectResult{
+		HasKubectl:     true,
+		HasDocker:      true,
+		HasNode:        true,
+		HasTerraform:   true,
+		HasAWSCLI:      true,
+		AWSCredentials: true,
 	}
 
-	if got := detectEnv(); got != "cline" {
-		t.Errorf("expected cline, got %q", got)
+	got := suggestedPolicies(result, map[string]bool{})
+	want := []string{"kubernetes", "docker", "terraform", "node-python", "aws-cli"}
+	if len(got) != len(want) {
+		t.Fatalf("suggestedPolicies length = %d, want %d (%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("suggestedPolicies[%d] = %q, want %q", i, got[i], want[i])
+		}
 	}
 }
 
-func TestQuickstartCmd_Help(t *testing.T) {
-	cmd := newQuickstartCmd()
-	if cmd.Use != "quickstart" {
-		t.Errorf("unexpected Use: %q", cmd.Use)
+func TestQuickstartSuggestedPolicies_SkipsInstalled(t *testing.T) {
+	result := &detect.DetectResult{HasKubectl: true, HasDocker: true, HasNode: true}
+	installed := map[string]bool{"docker": true, "node-python": true}
+
+	got := suggestedPolicies(result, installed)
+	if len(got) != 1 || got[0] != "kubernetes" {
+		t.Fatalf("suggestedPolicies() = %v, want [kubernetes]", got)
 	}
-	if cmd.Short == "" {
-		t.Error("Short description should not be empty")
+}
+
+func TestQuickstartUnsupportedAgentWrapSuggestion(t *testing.T) {
+	selected, err := selectQuickstartAgents(&detect.DetectResult{HasCursor: true}, "", "")
+	if err != nil {
+		t.Fatalf("selectQuickstartAgents error = %v", err)
+	}
+	if len(selected) != 1 {
+		t.Fatalf("expected one selected agent, got %d", len(selected))
+	}
+	if selected[0].HasSetup {
+		t.Fatal("cursor should be unsupported (HasSetup=false)")
+	}
+	if selected[0].WrapCmd != "rampart wrap -- cursor" {
+		t.Fatalf("wrap cmd = %q, want cursor wrap command", selected[0].WrapCmd)
 	}
 }
 
 func TestQuickstartCmd_Flags(t *testing.T) {
 	cmd := newQuickstartCmd()
 
+	agentsFlag := cmd.Flags().Lookup("agents")
+	if agentsFlag == nil {
+		t.Fatal("--agents flag not registered")
+	}
 	envFlag := cmd.Flags().Lookup("env")
 	if envFlag == nil {
-		t.Fatal("--env flag not registered")
+		t.Fatal("--env alias flag not registered")
 	}
-
-	skipFlag := cmd.Flags().Lookup("skip-doctor")
-	if skipFlag == nil {
-		t.Fatal("--skip-doctor flag not registered")
+	if !envFlag.Hidden {
+		t.Fatal("--env flag should be hidden")
+	}
+	profileFlag := cmd.Flags().Lookup("profile")
+	if profileFlag == nil {
+		t.Fatal("--profile flag not registered")
 	}
 }
 
@@ -212,5 +239,53 @@ func TestQuickstartHooksConfigured_ClaudeCode(t *testing.T) {
 
 	if !quickstartHooksConfigured("claude-code") {
 		t.Fatal("expected claude-code hooks to be detected")
+	}
+}
+
+func TestQuickstartHooksConfigured_Codex(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+
+	wrapperPath := filepath.Join(home, ".local", "bin", "codex")
+	if err := os.MkdirAll(filepath.Dir(wrapperPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(wrapperPath, []byte("#!/bin/sh\nexec rampart preload -- /usr/bin/codex \"$@\"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if !quickstartHooksConfigured("codex") {
+		t.Fatal("expected codex wrapper to be detected")
+	}
+}
+
+func TestQuickstartHooksConfigured_Cline(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+
+	pre := filepath.Join(home, "Documents", "Cline", "Hooks", "PreToolUse", "rampart-policy")
+	post := filepath.Join(home, "Documents", "Cline", "Hooks", "PostToolUse", "rampart-audit")
+	if err := os.MkdirAll(filepath.Dir(pre), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(post), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(pre, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(post, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if !quickstartHooksConfigured("cline") {
+		t.Fatal("expected cline hooks to be detected")
+	}
+}
+
+func writeTestExecutable(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write test executable %s: %v", path, err)
 	}
 }

--- a/cmd/rampart/cli/setup_extra_test.go
+++ b/cmd/rampart/cli/setup_extra_test.go
@@ -223,15 +223,15 @@ func TestReadLine_Empty(t *testing.T) {
 
 func TestDetectAgents(t *testing.T) {
 	agents := detectAgents()
-	if len(agents) != 4 {
-		t.Errorf("expected 4 agents, got %d", len(agents))
+	if len(agents) != 7 {
+		t.Errorf("expected 7 agents, got %d", len(agents))
 	}
 	// Verify names
 	names := make([]string, len(agents))
 	for i, a := range agents {
 		names[i] = a.Name
 	}
-	for _, want := range []string{"Claude Code", "Cline", "OpenClaw", "Codex"} {
+	for _, want := range []string{"Claude Code", "Cline", "OpenClaw", "Codex", "Aider", "Cursor", "Windsurf"} {
 		found := false
 		for _, n := range names {
 			if n == want {

--- a/cmd/rampart/cli/setup_interactive.go
+++ b/cmd/rampart/cli/setup_interactive.go
@@ -18,10 +18,10 @@ import (
 	"fmt"
 	"io"
 	"os"
-	osexec "os/exec"
 	"path/filepath"
 	"strings"
 
+	"github.com/peg/rampart/internal/detect"
 	"github.com/peg/rampart/policies"
 	"github.com/spf13/cobra"
 )
@@ -37,8 +37,6 @@ type agentInfo struct {
 
 // detectAgents checks PATH and common locations for known AI agents.
 func detectAgents() []agentInfo {
-	home, _ := os.UserHomeDir()
-
 	agents := []agentInfo{
 		{
 			Name:     "Claude Code",
@@ -60,43 +58,31 @@ func detectAgents() []agentInfo {
 			HasSetup: true,
 			SetupCmd: "codex",
 		},
+		{
+			Name:      "Aider",
+			HasSetup:  false,
+			ManualCmd: "rampart wrap -- aider",
+		},
+		{
+			Name:      "Cursor",
+			HasSetup:  false,
+			ManualCmd: "rampart wrap -- cursor",
+		},
+		{
+			Name:      "Windsurf",
+			HasSetup:  false,
+			ManualCmd: "rampart wrap -- windsurf",
+		},
 	}
 
-	// Claude Code: check PATH or ~/.claude/
-	if _, err := osexec.LookPath("claude"); err == nil {
-		agents[0].Detected = true
-	} else if home != "" {
-		if _, err := os.Stat(filepath.Join(home, ".claude")); err == nil {
-			agents[0].Detected = true
-		}
-	}
-
-	// Cline: check ~/.vscode/extensions/ for cline or ~/Documents/Cline/
-	if home != "" {
-		clineExtDir := filepath.Join(home, ".vscode", "extensions")
-		if entries, err := os.ReadDir(clineExtDir); err == nil {
-			for _, e := range entries {
-				if strings.Contains(strings.ToLower(e.Name()), "cline") {
-					agents[1].Detected = true
-					break
-				}
-			}
-		}
-		if !agents[1].Detected {
-			if _, err := os.Stat(filepath.Join(home, "Documents", "Cline")); err == nil {
-				agents[1].Detected = true
-			}
-		}
-	}
-
-	// OpenClaw: check PATH or running process
-	if _, err := osexec.LookPath("openclaw"); err == nil {
-		agents[2].Detected = true
-	}
-
-	// Codex: check PATH
-	if _, err := osexec.LookPath("codex"); err == nil {
-		agents[3].Detected = true
+	if env, err := detect.Environment(); err == nil && env != nil {
+		agents[0].Detected = env.ClaudeCode
+		agents[1].Detected = env.HasCline
+		agents[2].Detected = env.HasOpenClaw
+		agents[3].Detected = env.HasCodex
+		agents[4].Detected = env.HasAider
+		agents[5].Detected = env.HasCursor
+		agents[6].Detected = env.HasWindsurf
 	}
 
 	return agents

--- a/cmd/rampart/cli/setup_interactive_test.go
+++ b/cmd/rampart/cli/setup_interactive_test.go
@@ -21,8 +21,8 @@ import (
 
 func TestDetectAgents_ReturnsAllKnownAgents(t *testing.T) {
 	agents := detectAgents()
-	if len(agents) != 4 {
-		t.Fatalf("expected 4 agents, got %d", len(agents))
+	if len(agents) != 7 {
+		t.Fatalf("expected 7 agents, got %d", len(agents))
 	}
 
 	names := map[string]bool{}
@@ -30,7 +30,7 @@ func TestDetectAgents_ReturnsAllKnownAgents(t *testing.T) {
 		names[a.Name] = true
 	}
 
-	for _, want := range []string{"Claude Code", "Cline", "OpenClaw", "Codex"} {
+	for _, want := range []string{"Claude Code", "Cline", "OpenClaw", "Codex", "Aider", "Cursor", "Windsurf"} {
 		if !names[want] {
 			t.Errorf("missing agent %q", want)
 		}
@@ -42,7 +42,12 @@ func TestDetectAgents_ClaudeCodeDetectedByDir(t *testing.T) {
 	tmpHome := t.TempDir()
 	testSetHome(t, tmpHome)
 
-	if err := os.MkdirAll(filepath.Join(tmpHome, ".claude"), 0o755); err != nil {
+	claudeDir := filepath.Join(tmpHome, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// detect.Environment() checks for settings.json, not just the directory.
+	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte("{}"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -58,11 +63,11 @@ func TestDetectAgents_ClaudeCodeDetectedByDir(t *testing.T) {
 	t.Error("Claude Code agent not found in results")
 }
 
-func TestDetectAgents_ClineDetectedByDocumentsDir(t *testing.T) {
+func TestDetectAgents_ClineDetectedByVSCodeExtension(t *testing.T) {
 	tmpHome := t.TempDir()
 	testSetHome(t, tmpHome)
 
-	if err := os.MkdirAll(filepath.Join(tmpHome, "Documents", "Cline"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(tmpHome, ".vscode", "extensions", "cline-1.0.0"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/detect/detect.go
+++ b/internal/detect/detect.go
@@ -19,20 +19,33 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
 
 // DetectResult contains the results of environment detection.
 type DetectResult struct {
 	ClaudeCode     bool
+	HasCodex       bool
+	HasCline       bool
+	HasOpenClaw    bool
+	HasAider       bool
+	HasCursor      bool
+	HasWindsurf    bool
+	HasCopilot     bool
 	MCPServers     []string
 	SSHKeys        bool
 	AWSCredentials bool
 	HasKubectl     bool
 	HasDocker      bool
-	HasTerraform   bool
 	HasNode        bool
 	HasPython      bool
+	HasTerraform   bool
+	HasGit         bool
+	HasNpm         bool
+	HasPip         bool
+	HasGo          bool
+	HasRust        bool
 	HasAWSCLI      bool
 }
 
@@ -42,14 +55,14 @@ func Environment() (*DetectResult, error) {
 
 	// Try to get home directory, but continue with partial results if it fails
 	homeDir, homeDirErr := os.UserHomeDir()
-	
+
 	// If we have a home directory, check home-based detection
 	if homeDirErr == nil {
 		// Detect Claude Code
 		claudeSettingsPath := filepath.Join(homeDir, ".claude", "settings.json")
 		if err := checkFileExists(claudeSettingsPath); err == nil {
 			result.ClaudeCode = true
-			
+
 			// Also check for MCP servers in Claude settings
 			servers, _ := detectMCPServersFromClaudeSettings(claudeSettingsPath)
 			result.MCPServers = append(result.MCPServers, servers...)
@@ -60,7 +73,7 @@ func Environment() (*DetectResult, error) {
 			filepath.Join(homeDir, ".cursor", "mcp.json"),
 			filepath.Join(homeDir, ".config", "codex", "mcp.json"),
 		}
-		
+
 		for _, path := range mcpPaths {
 			if servers, err := detectMCPServersFromFile(path); err == nil {
 				result.MCPServers = append(result.MCPServers, servers...)
@@ -88,36 +101,139 @@ func Environment() (*DetectResult, error) {
 			result.AWSCredentials = true
 		}
 		// Note: we skip AWS detection on permission errors rather than failing
+
+		// Detect Cursor
+		if st, err := os.Stat(filepath.Join(homeDir, ".cursor")); err == nil && st.IsDir() {
+			result.HasCursor = true
+		}
+
+		// Detect Windsurf
+		if st, err := os.Stat(filepath.Join(homeDir, ".windsurf")); err == nil && st.IsDir() {
+			result.HasWindsurf = true
+		}
+
+		// Detect Cline extension installs.
+		clinePatterns := []string{
+			filepath.Join(homeDir, ".vscode", "extensions", "saoud-m.vscode-claude-dev-*"),
+			filepath.Join(homeDir, ".vscode", "extensions", "cline-*"),
+		}
+		if runtime.GOOS != "windows" {
+			clinePatterns = append(clinePatterns,
+				filepath.Join(homeDir, ".vscode-server", "extensions", "saoud-m.vscode-claude-dev-*"),
+				filepath.Join(homeDir, ".vscode-server", "extensions", "cline-*"),
+			)
+		}
+		for _, pattern := range clinePatterns {
+			if matches, err := filepath.Glob(pattern); err == nil && len(matches) > 0 {
+				result.HasCline = true
+				break
+			}
+		}
 	}
 
-	// Detect CLI tools in PATH (works regardless of home directory)
-	if _, err := exec.LookPath("kubectl"); err == nil {
-		result.HasKubectl = true
+	// Env-based agent signals.
+	if os.Getenv("CLINE_ACTIVE") != "" || os.Getenv("CLINE_SESSION") != "" {
+		result.HasCline = true
 	}
-	if _, err := exec.LookPath("docker"); err == nil {
-		result.HasDocker = true
+	if os.Getenv("OPENCLAW_SERVICE_MARKER") != "" {
+		result.HasOpenClaw = true
 	}
-	if _, err := exec.LookPath("terraform"); err == nil {
-		result.HasTerraform = true
-	}
-	if _, err := exec.LookPath("node"); err == nil {
-		result.HasNode = true
-	} else if _, err := exec.LookPath("npm"); err == nil {
-		result.HasNode = true
-	}
-	if _, err := exec.LookPath("python3"); err == nil {
-		result.HasPython = true
-	} else if _, err := exec.LookPath("python"); err == nil {
-		result.HasPython = true
-	} else if _, err := exec.LookPath("pip"); err == nil {
-		result.HasPython = true
-	}
-	if _, err := exec.LookPath("aws"); err == nil {
-		result.HasAWSCLI = true
-	}
+
+	// Binary-based detection (works regardless of home directory).
+	result.ClaudeCode = result.ClaudeCode || hasBinary("claude")
+	result.HasCodex = hasBinary("codex")
+	result.HasOpenClaw = result.HasOpenClaw || hasBinary("openclaw")
+	result.HasAider = hasBinary("aider")
+	result.HasWindsurf = result.HasWindsurf || hasBinary("windsurf")
+	result.HasCopilot = hasBinary("github-copilot-cli") || hasBinary("gh-copilot")
+	result.HasKubectl = hasBinary("kubectl")
+	result.HasDocker = hasBinary("docker")
+	result.HasNode = hasBinary("node")
+	result.HasNpm = hasBinary("npm")
+	result.HasPython = hasBinary("python3") || hasBinary("python")
+	result.HasPip = hasBinary("pip3") || hasBinary("pip")
+	result.HasTerraform = hasBinary("terraform") || hasBinary("tofu")
+	result.HasGit = hasBinary("git")
+	result.HasGo = hasBinary("go")
+	result.HasRust = hasBinary("cargo")
+	result.HasAWSCLI = hasBinary("aws")
 
 	// Always return results, even if we couldn't access home directory
 	return result, nil
+}
+
+func hasBinary(name string) bool {
+	_, err := exec.LookPath(name)
+	return err == nil
+}
+
+// DetectedAgents returns detected AI coding agents in stable display order.
+func (r *DetectResult) DetectedAgents() []string {
+	agents := make([]string, 0, 8)
+	if r.ClaudeCode {
+		agents = append(agents, "claude-code")
+	}
+	if r.HasCodex {
+		agents = append(agents, "codex")
+	}
+	if r.HasCline {
+		agents = append(agents, "cline")
+	}
+	if r.HasOpenClaw {
+		agents = append(agents, "openclaw")
+	}
+	if r.HasCursor {
+		agents = append(agents, "cursor")
+	}
+	if r.HasAider {
+		agents = append(agents, "aider")
+	}
+	if r.HasWindsurf {
+		agents = append(agents, "windsurf")
+	}
+	if r.HasCopilot {
+		agents = append(agents, "copilot")
+	}
+	return agents
+}
+
+// DetectedTools returns detected dev tools in stable display order.
+func (r *DetectResult) DetectedTools() []string {
+	tools := make([]string, 0, 11)
+	if r.HasKubectl {
+		tools = append(tools, "kubectl")
+	}
+	if r.HasDocker {
+		tools = append(tools, "docker")
+	}
+	if r.HasNode {
+		tools = append(tools, "node")
+	}
+	if r.HasNpm {
+		tools = append(tools, "npm")
+	}
+	if r.HasPython {
+		tools = append(tools, "python")
+	}
+	if r.HasPip {
+		tools = append(tools, "pip")
+	}
+	if r.HasTerraform {
+		tools = append(tools, "terraform")
+	}
+	if r.HasGit {
+		tools = append(tools, "git")
+	}
+	if r.HasGo {
+		tools = append(tools, "go")
+	}
+	if r.HasRust {
+		tools = append(tools, "rust")
+	}
+	if r.HasAWSCLI {
+		tools = append(tools, "aws-cli")
+	}
+	return tools
 }
 
 // checkFileExists checks if a file exists, properly handling permission errors.
@@ -186,16 +302,16 @@ func removeDuplicates(slice []string) []string {
 	if len(slice) == 0 {
 		return []string{}
 	}
-	
+
 	keys := make(map[string]bool)
 	result := make([]string, 0, len(slice))
-	
+
 	for _, item := range slice {
 		if !keys[item] {
 			keys[item] = true
 			result = append(result, item)
 		}
 	}
-	
+
 	return result
 }

--- a/internal/detect/detect_test.go
+++ b/internal/detect/detect_test.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"testing"
 )
 
@@ -191,5 +192,101 @@ func TestDetectMCPServersFromFileInvalidJSON(t *testing.T) {
 	_, err = detectMCPServersFromFile(configPath)
 	if err == nil {
 		t.Fatal("Expected error for invalid JSON")
+	}
+}
+
+func TestEnvironmentDetectsAgentsAndToolsFromSignals(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PATH binary shims in this test are Unix-only")
+	}
+
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", tmpHome)
+	}
+
+	t.Setenv("CLINE_ACTIVE", "1")
+	t.Setenv("OPENCLAW_SERVICE_MARKER", "openclaw")
+
+	binDir := t.TempDir()
+	writeExecutable(t, filepath.Join(binDir, "codex"))
+	writeExecutable(t, filepath.Join(binDir, "aider"))
+	writeExecutable(t, filepath.Join(binDir, "kubectl"))
+	writeExecutable(t, filepath.Join(binDir, "docker"))
+	writeExecutable(t, filepath.Join(binDir, "node"))
+	writeExecutable(t, filepath.Join(binDir, "npm"))
+	writeExecutable(t, filepath.Join(binDir, "python3"))
+	writeExecutable(t, filepath.Join(binDir, "pip3"))
+	writeExecutable(t, filepath.Join(binDir, "terraform"))
+	writeExecutable(t, filepath.Join(binDir, "git"))
+	writeExecutable(t, filepath.Join(binDir, "go"))
+	writeExecutable(t, filepath.Join(binDir, "cargo"))
+	writeExecutable(t, filepath.Join(binDir, "aws"))
+	t.Setenv("PATH", binDir)
+
+	if err := os.MkdirAll(filepath.Join(tmpHome, ".cursor"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(tmpHome, ".windsurf"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := Environment()
+	if err != nil {
+		t.Fatalf("Environment() error = %v", err)
+	}
+
+	if !got.HasCodex || !got.HasAider || !got.HasOpenClaw || !got.HasCline {
+		t.Fatalf("missing expected agent signals: %+v", got)
+	}
+	if !got.HasCursor || !got.HasWindsurf {
+		t.Fatalf("missing expected directory signals: %+v", got)
+	}
+	if !got.HasKubectl || !got.HasDocker || !got.HasNode || !got.HasNpm || !got.HasPython || !got.HasPip || !got.HasTerraform || !got.HasGit || !got.HasGo || !got.HasRust || !got.HasAWSCLI {
+		t.Fatalf("missing expected tool signals: %+v", got)
+	}
+}
+
+func TestDetectedAgentsAndToolsOrder(t *testing.T) {
+	r := &DetectResult{
+		ClaudeCode:   true,
+		HasCodex:     true,
+		HasCline:     true,
+		HasOpenClaw:  true,
+		HasCursor:    true,
+		HasAider:     true,
+		HasWindsurf:  true,
+		HasCopilot:   true,
+		HasKubectl:   true,
+		HasDocker:    true,
+		HasNode:      true,
+		HasNpm:       true,
+		HasPython:    true,
+		HasPip:       true,
+		HasTerraform: true,
+		HasGit:       true,
+		HasGo:        true,
+		HasRust:      true,
+		HasAWSCLI:    true,
+	}
+
+	agents := r.DetectedAgents()
+	wantAgents := []string{"claude-code", "codex", "cline", "openclaw", "cursor", "aider", "windsurf", "copilot"}
+	if !reflect.DeepEqual(agents, wantAgents) {
+		t.Fatalf("DetectedAgents() = %v, want %v", agents, wantAgents)
+	}
+
+	tools := r.DetectedTools()
+	wantTools := []string{"kubectl", "docker", "node", "npm", "python", "pip", "terraform", "git", "go", "rust", "aws-cli"}
+	if !reflect.DeepEqual(tools, wantTools) {
+		t.Fatalf("DetectedTools() = %v, want %v", tools, wantTools)
+	}
+}
+
+func writeExecutable(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write executable %s: %v", path, err)
 	}
 }

--- a/registry/registry.json
+++ b/registry/registry.json
@@ -1,13 +1,13 @@
 {
   "version": "1",
-  "updated_at": "2026-03-04T09:30:18Z",
+  "updated_at": "2026-03-05T17:58:21Z",
   "policies": [
     {
       "name": "mcp-server",
       "description": "First-party policy profile",
       "tags": null,
       "url": "https://raw.githubusercontent.com/peg/rampart/main/registry/policies/mcp-server.yaml",
-      "sha256": "2c7235019bbfdeca41d18044c54d862643ea92b153a03714adc236cbc36bc331",
+      "sha256": "91badc1dbad59b40ed5531590d348d8da1873eac4c3fb79295341eb82ae07511",
       "version": "1.0.0",
       "author": ""
     },
@@ -16,7 +16,7 @@
       "description": "First-party policy profile",
       "tags": null,
       "url": "https://raw.githubusercontent.com/peg/rampart/main/registry/policies/research-agent.yaml",
-      "sha256": "a1dc454e5a07ee9d1d50cd284a001ae2d210610e026091d3c6f4c2b0a4c5770a",
+      "sha256": "8191718bc9296bf558d07d612a4ec5d64544305a814ed81de637ade2ff5a8629",
       "version": "1.0.0",
       "author": ""
     },
@@ -29,7 +29,7 @@
         "iam"
       ],
       "url": "https://raw.githubusercontent.com/peg/rampart/main/policies/community/aws-cli.yaml",
-      "sha256": "84ba66deeb176e01f22aa720273fc09b7d910e034cb552ebf237a05f80555cf3",
+      "sha256": "43aec7f3acfe5de9519685ff098b8614e6d24e31dd770bb76f163b8c0ad6a5a0",
       "version": "1.0.0",
       "author": "@rampart-team",
       "min_rampart": "0.6.0"
@@ -43,7 +43,7 @@
         "compose"
       ],
       "url": "https://raw.githubusercontent.com/peg/rampart/main/policies/community/docker.yaml",
-      "sha256": "784b6d1679ffeb5efa6dfbe576002b11869989b14b8cf0baa069000653c81292",
+      "sha256": "9ddd51b50ea5f13a5c3e720d09d033336e754e87596124a720d897bb3940ef78",
       "version": "1.0.0",
       "author": "@rampart-team",
       "min_rampart": "0.6.0"
@@ -57,7 +57,7 @@
         "cluster"
       ],
       "url": "https://raw.githubusercontent.com/peg/rampart/main/policies/community/kubernetes.yaml",
-      "sha256": "54628496cc2d759417eab0e2c7ec7054f3d22b8c9a4b3655ea6c13dd5aaddce3",
+      "sha256": "faade383426f918fd6f19434196e2cbd7a1b30a3808484aa93902ba08f5bf3b9",
       "version": "1.0.0",
       "author": "@rampart-team",
       "min_rampart": "0.6.0"
@@ -72,7 +72,7 @@
         "pip"
       ],
       "url": "https://raw.githubusercontent.com/peg/rampart/main/policies/community/node-python.yaml",
-      "sha256": "fd40c39e956bd2632b4fd89bfbe05df1f3f87515b73622a14896c56f40f45dea",
+      "sha256": "7500840f461436397496a57c1e7f642e617eae21d1989d6ab4f8f1ebd8165816",
       "version": "1.0.0",
       "author": "@rampart-team",
       "min_rampart": "0.6.0"
@@ -86,7 +86,7 @@
         "opentofu"
       ],
       "url": "https://raw.githubusercontent.com/peg/rampart/main/policies/community/terraform.yaml",
-      "sha256": "d5dfe3ca773c2fc3765c2a99441ccbf782defc87abba405ef7b3f76b94faa614",
+      "sha256": "369178e10a245f75dd4312941d02dfa5befa4b62a5e20e656841b35254df06ef",
       "version": "1.0.0",
       "author": "@rampart-team",
       "min_rampart": "0.6.0"


### PR DESCRIPTION
Overhauls `rampart quickstart` for a polished first-run experience.

## Changes

### Multi-agent detection
- Scans for **8 AI agents**: Claude Code, Codex CLI, Cline, OpenClaw, Cursor, Aider, Windsurf, GitHub Copilot CLI
- Sets up all detected agents with native hook support (not just the first match)
- Agents without setup support get `rampart wrap` guidance

### Expanded environment detection (`internal/detect`)
- New fields: `HasCodex`, `HasCline`, `HasOpenClaw`, `HasAider`, `HasCursor`, `HasWindsurf`, `HasCopilot`
- Dev tool detection: `HasNode`, `HasPython`, `HasTerraform`, `HasGit`, `HasNpm`, `HasPip`, `HasGo`, `HasRust`, `HasAWSCLI`
- Convenience methods: `DetectedAgents()`, `DetectedTools()`
- `setup_interactive.go` now uses unified `detect.Environment()` instead of duplicating logic

### Policy suggestions
- Suggests community policies based on detected tools (kubectl → kubernetes, docker → docker, etc.)
- Skips already-installed policies
- Shows install command for easy copy-paste

### UX improvements
- Displays grid of detected agents and dev tools
- Shows active rule count in health check summary
- Better error messages for `serve install` failures (suggests sudo, manual fallback)
- `--agents` flag (comma-separated) replaces `--env` (kept as hidden alias)
- New `--profile` flag for policy profile override

### Output example
```
◆ Rampart quickstart

  Scanning environment...

  AI Agents:
    ✓ Claude Code
    ✓ Codex CLI
    ✗ Cline
    ✗ Cursor
    ✗ Aider

  Dev Tools:
    ✓ kubectl    ✓ docker    ✓ node/npm
    ✓ python     ✓ git       ✗ terraform

  Configuring hooks...
  ✓ Claude Code: hooks installed
  ✓ Codex CLI: wrapper installed

  Installing policies...
  ✓ standard profile installed
  💡 Suggested: kubernetes, docker, node-python
    → Install with: rampart policy install kubernetes docker node-python

◆ You're protected.
```

## Tests
18 test cases covering multi-agent detection, `--agents` flag override, policy suggestions, unsupported agent wrap output, hook detection for all supported agents.