### PR TITLE
fix: github release url

### DIFF
--- a/docs/install
+++ b/docs/install
@@ -75,10 +75,10 @@ esac
 info "Version:  ${BOLD}${VERSION}${RESET}"
 
 # ── Build URLs ─────────────────────────────────────────────────────────────────
-TARBALL="rampart_${OS}_${ARCH}.tar.gz"
+TARBALL="rampart_${VERSION#v}_${OS}_${ARCH}.tar.gz"
 BASE_URL="https://github.com/${REPO}/releases/download/${VERSION}"
 TARBALL_URL="${BASE_URL}/${TARBALL}"
-CHECKSUM_URL="${BASE_URL}/rampart_${OS}_${ARCH}_checksums.txt"
+CHECKSUM_URL="${BASE_URL}/checksums.txt"
 
 if [ "$DRY_RUN" = "1" ]; then
     step "Dry-run — no changes will be made"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -75,10 +75,10 @@ esac
 info "Version:  ${BOLD}${VERSION}${RESET}"
 
 # ── Build URLs ─────────────────────────────────────────────────────────────────
-TARBALL="rampart_${OS}_${ARCH}.tar.gz"
+TARBALL="rampart_${VERSION#v}_${OS}_${ARCH}.tar.gz"
 BASE_URL="https://github.com/${REPO}/releases/download/${VERSION}"
 TARBALL_URL="${BASE_URL}/${TARBALL}"
-CHECKSUM_URL="${BASE_URL}/rampart_${OS}_${ARCH}_checksums.txt"
+CHECKSUM_URL="${BASE_URL}/checksums.txt"
 
 if [ "$DRY_RUN" = "1" ]; then
     step "Dry-run — no changes will be made"


### PR DESCRIPTION
Otherwise the install script fails like this :
```
siddarthkumar in ~ λ curl -fsSL https://rampart.sh/install | bash
15ms
▸ Platform: \033[1mdarwin/arm64\033[0m
▸ Fetching latest release...
▸ Version:  \033[1mv0.8.4\033[0m

Downloading rampart v0.8.4...
curl: (56) The requested URL returned error: 404
✗ Download failed.\nURL:
https://github.com/peg/rampart/releases/download/v0.8.4/rampart_darwin_arm64.tar.gz\nCheck
that v0.8.4 exists: https://github.com/peg/rampart/releases
```