### PR TITLE
fix: staging review — self-bypass, serve TLS state, eval scope, changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Self-protection policies** (`standard.yaml`): block agents from killing Rampart processes (`pkill rampart`, `killall rampart`, `kill $(pgrep rampart)`) or removing the Rampart binary.
+- **Interpreter base64 obfuscation blocking** (`standard.yaml`): deny `python3 -c "exec(base64.b64decode(...))"`, Ruby `Base64.decode64`, Perl `MIME::Base64`, Node `Buffer.from` one-liners.
+- **`rampart report export`**: shareable audit summary command.
+
+### Changed
+
+- **BREAKING: Eval token scope narrowed.** Audit reads, status checks, approval listing, and rule management now require admin-scoped tokens. Eval tokens are limited to tool call evaluation (`POST /v1/eval`). Update integrations using eval tokens for audit/status endpoints.
+
+### Fixed
+
+- **OpenClaw profile self-bypass** (`openclaw.yaml`): bare `rampart serve` and `rampart upgrade` no longer allowed — an agent could restart serve with altered flags or upgrade to a tampered binary. Only explicit safe subcommands (`serve stop`, `serve install`) are permitted.
+- **Serve state TLS scheme**: `writeServeState` now records `https://` when TLS is enabled. Fixes `doctor`, `watch`, and `status` probing the wrong URL after `rampart serve --tls-auto`.
+- **Upgrade restart reminder**: only shown when serve was not successfully auto-restarted.
+- **Docs accuracy**: OWASP ASI05 downgraded from Covered to Partial, broken anchors fixed, version references updated, prompt injection default action corrected.
+
+### Security
+
+- Self-protection policies prevent agents from disabling their own enforcement.
+- OpenClaw profile hardened against serve restart and upgrade abuse.
+
 ## [0.7.1] - 2026-03-01
 
 ### Fixed

--- a/cmd/rampart/cli/serve.go
+++ b/cmd/rampart/cli/serve.go
@@ -426,7 +426,7 @@ func newServeCmd(opts *rootOptions, deps *serveDeps) *cobra.Command {
 
 				// Write serve state file for discovery by doctor/watch/log.
 				if rampartDir != "" {
-					if err := writeServeState(rampartDir, listenPort, os.Getpid()); err != nil {
+					if err := writeServeState(rampartDir, listenPort, os.Getpid(), tlsCfg != nil); err != nil {
 						logger.Warn("serve: failed to write state file", "error", err)
 					}
 				}

--- a/cmd/rampart/cli/serve_state.go
+++ b/cmd/rampart/cli/serve_state.go
@@ -24,9 +24,13 @@ type serveState struct {
 const serveStateFile = "serve.state"
 
 // writeServeState writes the serve state to ~/.rampart/serve.state.
-func writeServeState(dir string, port, pid int) error {
+func writeServeState(dir string, port, pid int, tls bool) error {
+	scheme := "http"
+	if tls {
+		scheme = "https"
+	}
 	state := serveState{
-		URL:     fmt.Sprintf("http://localhost:%d", port),
+		URL:     fmt.Sprintf("%s://localhost:%d", scheme, port),
 		Port:    port,
 		PID:     pid,
 		Started: time.Now().UTC().Format(time.RFC3339),

--- a/internal/token/store.go
+++ b/internal/token/store.go
@@ -38,7 +38,8 @@ const (
 	// Prefix for all rampart tokens.
 	Prefix = "rampart_"
 
-	// ScopeEval allows tool call evaluation, audit reads, and status checks.
+	// ScopeEval allows tool call evaluation (POST /v1/eval).
+	// Audit reads, status checks, approvals, and rule management require ScopeAdmin.
 	ScopeEval = "eval"
 
 	// ScopeAdmin allows mutations: approvals, rule deletion, policy reload, token management.

--- a/policies/openclaw.yaml
+++ b/policies/openclaw.yaml
@@ -31,24 +31,22 @@ policies:
     match:
       tool: ["exec"]
     rules:
-      # Allow serve lifecycle commands — stopping/restarting serve is operational, not policy modification.
+      # Allow read-only and safe operational commands.
+      # SECURITY: do NOT allow bare "rampart serve" — an agent could restart
+      # with --mode disabled or altered flags. Only allow explicit safe subcommands.
       - action: allow
         when:
           command_contains:
-            - "rampart serve"
-        message: "Serve lifecycle commands are allowed"
-      # Allow version/status/doctor — read-only commands.
-      - action: allow
-        when:
-          command_contains:
+            - "rampart serve stop"
+            - "rampart serve install"
+            - "rampart serve uninstall"
             - "rampart version"
             - "rampart status"
             - "rampart doctor"
             - "rampart log"
             - "rampart watch"
             - "rampart convert"
-            - "rampart upgrade"
-        message: "Read-only rampart commands are allowed"
+        message: "Read-only/safe rampart commands are allowed"
       - action: deny
         when:
           command_contains:


### PR DESCRIPTION
## Pre-release fixes from GPT-5.4 staging review

### 🚨 Security: OpenClaw profile self-bypass (Finding #1)
`openclaw.yaml` allowed bare `rampart serve` before deny rules. First-match-wins meant an agent could run `rampart serve --mode disabled` to kill its own enforcement, or `rampart upgrade` to replace the binary. 

**Fix:** Only explicit safe subcommands allowed now (`serve stop`, `serve install`, `version`, `status`, `doctor`, `log`, `watch`, `convert`). `rampart serve` (bare) and `rampart upgrade` removed from allow list.

### 🐛 Bug: Serve state TLS scheme (Finding #2)
`writeServeState` hardcoded `http://` even with `--tls-auto`. Doctor/watch/status would probe wrong URL and report serve as down.

**Fix:** Added `tls bool` param, writes `https://` when TLS is enabled.

### ⚠️ API: Eval token scope docs (Finding #3)
`ScopeEval` comment claimed eval tokens could do audit reads and status checks — they can't anymore (moved to `checkAdminAuth`).

**Fix:** Comment updated. CHANGELOG notes this as a breaking change.

### 📝 Changelog (Finding #4)
Populated empty Unreleased section with all staging changes.

### Testing
`go vet ./...` clean, `go test ./... -count=1` — all 23 suites pass.