### PR TITLE
chore: migrate goreleaser brews → homebrew_casks (v2 config)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -54,7 +54,7 @@ release:
 # Homebrew tap auto-update on release.
 # Requires HOMEBREW_TAP_GITHUB_TOKEN secret in GitHub Actions — a PAT with repo scope
 # that has write access to the peg/homebrew-tap repository.
-brews:
+homebrew_casks:
   - directory: Formula
     repository:
       owner: peg


### PR DESCRIPTION
The `brews` key is deprecated in GoReleaser v2. This renames it to `homebrew_casks` to match the current v2 config schema.

Without this fix, any release using GoReleaser v2 will emit a deprecation warning (and may fail in future versions) when trying to auto-update the peg/homebrew-tap Formula.

**Change:** `.goreleaser.yml` line 57: `brews:` → `homebrew_casks:`