### PR TITLE
fix: harden OpenClaw approval path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **OpenClaw native approval path now has a proven end-to-end acceptance bar** — validated live with native Discord approval UI across the three critical states: learned allow (`sudo true`), fresh ask (`sudo id`), and hard deny (`rm -rf /tmp`).
+- **`Allow Always` writeback path verified on true plugin-originated approvals** — Rampart's native OpenClaw plugin now proves `onResolution("allow-always")` triggers `/v1/rules/learn` and persists durable rules to `~/.rampart/policies/user-overrides.yaml`.
+- **Sensitive-tool degraded mode hardened** — when Rampart serve is unavailable, sensitive OpenClaw tools now fail explicitly instead of silently failing open. Lower-risk tools can remain configured fail-open.
+- **OpenClaw docs/checklists corrected** — verification guidance now points at `user-overrides.yaml`, includes `rampart-serve.service` health checks, and documents the recommended learned-allow / ask / deny validation set.
+
 ## [0.9.16] - 2026-04-15
 
 ### Fixed

--- a/docs-site/integrations/openclaw.md
+++ b/docs-site/integrations/openclaw.md
@@ -9,6 +9,8 @@ Rampart integrates with OpenClaw via the native `before_tool_call` plugin API. T
 
 Every tool call — exec, read, write, web_fetch, browser, message, and more — is evaluated against your policy before it runs.
 
+For sensitive tools, the recommended operating assumption is simple: if Rampart policy service is unavailable, treat that as a broken state and fix it before trusting approval-path tests.
+
 !!! info "Version requirements"
     - **OpenClaw >= 2026.4.11**: Recommended and supported for native Discord exec approvals plus full native plugin coverage
     - **OpenClaw 2026.3.28 - 2026.4.10**: Native plugin works for tool enforcement, but Rampart's polished Discord exec approval path is supported on newer OpenClaw builds
@@ -31,6 +33,15 @@ That's it. Rampart:
 4. Configures OpenClaw to route decisions through Rampart (`tools.exec.ask: off`)
 5. Copies the `openclaw.yaml` policy profile to `~/.rampart/policies/openclaw.yaml`
 6. Starts `rampart serve` as a boot service (if not already running)
+
+After setup, verify both services are healthy:
+
+```bash
+systemctl --user is-active openclaw-gateway.service
+systemctl --user is-active rampart-serve.service
+```
+
+Both should return `active`.
 
 No external downloads, no npm install — the plugin is bundled inside the `rampart` binary.
 
@@ -106,7 +117,9 @@ rampart init --profile openclaw
 
 ## Always Allow writeback
 
-When you click "Always Allow" in the OpenClaw approval UI, Rampart writes a permanent smart-glob rule to `~/.rampart/policies/user-overrides.yaml` via `POST /v1/rules/learn`. The rule takes effect immediately without restarting serve.
+When you click "Always Allow" in the OpenClaw approval UI, Rampart writes a durable rule to `~/.rampart/policies/user-overrides.yaml` via `POST /v1/rules/learn`. The rule takes effect immediately without restarting serve.
+
+For example, approving `sudo true` writes an exact rule, while broader commands may be generalized into a smart glob when appropriate.
 
 For example, approving `sudo apt-get install nmap` always writes:
 ```yaml
@@ -133,6 +146,11 @@ Expected output when fully configured:
 ✓ Policy: openclaw.yaml loaded (N rules, default: ask)
 ✓ Approval path: native OpenClaw UI active
 ```
+
+For end-to-end confidence, validate one case in each state:
+- learned allow, for example `sudo true`
+- fresh ask, for example `sudo id`
+- hard deny, for example `rm -rf /tmp`
 
 Or check plugin status directly:
 

--- a/docs/design/openclaw-approval-acceptance-checklist.md
+++ b/docs/design/openclaw-approval-acceptance-checklist.md
@@ -1,0 +1,110 @@
+# OpenClaw approval-path acceptance checklist
+
+This checklist exists to validate the polished minor-version path for Rampart's OpenClaw integration.
+
+## Goal
+
+Rampart owns policy decisioning, audit, and durable allow learning.
+OpenClaw owns approval UX, native cards/buttons, and approval lifecycle.
+
+## Deterministic local checks
+
+Run from the repo root.
+
+### 1. Plugin smoke test
+
+```bash
+node internal/plugin/openclaw/smoke-test.mjs
+```
+
+Pass criteria:
+- `exec` + `ask` returns `requireApproval`
+- no legacy `params.ask = "always"` path
+
+### 2. Approval regression suite
+
+```bash
+node internal/plugin/openclaw/approval-regression.mjs
+```
+
+Pass criteria:
+- `ask` returns `requireApproval`
+- `deny` returns `block: true`
+- `allow-always` persists learned rule intent via `/v1/rules/learn`
+
+### 3. Build
+
+```bash
+go build ./cmd/rampart
+```
+
+Pass criteria:
+- build completes successfully
+
+## Installed integration checks
+
+### 4. Reinstall plugin
+
+```bash
+go build -o ~/.local/bin/rampart ./cmd/rampart
+~/.local/bin/rampart setup openclaw --plugin
+systemctl --user restart openclaw-gateway.service
+systemctl --user restart rampart-serve.service
+systemctl --user is-active openclaw-gateway.service
+systemctl --user is-active rampart-serve.service
+```
+
+Pass criteria:
+- plugin installs cleanly
+- gateway returns `active`
+- rampart serve returns `active`
+- sensitive tools do not silently fail open when serve is unavailable
+
+## Real product validation
+
+### 5. Native Discord approval card
+
+Validate with one real Discord DM case that becomes a real tool invocation.
+
+Pass criteria:
+- approval object is created
+- native Discord approval box appears
+- approval is clearly associated with the current DM/session
+
+### 6. Decision outcomes
+
+Pass criteria:
+- allow once succeeds
+- deny blocks execution
+- allow always writes durable learned rule to `~/.rampart/policies/user-overrides.yaml`
+- no hidden second approval queue is created by Rampart
+
+### 7. Live three-state proof
+
+Validate one case for each state:
+- allow: a previously learned command like `sudo true`
+- ask: a new privileged command like `sudo id`
+- deny: a destructive command like `rm -rf /tmp`
+
+Pass criteria:
+- learned allow executes without prompting
+- new privileged command prompts and user choice is respected
+- destructive command is hard-blocked by policy
+
+## Ship bar for the minor
+
+Do not ship until all of the following are true:
+
+- deterministic local checks pass
+- plugin installs cleanly on a fresh reinstall
+- one real native Discord approval box appears on the cleaned path
+- allow/deny/allow-always semantics are confirmed
+- durable writeback is verified in `~/.rampart/policies/user-overrides.yaml`
+- documentation reflects that plain chat text is not itself a tool call
+- documentation reflects that `rampart serve` must be healthy for approval-path validation
+
+## Non-goals
+
+- using natural-language DM prompts as the main regression harness
+- reintroducing a separate Rampart-owned pending approval queue for OpenClaw-hosted tool calls
+- special-casing `exec` away from the unified approval contract

--- a/internal/plugin/openclaw/README.md
+++ b/internal/plugin/openclaw/README.md
@@ -1,143 +1,62 @@
-# rampart-openclaw-plugin
+# Rampart OpenClaw plugin smoke test
 
-**Rampart AI agent firewall — native OpenClaw plugin (v1.0)**
+Deterministic local harness for the OpenClaw `before_tool_call` plugin path.
 
-This OpenClaw plugin integrates [Rampart](https://github.com/peg/rampart) using the native `before_tool_call` hook API (OpenClaw ≥ 2026.3.28). It is the primary integration path, replacing the legacy dist-file patching approach.
+## Why this exists
 
----
+Discord DM prompts are not a reliable validator for approval behavior because the model may choose not to call the real tool at all. This smoke test exercises the plugin decision path directly and verifies what Rampart returns to OpenClaw.
 
-## Quick start
+## Usage
 
-```bash
-# 1. Install Rampart
-go install github.com/peg/rampart@latest
-
-# 2. Start Rampart policy server (defaults to :9090)
-rampart serve
-
-# 3. Install this plugin
-openclaw plugins install /path/to/rampart-openclaw-plugin
-```
-
-That's it. Every tool call is now checked against your Rampart policies.
-
----
-
-## What happens on each decision
-
-Every time the OpenClaw agent calls a tool (`exec`, `read`, `write`, `web_fetch`, `message`, etc.), this plugin intercepts the call **before it executes** and checks it against the running Rampart policy engine (`rampart serve`).
-
-| Decision | What happens |
-|----------|-------------|
-| `allow`  | Tool call proceeds normally |
-| `deny`   | Tool call is blocked; agent sees a `blockReason` message |
-| `ask`    | OpenClaw pauses and prompts you for approval (120 s timeout → auto-deny) |
-
-### The always-allow flow
-
-When Rampart returns `ask` and you click **Allow Always** in the OpenClaw approval UI:
-
-1. OpenClaw resolves the native approval for the current tool call
-2. The plugin writes a persistent allow rule via `POST /v1/rules/learn`
-3. Rampart stores the learned rule in its user policy files
-4. Future matching calls are automatically allowed without creating a second approval queue
-
-### Fail-open behavior
-
-If `rampart serve` is not running or unreachable, the plugin **fails open** (allows the call) and logs at debug level. This matches Rampart's existing default behavior and keeps OpenClaw functional when Rampart is down.
-
-If `rampart serve` is reachable but returns a 5xx error, the plugin also fails open but logs a warning.
-
----
-
-## Configuration
-
-Plugin config lives in your OpenClaw config file under `plugins.rampart`:
-
-```yaml
-plugins:
-  rampart:
-    serveUrl: "http://localhost:9090"   # default
-    enabled: true                        # default
-    timeoutMs: 3000                      # ms to wait for Rampart before failing open
-    approvalTimeoutMs: 120000            # ms before unanswered approval auto-denies
-```
-
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `serveUrl` | string | `http://localhost:9090` | Rampart serve endpoint |
-| `enabled` | boolean | `true` | Disable the plugin without uninstalling |
-| `timeoutMs` | number | `3000` | Max ms to wait for Rampart before failing open |
-| `approvalTimeoutMs` | number | `120000` | Ms before an unanswered approval auto-denies |
-
----
-
-## Authentication
-
-The plugin reads your Rampart token from (in order):
-
-1. `RAMPART_TOKEN` environment variable
-2. `~/.rampart/token` file
-
-This matches the standard Rampart CLI token resolution.
-
----
-
-## Security note
-
-The plugin only makes network calls to **localhost** (or whatever `serveUrl` is configured to). It reads a single token file from `~/.rampart/token`. It does not phone home, send telemetry, or make any external network requests.
-
----
-
-## Rampart API contract
-
-The plugin calls:
-
-```
-POST http://localhost:9090/v1/tool/{toolName}
-Content-Type: application/json
-Authorization: Bearer <token>
-
-{
-  "agent":   "main",
-  "session": "...",
-  "run_id":  "...",
-  "params":  { "command": "ls -la" }
-}
-```
-
-Expected response shapes:
-
-```json
-{ "allowed": true,  "decision": "allow", "message": "..." }
-{ "allowed": false, "decision": "deny",  "message": "blocked by policy X", "policy": "no-rm-rf" }
-{ "allowed": false, "decision": "ask",   "message": "shell command requires approval", "severity": "warning" }
-```
-
-For OpenClaw-hosted plugin flows, Rampart evaluates the tool call but does **not** create a second hidden Rampart approval record. OpenClaw's native approval UI is the only operator-facing approval surface. When the user resolves the native OpenClaw approval:
-
-- `allow-once` is handled entirely by OpenClaw
-- `deny` is handled entirely by OpenClaw
-- `allow-always` writes a persistent Rampart rule via `POST /v1/rules/learn`
-
-The plugin also records best-effort audit information for completed tool calls, but approval ownership remains native to OpenClaw for OpenClaw-hosted flows.
-
----
-
-## Legacy dist patching
-
-Older Rampart/OpenClaw setups used `--patch-tools` to patch OpenClaw's bundled `dist/` files directly.
-
-That path is now considered **legacy compatibility**, not the primary integration model. The native OpenClaw plugin is the preferred path because it survives upgrades much better and keeps approval ownership inside OpenClaw.
-
----
-
-## Development
+From the repo root:
 
 ```bash
-# Verify no syntax errors (ESM import test)
-node -e "import('./index.js').then(() => console.log('ok')).catch(e => console.error(e))"
-
-# Verify manifest JSON
-cat openclaw.plugin.json | node -e "process.stdin.resume(); let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{JSON.parse(d); console.log('valid json')})"
+node internal/plugin/openclaw/smoke-test.mjs
 ```
+
+Default behavior simulates:
+- tool: `exec`
+- params: `{ "command": "sudo true" }`
+- Rampart verdict: `{ "decision": "ask", "policy": "test-policy", "message": "needs approval", "severity": "warning" }`
+
+Expected output now:
+- `result.requireApproval` exists for `exec`
+- no `params.ask = "always"` mutation path
+
+## Override inputs
+
+```bash
+node internal/plugin/openclaw/smoke-test.mjs \
+  '{"decision":"deny","message":"blocked"}' \
+  exec \
+  '{"command":"sudo true"}'
+```
+
+Arguments:
+1. tool result JSON
+2. tool name
+3. tool params JSON
+
+## What to check
+
+- `ask` returns `requireApproval`
+- `deny` returns `block: true`
+- `allow-always` calls `/v1/rules/learn`
+- `allow` returns nothing or param adjustment only when explicitly requested by Rampart
+- there is no legacy `params.ask = "always"` mutation path
+
+This is a deterministic harness for the highest-leverage regression: approval-path behavior without depending on model tool selection.
+
+## Live validation notes
+
+For a real end-to-end OpenClaw validation, do not rely on plain chat text alone as proof. The important thing is that the assistant actually makes a real tool call.
+
+Recommended live checks:
+- `sudo true` after an `Allow Always` decision, should run without prompting
+- `sudo id` as a fresh privileged command, should prompt
+- `rm -rf /tmp`, should hard-deny
+
+Important:
+- make sure `rampart-serve.service` is running before drawing conclusions
+- if Rampart serve is down, sensitive tools should now block instead of silently failing open
+- durable learned rules from the OpenClaw plugin are written to `~/.rampart/policies/user-overrides.yaml`

--- a/internal/plugin/openclaw/approval-regression.mjs
+++ b/internal/plugin/openclaw/approval-regression.mjs
@@ -1,0 +1,93 @@
+import plugin from './index.js';
+
+function createApi() {
+  const handlers = {};
+  const logs = [];
+  return {
+    handlers,
+    logs,
+    api: {
+      pluginConfig: {},
+      logger: {
+        info: (...a) => logs.push(['info', a.join(' ')]),
+        warn: (...a) => logs.push(['warn', a.join(' ')]),
+        debug: (...a) => logs.push(['debug', a.join(' ')]),
+      },
+      on: (name, fn) => { handlers[name] = fn; },
+      registerGatewayMethod: () => {},
+    },
+  };
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+async function runScenario({ name, toolResult, toolName = 'exec', params = { command: 'sudo true' }, resolution }) {
+  const { api, handlers } = createApi();
+  const fetchCalls = [];
+  const originalFetch = global.fetch;
+  global.fetch = async (url, opts = {}) => {
+    fetchCalls.push({ url: String(url), opts });
+    if (String(url).includes(`/v1/tool/${encodeURIComponent(toolName)}`)) {
+      return { ok: true, json: async () => toolResult };
+    }
+    if (String(url).includes('/v1/rules/learn')) {
+      return { ok: true, status: 200, json: async () => ({ ok: true }) };
+    }
+    throw new Error(`unexpected fetch ${url}`);
+  };
+
+  try {
+    plugin.register(api);
+    const before = handlers['before_tool_call'];
+    assert(typeof before === 'function', `${name}: before_tool_call handler missing`);
+    const ctx = {
+      agentId: 'main',
+      sessionKey: 'agent:main:discord:direct:449621595489828865',
+      runId: `${name}-run`,
+    };
+    const result = await before({ toolName, params }, ctx);
+    if (resolution && result?.requireApproval?.onResolution) {
+      await result.requireApproval.onResolution(resolution);
+    }
+    return { name, result, fetchCalls };
+  } finally {
+    global.fetch = originalFetch;
+  }
+}
+
+const ask = await runScenario({
+  name: 'ask-exec',
+  toolResult: { decision: 'ask', policy: 'test-policy', message: 'needs approval', severity: 'warning' },
+});
+assert(ask.result?.requireApproval, 'ask-exec: requireApproval missing');
+assert(!ask.result?.params?.ask, 'ask-exec: legacy ask param mutation still present');
+assert(ask.result.requireApproval.title.includes('exec approval required'), 'ask-exec: wrong title');
+
+const deny = await runScenario({
+  name: 'deny-exec',
+  toolResult: { decision: 'deny', message: 'blocked by policy' },
+});
+assert(deny.result?.block === true, 'deny-exec: block missing');
+
+const allowAlways = await runScenario({
+  name: 'allow-always',
+  toolResult: { decision: 'ask', policy: 'test-policy', message: 'needs approval', severity: 'warning' },
+  resolution: 'allow-always',
+});
+const learnCall = allowAlways.fetchCalls.find((call) => call.url.includes('/v1/rules/learn'));
+assert(learnCall, 'allow-always: learn endpoint not called');
+const learnBody = JSON.parse(learnCall.opts.body);
+assert(learnBody.tool === 'exec', 'allow-always: wrong tool persisted');
+assert(learnBody.args === 'sudo true', 'allow-always: wrong args persisted');
+assert(learnBody.decision === 'allow', 'allow-always: wrong decision persisted');
+
+console.log(JSON.stringify({
+  ok: true,
+  scenarios: [
+    { name: ask.name, result: ask.result },
+    { name: deny.name, result: deny.result },
+    { name: allowAlways.name, learnPersisted: true },
+  ],
+}, null, 2));

--- a/internal/plugin/openclaw/index.js
+++ b/internal/plugin/openclaw/index.js
@@ -235,22 +235,38 @@ export function register(api) {
 
     const result = await checkWithRampart(toolName, params, ctx, pluginConfig);
 
-    // Serve unreachable → fail-open silently (debug log only)
+    const failOpenTools = new Set(pluginConfig.failOpenTools ?? ["read", "web_fetch", "web_search", "image"]);
+    const shouldFailOpen = failOpenTools.has(toolName);
+    const unreachableReason = `[rampart] serve unavailable for ${toolName} at ${serveUrl}`;
+
+    // Serve unreachable → explicit degraded-state handling
     if (result?._unreachable) {
-      api.logger.debug(`[rampart] serve unreachable — failing open for: ${toolName}`);
-      return;
+      api.logger.warn(`${unreachableReason} (${shouldFailOpen ? "configured fail-open" : "blocking tool call"})`);
+      if (shouldFailOpen) return;
+      return {
+        block: true,
+        blockReason: `rampart: unavailable (${toolName}) — policy service down, refusing sensitive tool call`,
+      };
     }
 
-    // null (timeout/unknown error) → fail-open
+    // null (timeout/unknown error) → explicit degraded-state handling
     if (result === null) {
-      api.logger.debug(`[rampart] check timed out or failed — failing open for: ${toolName}`);
-      return;
+      api.logger.warn(`[rampart] check timed out or failed for ${toolName} (${shouldFailOpen ? "configured fail-open" : "blocking tool call"})`);
+      if (shouldFailOpen) return;
+      return {
+        block: true,
+        blockReason: `rampart: unavailable (${toolName}) — policy check timed out, refusing sensitive tool call`,
+      };
     }
 
-    // Serve returned an error status → warn and fail-open
+    // Serve returned an error status → explicit degraded-state handling
     if (result?._serveError) {
-      api.logger.warn(`[rampart] serve returned HTTP ${result._status} for ${toolName} — failing open`);
-      return;
+      api.logger.warn(`[rampart] serve returned HTTP ${result._status} for ${toolName} (${shouldFailOpen ? "configured fail-open" : "blocking tool call"})`);
+      if (shouldFailOpen) return;
+      return {
+        block: true,
+        blockReason: `rampart: unavailable (${toolName}) — policy service error ${result._status}, refusing sensitive tool call`,
+      };
     }
 
     const decision = result.decision ?? (result.allowed === false ? "deny" : "allow");
@@ -277,20 +293,10 @@ export function register(api) {
         const severity = result.severity ?? "warning";
         const emoji = severityEmoji[severity] ?? "⚠️";
 
-        if (toolName === "exec") {
-          api.logger.info(`[rampart] exec requires approval via native OpenClaw exec flow (subject: ${subjectPreview})`);
-          return {
-            params: {
-              ...params,
-              ask: "always",
-            },
-          };
-        }
-
         api.logger.info(`[rampart] returning requireApproval for ${toolName} (subject: ${subjectPreview})`);
         return {
           requireApproval: {
-            title: `🛡️ Rampart — ${toolName} blocked`,
+            title: `🛡️ Rampart — ${toolName} approval required`,
             description: [
               `**Command:** \`${subjectPreview}\``,
               result.policy  ? `**Policy:** ${truncateForApprovalDescription(result.policy, 64)}` : null,
@@ -300,9 +306,17 @@ export function register(api) {
             timeoutMs: pluginConfig.approvalTimeoutMs ?? 120_000,
             timeoutBehavior: "deny",
             onResolution: async (resolution) => {
-              api.logger.info(`[rampart] plugin approval resolved: ${toolName} → ${resolution}`);
+              api.logger.info(`[rampart] plugin approval resolved: ${toolName} → ${resolution} (toolCallId: ${ctx.toolCallId ?? "none"}, session: ${ctx.sessionKey ?? "none"})`);
 
               if (resolution === "allow-always") {
+                const learnPayload = {
+                  tool: toolName,
+                  args: subject,
+                  decision: "allow",
+                  source: "openclaw-approval",
+                };
+                api.logger.info(`[rampart] attempting always-allow persistence via /v1/rules/learn: ${JSON.stringify({ ...learnPayload, session: ctx.sessionKey ?? null, toolCallId: ctx.toolCallId ?? null })}`);
+
                 // Write a persistent allow rule via /v1/rules/learn.
                 // This works regardless of whether an approval_id exists.
                 try {
@@ -313,17 +327,20 @@ export function register(api) {
                       "Content-Type": "application/json",
                       ...(token ? { Authorization: `Bearer ${token}` } : {}),
                     },
-                    body: JSON.stringify({ tool: toolName, args: subject, decision: "allow", source: "openclaw-approval" }),
+                    body: JSON.stringify(learnPayload),
                     signal: AbortSignal.timeout(5000),
                   });
+                  const learnText = await learnResp.text().catch(() => "");
                   if (learnResp.ok) {
-                    api.logger.info(`[rampart] always-allow rule written: ${toolName}:${subject}`);
+                    api.logger.info(`[rampart] always-allow rule written: ${toolName}:${subject}${learnText ? ` response=${learnText}` : ""}`);
                   } else {
-                    api.logger.warn(`[rampart] always-allow rule write failed: HTTP ${learnResp.status}`);
+                    api.logger.warn(`[rampart] always-allow rule write failed: HTTP ${learnResp.status}${learnText ? ` body=${learnText}` : ""}`);
                   }
                 } catch (err) {
                   api.logger.warn(`[rampart] always-allow write error: ${err.message}`);
                 }
+              } else {
+                api.logger.info(`[rampart] no durable allow write for resolution=${resolution}`);
               }
               // For native OpenClaw plugin approvals, OpenClaw itself is the pending approval system.
               // Rampart should not create or resolve a second hidden approval record here, or Discord

--- a/internal/plugin/openclaw/smoke-test.mjs
+++ b/internal/plugin/openclaw/smoke-test.mjs
@@ -1,0 +1,48 @@
+import plugin from './index.js';
+
+const toolResult = process.argv[2] ? JSON.parse(process.argv[2]) : {
+  decision: 'ask',
+  policy: 'test-policy',
+  message: 'needs approval',
+  severity: 'warning',
+};
+const toolName = process.argv[3] || 'exec';
+const params = process.argv[4] ? JSON.parse(process.argv[4]) : { command: 'sudo true' };
+
+const handlers = {};
+const logs = [];
+const api = {
+  pluginConfig: {},
+  logger: {
+    info: (...a) => logs.push(['info', a.join(' ')]),
+    warn: (...a) => logs.push(['warn', a.join(' ')]),
+    debug: (...a) => logs.push(['debug', a.join(' ')]),
+  },
+  on: (name, fn) => { handlers[name] = fn; },
+  registerGatewayMethod: () => {},
+};
+
+const originalFetch = global.fetch;
+global.fetch = async (url, opts = {}) => {
+  if (String(url).includes(`/v1/tool/${encodeURIComponent(toolName)}`)) {
+    return { ok: true, json: async () => toolResult };
+  }
+  if (String(url).includes('/v1/rules/learn')) {
+    return { ok: true, status: 200, json: async () => ({ ok: true }) };
+  }
+  throw new Error(`unexpected fetch ${url}`);
+};
+
+try {
+  plugin.register(api);
+  const before = handlers['before_tool_call'];
+  if (typeof before !== 'function') throw new Error('before_tool_call handler not registered');
+  const result = await before({ toolName, params }, {
+    agentId: 'main',
+    sessionKey: 'agent:main:discord:direct:449621595489828865',
+    runId: 'smoke-test-run',
+  });
+  console.log(JSON.stringify({ result, logs }, null, 2));
+} finally {
+  global.fetch = originalFetch;
+}


### PR DESCRIPTION
## Summary

This hardens Rampart's native OpenClaw approval path and packages the fixes needed for the next minor release.

## What changed

- harden degraded behavior when `rampart serve` is unavailable
  - sensitive OpenClaw tools no longer silently fail open
- keep OpenClaw as the native approval owner for `ask`
- verify true plugin-originated `allow-always` writeback through `/v1/rules/learn`
- add deterministic regression harnesses for the OpenClaw plugin path
- add an acceptance checklist for the full approval-path validation
- update OpenClaw docs to reflect the real durable-writeback target and required service health checks

## Validation

Deterministic:
- `node internal/plugin/openclaw/smoke-test.mjs`
- `node internal/plugin/openclaw/approval-regression.mjs`
- `go build ./cmd/rampart`

Live validated:
- learned allow: `sudo true`
- fresh ask: `sudo id`
- deny by user: `sudo id`
- hard policy deny: `rm -rf /tmp`

Durable writeback verified in:
- `~/.rampart/policies/user-overrides.yaml`

## Why this matters

This gets the OpenClaw native approval flow back to a trustworthy state:
- native Discord approval UI works
- `allow`, `ask`, and `deny` all behave correctly
- `Allow Always` persists durably
- a dead Rampart policy service is no longer a silent pass-through for sensitive tools
