### PR TITLE
fix: allow safe GitHub workflow commands

### DIFF
--- a/policies/openclaw.yaml
+++ b/policies/openclaw.yaml
@@ -189,6 +189,14 @@ policies:
             - "git rebase*"
             - "git reset*"
             - "git revert*"
+            # Safe GitHub CLI workflow
+            - "gh pr create*"
+            - "gh pr view*"
+            - "gh pr checks*"
+            - "gh pr comment*"
+            - "gh pr status*"
+            - "gh issue view*"
+            - "gh issue comment*"
             # Node/npm/yarn
             - "node *"
             - "npm *"


### PR DESCRIPTION
## Summary

This is a small policy follow-up to the OpenClaw approval-path fix.

It allows normal GitHub CLI workflow commands in the OpenClaw exec allowlist so the agent can handle routine PR operations without weakening Rampart's actual self-protection boundary.

## What changed

Added these commands to the safe exec allowlist in `policies/openclaw.yaml`:

- `gh pr create*`
- `gh pr view*`
- `gh pr checks*`
- `gh pr comment*`
- `gh pr status*`
- `gh issue view*`
- `gh issue comment*`

## What did not change

This does **not** loosen real Rampart self-modification protections.

Still blocked:
- `rampart allow*`
- `rampart block*`
- `rampart policy*`
- `rampart setup*`
- force-push / branch deletion protections
- commands that disable or kill Rampart enforcement

## Why this matters

The previous policy boundary was too blunt:
- read-only git inspection worked
- normal GitHub PR workflow was blocked as if it were policy tampering

This change keeps the real safety boundary while removing unnecessary friction from normal repo collaboration.

## Validation

- reviewed current `openclaw.yaml` exec allowlist and deny rules
- confirmed this is a narrow allowlist-only change
- full test suite run showed an unrelated existing failure in `internal/proxy`; this PR does not touch that code path
