### PR TITLE
release: v0.9.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **OpenClaw native approval path now has a proven end-to-end acceptance bar** — validated live with native Discord approval UI across the three critical states: learned allow (`sudo true`), fresh ask (`sudo id`), and hard deny (`rm -rf /tmp`).
+- **`Allow Always` writeback path verified on true plugin-originated approvals** — Rampart's native OpenClaw plugin now proves `onResolution("allow-always")` triggers `/v1/rules/learn` and persists durable rules to `~/.rampart/policies/user-overrides.yaml`.
+- **Sensitive-tool degraded mode hardened** — when Rampart serve is unavailable, sensitive OpenClaw tools now fail explicitly instead of silently failing open. Lower-risk tools can remain configured fail-open.
+- **OpenClaw docs/checklists corrected** — verification guidance now points at `user-overrides.yaml`, includes `rampart-serve.service` health checks, and documents the recommended learned-allow / ask / deny validation set.
+
 ## [0.9.16] - 2026-04-15
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.16] - 2026-04-15
+
 ### Fixed
 
-- OpenClaw plugin now routes Rampart `ask` decisions for `exec` through native OpenClaw approval cards by reissuing only matched commands with `ask: "always"`, while keeping global `tools.exec.ask` off.
+- **Durable global exec overrides now work correctly** — `rampart allow --global --tool exec ...` writes to `~/.rampart/policies/user-overrides.yaml`, and the proxy now honors those durable user carve-outs before broad deny resolution.
+- **Sensitive agent-state defaults polished** — `standard.yaml` now denies real credential stores by default and uses `ask` for sensitive agent session/history/runtime/config artifacts across Claude Code, Codex, and OpenClaw.
+- **OpenClaw plugin approval path kept native** — Rampart `ask` decisions for `exec` continue through native OpenClaw approval cards by reissuing only matched commands with `ask: "always"`, while keeping global `tools.exec.ask` off.
+- **Docs aligned with current behavior** — user-facing docs now reflect `action: ask`, durable `user-overrides.yaml` behavior, and the current standard-vs-product-profile split.
 
 ## [0.9.15] - 2026-04-06
 
@@ -1008,7 +1013,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `rampart watch` TUI
 - Standard policy (`policies/standard.yaml`)
 
-[Unreleased]: https://github.com/peg/rampart/compare/v0.9.5...HEAD
+[Unreleased]: https://github.com/peg/rampart/compare/v0.9.16...HEAD
 [0.9.5]: https://github.com/peg/rampart/compare/v0.9.4...v0.9.5
 [0.9.4]: https://github.com/peg/rampart/compare/v0.9.3...v0.9.4
 [0.9.3]: https://github.com/peg/rampart/compare/v0.9.2...v0.9.3

--- a/cmd/rampart/cli/allow.go
+++ b/cmd/rampart/cli/allow.go
@@ -176,56 +176,80 @@ func runAllowBlock(cmd *cobra.Command, pattern, action string, opts *allowBlockO
 		}
 	}
 
-	// Load (or create) the custom policy file.
-	p, err := policy.LoadCustomPolicy(policyPath)
-	if err != nil {
-		return fmt.Errorf("load policy: %w", err)
-	}
-
-	// Check for duplicate pattern.
-	if exists, existingAction, existingTool := p.HasPattern(pattern); exists {
-		fmt.Fprintf(out, "\n  ⚠️  Pattern already exists: %s %s %q\n", existingAction, existingTool, pattern)
-		fmt.Fprintln(out, "  Use 'rampart rules' to view existing rules.")
-		return nil
-	}
-
 	// Build the message.
 	msg := opts.message
 	if msg == "" {
 		msg = defaultMessage(action, pattern, detectedTool)
 	}
 
-	// Add the rule with optional temporal constraints.
-	temporal := policy.TemporalOpts{Once: opts.once}
-	if opts.forDur != "" {
-		dur, err := time.ParseDuration(opts.forDur)
+	usedUserOverride := false
+	ruleCount := 0
+
+	// Global exec allow rules are durable human carve-outs, so write them to the
+	// explicit user override tier instead of generic custom policy. That makes
+	// their behavior match user expectations even when broad deny policies exist.
+	if action == "allow" && opts.global && detectedTool == "exec" && opts.forDur == "" && !opts.once {
+		home, err := os.UserHomeDir()
 		if err != nil {
-			return fmt.Errorf("invalid --for duration %q: %w", opts.forDur, err)
+			return fmt.Errorf("resolve home: %w", err)
 		}
-		if dur <= 0 {
-			return fmt.Errorf("--for duration must be positive")
+		overridesPath := filepath.Join(home, ".rampart", "policies", "user-overrides.yaml")
+		if _, err := policy.AddUserOverrideAllow(overridesPath, "exec", pattern, msg); err != nil {
+			return fmt.Errorf("save user override: %w", err)
 		}
-		exp := time.Now().UTC().Add(dur)
-		temporal.ExpiresAt = &exp
-	}
-
-	if temporal.ExpiresAt != nil || temporal.Once {
-		if err := p.AddRuleTemporal(action, pattern, msg, opts.tool, temporal); err != nil {
-			return fmt.Errorf("add rule: %w", err)
+		overrides, err := policy.LoadUserOverridesPolicy(overridesPath)
+		if err != nil {
+			return fmt.Errorf("reload user override count: %w", err)
 		}
+		ruleCount = len(overrides.Policies)
+		policyPath = overridesPath
+		usedUserOverride = true
 	} else {
-		if err := p.AddRule(action, pattern, msg, opts.tool); err != nil {
-			return fmt.Errorf("add rule: %w", err)
+		// Load (or create) the custom policy file.
+		p, err := policy.LoadCustomPolicy(policyPath)
+		if err != nil {
+			return fmt.Errorf("load policy: %w", err)
 		}
-	}
 
-	// Save.
-	if err := policy.SaveCustomPolicy(policyPath, p); err != nil {
-		return fmt.Errorf("save policy: %w", err)
+		// Check for duplicate pattern.
+		if exists, existingAction, existingTool := p.HasPattern(pattern); exists {
+			fmt.Fprintf(out, "\n  ⚠️  Pattern already exists: %s %s %q\n", existingAction, existingTool, pattern)
+			fmt.Fprintln(out, "  Use 'rampart rules' to view existing rules.")
+			return nil
+		}
+
+		// Add the rule with optional temporal constraints.
+		temporal := policy.TemporalOpts{Once: opts.once}
+		if opts.forDur != "" {
+			dur, err := time.ParseDuration(opts.forDur)
+			if err != nil {
+				return fmt.Errorf("invalid --for duration %q: %w", opts.forDur, err)
+			}
+			if dur <= 0 {
+				return fmt.Errorf("--for duration must be positive")
+			}
+			exp := time.Now().UTC().Add(dur)
+			temporal.ExpiresAt = &exp
+		}
+
+		if temporal.ExpiresAt != nil || temporal.Once {
+			if err := p.AddRuleTemporal(action, pattern, msg, opts.tool, temporal); err != nil {
+				return fmt.Errorf("add rule: %w", err)
+			}
+		} else {
+			if err := p.AddRule(action, pattern, msg, opts.tool); err != nil {
+				return fmt.Errorf("add rule: %w", err)
+			}
+		}
+
+		// Save.
+		if err := policy.SaveCustomPolicy(policyPath, p); err != nil {
+			return fmt.Errorf("save policy: %w", err)
+		}
+		ruleCount = p.TotalRules()
 	}
 
 	// Print success (brief - details already shown in printRuleSummary).
-	ruleCount := p.TotalRules()
 	suffix := ""
 	if opts.forDur != "" {
 		suffix = fmt.Sprintf(" (expires in %s)", opts.forDur)
@@ -236,6 +260,9 @@ func runAllowBlock(cmd *cobra.Command, pattern, action string, opts *allowBlockO
 		fmt.Fprintf(out, "\n  %s✓%s Rule added to %s%s\n", colorGreen, colorReset, filepath.Base(policyPath), suffix)
 	} else {
 		fmt.Fprintf(out, "\n  ✓ Rule added to %s%s\n", filepath.Base(policyPath), suffix)
+	}
+	if usedUserOverride {
+		fmt.Fprintln(out, "  Stored as a durable user override so it can carve out a narrow exception to broader deny policies")
 	}
 
 	// Try to reload the daemon.

--- a/cmd/rampart/cli/allow_test.go
+++ b/cmd/rampart/cli/allow_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/peg/rampart/internal/policy"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 )
 
@@ -293,7 +294,7 @@ func TestAllowCmd_Basic(t *testing.T) {
 	_ = os.MkdirAll(filepath.Join(dir, ".rampart", "policies"), 0o755)
 
 	// The global policy path is derived from HOME.
-	policyPath := filepath.Join(dir, ".rampart", "policies", "custom.yaml")
+	policyPath := filepath.Join(dir, ".rampart", "policies", "user-overrides.yaml")
 
 	outBuf := &bytes.Buffer{}
 	cmd := NewRootCmd(context.Background(), outBuf, &bytes.Buffer{})
@@ -307,13 +308,42 @@ func TestAllowCmd_Basic(t *testing.T) {
 
 	_ = cmd.Execute()
 
-	// Verify the policy file was created with at least one rule.
+	// Verify the override file was created with at least one rule.
+	overrides, err := policy.LoadUserOverridesPolicy(policyPath)
+	if err != nil {
+		t.Fatalf("load overrides: %v", err)
+	}
+	if len(overrides.Policies) == 0 {
+		t.Fatal("expected at least one override rule to be written")
+	}
+}
+
+func TestAllowCmd_ProjectStillUsesProjectPolicy(t *testing.T) {
+	dir := t.TempDir()
+	testSetHome(t, dir)
+	oldWd, _ := os.Getwd()
+	defer os.Chdir(oldWd)
+	require.NoError(t, os.Chdir(dir))
+
+	policyPath := filepath.Join(dir, ".rampart", "policy.yaml")
+
+	cmd := NewRootCmd(context.Background(), &bytes.Buffer{}, &bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"allow",
+		"npm install *",
+		"--project",
+		"--yes",
+		"--api", "http://127.0.0.1:0",
+	})
+
+	_ = cmd.Execute()
+
 	p, err := policy.LoadCustomPolicy(policyPath)
 	if err != nil {
-		t.Fatalf("load policy: %v", err)
+		t.Fatalf("load project policy: %v", err)
 	}
 	if p.TotalRules() == 0 {
-		t.Fatal("expected at least one rule to be written")
+		t.Fatal("expected project allow rule in project policy")
 	}
 }
 

--- a/docs-site/features/dashboard.md
+++ b/docs-site/features/dashboard.md
@@ -5,7 +5,7 @@ description: "Use Rampart's approval dashboard to review and decide risky AI age
 
 # Approval Dashboard
 
-Rampart includes an embedded web dashboard for managing `require_approval` decisions. View pending approvals, approve or deny them, and review decision history — all from your browser.
+Rampart includes an embedded web dashboard for managing approval-gated decisions. View pending approvals, approve or deny them, and review decision history — all from your browser.
 
 ## Accessing the Dashboard
 
@@ -42,7 +42,7 @@ Both token types can authenticate to the dashboard and the `/v1/approvals` API. 
 
 ## Features
 
-- **Pending approvals**: See all `require_approval` decisions waiting for human input
+- **Pending approvals**: See all approval-gated decisions waiting for human input
 - **Approve / Deny**: Click to resolve approvals directly from the browser
 - **History**: View past decisions with timestamps, agents, commands, and who resolved them
 - **Auto-refresh**: Dashboard polls for new approvals automatically
@@ -55,7 +55,7 @@ Both token types can authenticate to the dashboard and the `/v1/approvals` API. 
 | `GET /v1/approvals` | Yes (Bearer token) | Lists pending and resolved approvals |
 | `POST /v1/approvals/{id}/resolve` | Yes (Bearer OR signed URL) | Resolves a pending approval |
 
-**Signed URLs**: When webhooks fire for `require_approval`, the notification includes a self-authenticating signed URL. Recipients can approve/deny by clicking the link without needing the Bearer token.
+**Signed URLs**: When webhooks fire for approval-gated decisions, the notification includes a self-authenticating signed URL. Recipients can approve/deny by clicking the link without needing the Bearer token.
 
 ## Network Access
 
@@ -92,7 +92,7 @@ curl -X POST http://localhost:9090/v1/approvals/APPROVAL_ID/resolve \
 
 ## Integration with Hooks
 
-When Claude Code triggers a `require_approval` policy, the flow is:
+When Claude Code triggers an `ask` policy, the flow is:
 
 1. Hook returns `permissionDecision: "ask"` — Claude Code shows native approval prompt
 2. Approval is also created in the server's approval store

--- a/docs-site/features/policy-engine.md
+++ b/docs-site/features/policy-engine.md
@@ -372,7 +372,7 @@ Rules are written to one of two files:
 | Scope | Path | When used |
 |-------|------|-----------|
 | Project | `.rampart/policy.yaml` | Current directory is inside a git repo (default) |
-| Global | `~/.rampart/policies/custom.yaml` | Outside a git repo (default) |
+| Global | `~/.rampart/policies/user-overrides.yaml` | Outside a git repo (default) |
 
 Force a scope:
 
@@ -386,22 +386,22 @@ Project rules travel with the repo (commit `.rampart/policy.yaml`). Global rules
 ### Listing and managing rules
 
 ```bash
-rampart rules                  # list all custom rules
+rampart rules                  # list all override rules
 rampart rules --global         # global rules only
 rampart rules --project        # project rules only
 rampart rules --json           # JSON output for scripting
 rampart rules remove 3         # remove rule #3 (shown by 'rampart rules')
-rampart rules reset            # remove all custom rules (prompts for confirmation)
+rampart rules reset            # remove all override rules (prompts for confirmation)
 rampart rules reset --force    # skip confirmation
 ```
 
-### The custom.yaml file
+### The override files
 
 Both scope files are standard Rampart policy YAML. You can edit them by hand:
 
 ```yaml
-# ~/.rampart/policies/custom.yaml
-# Rampart custom policy — managed by `rampart allow` / `rampart block`.
+# ~/.rampart/policies/user-overrides.yaml
+# Rampart user overrides — managed by `rampart allow` / `rampart block`.
 # You can edit this file manually. Changes take effect on reload.
 
 version: "1"
@@ -428,7 +428,7 @@ policies:
 ```
 
 !!! tip "Priority"
-    Custom rules are standard policy documents and participate in the normal evaluation order: **deny always wins**. A deny rule in `custom.yaml` overrides any allow rule in `standard.yaml`, and vice versa.
+    Project policy files are standard policy documents and participate in the normal evaluation order: **deny always wins**. Durable human overrides in `user-overrides.yaml` are treated separately so explicit user carve-outs can persist without being swallowed by unrelated broad denies.
 
 ### Denial suggestions
 

--- a/docs-site/getting-started/how-it-works.md
+++ b/docs-site/getting-started/how-it-works.md
@@ -65,7 +65,7 @@ Agent (Claude Code, Codex, etc.)
 Rampart daemon (localhost:9090)
   │
   ├─ Load policies from ~/.rampart/policies/
-  ├─ Evaluate: allow / deny / require_approval
+  ├─ Evaluate: allow / deny / ask
   ├─ Write audit event to ~/.rampart/audit/
   │
   ▼

--- a/docs-site/getting-started/quickstart.md
+++ b/docs-site/getting-started/quickstart.md
@@ -89,7 +89,7 @@ rampart test "rm -rf /"
 # → deny (block-destructive)
 
 rampart test "git push origin main"
-# → allow (or require_approval if you've configured it)
+# → allow (or ask if you've configured it)
 ```
 
 You can also write test suites to verify your policies in CI. See the [Testing Policies](../guides/testing-policies.md) guide.
@@ -106,7 +106,7 @@ echo '{"tool_name":"Bash","tool_input":{"command":"rm -rf /"}}' | rampart hook
 
 ## Approve Risky Commands
 
-When a command hits a `require_approval` rule, Rampart pauses the agent and waits. Approve or deny it from the dashboard:
+When a command hits an `ask` rule, Rampart pauses the agent and waits. Approve or deny it from the dashboard:
 
 ```bash
 open http://localhost:9090/dashboard/
@@ -131,7 +131,7 @@ rampart init --profile standard
 ```
 
 !!! tip "See all profiles"
-    Run `rampart policy list` to see every available built-in profile and any custom ones you've added.
+    Run `rampart policy list` to see every available built-in profile and any policy files you've added.
 
 ## Customize Your Rules
 
@@ -143,7 +143,7 @@ When Rampart blocks something it shouldn't, unblock it in one command — no YAM
 rampart allow "npm install *"
 ```
 
-Adds an allow rule for `npm install <anything>` to your custom policy and hot-reloads the daemon immediately.
+Adds an allow rule for `npm install <anything>` to your overrides and hot-reloads the daemon immediately.
 
 For file-based overrides, use `--tool`:
 
@@ -159,17 +159,17 @@ rampart block "curl * | bash"
 rampart block "npm publish *"
 ```
 
-### See your custom rules
+### See your override rules
 
 ```bash
 rampart rules
 ```
 
 ```
-  Custom Rules
+  Override Rules
   ──────────────────────────────────────────────────────────────
 
-  Global  (~/.rampart/policies/custom.yaml)
+  Global  (~/.rampart/policies/user-overrides.yaml)
 
   #     ACTION   TOOL      PATTERN                ADDED
      1  allow    exec      npm install *          just now
@@ -182,7 +182,7 @@ rampart rules
 rampart rules remove 2    # removes curl * | bash
 ```
 
-### Reset all custom rules
+### Reset all override rules
 
 ```bash
 rampart rules reset

--- a/docs-site/guides/customizing-policy.md
+++ b/docs-site/guides/customizing-policy.md
@@ -7,7 +7,12 @@ description: "Add allow and deny rules without editing YAML using rampart allow,
 
 Rampart ships with `standard.yaml` — a policy that blocks dangerous commands and watches suspicious ones. When you need to adjust what's allowed or blocked, you don't have to edit YAML by hand.
 
-`rampart allow` and `rampart block` add rules from the command line. They write to a separate `custom.yaml` file (or a project-local equivalent), hot-reload the daemon, and stay out of the way of future policy upgrades.
+`rampart allow` and `rampart block` add rules from the command line. They write to separate override files, hot-reload the daemon, and stay out of the way of future policy upgrades.
+
+There are two important buckets to keep in mind:
+
+- **Policy rules** in `standard.yaml`, product profiles like `openclaw.yaml`, and project policy files describe the default security model
+- **Durable human overrides** created by commands like `rampart allow --global ...` are personal carve-outs and are stored separately from the built-in policy profiles
 
 ## Allow a blocked command
 
@@ -20,7 +25,7 @@ rampart allow "npm install *"
 Output:
 
 ```
-  Adding rule to global policy (~/.rampart/policies/custom.yaml):
+  Adding rule to global policy (~/.rampart/policies/user-overrides.yaml):
 
     Action:  allow
     Pattern: npm install *
@@ -28,7 +33,7 @@ Output:
 
   Add this rule? [y/N] y
 
-  ✓ Rule added to custom.yaml
+  ✓ Rule added to user-overrides.yaml
 
     Action:  allow
     Pattern: npm install *
@@ -119,7 +124,7 @@ Rules live in one of two files:
 | Scope | Path | When |
 |-------|------|------|
 | **Project** | `.rampart/policy.yaml` | Inside a git repo (automatic) |
-| **Global** | `~/.rampart/policies/custom.yaml` | Outside a git repo (automatic) |
+| **Global** | `~/.rampart/policies/user-overrides.yaml` | Outside a git repo (automatic) |
 
 Rampart auto-detects your scope by looking for a `.git` directory. Force it explicitly:
 
@@ -151,7 +156,7 @@ rampart allow "gh pr create *" --global
 rampart allow "brew install *" --global
 ```
 
-## List your custom rules
+## List your override rules
 
 ```bash
 rampart rules
@@ -161,7 +166,7 @@ rampart rules
   Custom Rules
   ──────────────────────────────────────────────────────────────
 
-  Global  (~/.rampart/policies/custom.yaml)
+  Global  (~/.rampart/policies/user-overrides.yaml)
 
   #     ACTION   TOOL      PATTERN                              ADDED
      1  allow    exec      npm install *                        2 hours ago
@@ -174,7 +179,7 @@ rampart rules
      4  allow    exec      make build                           1 week ago
 
   ──────────────────────────────────────────────────────────────
-  Total: 30 rules (26 standard + 4 custom)
+  Total: 30 rules (26 standard + 4 overrides)
   Manage: rampart rules remove <#>
 ```
 
@@ -216,7 +221,7 @@ Use `--force` to skip the confirmation prompt:
 rampart rules remove 3 --force
 ```
 
-## Reset all custom rules
+## Reset all override rules
 
 ```bash
 rampart rules reset
@@ -239,13 +244,13 @@ rampart block "npm publish *" --message "Publishing to npm requires manual revie
 
 Messages appear in `rampart watch` and the audit log.
 
-## Manually editing custom.yaml
+## Manually editing override files
 
 Both scope files are plain Rampart policy YAML. Open them in an editor to batch-add rules or fine-tune conditions:
 
 ```yaml
-# ~/.rampart/policies/custom.yaml
-# Rampart custom policy — managed by `rampart allow` / `rampart block`.
+# ~/.rampart/policies/user-overrides.yaml
+# Rampart user overrides — managed by `rampart allow` / `rampart block`.
 # You can edit this file manually. Changes take effect on reload.
 
 version: "1"
@@ -342,7 +347,7 @@ This keeps the security boundary intact. Agents can request permission by surfac
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--global` | — | Write to global policy (`~/.rampart/policies/custom.yaml`) |
+| `--global` | — | Write to global overrides (`~/.rampart/policies/user-overrides.yaml`) |
 | `--project` | — | Write to project policy (`.rampart/policy.yaml`) |
 | `--tool` | auto | Tool type: `exec`, `read`, `write`, `edit` |
 | `--message` | auto | Reason displayed when the rule fires |

--- a/docs-site/guides/native-ask.md
+++ b/docs-site/guides/native-ask.md
@@ -88,23 +88,19 @@ policies:
 
 This lets you write one policy that works both locally (with prompts) and in CI (with denies). See [CI/Headless Agents](ci-headless.md) for more details.
 
-### `require_approval` Alias
+### `require_approval` Migration Note
 
-`action: require_approval` is a deprecated alias for `action: ask` with `audit: true`:
+Older Rampart docs and policies may still reference `action: require_approval`, but current Rampart releases require `action: ask` explicitly.
+
+Use this form instead:
 
 ```yaml
-# These are equivalent:
-- action: require_approval
-  message: "Needs approval"
-
 - action: ask
-  ask:
-    audit: true
   message: "Needs approval"
 ```
 
-!!! warning "Deprecated in v0.9.9"
-    `action: require_approval` is now a hard error in v0.9.9+. Update your policies to use `action: ask` explicitly.
+!!! warning "Removed in current releases"
+    `action: require_approval` is no longer accepted by the policy engine. Update old examples and local policies to use `action: ask`.
 
 > ⚠️ Common mistake: putting `action: ask` directly inside the policy (as a sibling of `name` or `rules`). `rampart policy lint` will catch this and explain the correct structure.
 

--- a/docs-site/guides/securing-claude-code.md
+++ b/docs-site/guides/securing-claude-code.md
@@ -48,7 +48,15 @@ rampart doctor
 
 ## Understanding the Standard Policy
 
-Rampart's standard policy lives at `~/.rampart/policies/standard.yaml`. It includes high-signal deny rules for destructive commands and credential access, with monitoring rules for suspicious content patterns.
+Rampart's standard policy lives at `~/.rampart/policies/standard.yaml`.
+
+The default model is:
+
+- **Deny** credential stores and high-confidence secret paths
+- **Ask** for sensitive agent-state artifacts such as session history, shell snapshots, durable memory, and security-relevant config
+- **Keep product-specific mechanics separate** in product profiles like `openclaw.yaml`
+
+That split matters. A credential file should not be silently exposed. But some agent artifacts, like Claude Code history or settings, are sensitive in a different way: a human may still intentionally inspect or modify them. Those are better handled with `ask` instead of a blanket deny.
 
 Policies are evaluated quickly and consistently on every tool call. You can inspect why a command was allowed or denied with:
 

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -107,7 +107,7 @@ No. Rampart runs entirely on your machine. Policy evaluation, audit logging, and
 Policy checks are pure in-memory pattern matching — no network calls, no disk I/O, no measurable impact on your agent's workflow.
 
 **What if I need to allow a command that's blocked?**  
-Run `rampart allow "your command pattern"` and it's done — no YAML editing required. The rule takes effect immediately. For one-time exceptions, use `require_approval` in your policy so you can approve each instance. [Full guide →](guides/customizing-policy.md)
+Run `rampart allow "your command pattern"` and it's done — no YAML editing required. The rule takes effect immediately. For one-time exceptions, use `action: ask` in your policy so you can approve each instance. [Full guide →](guides/customizing-policy.md)
 
 ## How It Works
 

--- a/docs-site/integrations/any-cli-agent.md
+++ b/docs-site/integrations/any-cli-agent.md
@@ -32,10 +32,10 @@ rampart wrap -- node agent.js
 Every time the agent spawns a shell command, the shim intercepts it, checks the preflight API, and either allows or blocks execution.
 
 ```
-Agent → spawns shell → $SHELL (rampart shim) → Policy Engine → Allow/Deny/Require Approval
+Agent → spawns shell → $SHELL (rampart shim) → Policy Engine → Allow/Deny/Ask
 ```
 
-**require_approval behavior**: The shell shim blocks execution and waits for human resolution via `rampart approve <id>` or the API. The agent sees the command as "hung" until resolved.
+**Ask behavior**: The shell shim blocks execution and waits for human resolution via `rampart approve <id>` or the API. The agent sees the command as "hung" until resolved.
 
 ## Monitor Mode
 

--- a/docs-site/integrations/claude-code.md
+++ b/docs-site/integrations/claude-code.md
@@ -18,18 +18,17 @@ Claude Code in `--dangerously-skip-permissions` mode gives the agent unrestricte
 
 Rampart sits between Claude Code and your system. Every command is evaluated against your policy before it runs. Dangerous commands are blocked in microseconds. Everything is logged.
 
-## What Gets Blocked by Default
+## What Gets Protected by Default
 
-The standard policy (`~/.rampart/policies/standard.yaml`) blocks:
+The standard policy (`~/.rampart/policies/standard.yaml`) uses three different defaults depending on the risk:
 
-| Command | Why |
-|---------|-----|
-| `rm -rf /`, `rm -rf ~` | Destructive filesystem wipe |
-| `curl ... \| bash` | Remote code execution |
-| `cat ~/.ssh/id_rsa` | SSH private key exfiltration |
-| `cat .env`, `cat .env.local`, `cat .env.production` | API key / secret exposure |
-| `dd if=/dev/urandom of=/dev/sda` | Disk destruction |
-| Credential patterns in responses | Data exfiltration detection |
+| Category | Example | Default |
+|---------|---------|---------|
+| Destructive commands | `rm -rf /`, `dd if=/dev/urandom of=/dev/sda` | `deny` |
+| Credential stores / secret files | `cat ~/.ssh/id_rsa`, `cat ~/.aws/credentials`, `cat ~/.codex/auth.json` | `deny` |
+| Sensitive agent-state artifacts | `cat ~/.claude/history.jsonl`, reading Claude sessions, editing `~/.claude/settings.json` | `ask` |
+
+This split is deliberate. Secret stores are too dangerous to expose silently. But agent history, shell snapshots, durable memory, and security-relevant settings are often legitimate to inspect, so Rampart requires human approval instead of hard-blocking them.
 
 ## Setup
 
@@ -65,7 +64,7 @@ When Claude Code wants to run a command, it sends the tool call to `rampart hook
 {"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"ask","permissionDecisionReason":"Rampart: Manual approval required"}}
 ```
 
-**require_approval behavior:** When a policy action is `require_approval`, the hook returns `"permissionDecision":"ask"`. Claude Code shows its native permission prompt — the user approves or denies directly in the Claude Code UI. No external approval store needed.
+**Ask behavior:** When a policy action is `ask`, the hook returns `"permissionDecision":"ask"`. Claude Code shows its native permission prompt, so the user approves or denies directly in the Claude Code UI.
 
 Denied commands never execute. Claude Code receives the denial reason and can explain it to the user.
 

--- a/docs-site/integrations/claude-desktop.md
+++ b/docs-site/integrations/claude-desktop.md
@@ -70,9 +70,9 @@ With the standard policy:
 
 For cloud MCP servers, use a more restrictive policy (deny by default, explicit allowlist).
 
-## require_approval Behavior
+## Ask Behavior
 
-When a policy action is `require_approval`, the MCP proxy blocks and waits for human resolution via `rampart approve <id>` or the API. If denied or expired, it returns a JSON-RPC error to Claude Desktop with code `-32600` and the denial reason.
+When a policy action is `ask`, the MCP proxy blocks and waits for human resolution via `rampart approve <id>` or the API. If denied or expired, it returns a JSON-RPC error to Claude Desktop with code `-32600` and the denial reason.
 
 ## Monitor
 

--- a/docs-site/integrations/cline.md
+++ b/docs-site/integrations/cline.md
@@ -32,9 +32,9 @@ When Cline wants to execute a tool:
 2. Rampart evaluates the call against your YAML policies (<10μs)
 3. If **allowed**: Rampart returns `{"cancel":false}`, Cline proceeds
 4. If **denied**: Rampart returns `{"cancel":true,"errorMessage":"Blocked by Rampart: reason"}`, Cline never executes the command
-5. If **require_approval**: Rampart returns `{"cancel":true}` immediately (no waiting), blocking execution
+5. If **ask**: Rampart returns `{"cancel":true}` immediately (no waiting), blocking execution
 
-**require_approval behavior:** Unlike other integrations that wait for human approval, Cline gets an immediate `cancel:true` response for `require_approval` policies. This prevents Cline from hanging while waiting for approval.
+**Ask behavior:** Unlike integrations with native approval UI, Cline gets an immediate `cancel:true` response for `ask` policies. This prevents Cline from hanging while waiting for approval.
 
 This happens transparently — you use Cline exactly as before.
 

--- a/docs-site/integrations/codex-cli.md
+++ b/docs-site/integrations/codex-cli.md
@@ -30,10 +30,10 @@ Codex CLI
             └─ HTTP POST to rampart /v1/preflight/exec
                  ├─ allow → real execve() runs
                  ├─ deny  → returns EPERM
-                 └─ require_approval → blocks until resolved, then allow/deny
+                 └─ ask   → blocks until resolved, then allow/deny
 ```
 
-**require_approval behavior**: The preload library blocks the exec call and polls the approval API until resolved by a human via `rampart approve <id>`. The process appears "hung" until approved or denied.
+**Ask behavior**: The preload library blocks the exec call and polls the approval API until resolved by a human via `rampart approve <id>`. The process appears "hung" until approved or denied.
 
 The preload library intercepts:
 

--- a/docs-site/integrations/cursor.md
+++ b/docs-site/integrations/cursor.md
@@ -36,7 +36,7 @@ Cursor → MCP tool call → rampart mcp (proxy) → Policy Engine → MCP Serve
 
 Rampart speaks the MCP protocol natively. It intercepts every `tools/call` request, evaluates it against your policies, and either forwards it to the real MCP server or returns a JSON-RPC error.
 
-**require_approval behavior**: When a policy action is `require_approval`, the MCP proxy blocks and waits for human resolution via `rampart approve <id>` or the API. If denied or expired, it returns a JSON-RPC error to Cursor.
+**Ask behavior**: When a policy action is `ask`, the MCP proxy blocks and waits for human resolution via `rampart approve <id>` or the API. If denied or expired, it returns a JSON-RPC error to Cursor.
 
 Denied tool calls never reach the MCP server. Cursor handles the error gracefully.
 

--- a/docs-site/integrations/index.md
+++ b/docs-site/integrations/index.md
@@ -19,9 +19,9 @@ Rampart works with every major AI agent through multiple integration methods. Ch
 | **Shim + Service** | Shell shim + file tool patching + LD_PRELOAD for sub-agents | OpenClaw |
 | **WebSocket Daemon** | WebSocket integration for real-time agents | OpenClaw (alternative) |
 
-## require_approval Behavior
+## Ask Behavior
 
-When a policy action is `require_approval`, behavior varies by integration:
+When a policy action is `ask`, behavior varies by integration:
 
 | Integration | Behavior |
 |-------------|----------|
@@ -31,7 +31,7 @@ When a policy action is `require_approval`, behavior varies by integration:
 | **OpenClaw** | Shim blocks, daemon sends webhook notifications |
 | **Shell Wrapper** | Shim blocks, command appears "hung" until resolved |
 | **LD_PRELOAD** | Library blocks exec call, process appears "hung" |
-| **HTTP API** | Returns `"decision":"require_approval"` with `approval_id` |
+| **HTTP API** | Returns `"decision":"ask"` with approval metadata when interactive review is required |
 
 ## Agent Compatibility
 

--- a/docs-site/integrations/openclaw.md
+++ b/docs-site/integrations/openclaw.md
@@ -5,7 +5,9 @@ description: "Native Rampart integration for OpenClaw — policy enforcement via
 
 # OpenClaw
 
-Rampart integrates natively with OpenClaw via the `before_tool_call` plugin API. Every tool call — exec, read, write, web_fetch, browser, message, and more — is evaluated against your policy before it runs.
+Rampart integrates with OpenClaw via the native `before_tool_call` plugin API. This is the primary supported path. OpenClaw owns the visible approval UX, while Rampart owns policy evaluation, audit logging, and durable allow-always writeback.
+
+Every tool call — exec, read, write, web_fetch, browser, message, and more — is evaluated against your policy before it runs.
 
 !!! info "Version requirements"
     - **OpenClaw >= 2026.4.11**: Recommended and supported for native Discord exec approvals plus full native plugin coverage
@@ -129,14 +131,14 @@ Expected output when fully configured:
 ✓ rampart serve: running (pid 12345)
 ✓ OpenClaw plugin: installed (before_tool_call hook active)
 ✓ Policy: openclaw.yaml loaded (N rules, default: ask)
-✓ Approval store: persistent (N pending)
+✓ Approval path: native OpenClaw UI active
 ```
 
 Or check plugin status directly:
 
 ```bash
 openclaw plugins list
-# rampart  v0.9.14  active
+# rampart  v0.9.16  active
 ```
 
 ## Troubleshooting

--- a/docs-site/integrations/openclaw.md
+++ b/docs-site/integrations/openclaw.md
@@ -9,6 +9,8 @@ Rampart integrates with OpenClaw via the native `before_tool_call` plugin API. T
 
 Every tool call — exec, read, write, web_fetch, browser, message, and more — is evaluated against your policy before it runs.
 
+For sensitive tools, the recommended operating assumption is simple: if Rampart policy service is unavailable, treat that as a broken state and fix it before trusting approval-path tests.
+
 !!! info "Version requirements"
     - **OpenClaw >= 2026.4.11**: Recommended and supported for native Discord exec approvals plus full native plugin coverage
     - **OpenClaw 2026.3.28 - 2026.4.10**: Native plugin works for tool enforcement, but Rampart's polished Discord exec approval path is supported on newer OpenClaw builds
@@ -31,6 +33,15 @@ That's it. Rampart:
 4. Configures OpenClaw to route decisions through Rampart (`tools.exec.ask: off`)
 5. Copies the `openclaw.yaml` policy profile to `~/.rampart/policies/openclaw.yaml`
 6. Starts `rampart serve` as a boot service (if not already running)
+
+After setup, verify both services are healthy:
+
+```bash
+systemctl --user is-active openclaw-gateway.service
+systemctl --user is-active rampart-serve.service
+```
+
+Both should return `active`.
 
 No external downloads, no npm install — the plugin is bundled inside the `rampart` binary.
 
@@ -106,7 +117,9 @@ rampart init --profile openclaw
 
 ## Always Allow writeback
 
-When you click "Always Allow" in the OpenClaw approval UI, Rampart writes a permanent smart-glob rule to `~/.rampart/policies/user-overrides.yaml` via `POST /v1/rules/learn`. The rule takes effect immediately without restarting serve.
+When you click "Always Allow" in the OpenClaw approval UI, Rampart writes a durable rule to `~/.rampart/policies/user-overrides.yaml` via `POST /v1/rules/learn`. The rule takes effect immediately without restarting serve.
+
+For example, approving `sudo true` writes an exact rule, while broader commands may be generalized into a smart glob when appropriate.
 
 For example, approving `sudo apt-get install nmap` always writes:
 ```yaml
@@ -133,6 +146,11 @@ Expected output when fully configured:
 ✓ Policy: openclaw.yaml loaded (N rules, default: ask)
 ✓ Approval path: native OpenClaw UI active
 ```
+
+For end-to-end confidence, validate one case in each state:
+- learned allow, for example `sudo true`
+- fresh ask, for example `sudo id`
+- hard deny, for example `rm -rf /tmp`
 
 Or check plugin status directly:
 

--- a/docs-site/reference/api-reference.md
+++ b/docs-site/reference/api-reference.md
@@ -32,7 +32,7 @@ The token is printed on startup (`rampart serve`) and stored in `~/.rampart/toke
 
 ### POST /v1/tool/{toolName}
 
-Evaluate a tool call against loaded policies. The agent calls this before executing a tool. Rampart returns a decision: `allow`, `deny`, `require_approval`, `watch`, or `webhook`.
+Evaluate a tool call against loaded policies. The agent calls this before executing a tool. Rampart returns a decision: `allow`, `deny`, `ask`, `watch`, or `webhook`.
 
 **Auth:** Bearer
 
@@ -71,11 +71,11 @@ Evaluate a tool call against loaded policies. The agent calls this before execut
 }
 ```
 
-**Response — 202 Require Approval:**
+**Response — 202 Ask:**
 
 ```json
 {
-  "decision": "require_approval",
+  "decision": "ask",
   "message": "destructive command requires approval",
   "eval_duration_us": 290,
   "approval_id": "apr_01j8k...",

--- a/docs-site/reference/cli-commands.md
+++ b/docs-site/reference/cli-commands.md
@@ -408,13 +408,13 @@ rampart audit replay --speed 0        # Replay instantly (no delays)
 
 ### `rampart allow`
 
-Add an allow rule to your custom policy without editing YAML.
+Add an allow rule to your override policy without editing YAML.
 
 ```bash
 rampart allow "npm install *"                  # Auto-detect tool type
 rampart allow "go test ./..."                  # Commands with ./ detected as exec
 rampart allow "/tmp/**" --tool read            # Explicit tool type
-rampart allow "docker build *" --global        # Write to global policy
+rampart allow "docker build *" --global        # Write to global overrides
 rampart allow "pytest *" --project             # Write to project policy
 rampart allow "git push *" --yes               # Skip confirmation
 rampart allow "docker *" --for 1h              # Expires after 1 hour
@@ -425,7 +425,7 @@ rampart allow "npm publish" --once             # Single-use — consumed after f
 
 ### `rampart block`
 
-Add a deny rule to your custom policy.
+Add a deny rule to your override policy.
 
 ```bash
 rampart block "rm -rf /*"                      # Block dangerous command
@@ -435,15 +435,15 @@ rampart block "**/.env" --tool read            # Block reading .env files
 
 ### `rampart rules`
 
-List, remove, and reset custom rules added via `allow`/`block`.
+List, remove, and reset override rules added via `allow`/`block`.
 
 ```bash
-rampart rules                                  # List all custom rules
+rampart rules                                  # List all override rules
 rampart rules --global                         # List only global rules
 rampart rules --project                        # List only project rules
 rampart rules --json                           # JSON output for scripting
 rampart rules remove 1                         # Remove rule by index
-rampart rules reset                            # Remove all custom rules
+rampart rules reset                            # Remove all override rules
 rampart rules reset --global                   # Reset only global rules
 ```
 
@@ -504,7 +504,7 @@ Lint a policy YAML file for errors, warnings, and suggestions. Checks for invali
 
 ```bash
 rampart policy lint policy.yaml
-rampart policy lint ~/.rampart/policies/custom.yaml
+rampart policy lint ~/.rampart/policies/user-overrides.yaml
 ```
 
 Exit code `1` if errors are found; `0` if only warnings or info.

--- a/docs-site/reference/policy-schema.md
+++ b/docs-site/reference/policy-schema.md
@@ -63,7 +63,7 @@ match:
 
 ```yaml
 rules:
-  - action: string         # Required. deny | allow | log | require_approval | webhook
+  - action: string         # Required. deny | allow | log/watch | ask | webhook
     when:                   # Optional. Conditions (omit for unconditional).
       command_matches: list
       command_not_matches: list
@@ -96,7 +96,7 @@ rules:
 | `deny` | Block the tool call. **Deny always wins.** |
 | `allow` | Permit the tool call. |
 | `log` | Permit but flag for review. |
-| `require_approval` | Block until human approves/denies. |
+| `ask` | Pause and require human approval or denial. |
 | `webhook` | Delegate decision to external HTTP endpoint. |
 
 ### Conditions (`when`)

--- a/docs/design/openclaw-approval-acceptance-checklist.md
+++ b/docs/design/openclaw-approval-acceptance-checklist.md
@@ -1,0 +1,110 @@
+# OpenClaw approval-path acceptance checklist
+
+This checklist exists to validate the polished minor-version path for Rampart's OpenClaw integration.
+
+## Goal
+
+Rampart owns policy decisioning, audit, and durable allow learning.
+OpenClaw owns approval UX, native cards/buttons, and approval lifecycle.
+
+## Deterministic local checks
+
+Run from the repo root.
+
+### 1. Plugin smoke test
+
+```bash
+node internal/plugin/openclaw/smoke-test.mjs
+```
+
+Pass criteria:
+- `exec` + `ask` returns `requireApproval`
+- no legacy `params.ask = "always"` path
+
+### 2. Approval regression suite
+
+```bash
+node internal/plugin/openclaw/approval-regression.mjs
+```
+
+Pass criteria:
+- `ask` returns `requireApproval`
+- `deny` returns `block: true`
+- `allow-always` persists learned rule intent via `/v1/rules/learn`
+
+### 3. Build
+
+```bash
+go build ./cmd/rampart
+```
+
+Pass criteria:
+- build completes successfully
+
+## Installed integration checks
+
+### 4. Reinstall plugin
+
+```bash
+go build -o ~/.local/bin/rampart ./cmd/rampart
+~/.local/bin/rampart setup openclaw --plugin
+systemctl --user restart openclaw-gateway.service
+systemctl --user restart rampart-serve.service
+systemctl --user is-active openclaw-gateway.service
+systemctl --user is-active rampart-serve.service
+```
+
+Pass criteria:
+- plugin installs cleanly
+- gateway returns `active`
+- rampart serve returns `active`
+- sensitive tools do not silently fail open when serve is unavailable
+
+## Real product validation
+
+### 5. Native Discord approval card
+
+Validate with one real Discord DM case that becomes a real tool invocation.
+
+Pass criteria:
+- approval object is created
+- native Discord approval box appears
+- approval is clearly associated with the current DM/session
+
+### 6. Decision outcomes
+
+Pass criteria:
+- allow once succeeds
+- deny blocks execution
+- allow always writes durable learned rule to `~/.rampart/policies/user-overrides.yaml`
+- no hidden second approval queue is created by Rampart
+
+### 7. Live three-state proof
+
+Validate one case for each state:
+- allow: a previously learned command like `sudo true`
+- ask: a new privileged command like `sudo id`
+- deny: a destructive command like `rm -rf /tmp`
+
+Pass criteria:
+- learned allow executes without prompting
+- new privileged command prompts and user choice is respected
+- destructive command is hard-blocked by policy
+
+## Ship bar for the minor
+
+Do not ship until all of the following are true:
+
+- deterministic local checks pass
+- plugin installs cleanly on a fresh reinstall
+- one real native Discord approval box appears on the cleaned path
+- allow/deny/allow-always semantics are confirmed
+- durable writeback is verified in `~/.rampart/policies/user-overrides.yaml`
+- documentation reflects that plain chat text is not itself a tool call
+- documentation reflects that `rampart serve` must be healthy for approval-path validation
+
+## Non-goals
+
+- using natural-language DM prompts as the main regression harness
+- reintroducing a separate Rampart-owned pending approval queue for OpenClaw-hosted tool calls
+- special-casing `exec` away from the unified approval contract

--- a/internal/engine/persist.go
+++ b/internal/engine/persist.go
@@ -32,6 +32,15 @@ func DefaultAutoAllowedPath() string {
 	return filepath.Join(home, ".rampart", "policies", "auto-allowed.yaml")
 }
 
+// DefaultUserOverridesPath returns the default path for durable user override rules.
+func DefaultUserOverridesPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = "."
+	}
+	return filepath.Join(home, ".rampart", "policies", "user-overrides.yaml")
+}
+
 // dangerousCommandPrefixes lists command prefixes that should NEVER be
 // generalized. These commands are kept exact to prevent accidental
 // auto-allow of destructive operations.

--- a/internal/plugin/openclaw/README.md
+++ b/internal/plugin/openclaw/README.md
@@ -1,143 +1,62 @@
-# rampart-openclaw-plugin
+# Rampart OpenClaw plugin smoke test
 
-**Rampart AI agent firewall — native OpenClaw plugin (v1.0)**
+Deterministic local harness for the OpenClaw `before_tool_call` plugin path.
 
-This OpenClaw plugin integrates [Rampart](https://github.com/peg/rampart) using the native `before_tool_call` hook API (OpenClaw ≥ 2026.3.28). It is the primary integration path, replacing the legacy dist-file patching approach.
+## Why this exists
 
----
+Discord DM prompts are not a reliable validator for approval behavior because the model may choose not to call the real tool at all. This smoke test exercises the plugin decision path directly and verifies what Rampart returns to OpenClaw.
 
-## Quick start
+## Usage
 
-```bash
-# 1. Install Rampart
-go install github.com/peg/rampart@latest
-
-# 2. Start Rampart policy server (defaults to :9090)
-rampart serve
-
-# 3. Install this plugin
-openclaw plugins install /path/to/rampart-openclaw-plugin
-```
-
-That's it. Every tool call is now checked against your Rampart policies.
-
----
-
-## What happens on each decision
-
-Every time the OpenClaw agent calls a tool (`exec`, `read`, `write`, `web_fetch`, `message`, etc.), this plugin intercepts the call **before it executes** and checks it against the running Rampart policy engine (`rampart serve`).
-
-| Decision | What happens |
-|----------|-------------|
-| `allow`  | Tool call proceeds normally |
-| `deny`   | Tool call is blocked; agent sees a `blockReason` message |
-| `ask`    | OpenClaw pauses and prompts you for approval (120 s timeout → auto-deny) |
-
-### The always-allow flow
-
-When Rampart returns `ask` and you click **Allow Always** in the OpenClaw approval UI:
-
-1. OpenClaw resolves the native approval for the current tool call
-2. The plugin writes a persistent allow rule via `POST /v1/rules/learn`
-3. Rampart stores the learned rule in its user policy files
-4. Future matching calls are automatically allowed without creating a second approval queue
-
-### Fail-open behavior
-
-If `rampart serve` is not running or unreachable, the plugin **fails open** (allows the call) and logs at debug level. This matches Rampart's existing default behavior and keeps OpenClaw functional when Rampart is down.
-
-If `rampart serve` is reachable but returns a 5xx error, the plugin also fails open but logs a warning.
-
----
-
-## Configuration
-
-Plugin config lives in your OpenClaw config file under `plugins.rampart`:
-
-```yaml
-plugins:
-  rampart:
-    serveUrl: "http://localhost:9090"   # default
-    enabled: true                        # default
-    timeoutMs: 3000                      # ms to wait for Rampart before failing open
-    approvalTimeoutMs: 120000            # ms before unanswered approval auto-denies
-```
-
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `serveUrl` | string | `http://localhost:9090` | Rampart serve endpoint |
-| `enabled` | boolean | `true` | Disable the plugin without uninstalling |
-| `timeoutMs` | number | `3000` | Max ms to wait for Rampart before failing open |
-| `approvalTimeoutMs` | number | `120000` | Ms before an unanswered approval auto-denies |
-
----
-
-## Authentication
-
-The plugin reads your Rampart token from (in order):
-
-1. `RAMPART_TOKEN` environment variable
-2. `~/.rampart/token` file
-
-This matches the standard Rampart CLI token resolution.
-
----
-
-## Security note
-
-The plugin only makes network calls to **localhost** (or whatever `serveUrl` is configured to). It reads a single token file from `~/.rampart/token`. It does not phone home, send telemetry, or make any external network requests.
-
----
-
-## Rampart API contract
-
-The plugin calls:
-
-```
-POST http://localhost:9090/v1/tool/{toolName}
-Content-Type: application/json
-Authorization: Bearer <token>
-
-{
-  "agent":   "main",
-  "session": "...",
-  "run_id":  "...",
-  "params":  { "command": "ls -la" }
-}
-```
-
-Expected response shapes:
-
-```json
-{ "allowed": true,  "decision": "allow", "message": "..." }
-{ "allowed": false, "decision": "deny",  "message": "blocked by policy X", "policy": "no-rm-rf" }
-{ "allowed": false, "decision": "ask",   "message": "shell command requires approval", "severity": "warning" }
-```
-
-For OpenClaw-hosted plugin flows, Rampart evaluates the tool call but does **not** create a second hidden Rampart approval record. OpenClaw's native approval UI is the only operator-facing approval surface. When the user resolves the native OpenClaw approval:
-
-- `allow-once` is handled entirely by OpenClaw
-- `deny` is handled entirely by OpenClaw
-- `allow-always` writes a persistent Rampart rule via `POST /v1/rules/learn`
-
-The plugin also records best-effort audit information for completed tool calls, but approval ownership remains native to OpenClaw for OpenClaw-hosted flows.
-
----
-
-## Legacy dist patching
-
-Older Rampart/OpenClaw setups used `--patch-tools` to patch OpenClaw's bundled `dist/` files directly.
-
-That path is now considered **legacy compatibility**, not the primary integration model. The native OpenClaw plugin is the preferred path because it survives upgrades much better and keeps approval ownership inside OpenClaw.
-
----
-
-## Development
+From the repo root:
 
 ```bash
-# Verify no syntax errors (ESM import test)
-node -e "import('./index.js').then(() => console.log('ok')).catch(e => console.error(e))"
-
-# Verify manifest JSON
-cat openclaw.plugin.json | node -e "process.stdin.resume(); let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{JSON.parse(d); console.log('valid json')})"
+node internal/plugin/openclaw/smoke-test.mjs
 ```
+
+Default behavior simulates:
+- tool: `exec`
+- params: `{ "command": "sudo true" }`
+- Rampart verdict: `{ "decision": "ask", "policy": "test-policy", "message": "needs approval", "severity": "warning" }`
+
+Expected output now:
+- `result.requireApproval` exists for `exec`
+- no `params.ask = "always"` mutation path
+
+## Override inputs
+
+```bash
+node internal/plugin/openclaw/smoke-test.mjs \
+  '{"decision":"deny","message":"blocked"}' \
+  exec \
+  '{"command":"sudo true"}'
+```
+
+Arguments:
+1. tool result JSON
+2. tool name
+3. tool params JSON
+
+## What to check
+
+- `ask` returns `requireApproval`
+- `deny` returns `block: true`
+- `allow-always` calls `/v1/rules/learn`
+- `allow` returns nothing or param adjustment only when explicitly requested by Rampart
+- there is no legacy `params.ask = "always"` mutation path
+
+This is a deterministic harness for the highest-leverage regression: approval-path behavior without depending on model tool selection.
+
+## Live validation notes
+
+For a real end-to-end OpenClaw validation, do not rely on plain chat text alone as proof. The important thing is that the assistant actually makes a real tool call.
+
+Recommended live checks:
+- `sudo true` after an `Allow Always` decision, should run without prompting
+- `sudo id` as a fresh privileged command, should prompt
+- `rm -rf /tmp`, should hard-deny
+
+Important:
+- make sure `rampart-serve.service` is running before drawing conclusions
+- if Rampart serve is down, sensitive tools should now block instead of silently failing open
+- durable learned rules from the OpenClaw plugin are written to `~/.rampart/policies/user-overrides.yaml`

--- a/internal/plugin/openclaw/approval-regression.mjs
+++ b/internal/plugin/openclaw/approval-regression.mjs
@@ -1,0 +1,93 @@
+import plugin from './index.js';
+
+function createApi() {
+  const handlers = {};
+  const logs = [];
+  return {
+    handlers,
+    logs,
+    api: {
+      pluginConfig: {},
+      logger: {
+        info: (...a) => logs.push(['info', a.join(' ')]),
+        warn: (...a) => logs.push(['warn', a.join(' ')]),
+        debug: (...a) => logs.push(['debug', a.join(' ')]),
+      },
+      on: (name, fn) => { handlers[name] = fn; },
+      registerGatewayMethod: () => {},
+    },
+  };
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+async function runScenario({ name, toolResult, toolName = 'exec', params = { command: 'sudo true' }, resolution }) {
+  const { api, handlers } = createApi();
+  const fetchCalls = [];
+  const originalFetch = global.fetch;
+  global.fetch = async (url, opts = {}) => {
+    fetchCalls.push({ url: String(url), opts });
+    if (String(url).includes(`/v1/tool/${encodeURIComponent(toolName)}`)) {
+      return { ok: true, json: async () => toolResult };
+    }
+    if (String(url).includes('/v1/rules/learn')) {
+      return { ok: true, status: 200, json: async () => ({ ok: true }) };
+    }
+    throw new Error(`unexpected fetch ${url}`);
+  };
+
+  try {
+    plugin.register(api);
+    const before = handlers['before_tool_call'];
+    assert(typeof before === 'function', `${name}: before_tool_call handler missing`);
+    const ctx = {
+      agentId: 'main',
+      sessionKey: 'agent:main:discord:direct:449621595489828865',
+      runId: `${name}-run`,
+    };
+    const result = await before({ toolName, params }, ctx);
+    if (resolution && result?.requireApproval?.onResolution) {
+      await result.requireApproval.onResolution(resolution);
+    }
+    return { name, result, fetchCalls };
+  } finally {
+    global.fetch = originalFetch;
+  }
+}
+
+const ask = await runScenario({
+  name: 'ask-exec',
+  toolResult: { decision: 'ask', policy: 'test-policy', message: 'needs approval', severity: 'warning' },
+});
+assert(ask.result?.requireApproval, 'ask-exec: requireApproval missing');
+assert(!ask.result?.params?.ask, 'ask-exec: legacy ask param mutation still present');
+assert(ask.result.requireApproval.title.includes('exec approval required'), 'ask-exec: wrong title');
+
+const deny = await runScenario({
+  name: 'deny-exec',
+  toolResult: { decision: 'deny', message: 'blocked by policy' },
+});
+assert(deny.result?.block === true, 'deny-exec: block missing');
+
+const allowAlways = await runScenario({
+  name: 'allow-always',
+  toolResult: { decision: 'ask', policy: 'test-policy', message: 'needs approval', severity: 'warning' },
+  resolution: 'allow-always',
+});
+const learnCall = allowAlways.fetchCalls.find((call) => call.url.includes('/v1/rules/learn'));
+assert(learnCall, 'allow-always: learn endpoint not called');
+const learnBody = JSON.parse(learnCall.opts.body);
+assert(learnBody.tool === 'exec', 'allow-always: wrong tool persisted');
+assert(learnBody.args === 'sudo true', 'allow-always: wrong args persisted');
+assert(learnBody.decision === 'allow', 'allow-always: wrong decision persisted');
+
+console.log(JSON.stringify({
+  ok: true,
+  scenarios: [
+    { name: ask.name, result: ask.result },
+    { name: deny.name, result: deny.result },
+    { name: allowAlways.name, learnPersisted: true },
+  ],
+}, null, 2));

--- a/internal/plugin/openclaw/index.js
+++ b/internal/plugin/openclaw/index.js
@@ -235,22 +235,38 @@ export function register(api) {
 
     const result = await checkWithRampart(toolName, params, ctx, pluginConfig);
 
-    // Serve unreachable → fail-open silently (debug log only)
+    const failOpenTools = new Set(pluginConfig.failOpenTools ?? ["read", "web_fetch", "web_search", "image"]);
+    const shouldFailOpen = failOpenTools.has(toolName);
+    const unreachableReason = `[rampart] serve unavailable for ${toolName} at ${serveUrl}`;
+
+    // Serve unreachable → explicit degraded-state handling
     if (result?._unreachable) {
-      api.logger.debug(`[rampart] serve unreachable — failing open for: ${toolName}`);
-      return;
+      api.logger.warn(`${unreachableReason} (${shouldFailOpen ? "configured fail-open" : "blocking tool call"})`);
+      if (shouldFailOpen) return;
+      return {
+        block: true,
+        blockReason: `rampart: unavailable (${toolName}) — policy service down, refusing sensitive tool call`,
+      };
     }
 
-    // null (timeout/unknown error) → fail-open
+    // null (timeout/unknown error) → explicit degraded-state handling
     if (result === null) {
-      api.logger.debug(`[rampart] check timed out or failed — failing open for: ${toolName}`);
-      return;
+      api.logger.warn(`[rampart] check timed out or failed for ${toolName} (${shouldFailOpen ? "configured fail-open" : "blocking tool call"})`);
+      if (shouldFailOpen) return;
+      return {
+        block: true,
+        blockReason: `rampart: unavailable (${toolName}) — policy check timed out, refusing sensitive tool call`,
+      };
     }
 
-    // Serve returned an error status → warn and fail-open
+    // Serve returned an error status → explicit degraded-state handling
     if (result?._serveError) {
-      api.logger.warn(`[rampart] serve returned HTTP ${result._status} for ${toolName} — failing open`);
-      return;
+      api.logger.warn(`[rampart] serve returned HTTP ${result._status} for ${toolName} (${shouldFailOpen ? "configured fail-open" : "blocking tool call"})`);
+      if (shouldFailOpen) return;
+      return {
+        block: true,
+        blockReason: `rampart: unavailable (${toolName}) — policy service error ${result._status}, refusing sensitive tool call`,
+      };
     }
 
     const decision = result.decision ?? (result.allowed === false ? "deny" : "allow");
@@ -277,20 +293,10 @@ export function register(api) {
         const severity = result.severity ?? "warning";
         const emoji = severityEmoji[severity] ?? "⚠️";
 
-        if (toolName === "exec") {
-          api.logger.info(`[rampart] exec requires approval via native OpenClaw exec flow (subject: ${subjectPreview})`);
-          return {
-            params: {
-              ...params,
-              ask: "always",
-            },
-          };
-        }
-
         api.logger.info(`[rampart] returning requireApproval for ${toolName} (subject: ${subjectPreview})`);
         return {
           requireApproval: {
-            title: `🛡️ Rampart — ${toolName} blocked`,
+            title: `🛡️ Rampart — ${toolName} approval required`,
             description: [
               `**Command:** \`${subjectPreview}\``,
               result.policy  ? `**Policy:** ${truncateForApprovalDescription(result.policy, 64)}` : null,
@@ -300,9 +306,17 @@ export function register(api) {
             timeoutMs: pluginConfig.approvalTimeoutMs ?? 120_000,
             timeoutBehavior: "deny",
             onResolution: async (resolution) => {
-              api.logger.info(`[rampart] plugin approval resolved: ${toolName} → ${resolution}`);
+              api.logger.info(`[rampart] plugin approval resolved: ${toolName} → ${resolution} (toolCallId: ${ctx.toolCallId ?? "none"}, session: ${ctx.sessionKey ?? "none"})`);
 
               if (resolution === "allow-always") {
+                const learnPayload = {
+                  tool: toolName,
+                  args: subject,
+                  decision: "allow",
+                  source: "openclaw-approval",
+                };
+                api.logger.info(`[rampart] attempting always-allow persistence via /v1/rules/learn: ${JSON.stringify({ ...learnPayload, session: ctx.sessionKey ?? null, toolCallId: ctx.toolCallId ?? null })}`);
+
                 // Write a persistent allow rule via /v1/rules/learn.
                 // This works regardless of whether an approval_id exists.
                 try {
@@ -313,17 +327,20 @@ export function register(api) {
                       "Content-Type": "application/json",
                       ...(token ? { Authorization: `Bearer ${token}` } : {}),
                     },
-                    body: JSON.stringify({ tool: toolName, args: subject, decision: "allow", source: "openclaw-approval" }),
+                    body: JSON.stringify(learnPayload),
                     signal: AbortSignal.timeout(5000),
                   });
+                  const learnText = await learnResp.text().catch(() => "");
                   if (learnResp.ok) {
-                    api.logger.info(`[rampart] always-allow rule written: ${toolName}:${subject}`);
+                    api.logger.info(`[rampart] always-allow rule written: ${toolName}:${subject}${learnText ? ` response=${learnText}` : ""}`);
                   } else {
-                    api.logger.warn(`[rampart] always-allow rule write failed: HTTP ${learnResp.status}`);
+                    api.logger.warn(`[rampart] always-allow rule write failed: HTTP ${learnResp.status}${learnText ? ` body=${learnText}` : ""}`);
                   }
                 } catch (err) {
                   api.logger.warn(`[rampart] always-allow write error: ${err.message}`);
                 }
+              } else {
+                api.logger.info(`[rampart] no durable allow write for resolution=${resolution}`);
               }
               // For native OpenClaw plugin approvals, OpenClaw itself is the pending approval system.
               // Rampart should not create or resolve a second hidden approval record here, or Discord

--- a/internal/plugin/openclaw/index.js
+++ b/internal/plugin/openclaw/index.js
@@ -212,7 +212,7 @@ async function auditLog(toolName, params, ctx, outcome, config) {
 export const id = "rampart";
 export const name = "Rampart";
 export const description = "AI agent firewall — YAML policy-as-code for every tool call";
-export const version = "0.9.15";
+export const version = "0.9.16";
 
 export function register(api) {
   const pluginConfig = api.pluginConfig ?? {};

--- a/internal/plugin/openclaw/openclaw.plugin.json
+++ b/internal/plugin/openclaw/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "rampart",
   "name": "Rampart",
   "description": "AI agent firewall \u2014 YAML policy-as-code for every tool call",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "author": "peg",
   "homepage": "https://rampart.sh",
   "repository": "https://github.com/peg/rampart",

--- a/internal/plugin/openclaw/package.json
+++ b/internal/plugin/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rampart",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "description": "Rampart AI agent firewall \u2014 OpenClaw native plugin (before_tool_call hook)",
   "type": "module",
   "main": "index.js",

--- a/internal/plugin/openclaw/smoke-test.mjs
+++ b/internal/plugin/openclaw/smoke-test.mjs
@@ -1,0 +1,48 @@
+import plugin from './index.js';
+
+const toolResult = process.argv[2] ? JSON.parse(process.argv[2]) : {
+  decision: 'ask',
+  policy: 'test-policy',
+  message: 'needs approval',
+  severity: 'warning',
+};
+const toolName = process.argv[3] || 'exec';
+const params = process.argv[4] ? JSON.parse(process.argv[4]) : { command: 'sudo true' };
+
+const handlers = {};
+const logs = [];
+const api = {
+  pluginConfig: {},
+  logger: {
+    info: (...a) => logs.push(['info', a.join(' ')]),
+    warn: (...a) => logs.push(['warn', a.join(' ')]),
+    debug: (...a) => logs.push(['debug', a.join(' ')]),
+  },
+  on: (name, fn) => { handlers[name] = fn; },
+  registerGatewayMethod: () => {},
+};
+
+const originalFetch = global.fetch;
+global.fetch = async (url, opts = {}) => {
+  if (String(url).includes(`/v1/tool/${encodeURIComponent(toolName)}`)) {
+    return { ok: true, json: async () => toolResult };
+  }
+  if (String(url).includes('/v1/rules/learn')) {
+    return { ok: true, status: 200, json: async () => ({ ok: true }) };
+  }
+  throw new Error(`unexpected fetch ${url}`);
+};
+
+try {
+  plugin.register(api);
+  const before = handlers['before_tool_call'];
+  if (typeof before !== 'function') throw new Error('before_tool_call handler not registered');
+  const result = await before({ toolName, params }, {
+    agentId: 'main',
+    sessionKey: 'agent:main:discord:direct:449621595489828865',
+    runId: 'smoke-test-run',
+  });
+  console.log(JSON.stringify({ result, logs }, null, 2));
+} finally {
+  global.fetch = originalFetch;
+}

--- a/internal/policy/user_overrides.go
+++ b/internal/policy/user_overrides.go
@@ -1,0 +1,114 @@
+package policy
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+type UserOverridesPolicy struct {
+	Policies []UserOverrideEntry `yaml:"policies"`
+}
+
+type UserOverrideEntry struct {
+	Name  string              `yaml:"name"`
+	Match UserOverrideMatch   `yaml:"match"`
+	Rules []UserOverrideRule  `yaml:"rules"`
+}
+
+type UserOverrideMatch struct {
+	Tool []string `yaml:"tool"`
+}
+
+type UserOverrideRule struct {
+	When    UserOverrideWhen `yaml:"when"`
+	Action  string           `yaml:"action"`
+	Message string           `yaml:"message"`
+}
+
+type UserOverrideWhen struct {
+	CommandMatches []string `yaml:"command_matches,omitempty,flow"`
+}
+
+func LoadUserOverridesPolicy(path string) (*UserOverridesPolicy, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &UserOverridesPolicy{}, nil
+		}
+		return nil, fmt.Errorf("policy: read %s: %w", path, err)
+	}
+
+	var p UserOverridesPolicy
+	if err := yaml.Unmarshal(data, &p); err != nil {
+		return nil, fmt.Errorf("policy: parse %s: %w", path, err)
+	}
+	return &p, nil
+}
+
+func SaveUserOverridesPolicy(path string, p *UserOverridesPolicy) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("policy: create dir %s: %w", dir, err)
+	}
+
+	data, err := yaml.Marshal(p)
+	if err != nil {
+		return fmt.Errorf("policy: marshal: %w", err)
+	}
+
+	header := "# Rampart user override policies\n# Auto-generated entries are added here when you create durable allow carve-outs\n# This file is never overwritten by upgrades or rampart setup\n"
+	out := append([]byte(header), data...)
+
+	tmp, err := os.CreateTemp(dir, ".user-overrides-*.yaml")
+	if err != nil {
+		return fmt.Errorf("policy: create temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(out); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("policy: write temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("policy: close temp file: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("policy: rename %s -> %s: %w", tmpPath, path, err)
+	}
+	return nil
+}
+
+func AddUserOverrideAllow(path, tool, rawCommand, message string) (string, error) {
+	p, err := LoadUserOverridesPolicy(path)
+	if err != nil {
+		return "", err
+	}
+	pattern := BuildAllowPattern(rawCommand)
+	ruleName := fmt.Sprintf("user-allow-%s", HashPattern(pattern))
+	for _, entry := range p.Policies {
+		if entry.Name == ruleName {
+			return pattern, nil
+		}
+	}
+	if message == "" {
+		message = "User allowed (always)"
+	}
+	p.Policies = append(p.Policies, UserOverrideEntry{
+		Name: ruleName,
+		Match: UserOverrideMatch{Tool: []string{tool}},
+		Rules: []UserOverrideRule{{
+			When: UserOverrideWhen{CommandMatches: []string{pattern}},
+			Action: "allow",
+			Message: message,
+		}},
+	})
+	if err := SaveUserOverridesPolicy(path, p); err != nil {
+		return "", err
+	}
+	return pattern, nil
+}

--- a/internal/policy/user_overrides_test.go
+++ b/internal/policy/user_overrides_test.go
@@ -1,0 +1,33 @@
+package policy
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestAddUserOverrideAllow(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "user-overrides.yaml")
+
+	pattern, err := AddUserOverrideAllow(path, "exec", "curl -fsS http://100.94.29.8:8989/api/v3/system/status", "User allowed (always)")
+	if err != nil {
+		t.Fatalf("AddUserOverrideAllow: %v", err)
+	}
+	if pattern == "" {
+		t.Fatal("expected non-empty pattern")
+	}
+
+	p, err := LoadUserOverridesPolicy(path)
+	if err != nil {
+		t.Fatalf("LoadUserOverridesPolicy: %v", err)
+	}
+	if len(p.Policies) != 1 {
+		t.Fatalf("expected 1 override policy, got %d", len(p.Policies))
+	}
+	if p.Policies[0].Rules[0].Action != "allow" {
+		t.Fatalf("expected allow action, got %q", p.Policies[0].Rules[0].Action)
+	}
+	if len(p.Policies[0].Rules[0].When.CommandMatches) != 1 {
+		t.Fatalf("expected one command_matches pattern")
+	}
+}

--- a/internal/proxy/eval_handlers.go
+++ b/internal/proxy/eval_handlers.go
@@ -142,6 +142,35 @@ func (s *Server) handleToolCall(w http.ResponseWriter, r *http.Request) {
 		resp["suggestions"] = []string{}
 	}
 
+	// Explicit durable human carve-outs should bypass normal deny/ask precedence.
+	// They are not ordinary policy rules, they are operator-approved overrides.
+	if s.mode == "enforce" {
+		policyName := ""
+		message := ""
+		if engine.MatchesAutoAllowFile(engine.DefaultAutoAllowedPath(), call) {
+			policyName = "auto-allowed"
+			message = "auto-allowed by user rule"
+		} else if engine.MatchesAutoAllowFile(engine.DefaultUserOverridesPath(), call) {
+			policyName = "user-overrides"
+			message = "allowed by durable user override"
+		}
+		if policyName != "" {
+			s.logger.Debug("proxy: user override matched, bypassing normal policy decision", "tool", toolName, "policy", policyName)
+			decision.Action = engine.ActionAllow
+			decision.Message = message
+			decision.MatchedPolicies = []string{policyName}
+			decision.Suggestions = nil
+			resp["allowed"] = true
+			resp["decision"] = decision.Action.String()
+			resp["message"] = decision.Message
+			resp["policy"] = policyName
+			resp["suggestions"] = []string{}
+			s.writeAudit(req, toolName, decision)
+			writeJSON(w, http.StatusOK, resp)
+			return
+		}
+	}
+
 	if s.mode == "enforce" && decision.Action == engine.ActionDeny {
 		writeJSON(w, http.StatusForbidden, resp)
 		return
@@ -199,27 +228,6 @@ func (s *Server) handleToolCall(w http.ResponseWriter, r *http.Request) {
 			resp["decision"] = decision.Action.String()
 			resp["message"] = decision.Message
 			resp["policy"] = "auto-approved"
-			s.writeAudit(req, toolName, decision)
-			writeJSON(w, http.StatusOK, resp)
-			return
-		}
-
-		// Check if the user has previously created an explicit durable allow override.
-		// These human carve-outs should bypass broader deny/approval policies.
-		if engine.MatchesAutoAllowFile(engine.DefaultAutoAllowedPath(), call) || engine.MatchesAutoAllowFile(engine.DefaultUserOverridesPath(), call) {
-			policyName := "auto-allowed"
-			message := "auto-allowed by user rule"
-			if engine.MatchesAutoAllowFile(engine.DefaultUserOverridesPath(), call) {
-				policyName = "user-overrides"
-				message = "allowed by durable user override"
-			}
-			s.logger.Debug("proxy: user override matched, bypassing approval queue", "tool", toolName, "policy", policyName)
-			decision.Action = engine.ActionAllow
-			decision.Message = message
-			decision.MatchedPolicies = []string{policyName}
-			resp["decision"] = decision.Action.String()
-			resp["message"] = decision.Message
-			resp["policy"] = policyName
 			s.writeAudit(req, toolName, decision)
 			writeJSON(w, http.StatusOK, resp)
 			return

--- a/internal/proxy/eval_handlers.go
+++ b/internal/proxy/eval_handlers.go
@@ -204,16 +204,22 @@ func (s *Server) handleToolCall(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		// Check if the user has previously "Always Allowed" this pattern.
-		// Auto-allow decisions override require_approval from global policies.
-		if engine.MatchesAutoAllowFile(engine.DefaultAutoAllowedPath(), call) {
-			s.logger.Debug("proxy: auto-allow matched, bypassing approval queue", "tool", toolName)
+		// Check if the user has previously created an explicit durable allow override.
+		// These human carve-outs should bypass broader deny/approval policies.
+		if engine.MatchesAutoAllowFile(engine.DefaultAutoAllowedPath(), call) || engine.MatchesAutoAllowFile(engine.DefaultUserOverridesPath(), call) {
+			policyName := "auto-allowed"
+			message := "auto-allowed by user rule"
+			if engine.MatchesAutoAllowFile(engine.DefaultUserOverridesPath(), call) {
+				policyName = "user-overrides"
+				message = "allowed by durable user override"
+			}
+			s.logger.Debug("proxy: user override matched, bypassing approval queue", "tool", toolName, "policy", policyName)
 			decision.Action = engine.ActionAllow
-			decision.Message = "auto-allowed by user rule"
-			decision.MatchedPolicies = []string{"auto-allowed"}
+			decision.Message = message
+			decision.MatchedPolicies = []string{policyName}
 			resp["decision"] = decision.Action.String()
 			resp["message"] = decision.Message
-			resp["policy"] = "auto-allowed"
+			resp["policy"] = policyName
 			s.writeAudit(req, toolName, decision)
 			writeJSON(w, http.StatusOK, resp)
 			return

--- a/internal/proxy/integration_test.go
+++ b/internal/proxy/integration_test.go
@@ -394,6 +394,38 @@ func TestStandardPolicy_GlobEdgeCases(t *testing.T) {
 			wantAction: "ask",
 		},
 		{
+			name:       "read: ~/.claude/history.jsonl → ask",
+			tool:       "read",
+			params:     map[string]any{"path": "/home/user/.claude/history.jsonl"},
+			wantStatus: http.StatusAccepted,
+			wantAction: "ask",
+			note:       "Claude conversation history may contain sensitive prompts, secrets, and workflow context",
+		},
+		{
+			name:       "write: ~/.claude/settings.json → ask",
+			tool:       "write",
+			params:     map[string]any{"path": "/home/user/.claude/settings.json"},
+			wantStatus: http.StatusAccepted,
+			wantAction: "ask",
+			note:       "Claude settings can weaken hooks and security posture",
+		},
+		{
+			name:       "read: ~/.codex/auth.json → denied",
+			tool:       "read",
+			params:     map[string]any{"path": "/home/user/.codex/auth.json"},
+			wantStatus: http.StatusForbidden,
+			wantAction: "deny",
+			note:       "Codex auth state is a credential file and should be blocked by default",
+		},
+		{
+			name:       "read: ~/.openclaw/credentials/token.json → denied",
+			tool:       "read",
+			params:     map[string]any{"path": "/home/user/.openclaw/credentials/token.json"},
+			wantStatus: http.StatusForbidden,
+			wantAction: "deny",
+			note:       "OpenClaw credentials should be blocked by default",
+		},
+		{
 			// read of ~/.aws/credentials should be blocked.
 			name:       "read: ~/.aws/credentials → denied",
 			tool:       "read",

--- a/internal/proxy/server_test.go
+++ b/internal/proxy/server_test.go
@@ -719,6 +719,61 @@ policies:
 	assert.Len(t, srv.approvals.List(), 1, "agent token must still enqueue Rampart approvals")
 }
 
+func TestUserOverridesBypassApprovalQueue(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("USERPROFILE", tmpHome)
+	overridesDir := filepath.Join(tmpHome, ".rampart", "policies")
+	require.NoError(t, os.MkdirAll(overridesDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(overridesDir, "user-overrides.yaml"), []byte(`# Rampart user override policies
+policies:
+  - name: user-allow-local-api
+    match:
+      tool:
+        - exec
+    rules:
+      - when:
+          command_matches: ['curl -fsS http://100.94.29.8:8989/api/v3/system/status']
+        action: allow
+        message: User allowed (always)
+`), 0o644))
+
+	configYAML := `version: "1"
+default_action: deny
+policies:
+  - name: require-human
+    match:
+      tool: exec
+    rules:
+      - action: ask
+        when:
+          command_matches:
+            - "curl *"
+        message: "needs approval"
+`
+
+	srv, token, _ := setupTestServer(t, configYAML, "enforce")
+	ts := httptest.NewServer(srv.handler())
+	defer ts.Close()
+
+	body := `{"agent":"main","session":"discord/direct/test","params":{"command":"curl -fsS http://100.94.29.8:8989/api/v3/system/status"}}`
+	req, err := http.NewRequest(http.MethodPost, ts.URL+"/v1/tool/exec", bytes.NewBufferString(body))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var got map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&got))
+	assert.Equal(t, "allow", got["decision"])
+	assert.Equal(t, "user-overrides", got["policy"])
+	assert.Len(t, srv.approvals.List(), 0, "durable user overrides should bypass approval queue")
+}
+
 func TestResolveApproval_AuditTrail(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/policies/openclaw.yaml
+++ b/policies/openclaw.yaml
@@ -189,6 +189,14 @@ policies:
             - "git rebase*"
             - "git reset*"
             - "git revert*"
+            # Safe GitHub CLI workflow
+            - "gh pr create*"
+            - "gh pr view*"
+            - "gh pr checks*"
+            - "gh pr comment*"
+            - "gh pr status*"
+            - "gh issue view*"
+            - "gh issue comment*"
             # Node/npm/yarn
             - "node *"
             - "npm *"

--- a/policies/standard.yaml
+++ b/policies/standard.yaml
@@ -484,6 +484,7 @@ policies:
             - "**/.npmrc"
             - "**/.pypirc"
             - "**/.terraform.d/credentials.tfrc.json"
+            - "**/.codex/auth.json"
             # GPG / keyring
             - "**/.gnupg/**"
             # Generic secrets dirs
@@ -1102,6 +1103,34 @@ policies:
             - "cp **/.config/chromium/**"
             - "cp **/.mozilla/firefox/**"
         message: "Browser profile access blocked (contains saved passwords and session tokens)"
+
+  - name: require-agent-state-artifact-approval
+    description: "Require approval for sensitive agent session, history, runtime, and security config artifacts"
+    match:
+      tool: ["read", "write", "edit"]
+    rules:
+      - action: ask
+        when:
+          path_matches:
+            # Claude Code sensitive state
+            - "**/.claude/history.jsonl"
+            - "**/.claude/sessions/**"
+            - "**/.claude/session-env/**"
+            - "**/.claude/shell-snapshots/**"
+            - "**/.claude/settings.json"
+            - "**/.claude/settings.local.json"
+            # Codex sensitive non-credential state
+            - "**/.codex/config.toml"
+            - "**/.codex/history.jsonl"
+            - "**/.codex/sessions/**"
+            - "**/.codex/shell_snapshots/**"
+            - "**/.codex/memories/**"
+            - "**/.codex/state_*.sqlite*"
+            - "**/.codex/logs_*.sqlite*"
+            # OpenClaw sensitive non-credential state
+            - "**/.openclaw/openclaw.json"
+            - "**/.openclaw/memory/**"
+        message: "Sensitive agent-state artifact access requires approval"
 
   - name: block-exfil-domains
     match:


### PR DESCRIPTION
## Summary

Release v0.9.17.

This ships the validated OpenClaw approval-path hardening work from `staging`, plus the small GitHub workflow policy follow-up.

## Included

- native OpenClaw approval-path hardening
- verified `Allow Always` durable writeback to `~/.rampart/policies/user-overrides.yaml`
- safer degraded behavior when Rampart serve is unavailable
- deterministic OpenClaw approval regression coverage
- acceptance checklist and OpenClaw docs corrections
- safe GitHub CLI PR/issue workflow allowlist
- preserved Rampart self-modification protections

## Validated from fresh staging install

- `sudo true` allowed from learned rule
- `sudo id` prompts for approval
- deny on `sudo id` works
- `rm -rf /tmp` is hard-denied
- `gh pr view` allowed
- `rampart setup openclaw --plugin` still blocked for agent-issued control-plane changes

## Notes

This release intentionally keeps scope tight. No additional feature work beyond the validated approval-path and policy ergonomics fixes is included.
