### PR TITLE
feat: prepare v0.9.18 ergonomics release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.18] - 2026-04-24
+
+### Added
+
+- **`rampart policy explain` now shows why decisions won** — matching policies include source files, agent/session/tool scope, explicit `[WINNER]` marking, winning-rule rationale, and clearer messaging when a policy matched scope but no rule matched the command. New `--session` support makes session-scoped policy debugging faithful to engine behavior.
+- **Durable overrides are visible in explain output** — learned `Allow Always` rules from `user-overrides.yaml` are labeled as durable user overrides in both matching-policy details and the final decision summary.
+- **`rampart doctor` now includes OpenClaw readiness** — a concise readiness signal confirms the native plugin is active, `rampart serve` is reachable, and approval-learning prerequisites are present.
+
+### Fixed
+
+- **Release hygiene tightened** — OpenClaw plugin metadata is bumped with the release, and the changelog now has explicit `0.9.17` and `0.9.18` sections instead of leaving shipped changes under `Unreleased`.
+
+## [0.9.17] - 2026-04-23
+
 ### Fixed
 
 - **OpenClaw native approval path now has a proven end-to-end acceptance bar** — validated live with native Discord approval UI across the three critical states: learned allow (`sudo true`), fresh ask (`sudo id`), and hard deny (`rm -rf /tmp`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **`rampart policy explain` now shows why decisions won** — matching policies include source files, agent/session/tool scope, explicit `[WINNER]` marking, winning-rule rationale, and clearer messaging when a policy matched scope but no rule matched the command. New `--session` support makes session-scoped policy debugging faithful to engine behavior.
+- **`rampart policy explain` now shows why decisions won** — matching policies include source files, agent/session/tool scope, explicit `[WINNER]` marking, winning-rule rationale, and clearer messaging when a policy matched scope but no rule matched the command. New `--session` support makes session-scoped policy debugging faithful to engine behavior; docs now show the upgraded examples.
 - **Durable overrides are visible in explain output** — learned `Allow Always` rules from `user-overrides.yaml` are labeled as durable user overrides in both matching-policy details and the final decision summary.
 - **`rampart doctor` now includes OpenClaw readiness** — a concise readiness signal confirms the native plugin is active, `rampart serve` is reachable, and approval-learning prerequisites are present.
 

--- a/cmd/rampart/cli/doctor.go
+++ b/cmd/rampart/cli/doctor.go
@@ -1403,7 +1403,7 @@ func doctorOpenClawPlugin(emit emitFn) (warnings int) {
 // native OpenClaw approval path trustworthy: plugin installed, serve reachable,
 // and a token available for authenticated policy/learning calls.
 func doctorOpenClawReadiness(emit emitFn, pluginActive bool, serveURL, token string) (warnings int) {
-	if !pluginActive || !isOpenClawInstalled() {
+	if !pluginActive {
 		return 0
 	}
 	if serveURL == "" {

--- a/cmd/rampart/cli/doctor.go
+++ b/cmd/rampart/cli/doctor.go
@@ -252,6 +252,9 @@ func runDoctor(w io.Writer, jsonOut bool) error {
 	if n := doctorOpenClawPlugin(emit); n > 0 {
 		warnings += n
 	}
+	if n := doctorOpenClawReadiness(emit, pluginActive, serveURL, token); n > 0 {
+		warnings += n
+	}
 
 	// 17. OpenClaw ask mode — only needed for legacy bridge users.
 	// With the native plugin active, before_tool_call covers all tool calls
@@ -1393,6 +1396,30 @@ func doctorOpenClawPlugin(emit emitFn) (warnings int) {
 	}
 
 	emit("OpenClaw plugin", "ok", "installed and enabled (before_tool_call hook active)")
+	return 0
+}
+
+// doctorOpenClawReadiness summarizes the runtime prerequisites that make the
+// native OpenClaw approval path trustworthy: plugin installed, serve reachable,
+// and a token available for authenticated policy/learning calls.
+func doctorOpenClawReadiness(emit emitFn, pluginActive bool, serveURL, token string) (warnings int) {
+	if !pluginActive || !isOpenClawInstalled() {
+		return 0
+	}
+	if serveURL == "" {
+		emit("OpenClaw readiness", "warn",
+			"plugin installed, but rampart serve is unreachable — sensitive tools use degraded-mode blocking and approval learning is unavailable"+hintSep+
+				"rampart serve --background")
+		return 1
+	}
+	if strings.TrimSpace(token) == "" {
+		emit("OpenClaw readiness", "warn",
+			"plugin installed and serve reachable, but no token was found for approval/audit calls"+hintSep+
+				"rampart setup openclaw --plugin")
+		return 1
+	}
+
+	emit("OpenClaw readiness", "ok", fmt.Sprintf("plugin active; serve reachable at %s; approval learning prerequisites present", serveURL))
 	return 0
 }
 

--- a/cmd/rampart/cli/doctor_test.go
+++ b/cmd/rampart/cli/doctor_test.go
@@ -312,6 +312,53 @@ func TestDoctorCoverage_OpenClawOnlyNoClaude(t *testing.T) {
 	}
 }
 
+func TestDoctorOpenClawReadiness(t *testing.T) {
+	t.Run("skips when plugin inactive", func(t *testing.T) {
+		var results []checkResult
+		emit := func(name, status, msg string) {
+			results = append(results, checkResult{Name: name, Status: status, Message: msg})
+		}
+		warnings := doctorOpenClawReadiness(emit, false, "", "")
+		if warnings != 0 || len(results) != 0 {
+			t.Fatalf("expected skip, got warnings=%d results=%+v", warnings, results)
+		}
+	})
+
+	t.Run("warns when serve unreachable", func(t *testing.T) {
+		home := t.TempDir()
+		testSetHome(t, home)
+		requireNoErr(t, os.MkdirAll(filepath.Join(home, ".openclaw"), 0o755))
+		var results []checkResult
+		emit := func(name, status, msg string) {
+			results = append(results, checkResult{Name: name, Status: status, Message: msg})
+		}
+		warnings := doctorOpenClawReadiness(emit, true, "", "token")
+		if warnings != 1 || len(results) != 1 || results[0].Status != "warn" {
+			t.Fatalf("expected one warning, got warnings=%d results=%+v", warnings, results)
+		}
+		if !strings.Contains(results[0].Message, "approval learning is unavailable") {
+			t.Fatalf("expected approval learning warning, got %s", results[0].Message)
+		}
+	})
+
+	t.Run("ok when prerequisites present", func(t *testing.T) {
+		home := t.TempDir()
+		testSetHome(t, home)
+		requireNoErr(t, os.MkdirAll(filepath.Join(home, ".openclaw"), 0o755))
+		var results []checkResult
+		emit := func(name, status, msg string) {
+			results = append(results, checkResult{Name: name, Status: status, Message: msg})
+		}
+		warnings := doctorOpenClawReadiness(emit, true, "http://localhost:9090", "token")
+		if warnings != 0 || len(results) != 1 || results[0].Status != "ok" {
+			t.Fatalf("expected ok, got warnings=%d results=%+v", warnings, results)
+		}
+		if !strings.Contains(results[0].Message, "approval learning prerequisites present") {
+			t.Fatalf("expected readiness summary, got %s", results[0].Message)
+		}
+	})
+}
+
 func requireNoErr(t *testing.T, err error) {
 	t.Helper()
 	if err != nil {

--- a/cmd/rampart/cli/policy.go
+++ b/cmd/rampart/cli/policy.go
@@ -35,13 +35,21 @@ type policyTestCall struct {
 }
 
 type explanation struct {
-	PolicyName  string
-	Priority    int
-	RuleIndex   int
-	Action      engine.Action
-	Message     string
-	MatchDetail string
-	RuleMatched bool
+	PolicyName      string
+	Priority        int
+	RuleIndex       int
+	Action          engine.Action
+	Message         string
+	MatchDetail     string
+	RuleMatched     bool
+	SourceFile      string
+	AgentScope      string
+	SessionScope    string
+	ToolScope       string
+	IsWinner        bool
+	WinnerReason    string
+	OverrideSummary string
+	IsUserOverride  bool
 }
 
 func newPolicyCmd(opts *rootOptions) *cobra.Command {
@@ -171,6 +179,7 @@ func newPolicyTestCmd(opts *rootOptions) *cobra.Command {
 func newPolicyExplainCmd(opts *rootOptions) *cobra.Command {
 	var tool string
 	var agent string
+	var session string
 
 	cmd := &cobra.Command{
 		Use:   "explain <command>",
@@ -206,6 +215,7 @@ func newPolicyExplainCmd(opts *rootOptions) *cobra.Command {
 			}
 			call := engine.ToolCall{
 				Agent:     normalizeAgent(agent),
+				Session:   normalizeSession(session),
 				Tool:      tool,
 				Params:    params,
 				Timestamp: time.Now().UTC(),
@@ -216,8 +226,20 @@ func newPolicyExplainCmd(opts *rootOptions) *cobra.Command {
 			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Evaluating: %s %q\n", tool, command); err != nil {
 				return fmt.Errorf("policy: write explain output: %w", err)
 			}
-			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "  Agent: %s | Tool: %s\n\n", normalizeAgent(agent), tool); err != nil {
+			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "  Agent: %s | Session: %s | Tool: %s\n\n", call.Agent, call.Session, tool); err != nil {
 				return fmt.Errorf("policy: write explain output: %w", err)
+			}
+
+			winnerName := ""
+			if len(decision.MatchedPolicies) > 0 {
+				winnerName = decision.MatchedPolicies[0]
+			}
+			for i := range explanations {
+				if explanations[i].PolicyName == winnerName {
+					explanations[i].IsWinner = true
+					explanations[i].WinnerReason = winnerReason(decision.Action)
+					break
+				}
 			}
 
 			if _, err := fmt.Fprintln(cmd.OutOrStdout(), "Matching policies:"); err != nil {
@@ -230,11 +252,28 @@ func newPolicyExplainCmd(opts *rootOptions) *cobra.Command {
 			}
 
 			for i, item := range explanations {
-				if _, err := fmt.Fprintf(cmd.OutOrStdout(), "  %d. %s (priority %d)\n", i+1, item.PolicyName, item.Priority); err != nil {
+				header := fmt.Sprintf("  %d. %s (priority %d)", i+1, item.PolicyName, item.Priority)
+				if item.IsWinner {
+					header += "  [WINNER]"
+				}
+				if _, err := fmt.Fprintln(cmd.OutOrStdout(), header); err != nil {
+					return fmt.Errorf("policy: write explain output: %w", err)
+				}
+				if item.SourceFile != "" {
+					if _, err := fmt.Fprintf(cmd.OutOrStdout(), "     Source: %s\n", item.SourceFile); err != nil {
+						return fmt.Errorf("policy: write explain output: %w", err)
+					}
+				}
+				if item.OverrideSummary != "" {
+					if _, err := fmt.Fprintf(cmd.OutOrStdout(), "     Override: %s\n", item.OverrideSummary); err != nil {
+						return fmt.Errorf("policy: write explain output: %w", err)
+					}
+				}
+				if _, err := fmt.Fprintf(cmd.OutOrStdout(), "     Scope: agent=%s session=%s tool=%s\n", item.AgentScope, item.SessionScope, item.ToolScope); err != nil {
 					return fmt.Errorf("policy: write explain output: %w", err)
 				}
 				if !item.RuleMatched {
-					if _, err := fmt.Fprintln(cmd.OutOrStdout(), "     -> No rule matched"); err != nil {
+					if _, err := fmt.Fprintln(cmd.OutOrStdout(), "     -> Policy matched scope, but no rule matched this call"); err != nil {
 						return fmt.Errorf("policy: write explain output: %w", err)
 					}
 					continue
@@ -247,17 +286,23 @@ func newPolicyExplainCmd(opts *rootOptions) *cobra.Command {
 						return fmt.Errorf("policy: write explain output: %w", err)
 					}
 				}
+				if item.IsWinner && item.WinnerReason != "" {
+					if _, err := fmt.Fprintf(cmd.OutOrStdout(), "        Why it won: %s\n", item.WinnerReason); err != nil {
+						return fmt.Errorf("policy: write explain output: %w", err)
+					}
+				}
 			}
 
-			policyName := ""
-			if len(decision.MatchedPolicies) > 0 {
-				policyName = decision.MatchedPolicies[0]
-			}
 			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "\nFinal decision: %s\n", strings.ToUpper(decision.Action.String())); err != nil {
 				return fmt.Errorf("policy: write explain output: %w", err)
 			}
-			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "  Policy: %s\n", policyName); err != nil {
+			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "  Winning policy: %s\n", winnerName); err != nil {
 				return fmt.Errorf("policy: write explain output: %w", err)
+			}
+			if winner := winningExplanation(explanations); winner != nil && winner.IsUserOverride {
+				if _, err := fmt.Fprintf(cmd.OutOrStdout(), "  Override source: %s\n", winner.OverrideSummary); err != nil {
+					return fmt.Errorf("policy: write explain output: %w", err)
+				}
 			}
 			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "  Message: %s\n", decision.Message); err != nil {
 				return fmt.Errorf("policy: write explain output: %w", err)
@@ -269,6 +314,7 @@ func newPolicyExplainCmd(opts *rootOptions) *cobra.Command {
 
 	cmd.Flags().StringVar(&tool, "tool", "exec", "Tool type to evaluate")
 	cmd.Flags().StringVar(&agent, "agent", "*", "Agent identity to evaluate")
+	cmd.Flags().StringVar(&session, "session", "*", "Session identity to evaluate")
 
 	return cmd
 }
@@ -333,8 +379,14 @@ func collectExplanations(cfg *engine.Config, call engine.ToolCall) []explanation
 		}
 
 		item := explanation{
-			PolicyName: policy.Name,
-			Priority:   policy.EffectivePriority(),
+			PolicyName:      policy.Name,
+			Priority:        policy.EffectivePriority(),
+			SourceFile:      shortenHomePath(policy.FilePath),
+			AgentScope:      policy.Match.EffectiveAgent(),
+			SessionScope:    policy.Match.EffectiveSession(),
+			ToolScope:       renderToolScope(policy.Match.Tool),
+			IsUserOverride:  isUserOverridePolicy(policy),
+			OverrideSummary: summarizeOverrideSource(policy),
 		}
 		for i, rule := range policy.Rules {
 			matched, detail := engine.ExplainCondition(rule.When, call)
@@ -364,6 +416,9 @@ func collectExplanations(cfg *engine.Config, call engine.ToolCall) []explanation
 
 func matchPolicyScope(match engine.Match, call engine.ToolCall) bool {
 	if !engine.MatchGlob(match.EffectiveAgent(), call.Agent) {
+		return false
+	}
+	if !engine.MatchGlob(match.EffectiveSession(), call.Session) {
 		return false
 	}
 	if len(match.Tool) == 0 {
@@ -404,6 +459,13 @@ func normalizeAgent(agent string) string {
 		return "*"
 	}
 	return agent
+}
+
+func normalizeSession(session string) string {
+	if strings.TrimSpace(session) == "" {
+		return "*"
+	}
+	return session
 }
 
 // newPolicyRulesCmd implements `rampart policy rules` — shows all currently
@@ -522,4 +584,67 @@ func renderCommand(params map[string]any) string {
 		return url
 	}
 	return ""
+}
+
+func renderToolScope(tools engine.StringOrSlice) string {
+	if len(tools) == 0 {
+		return "*"
+	}
+	return strings.Join(tools, ",")
+}
+
+func shortenHomePath(path string) string {
+	if strings.TrimSpace(path) == "" {
+		return ""
+	}
+	home, err := os.UserHomeDir()
+	if err == nil && home != "" {
+		if rel, relErr := filepath.Rel(home, path); relErr == nil && !strings.HasPrefix(rel, "..") {
+			return "~/" + rel
+		}
+	}
+	return path
+}
+
+func winnerReason(action engine.Action) string {
+	switch action {
+	case engine.ActionDeny:
+		return "deny wins immediately over all other matching policies"
+	case engine.ActionAsk:
+		return "ask beat allow/watch after no deny matched"
+	case engine.ActionRequireApproval:
+		return "require_approval beat allow/watch after no deny matched"
+	case engine.ActionWebhook:
+		return "webhook beat allow/watch after no deny matched"
+	case engine.ActionWatch:
+		return "watch beat allow after no deny or ask matched"
+	case engine.ActionAllow:
+		return "allow won because no higher-impact action matched"
+	default:
+		return ""
+	}
+}
+
+func isUserOverridePolicy(policy engine.Policy) bool {
+	path := strings.ToLower(policy.FilePath)
+	return strings.Contains(path, "user-overrides.yaml") || strings.HasPrefix(policy.Name, "user-allow-")
+}
+
+func summarizeOverrideSource(policy engine.Policy) string {
+	if !isUserOverridePolicy(policy) {
+		return ""
+	}
+	if policy.FilePath != "" {
+		return fmt.Sprintf("durable user override from %s", shortenHomePath(policy.FilePath))
+	}
+	return "durable user override"
+}
+
+func winningExplanation(items []explanation) *explanation {
+	for i := range items {
+		if items[i].IsWinner {
+			return &items[i]
+		}
+	}
+	return nil
 }

--- a/cmd/rampart/cli/policy_test.go
+++ b/cmd/rampart/cli/policy_test.go
@@ -33,6 +33,19 @@ func TestNormalizeAgent(t *testing.T) {
 	}
 }
 
+func TestNormalizeSession(t *testing.T) {
+	tests := []struct{ input, want string }{
+		{"", "*"},
+		{"  ", "*"},
+		{"discord/direct/test", "discord/direct/test"},
+	}
+	for _, tt := range tests {
+		if got := normalizeSession(tt.input); got != tt.want {
+			t.Errorf("normalizeSession(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
 func TestRenderCommand(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -109,11 +122,62 @@ policies:
 		t.Fatal(err)
 	}
 
-	if !strings.Contains(out.String(), "DENY") {
-		t.Errorf("expected DENY in output: %s", out.String())
+	got := out.String()
+	for _, want := range []string{
+		"DENY",
+		"block-rm",
+		"[WINNER]",
+		"Source:",
+		"Agent: * | Session: * | Tool: exec",
+		"Scope: agent=* session=* tool=exec",
+		"Why it won: deny wins immediately",
+		"Winning policy: block-rm",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %q in output: %s", want, got)
+		}
 	}
-	if !strings.Contains(out.String(), "block-rm") {
-		t.Errorf("expected policy name: %s", out.String())
+}
+
+func TestPolicyExplainUserOverride(t *testing.T) {
+	dir := t.TempDir()
+	policyFile := filepath.Join(dir, "user-overrides.yaml")
+	os.WriteFile(policyFile, []byte(`
+version: "1"
+default_action: deny
+policies:
+  - name: user-allow-echo
+    priority: 1
+    match:
+      tool: ["exec"]
+    rules:
+      - action: allow
+        message: learned allow
+        when:
+          command_matches:
+            - "echo *"
+`), 0o644)
+
+	opts := &rootOptions{configPath: policyFile}
+	cmd := newPolicyExplainCmd(opts)
+	var out strings.Builder
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"echo hi"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	got := out.String()
+	for _, want := range []string{
+		"ALLOW",
+		"Override: durable user override",
+		"Override source: durable user override",
+		"user-overrides.yaml",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %q in output: %s", want, got)
+		}
 	}
 }
 

--- a/docs-site/guides/securing-claude-code.md
+++ b/docs-site/guides/securing-claude-code.md
@@ -61,8 +61,10 @@ That split matters. A credential file should not be silently exposed. But some a
 Policies are evaluated quickly and consistently on every tool call. You can inspect why a command was allowed or denied with:
 
 ```bash
-rampart policy explain --tool exec --input 'rm -rf /'
+rampart policy explain --tool exec 'rm -rf /'
 ```
+
+The explain output marks the winning policy, shows where it came from, and calls out durable user overrides from `user-overrides.yaml` so you can tell whether an `Allow Always` decision is coming from learned local policy.
 
 Use `default_action` and explicit rule ordering to control strictness. In higher-security environments, set `default_action: deny` and add narrow allow rules.
 

--- a/docs-site/reference/cli-commands.md
+++ b/docs-site/reference/cli-commands.md
@@ -479,11 +479,12 @@ rampart policy check
 
 ### `rampart policy explain`
 
-Trace how a command would be evaluated.
+Trace how a command would be evaluated, including matching policy source files, scope, winning rule, and why the final decision won. Durable user overrides from `user-overrides.yaml` are labeled explicitly.
 
 ```bash
 rampart policy explain "rm -rf /"
-rampart policy explain "git status"
+rampart policy explain --tool exec --agent openclaw --session discord/direct/main "git status"
+rampart policy explain --config ~/.rampart/policies/user-overrides.yaml "sudo true"
 ```
 
 ### `rampart policy test`

--- a/internal/plugin/openclaw/index.js
+++ b/internal/plugin/openclaw/index.js
@@ -212,7 +212,7 @@ async function auditLog(toolName, params, ctx, outcome, config) {
 export const id = "rampart";
 export const name = "Rampart";
 export const description = "AI agent firewall — YAML policy-as-code for every tool call";
-export const version = "0.9.16";
+export const version = "0.9.18";
 
 export function register(api) {
   const pluginConfig = api.pluginConfig ?? {};

--- a/internal/plugin/openclaw/openclaw.plugin.json
+++ b/internal/plugin/openclaw/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "rampart",
   "name": "Rampart",
   "description": "AI agent firewall \u2014 YAML policy-as-code for every tool call",
-  "version": "0.9.16",
+  "version": "0.9.18",
   "author": "peg",
   "homepage": "https://rampart.sh",
   "repository": "https://github.com/peg/rampart",

--- a/internal/plugin/openclaw/package.json
+++ b/internal/plugin/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rampart",
-  "version": "0.9.16",
+  "version": "0.9.18",
   "description": "Rampart AI agent firewall \u2014 OpenClaw native plugin (before_tool_call hook)",
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
## Summary
- improve `rampart policy explain` with source/scope details, winner marking, why-it-won output, durable override visibility, and `--session` support
- add a concise OpenClaw readiness check to `rampart doctor`
- clean v0.9.18 release hygiene: changelog sections and OpenClaw plugin metadata version bump

## Validation
- `go test ./cmd/rampart/cli/... -count=1`
- `HOME=$(mktemp -d) USERPROFILE=$HOME go test ./... -count=1`
- `HOME=$(mktemp -d) USERPROFILE=$HOME go build ./cmd/rampart`

Note: full tests need an isolated HOME because local durable overrides can intentionally affect proxy approval tests.