### PR TITLE
docs: polish integration platform guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Once running, every tool call goes through Rampart's policy engine first:
 ✅ 14:23:03  read  ~/project/src/main.go                [default]
 🔴 14:23:05  exec  "rm -rf /tmp/*"                      [block-destructive]
 🟡 14:23:08  exec  "curl https://api.example.com"       [log-network]
-👤 14:23:10  exec  "kubectl apply -f prod.yaml"         [require-approval]
+👤 14:23:10  exec  "kubectl apply -f prod.yaml"         [ask]
 🔴 14:23:12  resp  read .env                            [block-credential-leak]
                     → blocked: response contained AWS_SECRET_ACCESS_KEY
 ```

--- a/docs-site/features/mcp-proxy.md
+++ b/docs-site/features/mcp-proxy.md
@@ -62,7 +62,7 @@ client -> rampart: "tools/call"
 rampart -> engine: "evaluate"
 engine -> server: "allow"
 engine -> error: "deny"
-engine -> pending: "require_approval"
+engine -> pending: "ask"
 pending -> server: "approved"
 pending -> error: "denied / timeout"
 server -> rampart: "response"
@@ -185,7 +185,7 @@ policies:
     match:
       tool: ["mcp-dangerous"]
     rules:
-      - action: require_approval
+      - action: ask
         message: "Risky MCP operation — approve?"
 
   - name: block-file-deletion

--- a/docs-site/features/policy-engine.md
+++ b/docs-site/features/policy-engine.md
@@ -66,7 +66,7 @@ match -> default: "no match"
 
 rules -> deny: "deny rule"
 rules -> webhook: "webhook rule"
-rules -> approval: "require_approval"
+rules -> approval: "ask"
 rules -> watch: "watch rule"
 rules -> allow: "allow rule"
 

--- a/docs-site/features/siem-integration.md
+++ b/docs-site/features/siem-integration.md
@@ -137,7 +137,7 @@ sudo systemctl restart wazuh-manager
 |---------------|-------------|-------------|
 | allow | 3 | Informational |
 | log | 5 | Notable |
-| require_approval | 8 | Needs human review |
+| ask | 8 | Needs human review |
 | deny | 10 | Blocked by policy |
 | deny (credentials) | 12 | Credential access attempt |
 | deny (exfiltration) | 13 | Data exfiltration attempt |

--- a/docs-site/features/webhooks.md
+++ b/docs-site/features/webhooks.md
@@ -17,7 +17,7 @@ default_action: allow
 
 notify:
   url: "https://discord.com/api/webhooks/your/webhook"
-  on: ["deny", "require_approval"]  # Notify on blocked and pending approval
+  on: ["deny", "ask"]  # Notify on blocked and pending approval
 
 policies:
   # ... your policies
@@ -29,7 +29,7 @@ policies:
 |-------|------|
 | `deny` | A tool call was blocked |
 | `log` | A tool call was flagged for review |
-| `require_approval` | A tool call needs human approval |
+| `ask` | A tool call needs human approval |
 
 ## Payload Format
 

--- a/docs-site/index.html
+++ b/docs-site/index.html
@@ -569,7 +569,7 @@
         <div class="feature-card reveal reveal-d3">
           <div class="feature-num">04</div>
           <div class="feature-title">Approval gates</div>
-          <div class="feature-desc">Some commands you want a human to approve before they run. Set <code>action: require-approval</code> on any rule and Rampart holds the command until you say yes or no.</div>
+          <div class="feature-desc">Some commands you want a human to approve before they run. Set <code>action: ask</code> on any rule and Rampart holds the command until you say yes or no.</div>
         </div>
         <div class="feature-card reveal reveal-d4">
           <div class="feature-num">05</div>
@@ -635,7 +635,7 @@
         <div class="agent-card">
           <div class="agent-card-info">
             <div class="agent-card-name">Claude Code</div>
-            <div class="agent-card-method">hooks + bridge &nbsp;·&nbsp; <span class="badge-native">✓ native</span></div>
+            <div class="agent-card-method">native hooks &nbsp;·&nbsp; <span class="badge-native">✓ native</span></div>
           </div>
           <div class="agent-setup-cmd" onclick="copySetup(this)" title="Click to copy" data-cmd="rampart setup claude-code">
             <span class="agent-cmd-prompt">$ </span>rampart setup claude-code
@@ -646,7 +646,7 @@
         <div class="agent-card">
           <div class="agent-card-info">
             <div class="agent-card-name">Codex CLI</div>
-            <div class="agent-card-method">hooks + bridge &nbsp;·&nbsp; <span class="badge-native">✓ native</span></div>
+            <div class="agent-card-method">wrapper + preload</div>
           </div>
           <div class="agent-setup-cmd" onclick="copySetup(this)" title="Click to copy" data-cmd="rampart setup codex">
             <span class="agent-cmd-prompt">$ </span>rampart setup codex
@@ -657,7 +657,7 @@
         <div class="agent-card">
           <div class="agent-card-info">
             <div class="agent-card-name">Cline</div>
-            <div class="agent-card-method">LD_PRELOAD &nbsp;·&nbsp; <span class="badge-native">✓ native</span></div>
+            <div class="agent-card-method">native hooks &nbsp;·&nbsp; <span class="badge-native">✓ native</span></div>
           </div>
           <div class="agent-setup-cmd" onclick="copySetup(this)" title="Click to copy" data-cmd="rampart setup cline">
             <span class="agent-cmd-prompt">$ </span>rampart setup cline
@@ -668,7 +668,7 @@
         <div class="agent-card">
           <div class="agent-card-info">
             <div class="agent-card-name">OpenClaw</div>
-            <div class="agent-card-method">shim + bridge &nbsp;·&nbsp; <span class="badge-native">✓ native</span></div>
+            <div class="agent-card-method">native plugin &nbsp;·&nbsp; <span class="badge-native">✓ native</span></div>
           </div>
           <div class="agent-setup-cmd" onclick="copySetup(this)" title="Click to copy" data-cmd="rampart setup openclaw">
             <span class="agent-cmd-prompt">$ </span>rampart setup openclaw
@@ -679,7 +679,7 @@
         <div class="agent-card agent-card-universal">
           <div class="agent-card-info">
             <div class="agent-card-name">Any agent</div>
-            <div class="agent-card-method">shim &nbsp;·&nbsp; <span class="badge-native">✓ universal</span></div>
+            <div class="agent-card-method">shell wrapper &nbsp;·&nbsp; <span class="badge-native">✓ universal</span></div>
           </div>
           <div class="agent-setup-cmd agent-setup-cmd-dim">
             <span class="agent-cmd-prompt">$ </span>rampart wrap -- &lt;cmd&gt;
@@ -715,13 +715,13 @@
         <span class="yd">action: deny</span>
         <span class="yk">message</span>: <span class="ys">"Credential access blocked"</span>
 
-  - <span class="yk">name</span>: <span class="ys">require-approval-outbound</span>
+  - <span class="yk">name</span>: <span class="ys">ask-outbound</span>
     <span class="yk">match</span>:
       <span class="yk">tool</span>: http
     <span class="yk">rules</span>:
       - <span class="yk">when</span>:
           <span class="yk">url_not_in_allowlist</span>: <span class="ys">true</span>
-        <span class="yk">action</span>: <span class="ys">require-approval</span></code></pre>
+        <span class="yk">action</span>: <span class="ys">ask</span></code></pre>
       </div>
     </div>
   </section>

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -198,18 +198,30 @@ verify -> outcomes.approval
 | **Cline** | Native hooks | `rampart setup cline` |
 | **Cursor** | MCP proxy | `rampart mcp --` |
 | **Claude Desktop** | MCP proxy | `rampart mcp --` |
-| **Codex CLI** | LD_PRELOAD | `rampart setup codex` |
+| **Codex CLI** | Wrapper + preload | `rampart setup codex` |
 | **OpenClaw** | Native plugin | `rampart setup openclaw` |
 | **Any CLI agent** | Shell wrapper | `rampart wrap --` |
 | **Python agents** | HTTP API / SDK | `localhost:9090` |
 
 [:octicons-arrow-right-24: See all integration guides](integrations/index.md)
 
-## What's New in v0.9.14
+## What's New in v0.9.19
 
-- **OpenClaw 2026.4.11+ native approval path** — Native Discord exec approvals are the supported path for Rampart's OpenClaw integration. OpenClaw owns approval UI/state, Rampart owns policy, audit, and allow-always persistence. [Details →](integrations/openclaw.md)
-- **`rampart status` shows `OpenClaw (plugin)`** — Status summary now correctly reflects when the native plugin (not legacy bridge) is active.
-- **Setup explains scanner warning** — `rampart setup openclaw --plugin` now clarifies that OpenClaw's security scanner false positive is safe to ignore.
+- **Integration hardening runway** — Codex wrapper setup is idempotent, uninstall is safer, and source builds now fail clearly when the preload library is missing. [Details →](integrations/codex-cli.md)
+- **OpenClaw degraded mode clarified** — Sensitive tools block when Rampart serve is unavailable; explicitly configured lower-risk tools can still fail open. [Details →](integrations/openclaw.md)
+- **Claude Code hook errors cleaned up** — Invalid or stale policies fail closed through structured hook responses instead of noisy shell-hook stderr.
+
+### v0.9.18
+
+- **Policy explain ergonomics** — `rampart policy explain` shows winning rules, source files, durable overrides, and session/tool context.
+- **OpenClaw readiness checks** — `rampart doctor` reports native plugin readiness and approval-path state more clearly.
+- **Release hygiene** — Changelog and plugin metadata now track release state more explicitly.
+
+### v0.9.17
+
+- **OpenClaw approval trust** — Native Discord exec approvals are the supported path for Rampart's OpenClaw integration. OpenClaw owns approval UI/state, Rampart owns policy, audit, and allow-always persistence. [Details →](integrations/openclaw.md)
+- **Durable Allow Always** — OpenClaw approvals can persist safe learned rules to `user-overrides.yaml`.
+- **Sensitive degraded-mode behavior** — High-risk OpenClaw tools stop silently bypassing policy when the service is unavailable.
 
 ### v0.9.13
 
@@ -221,7 +233,7 @@ verify -> outcomes.approval
 ### v0.9.12
 
 - **Plugin bundled in binary** — The OpenClaw plugin is now embedded directly in the `rampart` binary. `rampart setup openclaw --plugin` works on any machine — no external checkout or npm install required. [Learn more →](integrations/openclaw.md)
-- **Bridge hardened** — Errors during require_approval escalations now fail closed (deny) instead of silently allowing.
+- **Bridge hardened** — Errors during approval escalations now fail closed (deny) instead of silently allowing.
 - **Learn endpoint secured** — `POST /v1/rules/learn` now rate-limited and restricted to `allow` decisions only.
 
 ### v0.9.11

--- a/docs-site/integrations/python-agents.md
+++ b/docs-site/integrations/python-agents.md
@@ -39,7 +39,7 @@ def safe_exec(command: str) -> dict:
 
     if result["decision"] == "deny":
         return {"blocked": True, "reason": result["message"]}
-    elif result["decision"] == "require_approval":
+    elif result["decision"] == "ask":
         # Poll for approval resolution
         approval_id = result["approval_id"]
         while True:

--- a/docs-site/migration/v0.6.6.md
+++ b/docs-site/migration/v0.6.6.md
@@ -9,7 +9,7 @@ Rampart v0.6.6 introduced `action: ask` — a native Claude Code permission prom
 
 ## What changed
 
-`action: require_approval` is now **deprecated** and will be removed in v1.0.
+`action: require_approval` was deprecated in v0.6.6 and is now a hard error in current Rampart releases. Use `action: ask`.
 
 | Old | New | Behaviour |
 |-----|-----|-----------|
@@ -17,7 +17,7 @@ Rampart v0.6.6 introduced `action: ask` — a native Claude Code permission prom
 | `action: require_approval` | `action: ask` with `ask.audit: true` | Inline prompt + audit log + serve dashboard |
 | `action: require_approval` (in CI) | `action: ask` with `ask.headless_only: true` | Deny in headless/CI, prompt when interactive |
 
-> **Backwards compatible:** `require_approval` still works as an alias and will continue to work until v1.0. You can migrate at your own pace.
+> **Current behavior:** modern Rampart releases reject `require_approval` at parse time. Migrate before upgrading old policy files.
 
 ## How to migrate
 
@@ -27,7 +27,7 @@ Rampart v0.6.6 introduced `action: ask` — a native Claude Code permission prom
 rampart policy lint ~/.rampart/policies/standard.yaml
 ```
 
-Any `require_approval` usage will show a deprecation warning with the exact migration path.
+Any `require_approval` usage will be reported with the exact migration path.
 
 ### Step 2 — Update your policy file
 
@@ -134,8 +134,8 @@ notify:
 | Version | Status |
 |---------|--------|
 | v0.6.6 | `action: ask` introduced; `require_approval` deprecated (alias) |
-| v0.6.10 | Standard policy still uses `require_approval` (alias works) |
+| v0.6.10 | Standard policy still used `require_approval` (legacy alias) |
 | v0.7.0 | Standard policy migrated to `action: ask` |
-| v1.0 | `require_approval` alias **removed** |
+| v0.9.9 | `require_approval` alias **removed**; use `action: ask` |
 
 Run `rampart upgrade` to get the latest standard policy with all `require_approval` references migrated.

--- a/docs-site/reference/api-reference.md
+++ b/docs-site/reference/api-reference.md
@@ -560,8 +560,8 @@ Returns a transparency-oriented list of active rules — useful for agents to un
       "summary": "Blocks rm -rf, curl | bash, and other dangerous patterns"
     },
     {
-      "name": "require-approval-network",
-      "action": "require_approval",
+      "name": "ask-network",
+      "action": "ask",
       "summary": "Network egress requires human approval"
     }
   ],

--- a/docs-site/reference/cli-commands.md
+++ b/docs-site/reference/cli-commands.md
@@ -61,7 +61,7 @@ rampart setup openclaw --remove  # Remove integration
 
 ### `rampart setup codex`
 
-Install a wrapper script that intercepts all Codex CLI tool calls via LD_PRELOAD.
+Install a wrapper script that runs Codex through `rampart preload`.
 
 ```bash
 rampart setup codex                   # Install wrapper
@@ -69,7 +69,7 @@ rampart setup codex --force           # Overwrite existing wrapper
 rampart setup codex --remove          # Remove wrapper
 ```
 
-The wrapper is installed at `~/.local/bin/codex` and transparently wraps the real Codex binary. Every command Codex executes — and every child process it spawns — goes through Rampart's policy engine via LD_PRELOAD inheritance.
+The wrapper is installed at `~/.local/bin/codex` and transparently wraps the real Codex binary. `rampart setup codex` requires `librampart.so` on Linux or `librampart.dylib` on macOS; source builds should place it in `~/.rampart/lib/` or `/usr/local/lib/` first. Codex subprocesses spawned through libc exec-family calls go through Rampart policy via preload inheritance.
 
 ### `rampart setup` (interactive)
 

--- a/docs/community-policies.md
+++ b/docs/community-policies.md
@@ -148,7 +148,7 @@ rampart bench --policy policies/community/my-policy.yaml --min-coverage 60
 ### Writing Good Community Policies
 
 1. **Start permissive** — block the dangerous stuff, allow everything else
-2. **Use `require_approval`** for risky-but-legitimate operations
+2. **Use `ask`** for risky-but-legitimate operations
 3. **Include `log` rules** for audit trail on read-only operations
 4. **Add clear comments** explaining what each rule does and why
 5. **Don't assume a specific setup** — work across cloud providers, cluster configs, etc.

--- a/docs/guides/native-ask.md
+++ b/docs/guides/native-ask.md
@@ -88,22 +88,20 @@ policies:
 
 This lets you write one policy that works both locally (with prompts) and in CI (with denies). See [CI/Headless Agents](./ci-headless.md) for more details.
 
-### `require_approval` Alias
+### `require_approval` Migration Note
 
-`action: require_approval` is now an alias for `action: ask` with `audit: true`:
+Older Rampart docs and policies may still reference `action: require_approval`, but current Rampart releases require `action: ask` explicitly.
+
+Use this form instead:
 
 ```yaml
-# These are equivalent:
-- action: require_approval
-  message: "Needs approval"
-
 - action: ask
   ask:
     audit: true
   message: "Needs approval"
 ```
 
-The alias exists for backwards compatibility. New policies should prefer the explicit `action: ask` syntax for clarity.
+`action: require_approval` is no longer accepted by the policy engine. Update old examples and local policies to use `action: ask`.
 
 > ⚠️ Common mistake: putting `action: ask` directly inside the policy (as a sibling of `name` or `rules`). `rampart policy lint` will catch this and explain the correct structure.
 
@@ -140,16 +138,9 @@ policies:
             - curl
 ```
 
-## Difference from `require_approval`
+## Difference from the old approval flow
 
-| | `action: ask` | `action: require_approval` |
-|---|---|---|
-| UI | Inline in Claude Code session | Rampart dashboard / `rampart watch` |
-| Requires `rampart serve` | No | Yes |
-| User stays in session | Yes | No (must switch terminal) |
-| Best for | Interactive development | Automated agents / CI |
-
-When `rampart serve` is not running and a `require_approval` rule fires, Rampart automatically falls back to the native ask prompt.
+`action: ask` is the current human-approval action. Depending on the integration, it can surface as Claude Code's inline prompt, OpenClaw's native approval UI, or Rampart's dashboard/CLI approval queue.
 
 ## Limitations
 

--- a/docs/guides/securing-claude-desktop.md
+++ b/docs/guides/securing-claude-desktop.md
@@ -158,7 +158,7 @@ policies:
             - "*curl*requestbin*"
         message: "Blocked: potential data exfiltration"
 
-  - name: require-approval-for-writes
+  - name: ask-for-writes
     match:
       tool: ["write"]
     rules:

--- a/docs/migration/v0.6.6.md
+++ b/docs/migration/v0.6.6.md
@@ -9,7 +9,7 @@ Rampart v0.6.6 introduced `action: ask` — a native Claude Code permission prom
 
 ## What changed
 
-`action: require_approval` is now **deprecated** and will be removed in v1.0.
+`action: require_approval` was deprecated in v0.6.6 and is now a hard error in current Rampart releases. Use `action: ask`.
 
 | Old | New | Behaviour |
 |-----|-----|-----------|
@@ -17,7 +17,7 @@ Rampart v0.6.6 introduced `action: ask` — a native Claude Code permission prom
 | `action: require_approval` | `action: ask` with `ask.audit: true` | Inline prompt + audit log + serve dashboard |
 | `action: require_approval` (in CI) | `action: ask` with `ask.headless_only: true` | Deny in headless/CI, prompt when interactive |
 
-> **Backwards compatible:** `require_approval` still works as an alias and will continue to work until v1.0. You can migrate at your own pace.
+> **Current behavior:** modern Rampart releases reject `require_approval` at parse time. Migrate before upgrading old policy files.
 
 ## How to migrate
 
@@ -27,7 +27,7 @@ Rampart v0.6.6 introduced `action: ask` — a native Claude Code permission prom
 rampart policy lint ~/.rampart/policies/standard.yaml
 ```
 
-Any `require_approval` usage will show a deprecation warning with the exact migration path.
+Any `require_approval` usage will be reported with the exact migration path.
 
 ### Step 2 — Update your policy file
 
@@ -134,8 +134,8 @@ notify:
 | Version | Status |
 |---------|--------|
 | v0.6.6 | `action: ask` introduced; `require_approval` deprecated (alias) |
-| v0.6.10 | Standard policy still uses `require_approval` (alias works) |
+| v0.6.10 | Standard policy still used `require_approval` (legacy alias) |
 | v0.7.0 | Standard policy migrated to `action: ask` |
-| v1.0 | `require_approval` alias **removed** |
+| v0.9.9 | `require_approval` alias **removed**; use `action: ask` |
 
 Run `rampart upgrade` to get the latest standard policy with all `require_approval` references migrated.


### PR DESCRIPTION
## Summary
- update public docs for the v0.9.19 runway without calling it 1.0
- align Codex docs around wrapper + preload, source-build `librampart` prerequisites, and Windows limitations
- refresh OpenClaw degraded-mode docs and landing-page integration labels
- clean stale `require_approval` / `require-approval` examples from current user-facing docs while preserving migration history

## Tests
- go test ./cmd/rampart/cli -run TestSetupCodex -count=1
- HOME=$(mktemp -d) USERPROFILE=$HOME go test ./... -count=1
- mkdocs build (passes; existing d2 plugin compile errors are logged by mkdocs-d2 but non-strict build exits 0)

## Notes
This is intentionally a minor-release docs polish PR, not a 1.0 announcement.