### PR TITLE
release: v0.9.19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,13 @@ jobs:
       - name: Build
         run: go build -v ./cmd/rampart
 
+      - name: OpenClaw plugin regression tests
+        if: runner.os != 'Windows'
+        run: |
+          node internal/plugin/openclaw/smoke-test.mjs
+          node internal/plugin/openclaw/approval-regression.mjs
+          node internal/plugin/openclaw/degraded-mode-test.mjs
+
       - name: Policy check (standard)
         run: go run ./cmd/rampart policy check --config policies/standard.yaml
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.19] - 2026-04-24
+
+### Fixed
+
+- **Codex setup is safer and idempotent** — `rampart setup codex` now refuses to install a wrapper when the preload library is missing, preserves the real Codex binary when `~/.local/bin` is first in `PATH`, and avoids self-recursive wrappers on repeated setup. `rampart setup codex --remove` no longer depends on Codex or the preload library being present.
+- **Claude Code hook failures are stderr-clean** — invalid or stale policy configurations now fail closed through Claude Code's hook protocol instead of surfacing scary shell-hook stderr noise.
+- **OpenClaw degraded-mode behavior is regression-tested** — sensitive tools block when `rampart serve` is unavailable or errors, while explicitly configured lower-risk `failOpenTools` remain fail-open.
+- **Integration docs now match platform behavior** — Codex, OpenClaw, Windows, source-build preload-library requirements, and current `action: ask` terminology are aligned across README and docs.
+
 ## [0.9.18] - 2026-04-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Pattern matching handles 95%+ of decisions in microseconds. The optional [rampar
 | **Claude Code** | `rampart setup claude-code` | Native `PreToolUse` hooks via `~/.claude/settings.json` |
 | **OpenClaw** | `rampart setup openclaw --plugin` | Native plugin + selective native approvals |
 | **Cline** | `rampart setup cline` | Native hooks via settings |
-| **Codex CLI** | `rampart setup codex` | Shell wrapper (v0.4.5+); LD_PRELOAD fallback for older versions |
+| **Codex CLI** | `rampart setup codex` | Wrapper that runs Codex through `rampart preload` |
 | **Any agent** | `rampart wrap -- <agent>` | Shell wrapping via `$SHELL` |
 | **MCP servers** | `rampart mcp -- <server>` | MCP protocol proxy |
 | **System-wide** | `rampart preload -- <cmd>` | LD_PRELOAD syscall interception |
@@ -575,7 +575,7 @@ rampart upgrade --no-binary                 # Refresh policies only
 | Claude Code | `rampart setup claude-code` | Linux, macOS, Windows |
 | OpenClaw | `rampart setup openclaw --plugin` | Linux, macOS |
 | Cline | `rampart setup cline` | Linux, macOS, Windows |
-| Codex CLI | `rampart setup codex` | Linux, macOS (shell wrapper v0.4.5+; LD_PRELOAD fallback) |
+| Codex CLI | `rampart setup codex` | Linux, macOS (requires `librampart.so`/`.dylib`) |
 | Claude Desktop | `rampart mcp` | All |
 | Aider, OpenCode, Continue | `rampart wrap` | Linux, macOS |
 | Python agents | `rampart preload` or HTTP API | Linux, macOS |

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Once running, every tool call goes through Rampart's policy engine first:
 ✅ 14:23:03  read  ~/project/src/main.go                [default]
 🔴 14:23:05  exec  "rm -rf /tmp/*"                      [block-destructive]
 🟡 14:23:08  exec  "curl https://api.example.com"       [log-network]
-👤 14:23:10  exec  "kubectl apply -f prod.yaml"         [require-approval]
+👤 14:23:10  exec  "kubectl apply -f prod.yaml"         [ask]
 🔴 14:23:12  resp  read .env                            [block-credential-leak]
                     → blocked: response contained AWS_SECRET_ACCESS_KEY
 ```

--- a/cmd/rampart/cli/hook.go
+++ b/cmd/rampart/cli/hook.go
@@ -272,12 +272,16 @@ Cline setup: Use "rampart setup cline" to install hooks automatically.`,
 				return fmt.Errorf("hook: create audit dir: %w", err)
 			}
 
-			// Logger goes to stderr — stdout is for the hook response
+			// Stdout is the hook protocol response. Stderr is also treated as a hook
+			// failure by some agents, so keep routine hook execution stderr-clean.
+			// Verbose mode is intentionally opt-in for manual debugging.
 			logLevel := slog.LevelWarn
+			logWriter := io.Discard
 			if opts.verbose {
 				logLevel = slog.LevelDebug
+				logWriter = cmd.ErrOrStderr()
 			}
-			logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: logLevel}))
+			logger := slog.New(slog.NewTextHandler(logWriter, &slog.HandlerOptions{Level: logLevel}))
 
 			// Cleanup stale session state files in the background (best-effort).
 			// This runs once per hook invocation; typically fires every few seconds
@@ -326,6 +330,14 @@ Cline setup: Use "rampart setup cline" to install hooks automatically.`,
 
 			eng, err := engine.New(store, logger)
 			if err != nil {
+				// Agent hook runners often treat any stderr output or non-zero exit as a
+				// scary hook failure. In enforce mode, fail closed through the hook
+				// protocol instead: the agent sees a normal policy block, not a broken
+				// Bash/PreToolUse hook.
+				if mode == "enforce" {
+					logger.Warn("hook: create engine", "error", err)
+					return outputHookResult(cmd, format, hookDeny, false, "Rampart policy configuration error; refusing tool call until policy is fixed", "")
+				}
 				return fmt.Errorf("hook: create engine: %w", err)
 			}
 
@@ -927,12 +939,12 @@ func validateToolUseID(id string) error {
 // (Cline has no native ask equivalent).
 // suggestions contains ready-to-run "rampart allow ..." commands shown on deny.
 func outputHookResult(cmd *cobra.Command, format string, decision hookDecisionType, isPostToolUse bool, reason string, command string, suggestions ...string) error {
-	if decision == hookDeny || decision == hookBlock {
+	// NOTE: Do NOT print to stderr for Claude Code hook decisions — Claude Code
+	// can interpret stderr as a hook failure. The structured JSON response carries
+	// deny/ask reasons. Keep Cline's historical stderr deny output for now.
+	if format == "cline" && (decision == hookDeny || decision == hookBlock) {
 		fmt.Fprint(os.Stderr, formatDenyMessage(command, reason, suggestions))
 	}
-	// NOTE: Do NOT print to stderr for hookAsk — Claude Code interprets any
-	// stderr output as a hook error. The native prompt shows the reason via
-	// PermissionDecisionReason in the JSON response.
 	switch format {
 	case "cline":
 		// Cline has no "ask" — cancel on deny, block, and ask.

--- a/cmd/rampart/cli/hook_ask_test.go
+++ b/cmd/rampart/cli/hook_ask_test.go
@@ -66,6 +66,62 @@ func runHookWithStdin(t *testing.T, opts *rootOptions, stdinJSON string, args ..
 	return stdout.String(), stderr.String(), err
 }
 
+// TestHookPreToolUse_InvalidPolicyDoesNotLeakStderr verifies stale policies fail closed
+// through Claude Code's hook protocol without stderr or non-zero hook errors.
+func TestHookPreToolUse_InvalidPolicyDoesNotLeakStderr(t *testing.T) {
+	dir := t.TempDir()
+	testSetHome(t, dir)
+
+	configPath := filepath.Join(dir, "policy.yaml")
+	if err := os.WriteFile(configPath, []byte(`version: "1"
+default_action: allow
+policies:
+  - name: stale-approval-rule
+    match:
+      tool: exec
+    rules:
+      - action: require_approval
+        message: stale policy should not leak stderr
+        when:
+          command_matches: ["sudo *"]
+`), 0o644); err != nil {
+		t.Fatalf("write policy: %v", err)
+	}
+
+	payload := map[string]any{
+		"hook_event_name": "PreToolUse",
+		"session_id":      "sess-invalid-policy",
+		"tool_use_id":     "toolu_invalid_policy",
+		"tool_name":       "Bash",
+		"tool_input":      map[string]any{"command": "sudo true"},
+	}
+	stdinJSON, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	stdout, stderr, hookErr := runHookWithStdin(t, &rootOptions{configPath: configPath}, string(stdinJSON), "--mode", "enforce")
+	if hookErr != nil {
+		t.Fatalf("hook RunE error: %v", hookErr)
+	}
+	if stderr != "" {
+		t.Fatalf("PreToolUse hook must not leak stderr; got %q", stderr)
+	}
+	var out hookOutput
+	if err := json.Unmarshal([]byte(stdout), &out); err != nil {
+		t.Fatalf("unmarshal hook output: %v (stdout=%q)", err, stdout)
+	}
+	if out.HookSpecificOutput == nil {
+		t.Fatal("expected hookSpecificOutput")
+	}
+	if out.HookSpecificOutput.PermissionDecision != "deny" {
+		t.Fatalf("PermissionDecision = %q, want deny", out.HookSpecificOutput.PermissionDecision)
+	}
+	if !strings.Contains(out.HookSpecificOutput.PermissionDecisionReason, "Rampart policy configuration error") {
+		t.Fatalf("PermissionDecisionReason = %q, want policy configuration error", out.HookSpecificOutput.PermissionDecisionReason)
+	}
+}
+
 // TestParseClaudeCodeInput_SessionAndToolUseID verifies that session_id and
 // tool_use_id from the Claude Code hook payload are propagated into the parse result.
 func TestParseClaudeCodeInput_SessionAndToolUseID(t *testing.T) {

--- a/cmd/rampart/cli/hook_test.go
+++ b/cmd/rampart/cli/hook_test.go
@@ -263,8 +263,8 @@ func TestOutputHookResult_ClaudeCode(t *testing.T) {
 		if err != nil {
 			t.Fatalf("deny outputHookResult error: %v", err)
 		}
-		if !strings.Contains(stderr, "Rampart blocked: rm -rf /") {
-			t.Fatalf("stderr missing deny message: %q", stderr)
+		if stderr != "" {
+			t.Fatalf("stderr should be empty for Claude Code deny (Claude treats stderr as hook error), got: %q", stderr)
 		}
 
 		var deny hookOutput

--- a/cmd/rampart/cli/setup_codex.go
+++ b/cmd/rampart/cli/setup_codex.go
@@ -38,18 +38,6 @@ Run 'rampart setup codex --remove' to uninstall.`,
 
 			out := cmd.OutOrStdout()
 
-			// Find the real codex binary.
-			realCodex, err := exec.LookPath("codex")
-			if err != nil {
-				return fmt.Errorf("setup codex: codex not found in PATH — install it first")
-			}
-
-			// Resolve symlinks so the wrapper doesn't point to itself.
-			realCodex, err = filepath.EvalSymlinks(realCodex)
-			if err != nil {
-				return fmt.Errorf("setup codex: resolve codex path: %w", err)
-			}
-
 			home, err := os.UserHomeDir()
 			if err != nil {
 				return fmt.Errorf("setup codex: resolve home: %w", err)
@@ -60,6 +48,17 @@ Run 'rampart setup codex --remove' to uninstall.`,
 
 			if remove {
 				return removeCodexWrapper(out, wrapperPath)
+			}
+
+			// Verify the preload library before installing a wrapper. A wrapper without
+			// librampart would replace a working codex binary with a broken command.
+			if _, _, err := resolvePreloadLibrary(); err != nil {
+				return fmt.Errorf("setup codex: preload library unavailable: %w", err)
+			}
+
+			realCodex, err := resolveRealCodexBinary(wrapperPath)
+			if err != nil {
+				return err
 			}
 
 			// Safety: don't overwrite if it's already pointing somewhere else.
@@ -132,6 +131,77 @@ exec %s preload -- %s "$@"
 	cmd.Flags().BoolVar(&remove, "remove", false, "Remove the Codex wrapper")
 	cmd.Flags().BoolVar(&force, "force", false, "Overwrite existing wrapper")
 	return cmd
+}
+
+func resolveRealCodexBinary(wrapperPath string) (string, error) {
+	candidates := filepath.SplitList(os.Getenv("PATH"))
+	for _, dir := range candidates {
+		if dir == "" {
+			continue
+		}
+		candidate := filepath.Join(dir, "codex")
+		resolved, err := filepath.EvalSymlinks(candidate)
+		if err != nil {
+			continue
+		}
+		if sameCodexPath(resolved, wrapperPath) || sameCodexPath(candidate, wrapperPath) {
+			if realFromWrapper := realCodexFromExistingWrapper(wrapperPath); realFromWrapper != "" {
+				return realFromWrapper, nil
+			}
+			continue
+		}
+		info, err := os.Stat(resolved)
+		if err != nil || info.IsDir() || info.Mode()&0o111 == 0 {
+			continue
+		}
+		if data, readErr := os.ReadFile(resolved); readErr == nil && containsRampartPreload(string(data)) {
+			continue
+		}
+		return resolved, nil
+	}
+
+	return "", fmt.Errorf("setup codex: codex not found in PATH — install it first")
+}
+
+func realCodexFromExistingWrapper(wrapperPath string) string {
+	data, err := os.ReadFile(wrapperPath)
+	if err != nil || !containsRampartPreload(string(data)) {
+		return ""
+	}
+	realBin := extractRealBinFromWrapper(string(data))
+	if realBin == "" {
+		return ""
+	}
+	info, err := os.Stat(realBin)
+	if err != nil || info.IsDir() || info.Mode()&0o111 == 0 {
+		return ""
+	}
+	return realBin
+}
+
+func sameCodexPath(a, b string) bool {
+	if a == "" || b == "" {
+		return false
+	}
+	cleanA := filepath.Clean(a)
+	cleanB := filepath.Clean(b)
+	if cleanA == cleanB {
+		return true
+	}
+	canonA := canonicalCodexPath(cleanA)
+	canonB := canonicalCodexPath(cleanB)
+	return canonA != "" && canonA == canonB
+}
+
+func canonicalCodexPath(path string) string {
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		path = resolved
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return ""
+	}
+	return filepath.Clean(abs)
 }
 
 func removeCodexWrapper(out io.Writer, wrapperPath string) error {

--- a/cmd/rampart/cli/setup_codex_test.go
+++ b/cmd/rampart/cli/setup_codex_test.go
@@ -1,0 +1,171 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestSetupCodexRequiresPreloadLibrary(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("codex setup is unsupported on Windows")
+	}
+
+	home := t.TempDir()
+	testSetHome(t, home)
+	binDir := filepath.Join(home, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	codexPath := filepath.Join(binDir, "codex")
+	if err := os.WriteFile(codexPath, []byte("#!/bin/sh\necho codex\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	cmd := NewRootCmd(context.Background(), &bytes.Buffer{}, &bytes.Buffer{})
+	cmd.SetArgs([]string{"setup", "codex"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected setup codex to fail when librampart is missing")
+	}
+	if !strings.Contains(err.Error(), "preload library unavailable") {
+		t.Fatalf("error = %q, want preload library unavailable", err.Error())
+	}
+	if _, statErr := os.Stat(filepath.Join(home, ".local", "bin", "codex")); !os.IsNotExist(statErr) {
+		t.Fatalf("wrapper should not be installed without preload library; stat err=%v", statErr)
+	}
+}
+
+func TestSetupCodexInstallsWrapperWhenPreloadLibraryExists(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("codex setup is unsupported on Windows")
+	}
+
+	home := t.TempDir()
+	testSetHome(t, home)
+	binDir := filepath.Join(home, "bin")
+	libDir := filepath.Join(home, ".rampart", "lib")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(libDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	codexPath := filepath.Join(binDir, "codex")
+	if err := os.WriteFile(codexPath, []byte("#!/bin/sh\necho codex\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	libName := "librampart.so"
+	if runtime.GOOS == "darwin" {
+		libName = "librampart.dylib"
+	}
+	if err := os.WriteFile(filepath.Join(libDir, libName), []byte("fake"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	cmd := NewRootCmd(context.Background(), &bytes.Buffer{}, &bytes.Buffer{})
+	cmd.SetArgs([]string{"setup", "codex"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("setup codex: %v", err)
+	}
+	wrapperPath := filepath.Join(home, ".local", "bin", "codex")
+	data, err := os.ReadFile(wrapperPath)
+	if err != nil {
+		t.Fatalf("read wrapper: %v", err)
+	}
+	if !strings.Contains(string(data), "rampart preload") {
+		t.Fatalf("wrapper missing rampart preload: %s", data)
+	}
+}
+
+func TestSetupCodexRemoveDoesNotRequireCodexOrPreloadLibrary(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("codex setup is unsupported on Windows")
+	}
+
+	home := t.TempDir()
+	testSetHome(t, home)
+	wrapperPath := filepath.Join(home, ".local", "bin", "codex")
+	if err := os.MkdirAll(filepath.Dir(wrapperPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	wrapper := "#!/bin/sh\n# Rampart wrapper for Codex — managed by 'rampart setup codex'\n# Real codex: /missing/codex\nexec rampart preload -- /missing/codex \"$@\"\n"
+	if err := os.WriteFile(wrapperPath, []byte(wrapper), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", t.TempDir())
+
+	cmd := NewRootCmd(context.Background(), &bytes.Buffer{}, &bytes.Buffer{})
+	cmd.SetArgs([]string{"setup", "codex", "--remove"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("remove should not require codex or librampart: %v", err)
+	}
+	if _, err := os.Stat(wrapperPath); !os.IsNotExist(err) {
+		t.Fatalf("wrapper should be removed, stat err=%v", err)
+	}
+}
+
+func TestSetupCodexIsIdempotentWhenWrapperFirstOnPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("codex setup is unsupported on Windows")
+	}
+
+	home := t.TempDir()
+	testSetHome(t, home)
+	realBinDir := filepath.Join(home, "real-bin")
+	wrapperDir := filepath.Join(home, ".local", "bin")
+	libDir := filepath.Join(home, ".rampart", "lib")
+	for _, dir := range []string{realBinDir, wrapperDir, libDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	realCodex := filepath.Join(realBinDir, "codex")
+	if err := os.WriteFile(realCodex, []byte("#!/bin/sh\necho real codex\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	libName := "librampart.so"
+	if runtime.GOOS == "darwin" {
+		libName = "librampart.dylib"
+	}
+	if err := os.WriteFile(filepath.Join(libDir, libName), []byte("fake"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("PATH", wrapperDir+string(os.PathListSeparator)+realBinDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	for i := 0; i < 2; i++ {
+		cmd := NewRootCmd(context.Background(), &bytes.Buffer{}, &bytes.Buffer{})
+		cmd.SetArgs([]string{"setup", "codex"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("setup codex iteration %d: %v", i+1, err)
+		}
+	}
+
+	wrapperPath := filepath.Join(wrapperDir, "codex")
+	data, err := os.ReadFile(wrapperPath)
+	if err != nil {
+		t.Fatalf("read wrapper: %v", err)
+	}
+	content := string(data)
+	recordedReal := extractRealBinFromWrapper(content)
+	if !sameCodexPath(recordedReal, realCodex) {
+		t.Fatalf("wrapper should keep real codex path %q, got %q in:\n%s", realCodex, recordedReal, content)
+	}
+	if sameCodexPath(recordedReal, wrapperPath) || strings.Contains(content, "preload -- "+wrapperPath) {
+		t.Fatalf("wrapper became self-recursive:\n%s", content)
+	}
+}

--- a/cmd/rampart/cli/status.go
+++ b/cmd/rampart/cli/status.go
@@ -58,10 +58,10 @@ func runStatus(w io.Writer) error {
 
 // Box dimensions.
 const (
-	statusBoxTotal   = 65 // total visual width including │ borders
-	statusBoxFrame   = 63 // dashes between corner chars (= statusBoxTotal - 2)
-	statusContentW   = 61 // visual content width between "│ " and " │"
-	statusLabelCol   = 14 // visual chars from start of content to value column
+	statusBoxTotal = 65 // total visual width including │ borders
+	statusBoxFrame = 63 // dashes between corner chars (= statusBoxTotal - 2)
+	statusContentW = 61 // visual content width between "│ " and " │"
+	statusLabelCol = 14 // visual chars from start of content to value column
 )
 
 // renderProgressBar renders a progress bar like "███████░░░" (0–100 pct, `width` segments).
@@ -103,11 +103,11 @@ func buildStatusBox(
 	useColor bool,
 ) string {
 	// Lipgloss styles – only applied when useColor is true.
-	accentSt  := lipgloss.NewStyle().Foreground(lipgloss.Color("#FF6392")).Bold(true)
+	accentSt := lipgloss.NewStyle().Foreground(lipgloss.Color("#FF6392")).Bold(true)
 	successSt := lipgloss.NewStyle().Foreground(lipgloss.Color("#22c55e"))
-	dangerSt  := lipgloss.NewStyle().Foreground(lipgloss.Color("#ef4444"))
-	warnSt    := lipgloss.NewStyle().Foreground(lipgloss.Color("#f59e0b"))
-	faintSt   := lipgloss.NewStyle().Faint(true)
+	dangerSt := lipgloss.NewStyle().Foreground(lipgloss.Color("#ef4444"))
+	warnSt := lipgloss.NewStyle().Foreground(lipgloss.Color("#f59e0b"))
+	faintSt := lipgloss.NewStyle().Faint(true)
 	_ = warnSt
 
 	styled := func(s string, st lipgloss.Style) string {
@@ -278,9 +278,9 @@ func detectProtectedAgents() []string {
 		}
 	}
 
-	// Codex wrapper
-	codexWrapper := filepath.Join(home, ".rampart", "bin", "codex")
-	if _, err := os.Stat(codexWrapper); err == nil {
+	// Codex wrapper installed by `rampart setup codex`.
+	codexWrapper := filepath.Join(home, ".local", "bin", "codex")
+	if data, err := os.ReadFile(codexWrapper); err == nil && containsRampartPreload(string(data)) {
 		agents = append(agents, "Codex (wrapper)")
 	}
 

--- a/cmd/rampart/cli/status_test.go
+++ b/cmd/rampart/cli/status_test.go
@@ -15,6 +15,8 @@ package cli
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -35,6 +37,48 @@ func TestRunStatus(t *testing.T) {
 	// Verify the status line is present.
 	if !strings.Contains(out, "Status") {
 		t.Error("missing Status row in status output")
+	}
+}
+
+func TestDetectProtectedAgents_CodexWrapper(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+	wrapperPath := filepath.Join(home, ".local", "bin", "codex")
+	if err := os.MkdirAll(filepath.Dir(wrapperPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(wrapperPath, []byte("#!/bin/sh\nexec rampart preload -- /usr/bin/codex \"$@\"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	agents := detectProtectedAgents()
+	found := false
+	for _, agent := range agents {
+		if agent == "Codex (wrapper)" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected Codex wrapper detection, got %v", agents)
+	}
+}
+
+func TestDetectProtectedAgents_IgnoresPlainCodexBinary(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+	wrapperPath := filepath.Join(home, ".local", "bin", "codex")
+	if err := os.MkdirAll(filepath.Dir(wrapperPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(wrapperPath, []byte("#!/bin/sh\nexec /usr/bin/codex \"$@\"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, agent := range detectProtectedAgents() {
+		if agent == "Codex (wrapper)" {
+			t.Fatalf("plain codex binary should not be reported as protected: %v", agent)
+		}
 	}
 }
 

--- a/docs-site/features/mcp-proxy.md
+++ b/docs-site/features/mcp-proxy.md
@@ -62,7 +62,7 @@ client -> rampart: "tools/call"
 rampart -> engine: "evaluate"
 engine -> server: "allow"
 engine -> error: "deny"
-engine -> pending: "require_approval"
+engine -> pending: "ask"
 pending -> server: "approved"
 pending -> error: "denied / timeout"
 server -> rampart: "response"
@@ -185,7 +185,7 @@ policies:
     match:
       tool: ["mcp-dangerous"]
     rules:
-      - action: require_approval
+      - action: ask
         message: "Risky MCP operation — approve?"
 
   - name: block-file-deletion

--- a/docs-site/features/policy-engine.md
+++ b/docs-site/features/policy-engine.md
@@ -66,7 +66,7 @@ match -> default: "no match"
 
 rules -> deny: "deny rule"
 rules -> webhook: "webhook rule"
-rules -> approval: "require_approval"
+rules -> approval: "ask"
 rules -> watch: "watch rule"
 rules -> allow: "allow rule"
 

--- a/docs-site/features/siem-integration.md
+++ b/docs-site/features/siem-integration.md
@@ -137,7 +137,7 @@ sudo systemctl restart wazuh-manager
 |---------------|-------------|-------------|
 | allow | 3 | Informational |
 | log | 5 | Notable |
-| require_approval | 8 | Needs human review |
+| ask | 8 | Needs human review |
 | deny | 10 | Blocked by policy |
 | deny (credentials) | 12 | Credential access attempt |
 | deny (exfiltration) | 13 | Data exfiltration attempt |

--- a/docs-site/features/webhooks.md
+++ b/docs-site/features/webhooks.md
@@ -17,7 +17,7 @@ default_action: allow
 
 notify:
   url: "https://discord.com/api/webhooks/your/webhook"
-  on: ["deny", "require_approval"]  # Notify on blocked and pending approval
+  on: ["deny", "ask"]  # Notify on blocked and pending approval
 
 policies:
   # ... your policies
@@ -29,7 +29,7 @@ policies:
 |-------|------|
 | `deny` | A tool call was blocked |
 | `log` | A tool call was flagged for review |
-| `require_approval` | A tool call needs human approval |
+| `ask` | A tool call needs human approval |
 
 ## Payload Format
 

--- a/docs-site/getting-started/how-it-works.md
+++ b/docs-site/getting-started/how-it-works.md
@@ -12,7 +12,7 @@ rampart serve
 
 You don't usually run this directly. `rampart quickstart` and `rampart setup` handle it for you by installing a system service (systemd on Linux, launchd on macOS).
 
-**What happens if it's not running?** Rampart is fail-open by design. If the daemon is down, agent tool calls proceed without policy checks. No hangs, no crashes. You lose enforcement and audit logging until it's back.
+**What happens if it's not running?** Behavior depends on the integration. Shell/preload integrations are fail-open by default so they do not lock you out of your own machine. The OpenClaw native plugin is stricter: sensitive tools such as `exec` and `write` block when `rampart serve` is unavailable, while explicitly configured lower-risk `failOpenTools` can still proceed.
 
 ## Agent setup (`rampart setup`)
 
@@ -21,7 +21,7 @@ This wires an agent to use the daemon. What it does depends on the agent:
 | Agent | What `setup` does |
 |-------|-------------------|
 | **Claude Code** | Writes `PreToolUse` hook in `~/.claude/settings.json` |
-| **Codex** | Writes hook config in `~/.codex/config.json` |
+| **Codex** | Installs `~/.local/bin/codex` wrapper that runs the real Codex binary through `rampart preload` |
 | **Cline** | Writes hook config in `~/.cline/settings.json` |
 | **OpenClaw** | Installs native `before_tool_call` plugin (all tools) on >= 2026.3.28; legacy shim on older versions |
 | **MCP servers** | Use `rampart mcp --` prefix instead of setup |

--- a/docs-site/getting-started/troubleshooting.md
+++ b/docs-site/getting-started/troubleshooting.md
@@ -189,7 +189,7 @@ rampart setup openclaw  # auto-detects and installs plugin
 
 **Rampart serve not running:**
 
-The plugin calls `localhost:9090` on every tool call. If serve isn't running, all calls fail-open (allowed silently).
+The plugin calls `localhost:9090` on every tool call. If serve isn't running, sensitive tools such as `exec` and `write` block instead of silently bypassing policy. Lower-risk tools listed in the plugin's `failOpenTools` config can still fail open.
 
 ```bash
 rampart status          # check if serve is running

--- a/docs-site/guides/codex-integration.md
+++ b/docs-site/guides/codex-integration.md
@@ -5,19 +5,29 @@ description: Protect OpenAI Codex CLI with Rampart using a shell wrapper. Every 
 
 # Securing Codex CLI with Rampart
 
-Protect OpenAI Codex CLI tool calls using Rampart's shell wrapper. Every shell command Codex makes passes through your policy before execution.
+Protect OpenAI Codex CLI subprocesses using Rampart's shell wrapper plus preload enforcement. Every shell command Codex spawns through libc exec-family calls passes through your policy before execution.
 
 ## How it works
 
-Unlike Claude Code and Cline — which expose hook APIs — Codex CLI v0.4.5+ uses a shell wrapper for integration. Rampart installs a `codex` wrapper script that transparently routes all Codex commands through policy evaluation.
+Unlike Claude Code and Cline — which expose hook APIs — Codex CLI does not expose a native hook system. Rampart installs a `codex` wrapper script that transparently runs the real Codex binary through `rampart preload`.
 
 ```
-Codex CLI → shell wrapper → Rampart policy check → allow / deny
+Codex CLI → shell wrapper → librampart preload → Rampart policy check → allow / deny
 ```
 
-For older Codex versions (< 0.4.5), Rampart falls back to LD_PRELOAD interception.
+## Setup
 
-## Setup (one command)
+`rampart setup codex` requires the preload library (`librampart.so` on Linux, `librampart.dylib` on macOS). If your install does not include it — common for source builds — build and place it first:
+
+```bash
+mkdir -p ~/.rampart/lib
+# Linux
+cc -shared -fPIC -o ~/.rampart/lib/librampart.so preload/librampart.c -ldl -lcurl -lpthread
+# macOS
+cc -dynamiclib -fPIC -o ~/.rampart/lib/librampart.dylib preload/librampart.c -lcurl
+```
+
+Then install the persistent wrapper:
 
 ```bash
 rampart setup codex
@@ -28,7 +38,7 @@ This creates `~/.local/bin/codex` — a wrapper script that runs the real Codex 
 ```
 ✓ Wrapper installed at /home/user/.local/bin/codex
   Wraps: /usr/local/bin/codex
-  Via:   /usr/local/bin/rampart
+  Via:   /usr/local/bin/rampart preload
 
 ✓ Run 'codex' normally — all tool calls are now enforced by Rampart.
   Uninstall: rampart setup codex --remove
@@ -55,7 +65,7 @@ which codex
 If you don't want the wrapper, you can invoke Rampart inline for any command:
 
 ```bash
-rampart wrap -- codex exec --full-auto 'fix the bug in auth.py'
+rampart preload -- codex exec --full-auto 'fix the bug in auth.py'
 ```
 
 ## Interactive setup wizard
@@ -118,8 +128,8 @@ Rampart verifies the file is its own wrapper before removing it. The real Codex 
 
 ## Platform Notes
 
-- **Linux:** Full support via shell wrapper. Older Codex versions (< 0.4.5) use LD_PRELOAD fallback.
-- **macOS:** Shell wrapper works for all versions. LD_PRELOAD fallback also available.
-- **Windows:** Not supported — use the HTTP API instead.
+- **Linux:** Wrapper + `LD_PRELOAD` coverage for dynamically linked binaries.
+- **macOS:** Wrapper + `DYLD_INSERT_LIBRARIES` coverage for Homebrew/user-installed binaries; SIP-protected system binaries cannot be interposed.
+- **Windows:** `rampart setup codex` is not supported. Use the HTTP API or MCP proxy mode instead.
 
 Run `rampart setup --help` for alternatives on unsupported platforms.

--- a/docs-site/index.html
+++ b/docs-site/index.html
@@ -569,7 +569,7 @@
         <div class="feature-card reveal reveal-d3">
           <div class="feature-num">04</div>
           <div class="feature-title">Approval gates</div>
-          <div class="feature-desc">Some commands you want a human to approve before they run. Set <code>action: require-approval</code> on any rule and Rampart holds the command until you say yes or no.</div>
+          <div class="feature-desc">Some commands you want a human to approve before they run. Set <code>action: ask</code> on any rule and Rampart holds the command until you say yes or no.</div>
         </div>
         <div class="feature-card reveal reveal-d4">
           <div class="feature-num">05</div>
@@ -635,7 +635,7 @@
         <div class="agent-card">
           <div class="agent-card-info">
             <div class="agent-card-name">Claude Code</div>
-            <div class="agent-card-method">hooks + bridge &nbsp;·&nbsp; <span class="badge-native">✓ native</span></div>
+            <div class="agent-card-method">native hooks &nbsp;·&nbsp; <span class="badge-native">✓ native</span></div>
           </div>
           <div class="agent-setup-cmd" onclick="copySetup(this)" title="Click to copy" data-cmd="rampart setup claude-code">
             <span class="agent-cmd-prompt">$ </span>rampart setup claude-code
@@ -646,7 +646,7 @@
         <div class="agent-card">
           <div class="agent-card-info">
             <div class="agent-card-name">Codex CLI</div>
-            <div class="agent-card-method">hooks + bridge &nbsp;·&nbsp; <span class="badge-native">✓ native</span></div>
+            <div class="agent-card-method">wrapper + preload</div>
           </div>
           <div class="agent-setup-cmd" onclick="copySetup(this)" title="Click to copy" data-cmd="rampart setup codex">
             <span class="agent-cmd-prompt">$ </span>rampart setup codex
@@ -657,7 +657,7 @@
         <div class="agent-card">
           <div class="agent-card-info">
             <div class="agent-card-name">Cline</div>
-            <div class="agent-card-method">LD_PRELOAD &nbsp;·&nbsp; <span class="badge-native">✓ native</span></div>
+            <div class="agent-card-method">native hooks &nbsp;·&nbsp; <span class="badge-native">✓ native</span></div>
           </div>
           <div class="agent-setup-cmd" onclick="copySetup(this)" title="Click to copy" data-cmd="rampart setup cline">
             <span class="agent-cmd-prompt">$ </span>rampart setup cline
@@ -668,7 +668,7 @@
         <div class="agent-card">
           <div class="agent-card-info">
             <div class="agent-card-name">OpenClaw</div>
-            <div class="agent-card-method">shim + bridge &nbsp;·&nbsp; <span class="badge-native">✓ native</span></div>
+            <div class="agent-card-method">native plugin &nbsp;·&nbsp; <span class="badge-native">✓ native</span></div>
           </div>
           <div class="agent-setup-cmd" onclick="copySetup(this)" title="Click to copy" data-cmd="rampart setup openclaw">
             <span class="agent-cmd-prompt">$ </span>rampart setup openclaw
@@ -679,7 +679,7 @@
         <div class="agent-card agent-card-universal">
           <div class="agent-card-info">
             <div class="agent-card-name">Any agent</div>
-            <div class="agent-card-method">shim &nbsp;·&nbsp; <span class="badge-native">✓ universal</span></div>
+            <div class="agent-card-method">shell wrapper &nbsp;·&nbsp; <span class="badge-native">✓ universal</span></div>
           </div>
           <div class="agent-setup-cmd agent-setup-cmd-dim">
             <span class="agent-cmd-prompt">$ </span>rampart wrap -- &lt;cmd&gt;
@@ -715,13 +715,13 @@
         <span class="yd">action: deny</span>
         <span class="yk">message</span>: <span class="ys">"Credential access blocked"</span>
 
-  - <span class="yk">name</span>: <span class="ys">require-approval-outbound</span>
+  - <span class="yk">name</span>: <span class="ys">ask-outbound</span>
     <span class="yk">match</span>:
       <span class="yk">tool</span>: http
     <span class="yk">rules</span>:
       - <span class="yk">when</span>:
           <span class="yk">url_not_in_allowlist</span>: <span class="ys">true</span>
-        <span class="yk">action</span>: <span class="ys">require-approval</span></code></pre>
+        <span class="yk">action</span>: <span class="ys">ask</span></code></pre>
       </div>
     </div>
   </section>

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -198,18 +198,30 @@ verify -> outcomes.approval
 | **Cline** | Native hooks | `rampart setup cline` |
 | **Cursor** | MCP proxy | `rampart mcp --` |
 | **Claude Desktop** | MCP proxy | `rampart mcp --` |
-| **Codex CLI** | LD_PRELOAD | `rampart setup codex` |
+| **Codex CLI** | Wrapper + preload | `rampart setup codex` |
 | **OpenClaw** | Native plugin | `rampart setup openclaw` |
 | **Any CLI agent** | Shell wrapper | `rampart wrap --` |
 | **Python agents** | HTTP API / SDK | `localhost:9090` |
 
 [:octicons-arrow-right-24: See all integration guides](integrations/index.md)
 
-## What's New in v0.9.14
+## What's New in v0.9.19
 
-- **OpenClaw 2026.4.11+ native approval path** — Native Discord exec approvals are the supported path for Rampart's OpenClaw integration. OpenClaw owns approval UI/state, Rampart owns policy, audit, and allow-always persistence. [Details →](integrations/openclaw.md)
-- **`rampart status` shows `OpenClaw (plugin)`** — Status summary now correctly reflects when the native plugin (not legacy bridge) is active.
-- **Setup explains scanner warning** — `rampart setup openclaw --plugin` now clarifies that OpenClaw's security scanner false positive is safe to ignore.
+- **Integration hardening runway** — Codex wrapper setup is idempotent, uninstall is safer, and source builds now fail clearly when the preload library is missing. [Details →](integrations/codex-cli.md)
+- **OpenClaw degraded mode clarified** — Sensitive tools block when Rampart serve is unavailable; explicitly configured lower-risk tools can still fail open. [Details →](integrations/openclaw.md)
+- **Claude Code hook errors cleaned up** — Invalid or stale policies fail closed through structured hook responses instead of noisy shell-hook stderr.
+
+### v0.9.18
+
+- **Policy explain ergonomics** — `rampart policy explain` shows winning rules, source files, durable overrides, and session/tool context.
+- **OpenClaw readiness checks** — `rampart doctor` reports native plugin readiness and approval-path state more clearly.
+- **Release hygiene** — Changelog and plugin metadata now track release state more explicitly.
+
+### v0.9.17
+
+- **OpenClaw approval trust** — Native Discord exec approvals are the supported path for Rampart's OpenClaw integration. OpenClaw owns approval UI/state, Rampart owns policy, audit, and allow-always persistence. [Details →](integrations/openclaw.md)
+- **Durable Allow Always** — OpenClaw approvals can persist safe learned rules to `user-overrides.yaml`.
+- **Sensitive degraded-mode behavior** — High-risk OpenClaw tools stop silently bypassing policy when the service is unavailable.
 
 ### v0.9.13
 
@@ -221,7 +233,7 @@ verify -> outcomes.approval
 ### v0.9.12
 
 - **Plugin bundled in binary** — The OpenClaw plugin is now embedded directly in the `rampart` binary. `rampart setup openclaw --plugin` works on any machine — no external checkout or npm install required. [Learn more →](integrations/openclaw.md)
-- **Bridge hardened** — Errors during require_approval escalations now fail closed (deny) instead of silently allowing.
+- **Bridge hardened** — Errors during approval escalations now fail closed (deny) instead of silently allowing.
 - **Learn endpoint secured** — `POST /v1/rules/learn` now rate-limited and restricted to `allow` decisions only.
 
 ### v0.9.11

--- a/docs-site/integrations/codex-cli.md
+++ b/docs-site/integrations/codex-cli.md
@@ -5,12 +5,23 @@ description: "Secure Codex CLI with Rampart using LD_PRELOAD syscall interceptio
 
 # Codex CLI
 
-Codex CLI v0.4.5+ is protected via a **shell wrapper** installed by `rampart setup codex`. For older versions, Rampart falls back to **LD_PRELOAD** syscall interception.
+Codex CLI is protected via a **shell wrapper** installed by `rampart setup codex`. The wrapper runs Codex through Rampart's preload library so spawned shell commands are checked before execution.
 
 ## Setup
 
+`rampart setup codex` requires the preload library (`librampart.so` on Linux, `librampart.dylib` on macOS). If your install does not include it — common for source builds — build and place it first:
+
 ```bash
-# Recommended: install persistent wrapper
+mkdir -p ~/.rampart/lib
+# Linux
+cc -shared -fPIC -o ~/.rampart/lib/librampart.so preload/librampart.c -ldl -lcurl -lpthread
+# macOS
+cc -dynamiclib -fPIC -o ~/.rampart/lib/librampart.dylib preload/librampart.c -lcurl
+```
+
+Then install the persistent wrapper:
+
+```bash
 rampart setup codex
 
 # Alternative: wrap a single session
@@ -61,7 +72,7 @@ rampart preload --mode monitor -- codex
 
 ## Requirements
 
-The preload library (`librampart.so` or `librampart.dylib`) must be installed. It's included in Homebrew installs and release tarballs, or build from `preload/` in the source tree.
+The preload library (`librampart.so` or `librampart.dylib`) must be installed before `rampart setup codex` will create a wrapper. This prevents Rampart from replacing a working `codex` command with a wrapper that cannot start. If you built Rampart from source, build the library from `preload/librampart.c` as shown above.
 
 ## Performance
 

--- a/docs-site/integrations/index.md
+++ b/docs-site/integrations/index.md
@@ -41,10 +41,12 @@ When a policy action is `ask`, behavior varies by integration:
 | [Cline](cline.md) | Native hooks | `rampart setup cline` | All |
 | [Cursor](cursor.md) | MCP proxy | `rampart mcp --` | All |
 | [Claude Desktop](claude-desktop.md) | MCP proxy | `rampart mcp --` | All |
-| [Codex CLI](codex-cli.md) | LD_PRELOAD | `rampart setup codex` | Linux, macOS |
-| [OpenClaw](openclaw.md) | Shim + service | `rampart setup openclaw` | Linux, macOS |
+| [Codex CLI](codex-cli.md) | Wrapper + preload | `rampart setup codex` | Linux, macOS* |
+| [OpenClaw](openclaw.md) | Native plugin | `rampart setup openclaw --plugin` | Linux, macOS |
 | [Python Agents](python-agents.md) | HTTP API | `rampart serve` | All |
 | [Any CLI Agent](any-cli-agent.md) | Shell wrapper | `rampart wrap --` | Linux, macOS |
+
+\* macOS preload coverage is best for Homebrew/user-installed binaries; SIP-protected system binaries cannot be interposed.
 
 ## Choosing an Integration
 

--- a/docs-site/integrations/openclaw.md
+++ b/docs-site/integrations/openclaw.md
@@ -9,7 +9,7 @@ Rampart integrates with OpenClaw via the native `before_tool_call` plugin API. T
 
 Every tool call — exec, read, write, web_fetch, browser, message, and more — is evaluated against your policy before it runs.
 
-For sensitive tools, the recommended operating assumption is simple: if Rampart policy service is unavailable, treat that as a broken state and fix it before trusting approval-path tests.
+For sensitive tools, the recommended operating assumption is simple: if Rampart policy service is unavailable, treat that as a broken state and fix it before trusting approval-path tests. By default the plugin blocks sensitive tools such as `exec` and `write` when `rampart serve` is unavailable; lower-risk tools (`read`, `web_fetch`, `web_search`, `image`) are explicitly configured fail-open and can be tightened with `plugins.entries.rampart.config.failOpenTools`.
 
 !!! info "Version requirements"
     - **OpenClaw >= 2026.4.11**: Recommended and supported for native Discord exec approvals plus full native plugin coverage
@@ -156,7 +156,7 @@ Or check plugin status directly:
 
 ```bash
 openclaw plugins list
-# rampart  v0.9.16  active
+# rampart  v0.9.18  active
 ```
 
 ## Troubleshooting

--- a/docs-site/integrations/python-agents.md
+++ b/docs-site/integrations/python-agents.md
@@ -39,7 +39,7 @@ def safe_exec(command: str) -> dict:
 
     if result["decision"] == "deny":
         return {"blocked": True, "reason": result["message"]}
-    elif result["decision"] == "require_approval":
+    elif result["decision"] == "ask":
         # Poll for approval resolution
         approval_id = result["approval_id"]
         while True:

--- a/docs-site/migration/v0.6.6.md
+++ b/docs-site/migration/v0.6.6.md
@@ -9,7 +9,7 @@ Rampart v0.6.6 introduced `action: ask` — a native Claude Code permission prom
 
 ## What changed
 
-`action: require_approval` is now **deprecated** and will be removed in v1.0.
+`action: require_approval` was deprecated in v0.6.6 and is now a hard error in current Rampart releases. Use `action: ask`.
 
 | Old | New | Behaviour |
 |-----|-----|-----------|
@@ -17,7 +17,7 @@ Rampart v0.6.6 introduced `action: ask` — a native Claude Code permission prom
 | `action: require_approval` | `action: ask` with `ask.audit: true` | Inline prompt + audit log + serve dashboard |
 | `action: require_approval` (in CI) | `action: ask` with `ask.headless_only: true` | Deny in headless/CI, prompt when interactive |
 
-> **Backwards compatible:** `require_approval` still works as an alias and will continue to work until v1.0. You can migrate at your own pace.
+> **Current behavior:** modern Rampart releases reject `require_approval` at parse time. Migrate before upgrading old policy files.
 
 ## How to migrate
 
@@ -27,7 +27,7 @@ Rampart v0.6.6 introduced `action: ask` — a native Claude Code permission prom
 rampart policy lint ~/.rampart/policies/standard.yaml
 ```
 
-Any `require_approval` usage will show a deprecation warning with the exact migration path.
+Any `require_approval` usage will be reported with the exact migration path.
 
 ### Step 2 — Update your policy file
 
@@ -134,8 +134,8 @@ notify:
 | Version | Status |
 |---------|--------|
 | v0.6.6 | `action: ask` introduced; `require_approval` deprecated (alias) |
-| v0.6.10 | Standard policy still uses `require_approval` (alias works) |
+| v0.6.10 | Standard policy still used `require_approval` (legacy alias) |
 | v0.7.0 | Standard policy migrated to `action: ask` |
-| v1.0 | `require_approval` alias **removed** |
+| v0.9.9 | `require_approval` alias **removed**; use `action: ask` |
 
 Run `rampart upgrade` to get the latest standard policy with all `require_approval` references migrated.

--- a/docs-site/reference/api-reference.md
+++ b/docs-site/reference/api-reference.md
@@ -560,8 +560,8 @@ Returns a transparency-oriented list of active rules — useful for agents to un
       "summary": "Blocks rm -rf, curl | bash, and other dangerous patterns"
     },
     {
-      "name": "require-approval-network",
-      "action": "require_approval",
+      "name": "ask-network",
+      "action": "ask",
       "summary": "Network egress requires human approval"
     }
   ],

--- a/docs-site/reference/cli-commands.md
+++ b/docs-site/reference/cli-commands.md
@@ -61,7 +61,7 @@ rampart setup openclaw --remove  # Remove integration
 
 ### `rampart setup codex`
 
-Install a wrapper script that intercepts all Codex CLI tool calls via LD_PRELOAD.
+Install a wrapper script that runs Codex through `rampart preload`.
 
 ```bash
 rampart setup codex                   # Install wrapper
@@ -69,7 +69,7 @@ rampart setup codex --force           # Overwrite existing wrapper
 rampart setup codex --remove          # Remove wrapper
 ```
 
-The wrapper is installed at `~/.local/bin/codex` and transparently wraps the real Codex binary. Every command Codex executes — and every child process it spawns — goes through Rampart's policy engine via LD_PRELOAD inheritance.
+The wrapper is installed at `~/.local/bin/codex` and transparently wraps the real Codex binary. `rampart setup codex` requires `librampart.so` on Linux or `librampart.dylib` on macOS; source builds should place it in `~/.rampart/lib/` or `/usr/local/lib/` first. Codex subprocesses spawned through libc exec-family calls go through Rampart policy via preload inheritance.
 
 ### `rampart setup` (interactive)
 

--- a/docs-site/reference/policy-schema.md
+++ b/docs-site/reference/policy-schema.md
@@ -303,11 +303,11 @@ policies:
           command_matches: ["curl *", "wget *"]
         message: "Network command logged"
 
-  - name: approve-deploys
+  - name: ask-deploys
     match:
       tool: ["exec"]
     rules:
-      - action: require_approval
+      - action: ask
         when:
           command_matches: ["kubectl apply *"]
         message: "Deployment requires approval"

--- a/docs/community-policies.md
+++ b/docs/community-policies.md
@@ -148,7 +148,7 @@ rampart bench --policy policies/community/my-policy.yaml --min-coverage 60
 ### Writing Good Community Policies
 
 1. **Start permissive** — block the dangerous stuff, allow everything else
-2. **Use `require_approval`** for risky-but-legitimate operations
+2. **Use `ask`** for risky-but-legitimate operations
 3. **Include `log` rules** for audit trail on read-only operations
 4. **Add clear comments** explaining what each rule does and why
 5. **Don't assume a specific setup** — work across cloud providers, cluster configs, etc.

--- a/docs/guides/codex-integration.md
+++ b/docs/guides/codex-integration.md
@@ -1,6 +1,6 @@
 # Securing Codex CLI with Rampart
 
-Protect OpenAI Codex CLI tool calls using Rampart's LD_PRELOAD syscall interception. Every shell command, file read, and network request Codex makes passes through your policy before execution.
+Protect OpenAI Codex CLI subprocesses using Rampart's LD_PRELOAD/DYLD interception. Every shell command Codex spawns through libc exec-family calls passes through your policy before execution.
 
 ## How it works
 
@@ -10,7 +10,19 @@ Unlike Claude Code and Cline — which expose hook APIs — Codex CLI doesn't ha
 Codex CLI → tool call → librampart.so intercept → Rampart policy → allow / deny
 ```
 
-## Setup (one command)
+## Setup
+
+`rampart setup codex` requires the preload library (`librampart.so` on Linux, `librampart.dylib` on macOS). If your install does not include it — common for source builds — build and place it first:
+
+```bash
+mkdir -p ~/.rampart/lib
+# Linux
+cc -shared -fPIC -o ~/.rampart/lib/librampart.so preload/librampart.c -ldl -lcurl -lpthread
+# macOS
+cc -dynamiclib -fPIC -o ~/.rampart/lib/librampart.dylib preload/librampart.c -lcurl
+```
+
+Then install the persistent Codex wrapper:
 
 ```bash
 rampart setup codex
@@ -109,6 +121,6 @@ rampart setup codex --remove
 
 Rampart verifies the file is its own wrapper before removing it. The real Codex binary is restored automatically (it was never moved).
 
-## Linux only
+## Platform support
 
-`rampart setup codex` requires Linux — LD_PRELOAD syscall interception is not available on macOS or Windows. On macOS, use `rampart wrap -- codex` (shell-level wrapping) or the MCP proxy mode instead. Run `rampart setup --help` for alternatives.
+`rampart setup codex` supports Linux and macOS by installing a wrapper at `~/.local/bin/codex` that invokes Codex through `rampart preload`. Linux provides full LD_PRELOAD coverage. macOS works for dynamically linked/Homebrew-style binaries, but SIP prevents preload interception for protected system binaries. Windows is not supported; use the HTTP API or MCP proxy mode instead. Run `rampart setup --help` for alternatives.

--- a/docs/guides/native-ask.md
+++ b/docs/guides/native-ask.md
@@ -88,22 +88,20 @@ policies:
 
 This lets you write one policy that works both locally (with prompts) and in CI (with denies). See [CI/Headless Agents](./ci-headless.md) for more details.
 
-### `require_approval` Alias
+### `require_approval` Migration Note
 
-`action: require_approval` is now an alias for `action: ask` with `audit: true`:
+Older Rampart docs and policies may still reference `action: require_approval`, but current Rampart releases require `action: ask` explicitly.
+
+Use this form instead:
 
 ```yaml
-# These are equivalent:
-- action: require_approval
-  message: "Needs approval"
-
 - action: ask
   ask:
     audit: true
   message: "Needs approval"
 ```
 
-The alias exists for backwards compatibility. New policies should prefer the explicit `action: ask` syntax for clarity.
+`action: require_approval` is no longer accepted by the policy engine. Update old examples and local policies to use `action: ask`.
 
 > ⚠️ Common mistake: putting `action: ask` directly inside the policy (as a sibling of `name` or `rules`). `rampart policy lint` will catch this and explain the correct structure.
 
@@ -140,16 +138,9 @@ policies:
             - curl
 ```
 
-## Difference from `require_approval`
+## Difference from the old approval flow
 
-| | `action: ask` | `action: require_approval` |
-|---|---|---|
-| UI | Inline in Claude Code session | Rampart dashboard / `rampart watch` |
-| Requires `rampart serve` | No | Yes |
-| User stays in session | Yes | No (must switch terminal) |
-| Best for | Interactive development | Automated agents / CI |
-
-When `rampart serve` is not running and a `require_approval` rule fires, Rampart automatically falls back to the native ask prompt.
+`action: ask` is the current human-approval action. Depending on the integration, it can surface as Claude Code's inline prompt, OpenClaw's native approval UI, or Rampart's dashboard/CLI approval queue.
 
 ## Limitations
 

--- a/docs/guides/securing-claude-desktop.md
+++ b/docs/guides/securing-claude-desktop.md
@@ -158,7 +158,7 @@ policies:
             - "*curl*requestbin*"
         message: "Blocked: potential data exfiltration"
 
-  - name: require-approval-for-writes
+  - name: ask-for-writes
     match:
       tool: ["write"]
     rules:

--- a/docs/migration/v0.6.6.md
+++ b/docs/migration/v0.6.6.md
@@ -9,7 +9,7 @@ Rampart v0.6.6 introduced `action: ask` — a native Claude Code permission prom
 
 ## What changed
 
-`action: require_approval` is now **deprecated** and will be removed in v1.0.
+`action: require_approval` was deprecated in v0.6.6 and is now a hard error in current Rampart releases. Use `action: ask`.
 
 | Old | New | Behaviour |
 |-----|-----|-----------|
@@ -17,7 +17,7 @@ Rampart v0.6.6 introduced `action: ask` — a native Claude Code permission prom
 | `action: require_approval` | `action: ask` with `ask.audit: true` | Inline prompt + audit log + serve dashboard |
 | `action: require_approval` (in CI) | `action: ask` with `ask.headless_only: true` | Deny in headless/CI, prompt when interactive |
 
-> **Backwards compatible:** `require_approval` still works as an alias and will continue to work until v1.0. You can migrate at your own pace.
+> **Current behavior:** modern Rampart releases reject `require_approval` at parse time. Migrate before upgrading old policy files.
 
 ## How to migrate
 
@@ -27,7 +27,7 @@ Rampart v0.6.6 introduced `action: ask` — a native Claude Code permission prom
 rampart policy lint ~/.rampart/policies/standard.yaml
 ```
 
-Any `require_approval` usage will show a deprecation warning with the exact migration path.
+Any `require_approval` usage will be reported with the exact migration path.
 
 ### Step 2 — Update your policy file
 
@@ -134,8 +134,8 @@ notify:
 | Version | Status |
 |---------|--------|
 | v0.6.6 | `action: ask` introduced; `require_approval` deprecated (alias) |
-| v0.6.10 | Standard policy still uses `require_approval` (alias works) |
+| v0.6.10 | Standard policy still used `require_approval` (legacy alias) |
 | v0.7.0 | Standard policy migrated to `action: ask` |
-| v1.0 | `require_approval` alias **removed** |
+| v0.9.9 | `require_approval` alias **removed**; use `action: ask` |
 
 Run `rampart upgrade` to get the latest standard policy with all `require_approval` references migrated.

--- a/internal/plugin/openclaw/README.md
+++ b/internal/plugin/openclaw/README.md
@@ -12,6 +12,8 @@ From the repo root:
 
 ```bash
 node internal/plugin/openclaw/smoke-test.mjs
+node internal/plugin/openclaw/approval-regression.mjs
+node internal/plugin/openclaw/degraded-mode-test.mjs
 ```
 
 Default behavior simulates:
@@ -44,6 +46,8 @@ Arguments:
 - `allow-always` calls `/v1/rules/learn`
 - `allow` returns nothing or param adjustment only when explicitly requested by Rampart
 - there is no legacy `params.ask = "always"` mutation path
+- degraded mode blocks sensitive tools (`exec`, `write`) when serve is unreachable or returns 5xx
+- configured fail-open tools (`read`, `web_fetch`, `web_search`, `image` by default) remain explicit and test-covered
 
 This is a deterministic harness for the highest-leverage regression: approval-path behavior without depending on model tool selection.
 
@@ -58,5 +62,5 @@ Recommended live checks:
 
 Important:
 - make sure `rampart-serve.service` is running before drawing conclusions
-- if Rampart serve is down, sensitive tools should now block instead of silently failing open
+- if Rampart serve is down, sensitive tools should now block instead of silently failing open; lower-risk tools listed in `failOpenTools` remain fail-open by configuration
 - durable learned rules from the OpenClaw plugin are written to `~/.rampart/policies/user-overrides.yaml`

--- a/internal/plugin/openclaw/degraded-mode-test.mjs
+++ b/internal/plugin/openclaw/degraded-mode-test.mjs
@@ -1,0 +1,76 @@
+import plugin from './index.js';
+
+function createApi(pluginConfig = {}) {
+  const handlers = {};
+  const logs = [];
+  return {
+    handlers,
+    logs,
+    api: {
+      pluginConfig,
+      logger: {
+        info: (...a) => logs.push(['info', a.join(' ')]),
+        warn: (...a) => logs.push(['warn', a.join(' ')]),
+        debug: (...a) => logs.push(['debug', a.join(' ')]),
+      },
+      on: (name, fn) => { handlers[name] = fn; },
+      registerGatewayMethod: () => {},
+    },
+  };
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+async function runScenario({ name, toolName, fetchImpl, pluginConfig }) {
+  const { api, handlers, logs } = createApi(pluginConfig);
+  const originalFetch = global.fetch;
+  global.fetch = fetchImpl;
+  try {
+    plugin.register(api);
+    const before = handlers['before_tool_call'];
+    assert(typeof before === 'function', `${name}: before_tool_call handler missing`);
+    const result = await before({ toolName, params: { command: 'echo hi' } }, {
+      agentId: 'main',
+      sessionKey: 'agent:main:test',
+      runId: `${name}-run`,
+    });
+    return { result, logs };
+  } finally {
+    global.fetch = originalFetch;
+  }
+}
+
+const unreachableExec = await runScenario({
+  name: 'unreachable-exec',
+  toolName: 'exec',
+  fetchImpl: async () => { throw new TypeError('fetch failed', { cause: { code: 'ECONNREFUSED' } }); },
+});
+assert(unreachableExec.result?.block === true, 'unreachable exec must block');
+assert(unreachableExec.result.blockReason.includes('policy service down'), 'unreachable exec reason should mention service down');
+
+const unreachableRead = await runScenario({
+  name: 'unreachable-read',
+  toolName: 'read',
+  fetchImpl: async () => { throw new TypeError('fetch failed', { cause: { code: 'ECONNREFUSED' } }); },
+});
+assert(unreachableRead.result === undefined, 'unreachable read should use configured fail-open default');
+
+const serverErrorWrite = await runScenario({
+  name: 'server-error-write',
+  toolName: 'write',
+  fetchImpl: async () => ({ ok: false, status: 503, text: async () => 'unavailable' }),
+});
+assert(serverErrorWrite.result?.block === true, 'write on serve 5xx must block');
+assert(serverErrorWrite.result.blockReason.includes('service error 503'), 'write 5xx reason should include status');
+
+const serverErrorReadWithStrictConfig = await runScenario({
+  name: 'server-error-read-strict',
+  toolName: 'read',
+  pluginConfig: { failOpenTools: [] },
+  fetchImpl: async () => ({ ok: false, status: 503, text: async () => 'unavailable' }),
+});
+assert(serverErrorReadWithStrictConfig.result?.block === true, 'read should block when failOpenTools is empty');
+
+console.log(JSON.stringify({ ok: true, scenarios: ['unreachable-exec', 'unreachable-read', 'server-error-write', 'server-error-read-strict'] }, null, 2));

--- a/internal/plugin/openclaw/index.js
+++ b/internal/plugin/openclaw/index.js
@@ -212,7 +212,7 @@ async function auditLog(toolName, params, ctx, outcome, config) {
 export const id = "rampart";
 export const name = "Rampart";
 export const description = "AI agent firewall — YAML policy-as-code for every tool call";
-export const version = "0.9.18";
+export const version = "0.9.19";
 
 export function register(api) {
   const pluginConfig = api.pluginConfig ?? {};

--- a/internal/plugin/openclaw/openclaw.plugin.json
+++ b/internal/plugin/openclaw/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "rampart",
   "name": "Rampart",
   "description": "AI agent firewall \u2014 YAML policy-as-code for every tool call",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "author": "peg",
   "homepage": "https://rampart.sh",
   "repository": "https://github.com/peg/rampart",

--- a/internal/plugin/openclaw/package.json
+++ b/internal/plugin/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rampart",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "description": "Rampart AI agent firewall \u2014 OpenClaw native plugin (before_tool_call hook)",
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
## Summary
- release v0.9.19 integration hardening runway
- harden Codex setup/status behavior across Linux/macOS and source builds
- make Claude Code policy-load hook failures stderr-clean and fail closed
- add OpenClaw degraded-mode regression coverage and CI harness runs
- align platform/docs truth for Codex, OpenClaw, Windows, and current `action: ask` terminology
- bump bundled OpenClaw plugin metadata to 0.9.19 and update changelog

## Included PRs
- #261 fix: harden agent integration checks
- #262 docs: polish integration platform guidance
- #263 chore: prepare v0.9.19 release notes

## Validation
- PR #261 CI passed: ubuntu, macOS, windows, GoReleaser snapshot
- PR #262 CI passed: ubuntu, macOS, windows, GoReleaser snapshot
- PR #263 CI passed: ubuntu, macOS, windows, GoReleaser snapshot
- local targeted check: go test ./cmd/rampart/cli -run TestSetupCodex|TestHookPreToolUse_InvalidPolicyDoesNotLeakStderr|TestDetectProtectedAgents -count=1
- local OpenClaw degraded harness: node internal/plugin/openclaw/degraded-mode-test.mjs

## Release note
This is a minor integration-hardening/docs-truth release, not 1.0.