### PR TITLE
fix: preserve modified built-in policy profiles

### DIFF
--- a/cmd/rampart/cli/doctor.go
+++ b/cmd/rampart/cli/doctor.go
@@ -531,26 +531,22 @@ func doctorPolicies(emit emitFn) int {
 				fmt.Sprintf("~/%s (%d policies, %d lint warning(s) — policy works, run lint for details)", rel, count, lintResult.Warnings))
 		default:
 			if builtInProfiles[filepath.Base(path)] {
-				modified, modErr := isModifiedBuiltInPolicy(path)
-				if modErr != nil {
+				state, stateErr := builtInPolicyState(path)
+				if stateErr != nil {
 					emit("Policy", "ok", fmt.Sprintf("~/%s (%d policies, valid)", rel, count))
 					continue
 				}
-				if staleMsg := checkPolicyVersionStamp(path); staleMsg != "" {
-					if modified {
-						emit("Policy", "warn", fmt.Sprintf("~/%s (%d policies, valid, customized built-in profile, %s)", rel, count, staleMsg)+
-							hintSep+"review changes, then run: rampart upgrade --no-binary --dry-run")
-					} else {
-						emit("Policy", "warn", fmt.Sprintf("~/%s (%d policies, valid, stock profile, %s)", rel, count, staleMsg)+
-							hintSep+"rampart upgrade --no-binary")
-					}
-				} else if modified {
-					emit("Policy", "ok", fmt.Sprintf("~/%s (%d policies, valid, customized built-in profile)", rel, count))
-				} else if !policyHasVersionStamp(path) {
+				switch {
+				case state.StaleMessage != "":
+					emit("Policy", "warn", fmt.Sprintf("~/%s (%d policies, valid, built-in profile from older Rampart release, %s)", rel, count, state.StaleMessage)+
+						hintSep+"review changes, then run: rampart upgrade --no-binary --dry-run")
+				case state.MatchesCurrent && !state.HasVersionStamp:
 					emit("Policy", "warn", fmt.Sprintf("~/%s (%d policies, valid, stock profile without version stamp)", rel, count)+
 						hintSep+"rampart upgrade --no-binary")
-				} else {
+				case state.MatchesCurrent:
 					emit("Policy", "ok", fmt.Sprintf("~/%s (%d policies, valid, stock profile current)", rel, count))
+				default:
+					emit("Policy", "ok", fmt.Sprintf("~/%s (%d policies, valid, customized built-in profile)", rel, count))
 				}
 			} else {
 				emit("Policy", "ok", fmt.Sprintf("~/%s (%d policies, valid)", rel, count))

--- a/cmd/rampart/cli/doctor.go
+++ b/cmd/rampart/cli/doctor.go
@@ -530,13 +530,27 @@ func doctorPolicies(emit emitFn) int {
 			emit("Policy", "ok",
 				fmt.Sprintf("~/%s (%d policies, %d lint warning(s) — policy works, run lint for details)", rel, count, lintResult.Warnings))
 		default:
-			// Check for stale built-in policies.
 			if builtInProfiles[filepath.Base(path)] {
+				modified, modErr := isModifiedBuiltInPolicy(path)
+				if modErr != nil {
+					emit("Policy", "ok", fmt.Sprintf("~/%s (%d policies, valid)", rel, count))
+					continue
+				}
 				if staleMsg := checkPolicyVersionStamp(path); staleMsg != "" {
-					emit("Policy", "warn", fmt.Sprintf("~/%s (%d policies, valid, %s)", rel, count, staleMsg)+
+					if modified {
+						emit("Policy", "warn", fmt.Sprintf("~/%s (%d policies, valid, customized built-in profile, %s)", rel, count, staleMsg)+
+							hintSep+"review changes, then run: rampart upgrade --no-binary --dry-run")
+					} else {
+						emit("Policy", "warn", fmt.Sprintf("~/%s (%d policies, valid, stock profile, %s)", rel, count, staleMsg)+
+							hintSep+"rampart upgrade --no-binary")
+					}
+				} else if modified {
+					emit("Policy", "ok", fmt.Sprintf("~/%s (%d policies, valid, customized built-in profile)", rel, count))
+				} else if !policyHasVersionStamp(path) {
+					emit("Policy", "warn", fmt.Sprintf("~/%s (%d policies, valid, stock profile without version stamp)", rel, count)+
 						hintSep+"rampart upgrade --no-binary")
 				} else {
-					emit("Policy", "ok", fmt.Sprintf("~/%s (%d policies, valid)", rel, count))
+					emit("Policy", "ok", fmt.Sprintf("~/%s (%d policies, valid, stock profile current)", rel, count))
 				}
 			} else {
 				emit("Policy", "ok", fmt.Sprintf("~/%s (%d policies, valid)", rel, count))
@@ -554,17 +568,6 @@ func doctorPolicies(emit emitFn) int {
 
 // doctorServer checks if rampart serve is running on defaultServePort.
 // Returns (issue count, serve URL for subsequent API checks).
-// builtInProfiles lists policy files that are managed by rampart and can be auto-updated.
-var builtInProfiles = map[string]bool{
-	"standard.yaml":               true,
-	"paranoid.yaml":               true,
-	"yolo.yaml":                   true,
-	"demo.yaml":                   true,
-	"block-prompt-injection.yaml": true,
-	"research-agent.yaml":         true,
-	"mcp-server.yaml":             true,
-	"openclaw.yaml":               true,
-}
 
 // checkPolicyVersionStamp reads the first line of a policy file looking for
 // "# rampart-policy-version: X.Y.Z". Returns a warning message if the stamp

--- a/cmd/rampart/cli/doctor_test.go
+++ b/cmd/rampart/cli/doctor_test.go
@@ -23,6 +23,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/peg/rampart/policies"
 )
 
 func TestRunDoctor(t *testing.T) {
@@ -219,6 +221,66 @@ func TestDoctorPolicies_EmptyCustomPlaceholderIsNotWarn(t *testing.T) {
 	}
 	if strings.Contains(results[0].Message, "lint warning") {
 		t.Fatalf("expected lint warning to be suppressed, got %q", results[0].Message)
+	}
+}
+
+func TestDoctorPolicies_BuiltInWithoutVersionStampWarnsAsStock(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+	policyDir := filepath.Join(home, ".rampart", "policies")
+	requireNoErr(t, os.MkdirAll(policyDir, 0o755))
+	standard, err := policies.Profile("standard")
+	requireNoErr(t, err)
+	requireNoErr(t, os.WriteFile(filepath.Join(policyDir, "standard.yaml"), standard, 0o644))
+
+	var results []checkResult
+	emit := func(name, status, msg string) {
+		results = append(results, checkResult{Name: name, Status: status, Message: msg})
+	}
+
+	issues := doctorPolicies(emit)
+	if issues != 0 {
+		t.Fatalf("expected no hard issues, got %d", issues)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Status != "warn" {
+		t.Fatalf("expected warn status, got %q (%s)", results[0].Status, results[0].Message)
+	}
+	if !strings.Contains(results[0].Message, "stock profile without version stamp") {
+		t.Fatalf("expected stock-profile warning, got %q", results[0].Message)
+	}
+}
+
+func TestDoctorPolicies_CustomizedBuiltInIsReportedClearly(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+	policyDir := filepath.Join(home, ".rampart", "policies")
+	requireNoErr(t, os.MkdirAll(policyDir, 0o755))
+	standard, err := policies.Profile("standard")
+	requireNoErr(t, err)
+	customized := append([]byte("# rampart-policy-version: 0.9.19\n"), standard...)
+	customized = append(customized, []byte("\n# local customization\n")...)
+	requireNoErr(t, os.WriteFile(filepath.Join(policyDir, "standard.yaml"), customized, 0o644))
+
+	var results []checkResult
+	emit := func(name, status, msg string) {
+		results = append(results, checkResult{Name: name, Status: status, Message: msg})
+	}
+
+	issues := doctorPolicies(emit)
+	if issues != 0 {
+		t.Fatalf("expected no hard issues, got %d", issues)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Status != "ok" {
+		t.Fatalf("expected ok status, got %q (%s)", results[0].Status, results[0].Message)
+	}
+	if !strings.Contains(results[0].Message, "customized built-in profile") {
+		t.Fatalf("expected customization note, got %q", results[0].Message)
 	}
 }
 

--- a/cmd/rampart/cli/doctor_test.go
+++ b/cmd/rampart/cli/doctor_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/peg/rampart/internal/build"
 	"github.com/peg/rampart/policies"
 )
 
@@ -253,6 +254,42 @@ func TestDoctorPolicies_BuiltInWithoutVersionStampWarnsAsStock(t *testing.T) {
 	}
 }
 
+func TestDoctorPolicies_StaleBuiltInDoesNotPretendItsCustomized(t *testing.T) {
+	if build.Version == "dev" {
+		t.Skip("stale-version detection disabled for dev builds")
+	}
+	home := t.TempDir()
+	testSetHome(t, home)
+	policyDir := filepath.Join(home, ".rampart", "policies")
+	requireNoErr(t, os.MkdirAll(policyDir, 0o755))
+	standard, err := policies.Profile("standard")
+	requireNoErr(t, err)
+	stale := append([]byte("# rampart-policy-version: 0.0.1\n"), standard...)
+	requireNoErr(t, os.WriteFile(filepath.Join(policyDir, "standard.yaml"), stale, 0o644))
+
+	var results []checkResult
+	emit := func(name, status, msg string) {
+		results = append(results, checkResult{Name: name, Status: status, Message: msg})
+	}
+
+	issues := doctorPolicies(emit)
+	if issues != 0 {
+		t.Fatalf("expected no hard issues, got %d", issues)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Status != "warn" {
+		t.Fatalf("expected warn status, got %q (%s)", results[0].Status, results[0].Message)
+	}
+	if !strings.Contains(results[0].Message, "older Rampart release") {
+		t.Fatalf("expected older-release note, got %q", results[0].Message)
+	}
+	if strings.Contains(results[0].Message, "customized built-in profile") {
+		t.Fatalf("did not expect stale stock profile to be labeled customized: %q", results[0].Message)
+	}
+}
+
 func TestDoctorPolicies_CustomizedBuiltInIsReportedClearly(t *testing.T) {
 	home := t.TempDir()
 	testSetHome(t, home)
@@ -260,7 +297,7 @@ func TestDoctorPolicies_CustomizedBuiltInIsReportedClearly(t *testing.T) {
 	requireNoErr(t, os.MkdirAll(policyDir, 0o755))
 	standard, err := policies.Profile("standard")
 	requireNoErr(t, err)
-	customized := append([]byte("# rampart-policy-version: 0.9.19\n"), standard...)
+	customized := append([]byte("# rampart-policy-version: "+build.Version+"\n"), standard...)
 	customized = append(customized, []byte("\n# local customization\n")...)
 	requireNoErr(t, os.WriteFile(filepath.Join(policyDir, "standard.yaml"), customized, 0o644))
 

--- a/cmd/rampart/cli/policy_profiles.go
+++ b/cmd/rampart/cli/policy_profiles.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/peg/rampart/internal/build"
 	"github.com/peg/rampart/policies"
 )
 
@@ -21,6 +22,12 @@ var builtInProfiles = map[string]bool{
 	"openclaw.yaml":               true,
 }
 
+type managedPolicyState struct {
+	HasVersionStamp bool
+	MatchesCurrent  bool
+	StaleMessage    string
+}
+
 func normalizeManagedPolicyContent(data []byte) []byte {
 	const prefix = "# rampart-policy-version: "
 	if bytes.HasPrefix(data, []byte(prefix)) {
@@ -33,6 +40,11 @@ func normalizeManagedPolicyContent(data []byte) []byte {
 	return data
 }
 
+func versionStampedPolicyContent(content []byte) []byte {
+	stamped := []byte(fmt.Sprintf("# rampart-policy-version: %s\n", build.Version))
+	return append(stamped, content...)
+}
+
 func policyHasVersionStamp(path string) bool {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -41,19 +53,24 @@ func policyHasVersionStamp(path string) bool {
 	return bytes.HasPrefix(data, []byte("# rampart-policy-version: "))
 }
 
-func isModifiedBuiltInPolicy(path string) (bool, error) {
+func builtInPolicyState(path string) (managedPolicyState, error) {
 	base := filepath.Base(path)
 	if !builtInProfiles[base] {
-		return false, nil
+		return managedPolicyState{}, nil
 	}
 	profileName := strings.TrimSuffix(base, filepath.Ext(base))
 	embedded, err := policies.Profile(profileName)
 	if err != nil {
-		return false, fmt.Errorf("load embedded profile %s: %w", profileName, err)
+		return managedPolicyState{}, fmt.Errorf("load embedded profile %s: %w", profileName, err)
 	}
 	installed, err := os.ReadFile(path)
 	if err != nil {
-		return false, fmt.Errorf("read installed profile %s: %w", path, err)
+		return managedPolicyState{}, fmt.Errorf("read installed profile %s: %w", path, err)
 	}
-	return !bytes.Equal(normalizeManagedPolicyContent(installed), embedded), nil
+	state := managedPolicyState{
+		HasVersionStamp: bytes.HasPrefix(installed, []byte("# rampart-policy-version: ")),
+		MatchesCurrent:  bytes.Equal(normalizeManagedPolicyContent(installed), embedded),
+		StaleMessage:    checkPolicyVersionStamp(path),
+	}
+	return state, nil
 }

--- a/cmd/rampart/cli/policy_profiles.go
+++ b/cmd/rampart/cli/policy_profiles.go
@@ -1,0 +1,59 @@
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/peg/rampart/policies"
+)
+
+var builtInProfiles = map[string]bool{
+	"standard.yaml":               true,
+	"paranoid.yaml":               true,
+	"yolo.yaml":                   true,
+	"demo.yaml":                   true,
+	"block-prompt-injection.yaml": true,
+	"research-agent.yaml":         true,
+	"mcp-server.yaml":             true,
+	"openclaw.yaml":               true,
+}
+
+func normalizeManagedPolicyContent(data []byte) []byte {
+	const prefix = "# rampart-policy-version: "
+	if bytes.HasPrefix(data, []byte(prefix)) {
+		if idx := bytes.IndexByte(data, '\n'); idx >= 0 {
+			data = data[idx+1:]
+		} else {
+			return nil
+		}
+	}
+	return data
+}
+
+func policyHasVersionStamp(path string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	return bytes.HasPrefix(data, []byte("# rampart-policy-version: "))
+}
+
+func isModifiedBuiltInPolicy(path string) (bool, error) {
+	base := filepath.Base(path)
+	if !builtInProfiles[base] {
+		return false, nil
+	}
+	profileName := strings.TrimSuffix(base, filepath.Ext(base))
+	embedded, err := policies.Profile(profileName)
+	if err != nil {
+		return false, fmt.Errorf("load embedded profile %s: %w", profileName, err)
+	}
+	installed, err := os.ReadFile(path)
+	if err != nil {
+		return false, fmt.Errorf("read installed profile %s: %w", path, err)
+	}
+	return !bytes.Equal(normalizeManagedPolicyContent(installed), embedded), nil
+}

--- a/cmd/rampart/cli/setup_extra_test.go
+++ b/cmd/rampart/cli/setup_extra_test.go
@@ -254,8 +254,16 @@ func TestInstallPolicy(t *testing.T) {
 	}
 
 	policyPath := filepath.Join(dir, ".rampart", "policies", "standard.yaml")
-	if _, err := os.Stat(policyPath); err != nil {
+	content, err := os.ReadFile(policyPath)
+	if err != nil {
 		t.Fatal("policy file not created")
+	}
+	if !strings.HasPrefix(string(content), "# rampart-policy-version: ") {
+		snippet := string(content)
+		if len(snippet) > 40 {
+			snippet = snippet[:40]
+		}
+		t.Fatalf("expected installed policy to be version stamped, got: %q", snippet)
 	}
 
 	// Run again - should say already exists

--- a/cmd/rampart/cli/setup_extra_test.go
+++ b/cmd/rampart/cli/setup_extra_test.go
@@ -275,3 +275,26 @@ func TestInstallPolicy(t *testing.T) {
 		t.Errorf("expected already exists, got: %s", buf.String())
 	}
 }
+
+func TestInstallOpenClawPolicyVersionStamped(t *testing.T) {
+	dir := t.TempDir()
+	testSetHome(t, dir)
+	var out bytes.Buffer
+
+	if err := installOpenClawPolicy(&out, &out); err != nil {
+		t.Fatal(err)
+	}
+
+	policyPath := filepath.Join(dir, ".rampart", "policies", "openclaw.yaml")
+	content, err := os.ReadFile(policyPath)
+	if err != nil {
+		t.Fatal("openclaw policy file not created")
+	}
+	if !strings.HasPrefix(string(content), "# rampart-policy-version: ") {
+		snippet := string(content)
+		if len(snippet) > 40 {
+			snippet = snippet[:40]
+		}
+		t.Fatalf("expected installed OpenClaw policy to be version stamped, got: %q", snippet)
+	}
+}

--- a/cmd/rampart/cli/setup_interactive.go
+++ b/cmd/rampart/cli/setup_interactive.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/peg/rampart/internal/build"
 	"github.com/peg/rampart/internal/detect"
 	"github.com/peg/rampart/policies"
 	"github.com/spf13/cobra"
@@ -337,7 +338,9 @@ func installPolicy(out io.Writer, home, profile string) error {
 		return fmt.Errorf("setup: read embedded profile %s: %w", profile, err)
 	}
 
-	if err := os.WriteFile(policyPath, content, 0o600); err != nil {
+	stamped := []byte(fmt.Sprintf("# rampart-policy-version: %s\n", build.Version))
+	stamped = append(stamped, content...)
+	if err := os.WriteFile(policyPath, stamped, 0o600); err != nil {
 		return fmt.Errorf("setup: write policy: %w", err)
 	}
 	fmt.Fprintf(out, "✓ Policy written to %s\n", policyPath)

--- a/cmd/rampart/cli/setup_interactive.go
+++ b/cmd/rampart/cli/setup_interactive.go
@@ -21,7 +21,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/peg/rampart/internal/build"
 	"github.com/peg/rampart/internal/detect"
 	"github.com/peg/rampart/policies"
 	"github.com/spf13/cobra"
@@ -338,9 +337,7 @@ func installPolicy(out io.Writer, home, profile string) error {
 		return fmt.Errorf("setup: read embedded profile %s: %w", profile, err)
 	}
 
-	stamped := []byte(fmt.Sprintf("# rampart-policy-version: %s\n", build.Version))
-	stamped = append(stamped, content...)
-	if err := os.WriteFile(policyPath, stamped, 0o600); err != nil {
+	if err := os.WriteFile(policyPath, versionStampedPolicyContent(content), 0o600); err != nil {
 		return fmt.Errorf("setup: write policy: %w", err)
 	}
 	fmt.Fprintf(out, "✓ Policy written to %s\n", policyPath)

--- a/cmd/rampart/cli/setup_openclaw_plugin.go
+++ b/cmd/rampart/cli/setup_openclaw_plugin.go
@@ -518,7 +518,7 @@ func installOpenClawPolicy(w io.Writer, errW io.Writer) error {
 	}
 
 	destPath := filepath.Join(policyDir, "openclaw.yaml")
-	if err := os.WriteFile(destPath, policyData, 0o600); err != nil {
+	if err := os.WriteFile(destPath, versionStampedPolicyContent(policyData), 0o600); err != nil {
 		return fmt.Errorf("write %s: %w", destPath, err)
 	}
 

--- a/cmd/rampart/cli/upgrade.go
+++ b/cmd/rampart/cli/upgrade.go
@@ -996,12 +996,15 @@ func upgradeStandardPolicies(out io.Writer, dryRun bool) error {
 	}
 
 	updated := 0
+	seenBuiltIn := 0
 	preserved := make([]string, 0)
+	reviewNeeded := make([]string, 0)
 	updatedNames := make([]string, 0, len(entries))
 	for _, e := range entries {
 		if e.IsDir() || !builtInProfiles[e.Name()] {
 			continue
 		}
+		seenBuiltIn++
 		profileName := strings.TrimSuffix(e.Name(), ".yaml")
 		content, err := policies.Profile(profileName)
 		if err != nil {
@@ -1009,17 +1012,22 @@ func upgradeStandardPolicies(out io.Writer, dryRun bool) error {
 			continue
 		}
 		destPath := filepath.Join(policyDir, e.Name())
-		modified, err := isModifiedBuiltInPolicy(destPath)
+		state, err := builtInPolicyState(destPath)
 		if err != nil {
 			fmt.Fprintf(out, "  ⚠ skip %s: %v\n", e.Name(), err)
 			continue
 		}
-		if modified {
+		if state.StaleMessage != "" {
+			fmt.Fprintf(out, "  review stale built-in policy before refreshing: %s\n", destPath)
+			reviewNeeded = append(reviewNeeded, e.Name())
+			continue
+		}
+		if !state.MatchesCurrent {
 			fmt.Fprintf(out, "  preserved modified policy: %s\n", destPath)
 			preserved = append(preserved, e.Name())
 			continue
 		}
-		if policyHasVersionStamp(destPath) && checkPolicyVersionStamp(destPath) == "" {
+		if state.HasVersionStamp {
 			continue
 		}
 		if dryRun {
@@ -1058,12 +1066,17 @@ func upgradeStandardPolicies(out io.Writer, dryRun bool) error {
 		updatedNames = append(updatedNames, e.Name())
 	}
 
-	if updated == 0 && len(preserved) == 0 {
+	if seenBuiltIn == 0 {
+		fmt.Fprintf(out, "  (no built-in policy files found in %s — skipped)\n", policyDir)
+		return nil
+	}
+	if updated == 0 && len(preserved) == 0 && len(reviewNeeded) == 0 {
 		fmt.Fprintf(out, "  (built-in policy files already current in %s — skipped)\n", policyDir)
 		return nil
 	}
 	sort.Strings(updatedNames)
 	sort.Strings(preserved)
+	sort.Strings(reviewNeeded)
 	if dryRun {
 		if len(updatedNames) > 0 {
 			fmt.Fprintf(out, "  Would update: %s\n", strings.Join(updatedNames, ", "))
@@ -1073,6 +1086,9 @@ func upgradeStandardPolicies(out io.Writer, dryRun bool) error {
 	}
 	if len(preserved) > 0 {
 		fmt.Fprintf(out, "Preserved modified: %s\n", strings.Join(preserved, ", "))
+	}
+	if len(reviewNeeded) > 0 {
+		fmt.Fprintf(out, "Review stale built-ins: %s\n", strings.Join(reviewNeeded, ", "))
 	}
 	return nil
 }

--- a/cmd/rampart/cli/upgrade.go
+++ b/cmd/rampart/cli/upgrade.go
@@ -995,22 +995,11 @@ func upgradeStandardPolicies(out io.Writer, dryRun bool) error {
 		return fmt.Errorf("read policy dir: %w", err)
 	}
 
-	// Built-in profile names — only these are ever auto-updated.
-	builtIn := map[string]bool{
-		"standard.yaml":               true,
-		"paranoid.yaml":               true,
-		"yolo.yaml":                   true,
-		"demo.yaml":                   true,
-		"block-prompt-injection.yaml": true,
-		"research-agent.yaml":         true,
-		"mcp-server.yaml":             true,
-		"openclaw.yaml":               true,
-	}
-
 	updated := 0
+	preserved := make([]string, 0)
 	updatedNames := make([]string, 0, len(entries))
 	for _, e := range entries {
-		if e.IsDir() || !builtIn[e.Name()] {
+		if e.IsDir() || !builtInProfiles[e.Name()] {
 			continue
 		}
 		profileName := strings.TrimSuffix(e.Name(), ".yaml")
@@ -1020,6 +1009,19 @@ func upgradeStandardPolicies(out io.Writer, dryRun bool) error {
 			continue
 		}
 		destPath := filepath.Join(policyDir, e.Name())
+		modified, err := isModifiedBuiltInPolicy(destPath)
+		if err != nil {
+			fmt.Fprintf(out, "  ⚠ skip %s: %v\n", e.Name(), err)
+			continue
+		}
+		if modified {
+			fmt.Fprintf(out, "  preserved modified policy: %s\n", destPath)
+			preserved = append(preserved, e.Name())
+			continue
+		}
+		if policyHasVersionStamp(destPath) && checkPolicyVersionStamp(destPath) == "" {
+			continue
+		}
 		if dryRun {
 			fmt.Fprintf(out, "  would update policy: %s\n", destPath)
 			updated++
@@ -1032,7 +1034,6 @@ func upgradeStandardPolicies(out io.Writer, dryRun bool) error {
 			return fmt.Errorf("create temp file: %w", err)
 		}
 		tmpPath := tmp.Name()
-		// Stamp with the current binary version so doctor can detect stale policies.
 		versionStamp := fmt.Sprintf("# rampart-policy-version: %s\n", build.Version)
 		if _, err := tmp.WriteString(versionStamp); err != nil {
 			tmp.Close()
@@ -1057,16 +1058,21 @@ func upgradeStandardPolicies(out io.Writer, dryRun bool) error {
 		updatedNames = append(updatedNames, e.Name())
 	}
 
-	if updated == 0 {
-		// No standard policy files found — user may be using a custom config path.
-		fmt.Fprintf(out, "  (no built-in policy files found in %s — skipped)\n", policyDir)
+	if updated == 0 && len(preserved) == 0 {
+		fmt.Fprintf(out, "  (built-in policy files already current in %s — skipped)\n", policyDir)
 		return nil
 	}
 	sort.Strings(updatedNames)
+	sort.Strings(preserved)
 	if dryRun {
-		fmt.Fprintf(out, "  Would update: %s\n", strings.Join(updatedNames, ", "))
-	} else {
+		if len(updatedNames) > 0 {
+			fmt.Fprintf(out, "  Would update: %s\n", strings.Join(updatedNames, ", "))
+		}
+	} else if len(updatedNames) > 0 {
 		fmt.Fprintf(out, "Updated: %s\n", strings.Join(updatedNames, ", "))
+	}
+	if len(preserved) > 0 {
+		fmt.Fprintf(out, "Preserved modified: %s\n", strings.Join(preserved, ", "))
 	}
 	return nil
 }

--- a/cmd/rampart/cli/upgrade_test.go
+++ b/cmd/rampart/cli/upgrade_test.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/peg/rampart/internal/build"
 	"github.com/peg/rampart/policies"
 )
 
@@ -188,7 +189,12 @@ func TestNewUpgradeCmdPreservesModifiedBuiltInPolicy(t *testing.T) {
 		t.Fatalf("mkdir: %v", err)
 	}
 	standardPath := filepath.Join(policyDir, "standard.yaml")
-	modified := []byte("# rampart-policy-version: 0.9.19\nversion: \"1\"\npolicies:\n  - name: local-rule\n")
+	standard, err := policies.Profile("standard")
+	if err != nil {
+		t.Fatalf("embedded standard profile: %v", err)
+	}
+	modified := append([]byte("# rampart-policy-version: "+build.Version+"\n"), standard...)
+	modified = append(modified, []byte("\n# local customization\n")...)
 	if err := os.WriteFile(standardPath, modified, 0o644); err != nil {
 		t.Fatalf("write modified policy: %v", err)
 	}
@@ -220,6 +226,57 @@ func TestNewUpgradeCmdPreservesModifiedBuiltInPolicy(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "Preserved modified: standard.yaml") {
 		t.Fatalf("expected preserved-modified output, got %q", out.String())
+	}
+}
+
+func TestNewUpgradeCmdFlagsStaleBuiltInForReview(t *testing.T) {
+	if build.Version == "dev" {
+		t.Skip("stale-version detection disabled for dev builds")
+	}
+	dir := t.TempDir()
+	testSetHome(t, dir)
+
+	policyDir := filepath.Join(dir, ".rampart", "policies")
+	if err := os.MkdirAll(policyDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	standardPath := filepath.Join(policyDir, "standard.yaml")
+	standard, err := policies.Profile("standard")
+	if err != nil {
+		t.Fatalf("embedded standard profile: %v", err)
+	}
+	stale := append([]byte("# rampart-policy-version: 0.0.1\n"), standard...)
+	if err := os.WriteFile(standardPath, stale, 0o644); err != nil {
+		t.Fatalf("write stale policy: %v", err)
+	}
+
+	deps := &upgradeDeps{
+		currentVersion: func(context.Context, commandRunner, func() (string, error)) (string, error) {
+			return "v1.2.3", nil
+		},
+		latestRelease: func(context.Context, *http.Client, string) (string, error) {
+			return "v1.2.3", nil
+		},
+	}
+
+	var out bytes.Buffer
+	cmd := newUpgradeCmdWithDeps(&rootOptions{}, deps)
+	cmd.SetOut(&out)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"--yes"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	got, err := os.ReadFile(standardPath)
+	if err != nil {
+		t.Fatalf("read policy: %v", err)
+	}
+	if !bytes.Equal(got, stale) {
+		t.Fatal("expected stale built-in policy to be left unchanged pending review")
+	}
+	if !strings.Contains(out.String(), "Review stale built-ins: standard.yaml") {
+		t.Fatalf("expected stale review output, got %q", out.String())
 	}
 }
 
@@ -530,6 +587,27 @@ func TestUpgradeStandardPoliciesUpdatesBuiltIns(t *testing.T) {
 
 	if !strings.Contains(out.String(), "Updated: block-prompt-injection.yaml, standard.yaml") {
 		t.Fatalf("missing updated summary line: %q", out.String())
+	}
+}
+
+func TestUpgradeStandardPoliciesNoBuiltInsFound(t *testing.T) {
+	dir := t.TempDir()
+	testSetHome(t, dir)
+
+	policyDir := filepath.Join(dir, ".rampart", "policies")
+	if err := os.MkdirAll(policyDir, 0o755); err != nil {
+		t.Fatalf("mkdir policy dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(policyDir, "custom.yaml"), []byte("version: \"1\"\n"), 0o644); err != nil {
+		t.Fatalf("write custom policy: %v", err)
+	}
+
+	var out bytes.Buffer
+	if err := upgradeStandardPolicies(&out, false); err != nil {
+		t.Fatalf("upgradeStandardPolicies: %v", err)
+	}
+	if !strings.Contains(out.String(), "no built-in policy files found") {
+		t.Fatalf("expected no-built-ins message, got %q", out.String())
 	}
 }
 

--- a/cmd/rampart/cli/upgrade_test.go
+++ b/cmd/rampart/cli/upgrade_test.go
@@ -126,9 +126,9 @@ func TestNewUpgradeCmdAlreadyLatest(t *testing.T) {
 	}
 }
 
-func TestNewUpgradeCmdAlreadyLatestStillRefreshesPolicy(t *testing.T) {
+func TestNewUpgradeCmdAlreadyLatestStillRefreshesStockPolicy(t *testing.T) {
 	// Regression test: when already on latest, upgrade should still refresh
-	// installed policy files from the embedded binary.
+	// a stock installed policy so it picks up version stamping and embedded changes.
 	dir := t.TempDir()
 	testSetHome(t, dir)
 
@@ -137,8 +137,12 @@ func TestNewUpgradeCmdAlreadyLatestStillRefreshesPolicy(t *testing.T) {
 		t.Fatalf("mkdir: %v", err)
 	}
 	standardPath := filepath.Join(policyDir, "standard.yaml")
-	if err := os.WriteFile(standardPath, []byte("old-stale-policy"), 0o644); err != nil {
-		t.Fatalf("write stale policy: %v", err)
+	standard, err := policies.Profile("standard")
+	if err != nil {
+		t.Fatalf("embedded standard profile: %v", err)
+	}
+	if err := os.WriteFile(standardPath, standard, 0o644); err != nil {
+		t.Fatalf("write stock policy: %v", err)
 	}
 
 	deps := &upgradeDeps{
@@ -163,8 +167,59 @@ func TestNewUpgradeCmdAlreadyLatestStillRefreshesPolicy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read policy: %v", err)
 	}
-	if string(got) == "old-stale-policy" {
-		t.Fatal("policy was not refreshed even though already on latest version")
+	if bytes.Equal(got, standard) {
+		t.Fatal("expected stock policy to be rewritten with a version stamp")
+	}
+	if !bytes.HasPrefix(got, []byte("# rampart-policy-version: ")) {
+		snippet := string(got)
+		if len(snippet) > 40 {
+			snippet = snippet[:40]
+		}
+		t.Fatalf("expected version stamp after refresh, got %q", snippet)
+	}
+}
+
+func TestNewUpgradeCmdPreservesModifiedBuiltInPolicy(t *testing.T) {
+	dir := t.TempDir()
+	testSetHome(t, dir)
+
+	policyDir := filepath.Join(dir, ".rampart", "policies")
+	if err := os.MkdirAll(policyDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	standardPath := filepath.Join(policyDir, "standard.yaml")
+	modified := []byte("# rampart-policy-version: 0.9.19\nversion: \"1\"\npolicies:\n  - name: local-rule\n")
+	if err := os.WriteFile(standardPath, modified, 0o644); err != nil {
+		t.Fatalf("write modified policy: %v", err)
+	}
+
+	deps := &upgradeDeps{
+		currentVersion: func(context.Context, commandRunner, func() (string, error)) (string, error) {
+			return "v1.2.3", nil
+		},
+		latestRelease: func(context.Context, *http.Client, string) (string, error) {
+			return "v1.2.3", nil
+		},
+	}
+
+	var out bytes.Buffer
+	cmd := newUpgradeCmdWithDeps(&rootOptions{}, deps)
+	cmd.SetOut(&out)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"--yes"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	got, err := os.ReadFile(standardPath)
+	if err != nil {
+		t.Fatalf("read policy: %v", err)
+	}
+	if !bytes.Equal(got, modified) {
+		t.Fatal("expected modified built-in policy to be preserved")
+	}
+	if !strings.Contains(out.String(), "Preserved modified: standard.yaml") {
+		t.Fatalf("expected preserved-modified output, got %q", out.String())
 	}
 }
 
@@ -427,10 +482,18 @@ func TestUpgradeStandardPoliciesUpdatesBuiltIns(t *testing.T) {
 
 	standardPath := filepath.Join(policyDir, "standard.yaml")
 	blockPath := filepath.Join(policyDir, "block-prompt-injection.yaml")
-	if err := os.WriteFile(standardPath, []byte("old-standard"), 0o644); err != nil {
+	stockStandard, err := policies.Profile("standard")
+	if err != nil {
+		t.Fatalf("load standard profile: %v", err)
+	}
+	stockBlock, err := policies.Profile("block-prompt-injection")
+	if err != nil {
+		t.Fatalf("load block-prompt-injection profile: %v", err)
+	}
+	if err := os.WriteFile(standardPath, stockStandard, 0o644); err != nil {
 		t.Fatalf("write standard: %v", err)
 	}
-	if err := os.WriteFile(blockPath, []byte("old-block"), 0o644); err != nil {
+	if err := os.WriteFile(blockPath, stockBlock, 0o644); err != nil {
 		t.Fatalf("write block-prompt-injection: %v", err)
 	}
 
@@ -594,8 +657,8 @@ func TestExtractRampartBinaryFromZip_GoreleaserLayout(t *testing.T) {
 	// Goreleaser produces: rampart_0.7.1_windows_amd64/rampart.exe
 	archive := makeZipArchive(t, map[string][]byte{
 		"rampart_0.7.1_windows_amd64/rampart.exe": []byte("real-windows-binary"),
-		"rampart_0.7.1_windows_amd64/LICENSE":      []byte("Apache 2.0"),
-		"rampart_0.7.1_windows_amd64/README.md":    []byte("# Rampart"),
+		"rampart_0.7.1_windows_amd64/LICENSE":     []byte("Apache 2.0"),
+		"rampart_0.7.1_windows_amd64/README.md":   []byte("# Rampart"),
 	})
 	got, err := extractRampartBinaryFromZip(archive)
 	if err != nil {


### PR DESCRIPTION
## Summary
- teach doctor to distinguish stock built-in policies from customized ones
- warn when a stock built-in profile is unstamped/stale and clearly label customized built-ins
- preserve modified built-in profiles during upgrade instead of overwriting them
- stamp policies written by setup so future drift checks are reliable

## Testing
- go test ./cmd/rampart/cli/... -count=1
