### PR TITLE
fix: harden OpenClaw approval fallback behavior

### DIFF
--- a/cmd/rampart/cli/doctor.go
+++ b/cmd/rampart/cli/doctor.go
@@ -31,6 +31,7 @@ import (
 	"github.com/peg/rampart/internal/build"
 	"github.com/peg/rampart/internal/detect"
 	"github.com/peg/rampart/internal/engine"
+	ochardening "github.com/peg/rampart/internal/openclaw/hardening"
 	"github.com/spf13/cobra"
 )
 
@@ -83,10 +84,20 @@ func runDoctorFix(cmd *cobra.Command) error {
 	needsLegacyPatch := !openclawWebFetchPatched() || !openclawBrowserPatched() ||
 		!openclawMessagePatched() || !openclawDistPatched() ||
 		(!pluginInstalled && !openclawExecPatched())
+	hardeningHealthy := openclawApprovalHardeningHealthy()
 
-	if pluginHealthy && !needsLegacyPatch {
+	if pluginHealthy && !needsLegacyPatch && hardeningHealthy {
 		fmt.Fprintln(cmd.OutOrStdout(), "✓ OpenClaw protection already looks healthy — nothing to fix.")
 		return nil
+	}
+	if pluginHealthy && !needsLegacyPatch && !hardeningHealthy {
+		fmt.Fprintln(cmd.OutOrStdout(), "Repairing OpenClaw approval hardening...")
+		if err := ensureOpenClawApprovalHardening(cmd.OutOrStdout(), cmd.ErrOrStderr()); err == nil {
+			fmt.Fprintln(cmd.OutOrStdout(), "✓ OpenClaw approval hardening repaired.")
+			return nil
+		} else {
+			fmt.Fprintf(cmd.ErrOrStderr(), "⚠ Approval hardening repair failed: %v\n", err)
+		}
 	}
 
 	if isOpenClawInstalled() {
@@ -253,6 +264,9 @@ func runDoctor(w io.Writer, jsonOut bool) error {
 		warnings += n
 	}
 	if n := doctorOpenClawReadiness(emit, pluginActive, serveURL, token); n > 0 {
+		warnings += n
+	}
+	if n := doctorOpenClawApprovalHardening(emit); n > 0 {
 		warnings += n
 	}
 
@@ -1420,6 +1434,59 @@ func doctorOpenClawReadiness(emit emitFn, pluginActive bool, serveURL, token str
 
 	emit("OpenClaw readiness", "ok", fmt.Sprintf("plugin active; serve reachable at %s; approval learning prerequisites present", serveURL))
 	return 0
+}
+
+func doctorOpenClawApprovalHardening(emit emitFn) (warnings int) {
+	if !isOpenClawInstalled() {
+		return 0
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return 0
+	}
+	state, err := ochardening.Inspect(home, openclawDistCandidates())
+	if err != nil {
+		emit("OpenClaw approvals", "warn", fmt.Sprintf("failed to inspect approval hardening: %v", err)+hintSep+
+			"rampart doctor --fix")
+		return 1
+	}
+	if state.ExecApprovalsPath == "" || state.BashToolsPath == "" {
+		emit("OpenClaw approvals", "warn", "approval bundles not found in supported dist paths"+hintSep+
+			"rampart doctor --fix")
+		return 1
+	}
+	if !state.Supported {
+		emit("OpenClaw approvals", "warn", "unsupported OpenClaw build shape; refusing blind approval patching"+hintSep+
+			"update Rampart or inspect the installed OpenClaw dist before patching")
+		return 1
+	}
+	if !state.FallbackSafe || !state.CompletionAttributionSafe {
+		emit("OpenClaw approvals", "warn", "approval fallback is not fail-closed or completion attribution is misleading"+hintSep+
+			"rampart doctor --fix")
+		warnings++
+	} else {
+		emit("OpenClaw approvals", "ok", "approval fallback is fail-closed and completion attribution is truthful")
+	}
+	if !state.ApprovalTimeoutAligned || !state.PluginApprovalTimeoutAligned {
+		emit("OpenClaw approval timeout", "warn", fmt.Sprintf("not aligned to %dms", ochardening.DesiredApprovalTimeoutMs)+hintSep+
+			"rampart doctor --fix")
+		warnings++
+	} else {
+		emit("OpenClaw approval timeout", "ok", fmt.Sprintf("aligned at %dms", ochardening.DesiredApprovalTimeoutMs))
+	}
+	return warnings
+}
+
+func openclawApprovalHardeningHealthy() bool {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return false
+	}
+	state, err := ochardening.Inspect(home, openclawDistCandidates())
+	if err != nil {
+		return false
+	}
+	return state.Supported && state.FallbackSafe && state.CompletionAttributionSafe && state.ApprovalTimeoutAligned && state.PluginApprovalTimeoutAligned
 }
 
 // doctorOpenClawAskMode checks if ~/.openclaw/openclaw.json has ask set to

--- a/cmd/rampart/cli/doctor_test.go
+++ b/cmd/rampart/cli/doctor_test.go
@@ -458,6 +458,51 @@ func TestDoctorOpenClawReadiness(t *testing.T) {
 	})
 }
 
+func TestDoctorOpenClawApprovalHardening(t *testing.T) {
+	skipOnWindows(t, "PATH shim binaries in this test are Unix-only")
+	home := t.TempDir()
+	testSetHome(t, home)
+	binDir := t.TempDir()
+	openclawBin := filepath.Join(binDir, "openclaw")
+	requireNoErr(t, os.WriteFile(openclawBin, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	t.Setenv("PATH", binDir)
+	requireNoErr(t, os.MkdirAll(filepath.Join(home, ".openclaw", "extensions", "rampart"), 0o755))
+	requireNoErr(t, os.MkdirAll(filepath.Join(home, ".openclaw"), 0o755))
+	requireNoErr(t, os.MkdirAll(filepath.Join(home, ".local", "lib", "node_modules", "openclaw", "dist"), 0o755))
+	requireNoErr(t, os.WriteFile(filepath.Join(home, ".local", "lib", "node_modules", "openclaw", "dist", "exec-approvals-test.js"), []byte(`const DEFAULT_EXEC_APPROVAL_TIMEOUT_MS = 18e5;
+const DEFAULT_EXEC_APPROVAL_ASK_FALLBACK = "full";
+const fallbackAskFallback = params.overrides?.askFallback ?? "full";
+`), 0o644))
+	requireNoErr(t, os.WriteFile(filepath.Join(home, ".local", "lib", "node_modules", "openclaw", "dist", "bash-tools-test.js"), []byte(`return ["An async command the user already approved has completed."].join("\n");
+if (!params.decision) {
+		if (params.askFallback === "full") return {
+			approvedByAsk: true,
+			deniedReason: null,
+			timedOut: true
+		};
+		if (params.askFallback === "deny") return {
+			approvedByAsk: false,
+			deniedReason: "approval-timeout",
+			timedOut: true
+		};
+}
+`), 0o644))
+	requireNoErr(t, os.WriteFile(filepath.Join(home, ".openclaw", "openclaw.json"), []byte(`{"plugins":{"entries":{"rampart":{"config":{"approvalTimeoutMs":300000}}}}}
+`), 0o644))
+
+	var results []checkResult
+	emit := func(name, status, msg string) {
+		results = append(results, checkResult{Name: name, Status: status, Message: msg})
+	}
+	warnings := doctorOpenClawApprovalHardening(emit)
+	if warnings != 2 {
+		t.Fatalf("expected two warnings, got %d (%+v)", warnings, results)
+	}
+	if len(results) != 2 || results[0].Status != "warn" || results[1].Status != "warn" {
+		t.Fatalf("expected warn results, got %+v", results)
+	}
+}
+
 func requireNoErr(t *testing.T, err error) {
 	t.Helper()
 	if err != nil {

--- a/cmd/rampart/cli/setup_openclaw_plugin.go
+++ b/cmd/rampart/cli/setup_openclaw_plugin.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	ochardening "github.com/peg/rampart/internal/openclaw/hardening"
 	ocplugin "github.com/peg/rampart/internal/plugin/openclaw"
 	"github.com/peg/rampart/policies"
 )
@@ -125,6 +126,14 @@ func runSetupOpenClawPlugin(w io.Writer, errW io.Writer) error {
 		fmt.Fprintln(w, "✓ rampart already in plugins.allow (no changes to other plugins)")
 	}
 
+	// 4c. Harden OpenClaw approval semantics and align approval timeouts.
+	if err := ensureOpenClawApprovalHardening(w, errW); err != nil {
+		fmt.Fprintf(errW, "⚠ Could not harden OpenClaw approvals: %v\n", err)
+		fmt.Fprintln(errW, "  Run `rampart doctor --fix` after reviewing the detected OpenClaw build shape.")
+	} else {
+		fmt.Fprintf(w, "✓ OpenClaw approval handling hardened (fail-closed fallback, truthful completion text, %dms timeout)\n", ochardening.DesiredApprovalTimeoutMs)
+	}
+
 	// 5. Copy openclaw.yaml policy profile.
 	if err := installOpenClawPolicy(w, errW); err != nil {
 		fmt.Fprintf(errW, "⚠ Could not install openclaw.yaml policy: %v\n", err)
@@ -152,10 +161,74 @@ func runSetupOpenClawPlugin(w io.Writer, errW io.Writer) error {
 	fmt.Fprintf(w, "  Policy engine:   %s\n", serveStatus)
 	fmt.Fprintln(w, "  Audit log:       ~/.rampart/audit/")
 	fmt.Fprintln(w, "")
-	fmt.Fprintln(w, "  → Restart the gateway:  systemctl --user restart openclaw-gateway.service")
+	fmt.Fprintln(w, "  → Restart the gateway if it was not restarted automatically:  systemctl --user restart openclaw-gateway.service")
 	fmt.Fprintln(w, "  → Run `rampart watch` to see policy decisions in real time")
 	fmt.Fprintln(w, "  → Run `rampart doctor` to verify your setup")
 
+	return nil
+}
+
+func ensureOpenClawApprovalHardening(w io.Writer, errW io.Writer) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("resolve home: %w", err)
+	}
+	state, err := ochardening.Inspect(home, openclawDistCandidates())
+	if err != nil {
+		return fmt.Errorf("inspect current hardening state: %w", err)
+	}
+	if state.ExecApprovalsPath == "" || state.BashToolsPath == "" {
+		return fmt.Errorf("openclaw approval bundles not found under supported dist paths")
+	}
+	if !state.Supported {
+		return fmt.Errorf("unsupported OpenClaw approval bundle shape; refusing blind patch")
+	}
+	if state.FallbackSafe && state.CompletionAttributionSafe && state.ApprovalTimeoutAligned && state.PluginApprovalTimeoutAligned {
+		fmt.Fprintln(w, "✓ OpenClaw approval semantics already hardened and timeout-aligned")
+		return nil
+	}
+	result, err := ochardening.Apply(home, openclawDistCandidates())
+	if err != nil {
+		return fmt.Errorf("apply approval hardening: %w", err)
+	}
+	for _, path := range result.PatchedFiles {
+		fmt.Fprintf(w, "  Hardened %s\n", filepath.Base(path))
+	}
+	if result.ConfigUpdated {
+		fmt.Fprintf(w, "  Set plugins.entries.rampart.config.approvalTimeoutMs = %d\n", ochardening.DesiredApprovalTimeoutMs)
+	}
+	if result.RestartSuggested {
+		if err := restartOpenClawGateway(); err != nil {
+			fmt.Fprintf(errW, "⚠ Approval hardening applied, but automatic gateway restart failed: %v\n", err)
+			fmt.Fprintln(errW, "  Restart manually: systemctl --user restart openclaw-gateway.service")
+		} else {
+			fmt.Fprintln(w, "  Restarted OpenClaw gateway to activate approval hardening")
+		}
+	}
+	return nil
+}
+
+func restartOpenClawGateway() error {
+	openclawBin, err := findOpenClawBinary()
+	if err == nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		cmd := osexec.CommandContext(ctx, openclawBin, "gateway", "restart")
+		if out, runErr := cmd.CombinedOutput(); runErr == nil {
+			return nil
+		} else if len(out) > 0 {
+			return fmt.Errorf("openclaw gateway restart: %w: %s", runErr, strings.TrimSpace(string(out)))
+		}
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cmd := osexec.CommandContext(ctx, "systemctl", "--user", "restart", "openclaw-gateway.service")
+	if out, runErr := cmd.CombinedOutput(); runErr != nil {
+		if len(out) > 0 {
+			return fmt.Errorf("systemctl restart: %w: %s", runErr, strings.TrimSpace(string(out)))
+		}
+		return fmt.Errorf("systemctl restart: %w", runErr)
+	}
 	return nil
 }
 

--- a/internal/bridge/openclaw.go
+++ b/internal/bridge/openclaw.go
@@ -552,7 +552,7 @@ func (b *OpenClawBridge) writeAllowAlwaysRule(command string) {
 		b.logger.Error("bridge: allow-always: close temp file", "error", cerr)
 		return
 	}
-	if rerr := os.Rename(tmpPath, overridesPath); rerr != nil {
+	if rerr := replaceFileWithRetries(tmpPath, overridesPath); rerr != nil {
 		os.Remove(tmpPath)
 		b.logger.Error("bridge: allow-always: rename to final path", "error", rerr)
 		return
@@ -564,6 +564,24 @@ func (b *OpenClawBridge) writeAllowAlwaysRule(command string) {
 	if err := b.engine.Reload(); err != nil {
 		b.logger.Warn("bridge: allow-always: engine reload failed", "error", err)
 	}
+}
+
+func replaceFileWithRetries(tmpPath, destPath string) error {
+	var lastErr error
+	for attempt := 0; attempt < 6; attempt++ {
+		if err := os.Rename(tmpPath, destPath); err == nil {
+			return nil
+		} else {
+			lastErr = err
+			if runtime.GOOS == "windows" {
+				if removeErr := os.Remove(destPath); removeErr != nil && !os.IsNotExist(removeErr) {
+					lastErr = fmt.Errorf("rename %s -> %s: %w (remove existing: %v)", tmpPath, destPath, err, removeErr)
+				}
+			}
+			time.Sleep(time.Duration(attempt+1) * 25 * time.Millisecond)
+		}
+	}
+	return lastErr
 }
 
 // commandHash returns the first 8 hex characters of the SHA-256 hash of s.

--- a/internal/openclaw/hardening/hardening.go
+++ b/internal/openclaw/hardening/hardening.go
@@ -1,0 +1,278 @@
+package hardening
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+const (
+	DesiredApprovalTimeoutMs = 120000
+	backupSuffix             = ".rampart-approval-hardening-backup"
+)
+
+type State struct {
+	ConfigPath                   string
+	DistDir                      string
+	ExecApprovalsPath            string
+	BashToolsPath                string
+	Supported                    bool
+	FallbackSafe                 bool
+	CompletionAttributionSafe    bool
+	ApprovalTimeoutAligned       bool
+	PluginApprovalTimeoutAligned bool
+}
+
+type ApplyResult struct {
+	ConfigUpdated    bool
+	PatchedFiles     []string
+	RestartSuggested bool
+}
+
+type replacement struct {
+	old string
+	new string
+}
+
+type patchTarget struct {
+	path         string
+	replacements []replacement
+}
+
+type openClawConfig struct {
+	Plugins struct {
+		Entries map[string]struct {
+			Config map[string]any `json:"config"`
+		} `json:"entries"`
+	} `json:"plugins"`
+}
+
+func Inspect(home string, distCandidates []string) (State, error) {
+	state := State{ConfigPath: filepath.Join(home, ".openclaw", "openclaw.json")}
+	if path, ok := findDistFile(distCandidates, "exec-approvals-*.js"); ok {
+		state.ExecApprovalsPath = path
+		state.DistDir = filepath.Dir(path)
+	}
+	if path, ok := findDistFile(distCandidates, "bash-tools-*.js"); ok {
+		state.BashToolsPath = path
+		if state.DistDir == "" {
+			state.DistDir = filepath.Dir(path)
+		}
+	}
+	if state.ExecApprovalsPath == "" || state.BashToolsPath == "" {
+		return state, nil
+	}
+
+	execText, err := os.ReadFile(state.ExecApprovalsPath)
+	if err != nil {
+		return state, fmt.Errorf("read exec approvals bundle: %w", err)
+	}
+	bashText, err := os.ReadFile(state.BashToolsPath)
+	if err != nil {
+		return state, fmt.Errorf("read bash tools bundle: %w", err)
+	}
+	state.FallbackSafe = strings.Contains(string(execText), `const DEFAULT_EXEC_APPROVAL_ASK_FALLBACK = "deny";`) &&
+		strings.Contains(string(execText), `const fallbackAskFallback = params.overrides?.askFallback ?? DEFAULT_EXEC_APPROVAL_ASK_FALLBACK;`)
+	state.ApprovalTimeoutAligned = strings.Contains(string(execText), `const DEFAULT_EXEC_APPROVAL_TIMEOUT_MS = 12e4;`) ||
+		strings.Contains(string(execText), `const DEFAULT_EXEC_APPROVAL_TIMEOUT_MS = 120000;`)
+	state.CompletionAttributionSafe = strings.Contains(string(bashText), `"An async approved command has completed."`) &&
+		strings.Contains(string(bashText), `if (params.askFallback === "deny" || params.askFallback === "full") return {`)
+	state.Supported = supportsExecApprovalsShape(string(execText)) && supportsBashToolsShape(string(bashText))
+
+	aligned, _, err := pluginApprovalTimeoutAligned(state.ConfigPath)
+	if err == nil {
+		state.PluginApprovalTimeoutAligned = aligned
+	}
+	return state, nil
+}
+
+func Apply(home string, distCandidates []string) (ApplyResult, error) {
+	state, err := Inspect(home, distCandidates)
+	if err != nil {
+		return ApplyResult{}, err
+	}
+	if state.ExecApprovalsPath == "" || state.BashToolsPath == "" {
+		return ApplyResult{}, fmt.Errorf("openclaw approval bundles not found")
+	}
+	if !state.Supported {
+		return ApplyResult{}, fmt.Errorf("unsupported OpenClaw approval bundle shape")
+	}
+
+	targets := []patchTarget{
+		{
+			path: state.ExecApprovalsPath,
+			replacements: []replacement{
+				{old: `const DEFAULT_EXEC_APPROVAL_TIMEOUT_MS = 18e5;`, new: `const DEFAULT_EXEC_APPROVAL_TIMEOUT_MS = 12e4;`},
+				{old: `const DEFAULT_EXEC_APPROVAL_ASK_FALLBACK = "full";`, new: `const DEFAULT_EXEC_APPROVAL_ASK_FALLBACK = "deny";`},
+				{old: `const fallbackAskFallback = params.overrides?.askFallback ?? "full";`, new: `const fallbackAskFallback = params.overrides?.askFallback ?? DEFAULT_EXEC_APPROVAL_ASK_FALLBACK;`},
+			},
+		},
+		{
+			path: state.BashToolsPath,
+			replacements: []replacement{
+				{old: `"An async command the user already approved has completed."`, new: `"An async approved command has completed."`},
+				{old: "if (params.askFallback === \"full\") return {\n\t\t\tapprovedByAsk: true,\n\t\t\tdeniedReason: null,\n\t\t\ttimedOut: true\n\t\t};\n\t\tif (params.askFallback === \"deny\") return {\n\t\t\tapprovedByAsk: false,\n\t\t\tdeniedReason: \"approval-timeout\",\n\t\t\ttimedOut: true\n\t\t};", new: "if (params.askFallback === \"deny\" || params.askFallback === \"full\") return {\n\t\t\tapprovedByAsk: false,\n\t\t\tdeniedReason: \"approval-timeout\",\n\t\t\ttimedOut: true\n\t\t};"},
+			},
+		},
+	}
+
+	result := ApplyResult{}
+	for _, target := range targets {
+		patched, err := applyReplacements(target)
+		if err != nil {
+			return ApplyResult{}, err
+		}
+		if patched {
+			result.PatchedFiles = append(result.PatchedFiles, target.path)
+		}
+	}
+
+	updated, err := ensurePluginApprovalTimeout(state.ConfigPath, DesiredApprovalTimeoutMs)
+	if err != nil {
+		return ApplyResult{}, err
+	}
+	result.ConfigUpdated = updated
+	result.RestartSuggested = updated || len(result.PatchedFiles) > 0
+	return result, nil
+}
+
+func findDistFile(candidates []string, pattern string) (string, bool) {
+	for _, dir := range candidates {
+		matches, _ := filepath.Glob(filepath.Join(dir, pattern))
+		sort.Strings(matches)
+		if len(matches) > 0 {
+			return matches[0], true
+		}
+	}
+	return "", false
+}
+
+func supportsExecApprovalsShape(text string) bool {
+	return (strings.Contains(text, `const DEFAULT_EXEC_APPROVAL_ASK_FALLBACK = "full";`) || strings.Contains(text, `const DEFAULT_EXEC_APPROVAL_ASK_FALLBACK = "deny";`)) &&
+		(strings.Contains(text, `const DEFAULT_EXEC_APPROVAL_TIMEOUT_MS = 18e5;`) || strings.Contains(text, `const DEFAULT_EXEC_APPROVAL_TIMEOUT_MS = 12e4;`) || strings.Contains(text, `const DEFAULT_EXEC_APPROVAL_TIMEOUT_MS = 120000;`))
+}
+
+func supportsBashToolsShape(text string) bool {
+	return (strings.Contains(text, `"An async command the user already approved has completed."`) || strings.Contains(text, `"An async approved command has completed."`)) &&
+		(strings.Contains(text, `if (params.askFallback === "full") return {`) || strings.Contains(text, `if (params.askFallback === "deny" || params.askFallback === "full") return {`))
+}
+
+func applyReplacements(target patchTarget) (bool, error) {
+	content, err := os.ReadFile(target.path)
+	if err != nil {
+		return false, fmt.Errorf("read %s: %w", filepath.Base(target.path), err)
+	}
+	text := string(content)
+	modified := text
+	changed := false
+	for _, rep := range target.replacements {
+		if strings.Contains(modified, rep.new) {
+			continue
+		}
+		if !strings.Contains(modified, rep.old) {
+			return false, fmt.Errorf("patch %s: expected marker not found", filepath.Base(target.path))
+		}
+		modified = strings.Replace(modified, rep.old, rep.new, 1)
+		changed = true
+	}
+	if !changed {
+		return false, nil
+	}
+	backupPath := target.path + backupSuffix
+	if _, err := os.Stat(backupPath); os.IsNotExist(err) {
+		if err := os.WriteFile(backupPath, content, 0o644); err != nil {
+			return false, fmt.Errorf("backup %s: %w", filepath.Base(target.path), err)
+		}
+	}
+	if err := os.WriteFile(target.path, []byte(modified), 0o644); err != nil {
+		return false, fmt.Errorf("write %s: %w", filepath.Base(target.path), err)
+	}
+	return true, nil
+}
+
+func pluginApprovalTimeoutAligned(configPath string) (bool, int, error) {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return true, DesiredApprovalTimeoutMs, nil
+		}
+		return false, 0, err
+	}
+	var cfg openClawConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return false, 0, err
+	}
+	entry, ok := cfg.Plugins.Entries["rampart"]
+	if !ok || entry.Config == nil {
+		return true, DesiredApprovalTimeoutMs, nil
+	}
+	raw, ok := entry.Config["approvalTimeoutMs"]
+	if !ok {
+		return true, DesiredApprovalTimeoutMs, nil
+	}
+	value, ok := asInt(raw)
+	if !ok {
+		return false, 0, fmt.Errorf("plugins.entries.rampart.config.approvalTimeoutMs is not numeric")
+	}
+	return value == DesiredApprovalTimeoutMs, value, nil
+}
+
+func ensurePluginApprovalTimeout(configPath string, timeoutMs int) (bool, error) {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return false, err
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return false, err
+	}
+	plugins, _ := raw["plugins"].(map[string]any)
+	if plugins == nil {
+		plugins = map[string]any{}
+		raw["plugins"] = plugins
+	}
+	entries, _ := plugins["entries"].(map[string]any)
+	if entries == nil {
+		entries = map[string]any{}
+		plugins["entries"] = entries
+	}
+	entry, _ := entries["rampart"].(map[string]any)
+	if entry == nil {
+		entry = map[string]any{}
+		entries["rampart"] = entry
+	}
+	config, _ := entry["config"].(map[string]any)
+	if config == nil {
+		config = map[string]any{}
+		entry["config"] = config
+	}
+	if current, ok := asInt(config["approvalTimeoutMs"]); ok && current == timeoutMs {
+		return false, nil
+	}
+	config["approvalTimeoutMs"] = timeoutMs
+	out, err := json.MarshalIndent(raw, "", "  ")
+	if err != nil {
+		return false, err
+	}
+	out = append(out, '\n')
+	if err := os.WriteFile(configPath, out, 0o600); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func asInt(value any) (int, bool) {
+	switch v := value.(type) {
+	case int:
+		return v, true
+	case int64:
+		return int(v), true
+	case float64:
+		return int(v), true
+	default:
+		return 0, false
+	}
+}

--- a/internal/openclaw/hardening/hardening_test.go
+++ b/internal/openclaw/hardening/hardening_test.go
@@ -1,0 +1,143 @@
+package hardening
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const execApprovalsPre = `const DEFAULT_EXEC_APPROVAL_TIMEOUT_MS = 18e5;
+const DEFAULT_EXEC_APPROVAL_ASK_FALLBACK = "full";
+const fallbackAskFallback = params.overrides?.askFallback ?? "full";
+`
+
+const execApprovalsPost = `const DEFAULT_EXEC_APPROVAL_TIMEOUT_MS = 12e4;
+const DEFAULT_EXEC_APPROVAL_ASK_FALLBACK = "deny";
+const fallbackAskFallback = params.overrides?.askFallback ?? DEFAULT_EXEC_APPROVAL_ASK_FALLBACK;
+`
+
+const bashToolsPre = `return [
+		"An async command the user already approved has completed.",
+].join("\n");
+if (!params.decision) {
+		if (params.askFallback === "full") return {
+			approvedByAsk: true,
+			deniedReason: null,
+			timedOut: true
+		};
+		if (params.askFallback === "deny") return {
+			approvedByAsk: false,
+			deniedReason: "approval-timeout",
+			timedOut: true
+		};
+}
+`
+
+const bashToolsPost = `return [
+		"An async approved command has completed.",
+].join("\n");
+if (!params.decision) {
+		if (params.askFallback === "deny" || params.askFallback === "full") return {
+			approvedByAsk: false,
+			deniedReason: "approval-timeout",
+			timedOut: true
+		};
+}
+`
+
+func TestInspectPrePatch(t *testing.T) {
+	home, dist := setupFixture(t, execApprovalsPre, bashToolsPre, "{}\n")
+	state, err := Inspect(home, []string{dist})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !state.Supported {
+		t.Fatal("expected supported build shape")
+	}
+	if state.FallbackSafe || state.CompletionAttributionSafe || state.ApprovalTimeoutAligned {
+		t.Fatalf("expected unsafe pre-patch state: %+v", state)
+	}
+	if !state.PluginApprovalTimeoutAligned {
+		t.Fatalf("expected plugin timeout to be aligned by default: %+v", state)
+	}
+}
+
+func TestApplyPatchesAndAlignsConfig(t *testing.T) {
+	home, dist := setupFixture(t, execApprovalsPre, bashToolsPre, "{\"plugins\":{\"entries\":{\"rampart\":{\"config\":{\"approvalTimeoutMs\":300000}}}}}\n")
+	result, err := Apply(home, []string{dist})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.PatchedFiles) != 2 {
+		t.Fatalf("expected 2 patched files, got %+v", result)
+	}
+	if !result.ConfigUpdated || !result.RestartSuggested {
+		t.Fatalf("expected config update + restart suggestion, got %+v", result)
+	}
+	state, err := Inspect(home, []string{dist})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !state.FallbackSafe || !state.CompletionAttributionSafe || !state.ApprovalTimeoutAligned || !state.PluginApprovalTimeoutAligned {
+		t.Fatalf("expected hardened/aligned state, got %+v", state)
+	}
+	execData := mustRead(t, state.ExecApprovalsPath)
+	if !strings.Contains(execData, `DEFAULT_EXEC_APPROVAL_ASK_FALLBACK = "deny"`) {
+		t.Fatalf("expected fallback patch, got %s", execData)
+	}
+	bashData := mustRead(t, state.BashToolsPath)
+	if !strings.Contains(bashData, `An async approved command has completed.`) {
+		t.Fatalf("expected wording patch, got %s", bashData)
+	}
+}
+
+func TestApplyRejectsUnsupportedShape(t *testing.T) {
+	home, dist := setupFixture(t, "const nope = true;", bashToolsPre, "{}\n")
+	if _, err := Apply(home, []string{dist}); err == nil {
+		t.Fatal("expected unsupported shape error")
+	}
+}
+
+func TestApplyIsIdempotentWhenAlreadyHardened(t *testing.T) {
+	home, dist := setupFixture(t, execApprovalsPost, bashToolsPost, "{\"plugins\":{\"entries\":{\"rampart\":{\"config\":{\"approvalTimeoutMs\":120000}}}}}\n")
+	result, err := Apply(home, []string{dist})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.PatchedFiles) != 0 || result.ConfigUpdated || result.RestartSuggested {
+		t.Fatalf("expected no-op apply result, got %+v", result)
+	}
+}
+
+func setupFixture(t *testing.T, execText, bashText, config string) (string, string) {
+	t.Helper()
+	home := t.TempDir()
+	dist := filepath.Join(home, "dist")
+	if err := os.MkdirAll(dist, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(home, ".openclaw"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(dist, "exec-approvals-test.js"), execText)
+	writeFile(t, filepath.Join(dist, "bash-tools-test.js"), bashText)
+	writeFile(t, filepath.Join(home, ".openclaw", "openclaw.json"), config)
+	return home, dist
+}
+
+func writeFile(t *testing.T, path, text string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(text), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustRead(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}

--- a/internal/proxy/server_test.go
+++ b/internal/proxy/server_test.go
@@ -123,8 +123,16 @@ func (m *mockSink) lastEvent() audit.Event {
 
 func setupTestServer(t *testing.T, configYAML, mode string) (*Server, string, *mockSink) {
 	t.Helper()
+	homeDir := t.TempDir()
+	return setupTestServerWithHome(t, configYAML, mode, homeDir)
+}
+
+func setupTestServerWithHome(t *testing.T, configYAML, mode, homeDir string) (*Server, string, *mockSink) {
+	t.Helper()
 
 	dir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 	policyPath := filepath.Join(dir, "policy.yaml")
 	require.NoError(t, os.WriteFile(policyPath, []byte(configYAML), 0o644))
 
@@ -752,7 +760,7 @@ policies:
         message: "needs approval"
 `
 
-	srv, token, _ := setupTestServer(t, configYAML, "enforce")
+	srv, token, _ := setupTestServerWithHome(t, configYAML, "enforce", tmpHome)
 	ts := httptest.NewServer(srv.handler())
 	defer ts.Close()
 


### PR DESCRIPTION
## Summary

This PR hardens Rampart's OpenClaw integration around approval handling and timeout behavior.

It adds a dedicated OpenClaw hardening layer that:

- detects whether the installed OpenClaw dist matches a supported bundle shape
- refuses blind patching on unknown shapes
- patches approval fallback behavior to fail closed on timeout
- replaces misleading async completion wording that implied prior user approval
- aligns Rampart plugin approval timeout to `120000` ms
- wires the checks into `rampart setup openclaw-plugin`, `rampart doctor`, and `rampart doctor --fix`

It also:

- fixes flaky proxy tests by isolating test HOME state so local `~/.rampart/policies/user-overrides.yaml` files cannot leak into test behavior
- makes allow-always user-override writeback more robust on Windows, which fixed the CI failure that surfaced on this branch

## Why

We saw approval flows that could be confusing or unsafe:

- timeout/fallback behavior could effectively fail open
- async completion text could imply the user had already approved a command
- local OpenClaw/Rampart timeout settings could drift
- approval-related test coverage was vulnerable to host state
- Windows file replacement around durable user-override writeback was less robust than it should be

This PR makes those cases stricter, more truthful, and more predictable.

## Changes

### OpenClaw hardening
- add `internal/openclaw/hardening`
- inspect current hardening state before patching
- patch only supported OpenClaw bundle shapes
- fail closed on approval timeout/fallback
- update async approval completion wording
- enforce `plugins.entries.rampart.config.approvalTimeoutMs = 120000`

### Setup / doctor integration
- apply hardening during `rampart setup openclaw-plugin`
- add doctor warnings for:
  - unsupported bundle shape
  - unsafe fallback behavior
  - misleading completion attribution
  - timeout misalignment
- allow `rampart doctor --fix` to repair approval-hardening drift

### Test and platform reliability
- isolate HOME in proxy tests by default
- add explicit helper for tests that intentionally need a specific HOME
- keep durable user override tests working with explicit test-owned state
- make allow-always writeback retry file replacement more defensively on Windows

## Validation

Passed:

```bash
go test ./... -count=1
```

## Notes

- patching intentionally depends on exact supported bundle markers
- unknown OpenClaw dist layouts are rejected rather than patched heuristically
- gateway restart remains best-effort, with clear manual fallback messaging
