### PR TITLE
chore: prepare v0.9.20 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.20] - 2026-04-26
+
+### Fixed
+
+- **Built-in policy upgrades are safer** — `rampart doctor` now distinguishes stock built-in profiles from customized ones, warns clearly on stale or unstamped stock profiles, stamps policies written by setup for future drift detection, and preserves modified built-in profiles during upgrade instead of clobbering them.
+- **OpenClaw approval fallback is fail-closed and more truthful** — approval timeout/fallback behavior is hardened, async completion wording no longer implies prior user approval, Rampart aligns the plugin approval timeout to `120000ms`, and `rampart doctor` / `rampart doctor --fix` can detect and repair approval-hardening drift on supported OpenClaw bundle shapes.
+- **Approval-path tests are more reliable across hosts** — proxy tests isolate HOME state by default, and durable allow-always writeback is more robust on Windows.
+
+### Docs
+
+- **README and landing-page voice tightened** — public copy is cleaner, more consistent, and keeps the deployed landing page aligned with the current product story.
+
 ## [0.9.19] - 2026-04-24
 
 ### Fixed

--- a/internal/plugin/openclaw/package.json
+++ b/internal/plugin/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rampart",
-  "version": "0.9.19",
+  "version": "0.9.20",
   "description": "Rampart AI agent firewall \u2014 OpenClaw native plugin (before_tool_call hook)",
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
## Summary
- bump OpenClaw plugin package version to 0.9.20
- add the v0.9.20 changelog entry for the current staging bundle

## Included release scope
- #273 preserve modified built-in policy profiles / safer drift-aware upgrades
- #275 harden OpenClaw approval fallback behavior
- #274 tighten README and landing page voice

## Validation
- go test ./... -count=1
- go build ./cmd/rampart
- go test ./cmd/rampart/cli -run 'Test(Doctor|Setup|Upgrade)' -count=1 -v
- Linux live doctor check on latest staging
- macOS full test + build on latest staging
