### PR TITLE
chore: prepare v0.9.21 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.21] - 2026-04-29
+
 ### Changed
 
 - **Phase 1 docs/UX coherence pass** — Rampart now presents a cleaner, more truthful integration story across README, quickstart, CLI help, status/doctor messaging, and docs-site reference pages. The goal is simple: users should not have to reverse-engineer which integration path they are actually on.

--- a/internal/plugin/openclaw/openclaw.plugin.json
+++ b/internal/plugin/openclaw/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "rampart",
   "name": "Rampart",
   "description": "AI agent firewall \u2014 YAML policy-as-code for every tool call",
-  "version": "0.9.19",
+  "version": "0.9.21",
   "author": "peg",
   "homepage": "https://rampart.sh",
   "repository": "https://github.com/peg/rampart",

--- a/internal/plugin/openclaw/package.json
+++ b/internal/plugin/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rampart",
-  "version": "0.9.20",
+  "version": "0.9.21",
   "description": "Rampart AI agent firewall \u2014 OpenClaw native plugin (before_tool_call hook)",
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
## Summary
- mark the current staging bundle as v0.9.21 in CHANGELOG.md
- bump bundled OpenClaw plugin metadata to 0.9.21 in both package manifests

## Included release scope
- #278 OpenClaw trust-signal and setup/docs coherence pass
- built-in self-modification policy false-positive reduction
- support matrix / docs-site cleanup for native-plugin-first OpenClaw story

## Validation
- go test ./... -count=1
- go vet ./...
- go build ./cmd/rampart
- go test -bench=. ./internal/engine/
- git diff --check

## Notes
- This is release prep only; do not tag or merge staging to main from this PR.
