### PR TITLE
fix: make pending/approve/deny respect serve URL resolution

### DIFF
--- a/cmd/rampart/cli/approve.go
+++ b/cmd/rampart/cli/approve.go
@@ -49,7 +49,7 @@ Example:
 		},
 	}
 
-	cmd.Flags().StringVar(&proxyAddr, "api", fmt.Sprintf("http://127.0.0.1:%d", defaultServePort), "Rampart API address (proxy or daemon)")
+	cmd.Flags().StringVar(&proxyAddr, "api", "", "Rampart API address (proxy or daemon)")
 	cmd.Flags().StringVar(&proxyToken, "token", "", "Proxy auth token (or set RAMPART_TOKEN)")
 
 	return cmd
@@ -69,7 +69,7 @@ func newDenyCmd(_ *rootOptions) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&proxyAddr, "api", fmt.Sprintf("http://127.0.0.1:%d", defaultServePort), "Rampart API address (proxy or daemon)")
+	cmd.Flags().StringVar(&proxyAddr, "api", "", "Rampart API address (proxy or daemon)")
 	cmd.Flags().StringVar(&proxyToken, "token", "", "Proxy auth token (or set RAMPART_TOKEN)")
 
 	return cmd
@@ -91,7 +91,7 @@ are blocked until someone approves or denies them (or they expire).`,
 		},
 	}
 
-	cmd.Flags().StringVar(&proxyAddr, "api", fmt.Sprintf("http://127.0.0.1:%d", defaultServePort), "Rampart API address (proxy or daemon)")
+	cmd.Flags().StringVar(&proxyAddr, "api", "", "Rampart API address (proxy or daemon)")
 	cmd.Flags().StringVar(&proxyToken, "token", "", "Proxy auth token (or set RAMPART_TOKEN)")
 
 	return cmd
@@ -112,13 +112,17 @@ func resolveToken(token string) string {
 }
 
 func resolveAddr(addr string) string {
-	if env := os.Getenv("RAMPART_API"); env != "" && addr == fmt.Sprintf("http://127.0.0.1:%d", defaultServePort) {
-		return env
+	// RAMPART_API takes precedence over the full resolution chain when explicitly set.
+	if addr == "" {
+		if env := strings.TrimSpace(os.Getenv("RAMPART_API")); env != "" {
+			return strings.TrimRight(env, "/")
+		}
 	}
-	return addr
+	return resolveServeURL(addr)
 }
 
 func resolveApproval(cmd *cobra.Command, addr, token, id string, approved bool) error {
+	addr = resolveAddr(addr)
 	token = resolveToken(token)
 	if token == "" {
 		return fmt.Errorf("proxy auth token required (--token or RAMPART_TOKEN)")
@@ -158,6 +162,7 @@ func resolveApproval(cmd *cobra.Command, addr, token, id string, approved bool) 
 }
 
 func listPending(cmd *cobra.Command, addr, token string) error {
+	addr = resolveAddr(addr)
 	token = resolveToken(token)
 	if token == "" {
 		return fmt.Errorf("proxy auth token required (--token or RAMPART_TOKEN)")


### PR DESCRIPTION
`resolveAddr` was defined but never called, so `rampart pending`, `rampart approve`, and `rampart deny` always connected to the hardcoded default (127.0.0.1:9090) regardless of RAMPART_URL, RAMPART_SERVE_URL, RAMPART_API env vars, or the serve.state auto-discovery file.

- Change --api flag defaults to "" so resolveServeURL can detect unset
- Update resolveAddr to check RAMPART_API first, then delegate to resolveServeURL (which checks RAMPART_URL, RAMPART_SERVE_URL, serve.state, and falls back to localhost:9090)
- Call resolveAddr at the top of resolveApproval and listPending

Is `RAMPART_API` meant to be distinct from `RAMPART_SERVE_URL`?