### PR TITLE
feat: add ~/.rampart/config.yaml for persistent user settings

### DIFF
--- a/cmd/rampart/cli/allow.go
+++ b/cmd/rampart/cli/allow.go
@@ -490,11 +490,15 @@ func defaultMessage(action, pattern, tool string) string {
 // resolveAddrAllow returns the effective API address.
 // Respects the RAMPART_API environment variable when the addr is the default.
 func resolveAddrAllow(addr string) string {
-	if env := os.Getenv("RAMPART_API"); env != "" && addr == "http://127.0.0.1:9090" {
-		return env
+	defaultAddr := fmt.Sprintf("http://127.0.0.1:%d", defaultServePort)
+	if addr == defaultAddr {
+		cfg, _ := loadUserConfig()
+		if cfg.APIAddr != "" {
+			return cfg.APIAddr
+		}
 	}
 	if addr == "" {
-		return "http://127.0.0.1:9090"
+		return defaultAddr
 	}
 	return addr
 }

--- a/cmd/rampart/cli/approve.go
+++ b/cmd/rampart/cli/approve.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -101,14 +100,8 @@ func resolveToken(token string) string {
 	if token != "" {
 		return token
 	}
-	if env := os.Getenv("RAMPART_TOKEN"); env != "" {
-		return env
-	}
-	// Check persisted token file (~/.rampart/token)
-	if persisted, err := readPersistedToken(); err == nil && persisted != "" {
-		return persisted
-	}
-	return ""
+	cfg, _ := loadUserConfig()
+	return cfg.Token
 }
 
 func resolveAddr(addr string) string {

--- a/cmd/rampart/cli/approve.go
+++ b/cmd/rampart/cli/approve.go
@@ -112,8 +112,9 @@ func resolveToken(token string) string {
 }
 
 func resolveAddr(addr string) string {
-	if env := os.Getenv("RAMPART_API"); env != "" && addr == fmt.Sprintf("http://127.0.0.1:%d", defaultServePort) {
-		return env
+	cfg, _ := loadUserConfig()
+	if cfg.APIAddr != "" && addr == fmt.Sprintf("http://127.0.0.1:%d", defaultServePort) {
+		return cfg.APIAddr
 	}
 	return addr
 }

--- a/cmd/rampart/cli/hook.go
+++ b/cmd/rampart/cli/hook.go
@@ -234,24 +234,10 @@ Cline setup: Use "rampart setup cline" to install hooks automatically.`,
 			gitCtx := deriveGitContext()
 			hookSession := gitCtx.session
 
-			// Resolve serve-url and serve-token from env if not set via flags.
-			serveAutoDiscovered := false
-			if serveURL == "" {
-				serveURL = os.Getenv("RAMPART_SERVE_URL")
-			}
-			if serveURL == "" {
-				serveURL = fmt.Sprintf("http://localhost:%d", defaultServePort)
-				serveAutoDiscovered = true
-			}
-			// Resolve token from RAMPART_TOKEN env var or ~/.rampart/token file.
-			// This means settings.json never needs to contain credentials —
-			// the hook discovers both the URL and the token from standard locations.
-			var serveToken string
-			if envToken := strings.TrimSpace(os.Getenv("RAMPART_TOKEN")); envToken != "" {
-				serveToken = envToken
-			} else if tok, err := readPersistedToken(); err == nil && tok != "" {
-				serveToken = tok
-			}
+			serveAutoDiscovered := serveURL == ""
+			serveURL = resolveServeURL(serveURL)
+			cfg, _ := loadUserConfig()
+			serveToken := cfg.Token
 
 			if mode != "enforce" && mode != "monitor" && mode != "audit" {
 				return fmt.Errorf("hook: invalid mode %q (must be enforce, monitor, or audit)", mode)

--- a/cmd/rampart/cli/paths.go
+++ b/cmd/rampart/cli/paths.go
@@ -1,0 +1,18 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// rampartDir returns the path to the ~/.rampart directory.
+func rampartDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".rampart"), nil
+}

--- a/cmd/rampart/cli/policy.go
+++ b/cmd/rampart/cli/policy.go
@@ -482,10 +482,7 @@ file each policy came from (standard.yaml, user-overrides.yaml, auto-allowed.yam
 
 Requires rampart serve to be running.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			serveURL := os.Getenv("RAMPART_SERVE_URL")
-			if serveURL == "" {
-				serveURL = fmt.Sprintf("http://localhost:%d", defaultServePort)
-			}
+			serveURL := resolveServeURL("")
 			token := os.Getenv("RAMPART_TOKEN")
 			if token == "" {
 				token, _ = readPersistedToken()

--- a/cmd/rampart/cli/policy.go
+++ b/cmd/rampart/cli/policy.go
@@ -483,10 +483,8 @@ file each policy came from (standard.yaml, user-overrides.yaml, auto-allowed.yam
 Requires rampart serve to be running.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			serveURL := resolveServeURL("")
-			token := os.Getenv("RAMPART_TOKEN")
-			if token == "" {
-				token, _ = readPersistedToken()
-			}
+			cfg, _ := loadUserConfig()
+			token := cfg.Token
 
 			req, _ := http.NewRequestWithContext(cmd.Context(), "GET", serveURL+"/v1/policies", nil)
 			req.Header.Set("Authorization", "Bearer "+token)

--- a/cmd/rampart/cli/preload.go
+++ b/cmd/rampart/cli/preload.go
@@ -56,9 +56,10 @@ func newPreloadCmd(_ *rootOptions) *cobra.Command {
 				return err
 			}
 
+			cfg, _ := loadUserConfig()
 			baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
-			if envURL := strings.TrimSpace(os.Getenv("RAMPART_URL")); envURL != "" {
-				baseURL = strings.TrimRight(envURL, "/")
+			if cfg.URL != "" {
+				baseURL = cfg.URL
 			}
 			if !isPreloadRuntimeReady(cmd.Context(), baseURL) {
 				fmt.Fprintf(cmd.ErrOrStderr(), "preload: warning: rampart serve is not reachable at %s/healthz; continuing\n", baseURL)
@@ -66,7 +67,7 @@ func newPreloadCmd(_ *rootOptions) *cobra.Command {
 
 			resolvedToken := token
 			if resolvedToken == "" {
-				resolvedToken = os.Getenv("RAMPART_TOKEN")
+				resolvedToken = cfg.Token
 			}
 
 			sessionID := strings.TrimSpace(session)

--- a/cmd/rampart/cli/serve.go
+++ b/cmd/rampart/cli/serve.go
@@ -345,17 +345,9 @@ func newServeCmd(opts *rootOptions, deps *serveDeps) *cobra.Command {
 				// Resolve token: flag > env > persisted file > generate new.
 				// Mirrors serve install behaviour so the token survives restarts.
 				{
-					var tok string
-					switch {
-					case os.Getenv("RAMPART_TOKEN") != "":
-						tok = os.Getenv("RAMPART_TOKEN")
-					default:
-						if persisted, err := readPersistedToken(); err == nil && persisted != "" {
-							tok = persisted
-						}
-					}
-					if tok != "" {
-						proxyOpts = append(proxyOpts, proxy.WithToken(tok))
+					cfg, _ := loadUserConfig()
+					if cfg.Token != "" {
+						proxyOpts = append(proxyOpts, proxy.WithToken(cfg.Token))
 					}
 				}
 				if resolveBaseURL != "" {

--- a/cmd/rampart/cli/serve_install.go
+++ b/cmd/rampart/cli/serve_install.go
@@ -133,11 +133,11 @@ func resolveServiceToken(tokenFlag string) (string, bool, error) {
 
 // tokenFilePath returns the path to the persisted token file.
 func tokenFilePath() (string, error) {
-	home, err := os.UserHomeDir()
+	dir, err := rampartDir()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(home, ".rampart", "token"), nil
+	return filepath.Join(dir, "token"), nil
 }
 
 // persistToken writes the token to ~/.rampart/token with owner-only permissions.

--- a/cmd/rampart/cli/serve_install.go
+++ b/cmd/rampart/cli/serve_install.go
@@ -117,12 +117,8 @@ func resolveServiceToken(tokenFlag string) (string, bool, error) {
 	if tokenFlag != "" {
 		return tokenFlag, false, nil
 	}
-	if env := os.Getenv("RAMPART_TOKEN"); env != "" {
-		return env, false, nil
-	}
-	// Check persisted token file written by a previous serve install.
-	if tok, err := readPersistedToken(); err == nil && tok != "" {
-		return tok, false, nil
+	if cfg, err := loadUserConfig(); err == nil && cfg.Token != "" {
+		return cfg.Token, false, nil
 	}
 	b := make([]byte, 16)
 	if _, err := rand.Read(b); err != nil {

--- a/cmd/rampart/cli/serve_state.go
+++ b/cmd/rampart/cli/serve_state.go
@@ -49,27 +49,26 @@ func removeServeState(dir string) {
 
 // resolveServeURL determines the serve URL using this priority:
 //  1. Explicit flag value (if non-empty)
-//  2. RAMPART_URL env var
+//  2. RAMPART_URL / config url  (via loadUserConfig: env overrides file)
 //  3. RAMPART_SERVE_URL env var
-//  4. serve.state file in ~/.rampart/
+//  4. serve.state file in ~/.rampart/ (written by rampart serve)
 //  5. Default port (9090)
 func resolveServeURL(flagValue string) string {
 	if flagValue != "" {
 		return strings.TrimRight(flagValue, "/")
 	}
 
-	if u := strings.TrimSpace(os.Getenv("RAMPART_URL")); u != "" {
-		return strings.TrimRight(u, "/")
+	cfg, _ := loadUserConfig()
+	if cfg.URL != "" {
+		return cfg.URL
 	}
-
 	if u := strings.TrimSpace(os.Getenv("RAMPART_SERVE_URL")); u != "" {
 		return strings.TrimRight(u, "/")
 	}
 
-	// Try state file.
-	home, err := os.UserHomeDir()
-	if err == nil {
-		statePath := filepath.Join(home, ".rampart", serveStateFile)
+	// Runtime state written by rampart serve.
+	if dir, err := rampartDir(); err == nil {
+		statePath := filepath.Join(dir, serveStateFile)
 		if data, err := os.ReadFile(statePath); err == nil {
 			var state serveState
 			if json.Unmarshal(data, &state) == nil && state.URL != "" {

--- a/cmd/rampart/cli/user_config.go
+++ b/cmd/rampart/cli/user_config.go
@@ -1,0 +1,68 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// UserConfig holds persistent user-level settings. Values are loaded from
+// ~/.rampart/config.yaml first, then overridden by environment variables.
+// Priority for any field: env var > config file > zero value.
+type UserConfig struct {
+	// URL is the rampart proxy base URL. Env: RAMPART_URL.
+	URL string `yaml:"url,omitempty"`
+	// APIAddr is the API address for approve/deny/pending commands. Env: RAMPART_API.
+	APIAddr string `yaml:"api,omitempty"`
+	// Token is the auth token. Not stored in yaml; sourced from RAMPART_TOKEN env or ~/.rampart/token.
+	Token string `yaml:"-"`
+}
+
+// userConfigPath returns the path to ~/.rampart/config.yaml.
+func userConfigPath() (string, error) {
+	dir, err := rampartDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "config.yaml"), nil
+}
+
+// loadUserConfig reads ~/.rampart/config.yaml then overlays environment
+// variables. The file is optional — missing file is not an error.
+func loadUserConfig() (UserConfig, error) {
+	var cfg UserConfig
+
+	p, err := userConfigPath()
+	if err != nil {
+		return cfg, err
+	}
+	if data, err := os.ReadFile(p); err == nil {
+		if err := yaml.Unmarshal(data, &cfg); err != nil {
+			return cfg, err
+		}
+	}
+
+	// Env vars override file values.
+	if v := strings.TrimSpace(os.Getenv("RAMPART_URL")); v != "" {
+		cfg.URL = v
+	}
+	if v := strings.TrimSpace(os.Getenv("RAMPART_API")); v != "" {
+		cfg.APIAddr = v
+	}
+
+	cfg.URL = strings.TrimRight(cfg.URL, "/")
+	cfg.APIAddr = strings.TrimRight(cfg.APIAddr, "/")
+
+	if v := strings.TrimSpace(os.Getenv("RAMPART_TOKEN")); v != "" {
+		cfg.Token = v
+	} else if tok, err := readPersistedToken(); err == nil && tok != "" {
+		cfg.Token = tok
+	}
+
+	return cfg, nil
+}

--- a/cmd/rampart/cli/watch.go
+++ b/cmd/rampart/cli/watch.go
@@ -98,8 +98,8 @@ func resolveWatchServeConfig(cmd *cobra.Command, serveURL string) (string, strin
 
 	cfg, _ := loadUserConfig()
 	resolvedToken = cfg.Token
-	if resolvedToken != "" && os.Getenv("RAMPART_TOKEN") == "" {
-		fmt.Fprintln(errW, "Note: using auto-discovered serve token from ~/.rampart/token")
+	if resolvedToken != "" {
+		fmt.Fprintln(errW, "Note: using auto-discovered serve token")
 	}
 
 	return resolvedURL, resolvedToken, nil

--- a/cmd/rampart/cli/watch.go
+++ b/cmd/rampart/cli/watch.go
@@ -96,10 +96,9 @@ func resolveWatchServeConfig(cmd *cobra.Command, serveURL string) (string, strin
 		fmt.Fprintf(errW, "Note: using serve URL %s\n", resolvedURL)
 	}
 
-	if envToken := strings.TrimSpace(os.Getenv("RAMPART_TOKEN")); envToken != "" {
-		resolvedToken = envToken
-	} else if tok, err := readPersistedToken(); err == nil && tok != "" {
-		resolvedToken = tok
+	cfg, _ := loadUserConfig()
+	resolvedToken = cfg.Token
+	if resolvedToken != "" && os.Getenv("RAMPART_TOKEN") == "" {
 		fmt.Fprintln(errW, "Note: using auto-discovered serve token from ~/.rampart/token")
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/charmbracelet/huh v0.8.0
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/fsnotify/fsnotify v1.8.0
+	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/oklog/ulid/v2 v2.1.1
 	github.com/prometheus/client_golang v1.23.2
@@ -33,7 +34,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect


### PR DESCRIPTION
Adds a config file and moves env reads into a single config interface.