### PR TITLE
fix(hook): suppress PostToolUseFailure noise for non-Rampart failures

### DIFF
--- a/cmd/rampart/cli/hook.go
+++ b/cmd/rampart/cli/hook.go
@@ -406,10 +406,27 @@ Cline setup: Use "rampart setup cline" to install hooks automatically.`,
 				return outputHookResult(cmd, format, hookOutcome, false, fmt.Sprintf("parse failure: %v", err), "")
 			}
 
-			// Short-circuit for PostToolUseFailure: the previous PreToolUse was denied by
-			// Rampart. Inject additionalContext telling Claude to stop retrying rather than
-			// burning 3-5 turns on workarounds.
+			// PostToolUseFailure: if the previous PreToolUse was denied by Rampart,
+			// inject additionalContext telling Claude to stop retrying rather than
+			// burning 3-5 turns on workarounds. If the call would be allowed by the
+			// current policy, the failure was unrelated to Rampart — return no context
+			// to avoid misleading the agent.
 			if parsed.HookEventName == "PostToolUseFailure" {
+				// Re-evaluate first: only act if Rampart would actually deny this call.
+				// This avoids injecting "blocked by security policy" noise for ordinary
+				// tool failures (e.g. grep exit 1, command not found, network errors).
+				failedCall := engine.ToolCall{
+					Tool:   parsed.Tool,
+					Params: parsed.Params,
+				}
+				denyDecision := eng.Evaluate(failedCall)
+
+				if denyDecision.Action != engine.ActionDeny {
+					// Not a Rampart denial — emit an empty response and let the agent
+					// handle the failure on its own.
+					return json.NewEncoder(cmd.OutOrStdout()).Encode(hookOutput{})
+				}
+
 				// If this failure corresponds to an ask+audit prompt denial, best-effort
 				// resolve the mirrored serve approval as denied for dashboard/watch sync.
 				if parsed.ToolUseID != "" && parsed.SessionID != "" && serveURL != "" && isServeRunning(serveURL) {
@@ -446,15 +463,6 @@ Cline setup: Use "rampart setup cline" to install hooks automatically.`,
 					_, _ = auditFile.Write(line)
 				}
 
-				// Re-evaluate the failed call to surface the specific deny reason and
-				// matched policy name. This is a fast local operation (< 10µs) and gives
-				// the agent the exact information it needs without storing state.
-				failedCall := engine.ToolCall{
-					Tool:   parsed.Tool,
-					Params: parsed.Params,
-				}
-				denyDecision := eng.Evaluate(failedCall)
-
 				explainCmd := "rampart policy explain '" + parsed.Tool + "'"
 				msg := "This tool call failed or was blocked by a security policy. " +
 					"Do not attempt alternative approaches or workarounds — " +
@@ -464,9 +472,7 @@ Cline setup: Use "rampart setup cline" to install hooks automatically.`,
 					"To allow this operation, update the policy at ~/.rampart/policies/ — " +
 					"see https://rampart.sh/docs/exceptions for guidance."
 
-				// Prepend the specific deny reason if available — gives the agent
-				// (and user) immediate context on why the call was blocked.
-				if denyDecision.Action == engine.ActionDeny && denyDecision.Message != "" {
+				if denyDecision.Message != "" {
 					policyHint := ""
 					if len(denyDecision.MatchedPolicies) > 0 {
 						policyHint = " [" + denyDecision.MatchedPolicies[0] + "]"

--- a/cmd/rampart/cli/hook_posttooluse_test.go
+++ b/cmd/rampart/cli/hook_posttooluse_test.go
@@ -98,15 +98,16 @@ func TestPostToolUseFailure_DenyReasonSurfaced(t *testing.T) {
 	}
 }
 
-// TestPostToolUseFailure_NoReasonForUnknownCommand verifies that when the
-// PostToolUseFailure event is for a command that doesn't match any deny rule
-// (e.g. the policy was updated between PreToolUse and PostToolUseFailure),
-// the fallback guidance is still returned without crashing.
-func TestPostToolUseFailure_NoReasonForUnknownCommand(t *testing.T) {
+// TestPostToolUseFailure_NoContextForAllowedCommand verifies that when the
+// PostToolUseFailure event is for a command that wouldn't be denied by Rampart
+// (e.g. tool failed for an unrelated reason like grep exit 1), no additionalContext
+// is injected — injecting "blocked by security policy" guidance for non-Rampart
+// failures misleads the agent into thinking it was blocked when it wasn't.
+func TestPostToolUseFailure_NoContextForAllowedCommand(t *testing.T) {
 	dir := t.TempDir()
 	testSetHome(t, dir)
 
-	// Policy that allows everything — simulates policy change between events.
+	// Policy that allows everything — simulates an ordinary tool failure.
 	allowAll := `version: "1"
 default_action: allow
 policies: []
@@ -137,16 +138,9 @@ policies: []
 	if err := json.Unmarshal([]byte(stdout), &out); err != nil {
 		t.Fatalf("unmarshal hook output: %v (stdout=%q)", err, stdout)
 	}
-	if out.HookSpecificOutput == nil {
-		t.Fatal("expected non-nil HookSpecificOutput")
-	}
-	// Should still have guidance even without a matching deny rule.
-	if out.HookSpecificOutput.AdditionalContext == "" {
-		t.Fatal("additionalContext must not be empty even when no deny rule matches")
-	}
-	// Should NOT have the ⛔ prefix since re-evaluation returned allow.
-	if strings.Contains(out.HookSpecificOutput.AdditionalContext, "⛔ Blocked") {
-		t.Errorf("additionalContext should not contain ⛔ Blocked when re-evaluation returns allow; got:\n%s",
+	// When re-evaluation returns allow, no additionalContext should be injected.
+	if out.HookSpecificOutput != nil && out.HookSpecificOutput.AdditionalContext != "" {
+		t.Errorf("expected no additionalContext for non-Rampart failure; got:\n%s",
 			out.HookSpecificOutput.AdditionalContext)
 	}
 }


### PR DESCRIPTION
PostToolUseFailure was unconditionally injecting "blocked by security policy / do not attempt workarounds" additionalContext for every tool failure, including ordinary ones like grep exiting 1 or a command returning a non-zero status unrelated to any policy decision.

Re-evaluate the failed call first. If the current policy would allow it, return an empty response — the failure has nothing to do with Rampart and injecting block guidance misleads the agent into treating a normal failure as a security denial.