### PR TITLE
fix: harden config resolution and hook approval integrity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   push:
     branches: [main, staging]
@@ -18,10 +21,10 @@ jobs:
         go-version: ['1.24.13']
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@v5
 
       - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
 
@@ -62,7 +65,7 @@ jobs:
         run: go test -bench=. -benchmem ./internal/engine/ ./internal/audit/
 
       - name: Upload coverage
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-${{ matrix.os }}
           path: coverage.out
@@ -74,17 +77,17 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.24.13'
 
       - name: GoReleaser snapshot (all platforms, no publish)
-        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
+        uses: goreleaser/goreleaser-action@v7
         with:
           args: release --snapshot --clean
         env:

--- a/.github/workflows/community-policy-ci.yml
+++ b/.github/workflows/community-policy-ci.yml
@@ -1,5 +1,8 @@
 name: Community Policy CI
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   pull_request:
     paths:
@@ -14,9 +17,9 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,8 @@
 name: Docker
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   push:
     tags: ['v*']
@@ -12,28 +15,28 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-qemu-action@v4
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/metadata-action@v5
+      - uses: docker/metadata-action@v6
         id: meta
         with:
           images: ghcr.io/peg/rampart
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable=${{ github.ref == format('refs/tags/{0}', github.event.repository.default_branch) || true }}
+            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
 
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,8 @@
 name: Deploy Docs
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   workflow_dispatch:
   push:
@@ -16,9 +19,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Release
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   push:
     tags:
@@ -12,17 +15,17 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.24.13"
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           version: "~> v2"
           args: release --clean

--- a/.github/workflows/render-diagrams.yml
+++ b/.github/workflows/render-diagrams.yml
@@ -1,5 +1,8 @@
 name: Render Diagrams
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   push:
     branches: [main, staging]
@@ -13,7 +16,7 @@ jobs:
   render:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@v5
 
       - name: Install D2
         run: curl -fsSL https://d2lang.com/install.sh | sh -s --

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.22] - 2026-04-29
+
+### Fixed
+
+- **Config resolution is stricter and more trustworthy** — CLI flows that depend on Rampart control-plane endpoints now surface malformed `~/.rampart/config.yaml` instead of silently falling back to defaults, reducing the chance of acting against the wrong endpoint during approval, reload, watch, preload, and hook-driven operations.
+- **Ask-flow failure handling preserves approval integrity** — `PostToolUseFailure` no longer infers a denial or resolves mirrored approvals as denied based only on an ambiguous hook failure event, preventing approved tool calls that later fail from being mislabeled as user denials.
+- **Endpoint resolution is more consistent across commands** — `preload` and related CLI paths now honor the same `url` / `serve_url` / `api` precedence model as the rest of Rampart, including compatibility alias support and auto-discovered state fallback.
+
+### Changed
+
+- **Workflow and release hardening for current GitHub Actions runtimes** — CI/docs/release workflows now use Node 24-safe action versions, and Docker prerelease tagging avoids publishing prereleases as `latest`.
+
+### Docs
+
+- **Config semantics are clearer for users and contributors** — README and help text now spell out the intended roles of `url`, `serve_url`, and `api`, including the distinction between API base URLs used by client commands and API listen addresses used by daemon/server commands.
+
 ## [0.9.21] - 2026-04-29
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -75,6 +75,23 @@ Then watch your agent in real time:
 rampart watch
 ```
 
+### Optional persistent local config
+
+If you do not want to keep exporting environment variables, Rampart also supports
+`~/.rampart/config.yaml` for local defaults:
+
+```yaml
+url: http://127.0.0.1:9090
+# serve_url: http://127.0.0.1:9090   # compatibility alias for url
+# api: http://127.0.0.1:9091         # optional advanced override for approval/control API flows
+```
+
+- `url` is the primary Rampart endpoint setting
+- `serve_url` is a compatibility alias for `url`
+- `api` is an advanced override and is usually unnecessary
+
+Resolution order is: flag → environment → config file → auto-discovered state → default.
+
 Once running, every tool call goes through Rampart's policy engine first:
 
 ```

--- a/README.md
+++ b/README.md
@@ -83,12 +83,19 @@ If you do not want to keep exporting environment variables, Rampart also support
 ```yaml
 url: http://127.0.0.1:9090
 # serve_url: http://127.0.0.1:9090   # compatibility alias for url
-# api: http://127.0.0.1:9091         # optional advanced override for approval/control API flows
+# api: http://127.0.0.1:9091         # optional advanced override for daemon/split-topology API setups
 ```
 
-- `url` is the primary Rampart endpoint setting
-- `serve_url` is a compatibility alias for `url`
-- `api` is an advanced override and is usually unnecessary
+| Setting | Use it for | Notes |
+| --- | --- | --- |
+| `url` | Primary Rampart base URL | Canonical setting for hook/watch/plugin/service-backed flows |
+| `serve_url` | Backwards-compatible alias for `url` | Kept for compatibility; prefer `url` in new configs |
+| `api` | Optional API base URL override for approval/control commands | Advanced only; usually unnecessary unless you split the API away from the main serve endpoint |
+
+Notes:
+- `url` is the main knob; use this unless you have a specific reason not to.
+- `api` is **not** the normal setting for `rampart serve`; it is for advanced daemon/split-topology setups.
+- Client-side `--api` flags expect an **API base URL** (`http://127.0.0.1:9091`), while daemon/server `--api` flags refer to an **API listen address** (`127.0.0.1:9091`).
 
 Resolution order is: flag → environment → config file → auto-discovered state → default.
 

--- a/cmd/rampart/cli/allow.go
+++ b/cmd/rampart/cli/allow.go
@@ -109,7 +109,7 @@ func addAllowBlockFlags(cmd *cobra.Command, opts *allowBlockOptions) {
 	cmd.Flags().StringVar(&opts.tool, "tool", "", "Tool type: exec, read, write, edit (default: auto-detect)")
 	cmd.Flags().StringVar(&opts.message, "message", "", "Optional reason displayed when the rule matches")
 	cmd.Flags().BoolVarP(&opts.yes, "yes", "y", false, "Skip confirmation prompt")
-	cmd.Flags().StringVar(&opts.apiAddr, "api", "http://127.0.0.1:9090", "Rampart serve API address for reload")
+	cmd.Flags().StringVar(&opts.apiAddr, "api", "", "Rampart API address override for reload (default: auto-discover via url/config/state)")
 	cmd.Flags().StringVar(&opts.token, "token", "", "API auth token (or set RAMPART_TOKEN)")
 	cmd.Flags().StringVar(&opts.forDur, "for", "", "Rule expires after duration (e.g. 1h, 30m, 24h)")
 	cmd.Flags().BoolVar(&opts.once, "once", false, "Single-use rule — removed after first match")

--- a/cmd/rampart/cli/allow.go
+++ b/cmd/rampart/cli/allow.go
@@ -488,13 +488,13 @@ func defaultMessage(action, pattern, tool string) string {
 }
 
 // resolveAddrAllow returns the effective API address.
-// Respects the RAMPART_API environment variable when the addr is the default.
+// Respects the user API override and otherwise falls back to serve URL resolution.
 func resolveAddrAllow(addr string) string {
-	if env := os.Getenv("RAMPART_API"); env != "" && addr == "http://127.0.0.1:9090" {
-		return env
-	}
 	if addr == "" {
-		return "http://127.0.0.1:9090"
+		if cfg, err := loadUserConfig(); err == nil && cfg.APIAddr != "" {
+			return cfg.APIAddr
+		}
+		return resolveServeURL("")
 	}
 	return addr
 }

--- a/cmd/rampart/cli/allow.go
+++ b/cmd/rampart/cli/allow.go
@@ -267,7 +267,10 @@ func runAllowBlock(cmd *cobra.Command, pattern, action string, opts *allowBlockO
 
 	// Try to reload the daemon.
 	token := resolveToken(opts.token)
-	addr := resolveAddrAllow(opts.apiAddr)
+	addr, err := resolveAddrAllow(opts.apiAddr)
+	if err != nil {
+		return fmt.Errorf("resolve reload API address: %w", err)
+	}
 	reloaded, reloadErr := reloadPolicy(cmd, addr, token)
 	if reloaded {
 		fmt.Fprintf(out, "\n  Policy reloaded (%d rules active)\n", ruleCount)
@@ -489,12 +492,14 @@ func defaultMessage(action, pattern, tool string) string {
 
 // resolveAddrAllow returns the effective API address.
 // Respects the user API override and otherwise falls back to serve URL resolution.
-func resolveAddrAllow(addr string) string {
+func resolveAddrAllow(addr string) (string, error) {
 	if addr == "" {
 		if cfg, err := loadUserConfig(); err == nil && cfg.APIAddr != "" {
-			return cfg.APIAddr
+			return cfg.APIAddr, nil
+		} else if err != nil {
+			return "", err
 		}
-		return resolveServeURL("")
+		return resolveServeURLStrict("", fmt.Sprintf("http://localhost:%d", defaultServePort))
 	}
-	return addr
+	return addr, nil
 }

--- a/cmd/rampart/cli/allow_test.go
+++ b/cmd/rampart/cli/allow_test.go
@@ -483,6 +483,40 @@ func TestReloadPolicy_Success(t *testing.T) {
 	}
 }
 
+func TestReloadPolicy_UsesConfigAPIOverride(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/v1/policy/reload" {
+			called = true
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+		} else {
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	testSetHome(t, dir)
+	_ = os.MkdirAll(filepath.Join(dir, ".rampart", "policies"), 0o755)
+	if err := os.WriteFile(filepath.Join(dir, ".rampart", "config.yaml"), []byte("api: "+srv.URL+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("RAMPART_TOKEN", "test-token")
+
+	cmd := NewRootCmd(context.Background(), &bytes.Buffer{}, &bytes.Buffer{})
+	outBuf := &bytes.Buffer{}
+	cmd.SetOut(outBuf)
+	cmd.SetArgs([]string{"allow", "npm install *", "--global", "--yes"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("command failed: %v", err)
+	}
+	if !called {
+		t.Fatal("expected reload endpoint to be called via config api override")
+	}
+}
+
 func TestReloadPolicy_DaemonUnreachable(t *testing.T) {
 	dir := t.TempDir()
 	testSetHome(t, dir)

--- a/cmd/rampart/cli/approve.go
+++ b/cmd/rampart/cli/approve.go
@@ -105,20 +105,25 @@ func resolveToken(token string) string {
 	return resolved
 }
 
-func resolveAddr(addr string) string {
+func resolveAddr(addr string) (string, error) {
 	if addr == "" {
 		if env := strings.TrimSpace(os.Getenv("RAMPART_API")); env != "" {
-			return strings.TrimRight(env, "/")
+			return strings.TrimRight(env, "/"), nil
 		}
 		if cfg, err := loadUserConfig(); err == nil && cfg.APIAddr != "" {
-			return cfg.APIAddr
+			return cfg.APIAddr, nil
+		} else if err != nil {
+			return "", err
 		}
 	}
-	return resolveServeURL(addr)
+	return resolveServeURLStrict(addr, fmt.Sprintf("http://localhost:%d", defaultServePort))
 }
 
 func resolveApproval(cmd *cobra.Command, addr, token, id string, approved bool) error {
-	addr = resolveAddr(addr)
+	resolvedAddr, err := resolveAddr(addr)
+	if err != nil {
+		return fmt.Errorf("resolve approval API address: %w", err)
+	}
 	token = resolveToken(token)
 	if token == "" {
 		return fmt.Errorf("proxy auth token required (--token or RAMPART_TOKEN)")
@@ -129,7 +134,7 @@ func resolveApproval(cmd *cobra.Command, addr, token, id string, approved bool) 
 		"resolved_by": "cli",
 	})
 
-	url := fmt.Sprintf("%s/v1/approvals/%s/resolve", strings.TrimRight(addr, "/"), id)
+	url := fmt.Sprintf("%s/v1/approvals/%s/resolve", strings.TrimRight(resolvedAddr, "/"), id)
 	req, err := http.NewRequestWithContext(cmd.Context(), http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
 		return err
@@ -139,7 +144,7 @@ func resolveApproval(cmd *cobra.Command, addr, token, id string, approved bool) 
 
 	resp, err := rampartHTTPClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("failed to connect to proxy at %s: %w", addr, err)
+		return fmt.Errorf("failed to connect to proxy at %s: %w", resolvedAddr, err)
 	}
 	defer resp.Body.Close()
 
@@ -158,13 +163,16 @@ func resolveApproval(cmd *cobra.Command, addr, token, id string, approved bool) 
 }
 
 func listPending(cmd *cobra.Command, addr, token string) error {
-	addr = resolveAddr(addr)
+	resolvedAddr, err := resolveAddr(addr)
+	if err != nil {
+		return fmt.Errorf("resolve approval API address: %w", err)
+	}
 	token = resolveToken(token)
 	if token == "" {
 		return fmt.Errorf("proxy auth token required (--token or RAMPART_TOKEN)")
 	}
 
-	url := fmt.Sprintf("%s/v1/approvals", strings.TrimRight(addr, "/"))
+	url := fmt.Sprintf("%s/v1/approvals", strings.TrimRight(resolvedAddr, "/"))
 	req, err := http.NewRequestWithContext(cmd.Context(), http.MethodGet, url, nil)
 	if err != nil {
 		return err
@@ -173,7 +181,7 @@ func listPending(cmd *cobra.Command, addr, token string) error {
 
 	resp, err := rampartHTTPClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("failed to connect to proxy at %s: %w", addr, err)
+		return fmt.Errorf("failed to connect to proxy at %s: %w", resolvedAddr, err)
 	}
 	defer resp.Body.Close()
 

--- a/cmd/rampart/cli/approve.go
+++ b/cmd/rampart/cli/approve.go
@@ -101,10 +101,8 @@ func resolveToken(token string) string {
 	if token != "" {
 		return token
 	}
-	if cfg, err := loadUserConfig(); err == nil && cfg.Token != "" {
-		return cfg.Token
-	}
-	return ""
+	resolved, _ := resolveTokenValue()
+	return resolved
 }
 
 func resolveAddr(addr string) string {

--- a/cmd/rampart/cli/approve.go
+++ b/cmd/rampart/cli/approve.go
@@ -49,7 +49,7 @@ Example:
 		},
 	}
 
-	cmd.Flags().StringVar(&proxyAddr, "api", fmt.Sprintf("http://127.0.0.1:%d", defaultServePort), "Rampart API address (proxy or daemon)")
+	cmd.Flags().StringVar(&proxyAddr, "api", "", "Rampart API address (proxy or daemon)")
 	cmd.Flags().StringVar(&proxyToken, "token", "", "Proxy auth token (or set RAMPART_TOKEN)")
 
 	return cmd
@@ -69,7 +69,7 @@ func newDenyCmd(_ *rootOptions) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&proxyAddr, "api", fmt.Sprintf("http://127.0.0.1:%d", defaultServePort), "Rampart API address (proxy or daemon)")
+	cmd.Flags().StringVar(&proxyAddr, "api", "", "Rampart API address (proxy or daemon)")
 	cmd.Flags().StringVar(&proxyToken, "token", "", "Proxy auth token (or set RAMPART_TOKEN)")
 
 	return cmd
@@ -91,7 +91,7 @@ are blocked until someone approves or denies them (or they expire).`,
 		},
 	}
 
-	cmd.Flags().StringVar(&proxyAddr, "api", fmt.Sprintf("http://127.0.0.1:%d", defaultServePort), "Rampart API address (proxy or daemon)")
+	cmd.Flags().StringVar(&proxyAddr, "api", "", "Rampart API address (proxy or daemon)")
 	cmd.Flags().StringVar(&proxyToken, "token", "", "Proxy auth token (or set RAMPART_TOKEN)")
 
 	return cmd
@@ -101,24 +101,26 @@ func resolveToken(token string) string {
 	if token != "" {
 		return token
 	}
-	if env := os.Getenv("RAMPART_TOKEN"); env != "" {
-		return env
-	}
-	// Check persisted token file (~/.rampart/token)
-	if persisted, err := readPersistedToken(); err == nil && persisted != "" {
-		return persisted
+	if cfg, err := loadUserConfig(); err == nil && cfg.Token != "" {
+		return cfg.Token
 	}
 	return ""
 }
 
 func resolveAddr(addr string) string {
-	if env := os.Getenv("RAMPART_API"); env != "" && addr == fmt.Sprintf("http://127.0.0.1:%d", defaultServePort) {
-		return env
+	if addr == "" {
+		if env := strings.TrimSpace(os.Getenv("RAMPART_API")); env != "" {
+			return strings.TrimRight(env, "/")
+		}
+		if cfg, err := loadUserConfig(); err == nil && cfg.APIAddr != "" {
+			return cfg.APIAddr
+		}
 	}
-	return addr
+	return resolveServeURL(addr)
 }
 
 func resolveApproval(cmd *cobra.Command, addr, token, id string, approved bool) error {
+	addr = resolveAddr(addr)
 	token = resolveToken(token)
 	if token == "" {
 		return fmt.Errorf("proxy auth token required (--token or RAMPART_TOKEN)")
@@ -158,6 +160,7 @@ func resolveApproval(cmd *cobra.Command, addr, token, id string, approved bool) 
 }
 
 func listPending(cmd *cobra.Command, addr, token string) error {
+	addr = resolveAddr(addr)
 	token = resolveToken(token)
 	if token == "" {
 		return fmt.Errorf("proxy auth token required (--token or RAMPART_TOKEN)")

--- a/cmd/rampart/cli/approve_test.go
+++ b/cmd/rampart/cli/approve_test.go
@@ -90,6 +90,24 @@ func TestResolveAddr(t *testing.T) {
 		}
 	})
 
+	t.Run("explicit serve-url alias resolves when url unset", func(t *testing.T) {
+		home := t.TempDir()
+		testSetHome(t, home)
+		os.Unsetenv("RAMPART_API")
+		os.Unsetenv("RAMPART_URL")
+		os.Unsetenv("RAMPART_SERVE_URL")
+		if err := os.MkdirAll(filepath.Join(home, ".rampart"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		cfgPath := filepath.Join(home, ".rampart", "config.yaml")
+		if err := os.WriteFile(cfgPath, []byte("serve_url: http://compat-serve:8124\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if got := resolveAddr(""); got != "http://compat-serve:8124" {
+			t.Errorf("got %q", got)
+		}
+	})
+
 	t.Run("explicit addr wins", func(t *testing.T) {
 		t.Setenv("RAMPART_API", "http://custom:1234")
 		if got := resolveAddr("http://other:5678"); got != "http://other:5678" {

--- a/cmd/rampart/cli/approve_test.go
+++ b/cmd/rampart/cli/approve_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -45,22 +46,54 @@ func TestResolveToken(t *testing.T) {
 }
 
 func TestResolveAddr(t *testing.T) {
-	defaultAddr := fmt.Sprintf("http://127.0.0.1:%d", defaultServePort)
+	defaultAddr := fmt.Sprintf("http://localhost:%d", defaultServePort)
 
-	// Default addr, no env
-	os.Unsetenv("RAMPART_API")
-	if got := resolveAddr(defaultAddr); got != defaultAddr {
-		t.Errorf("got %q", got)
-	}
+	t.Run("empty addr falls back to default", func(t *testing.T) {
+		os.Unsetenv("RAMPART_API")
+		os.Unsetenv("RAMPART_URL")
+		os.Unsetenv("RAMPART_SERVE_URL")
+		if got := resolveAddr(""); got != defaultAddr {
+			t.Errorf("got %q", got)
+		}
+	})
 
-	// Default addr, with env override
-	t.Setenv("RAMPART_API", "http://custom:1234")
-	if got := resolveAddr(defaultAddr); got != "http://custom:1234" {
-		t.Errorf("got %q", got)
-	}
+	t.Run("empty addr uses RAMPART_API override", func(t *testing.T) {
+		t.Setenv("RAMPART_API", "http://custom:1234/")
+		if got := resolveAddr(""); got != "http://custom:1234" {
+			t.Errorf("got %q", got)
+		}
+	})
 
-	// Non-default addr, env should not override
-	if got := resolveAddr("http://other:5678"); got != "http://other:5678" {
-		t.Errorf("got %q", got)
-	}
+	t.Run("empty addr uses serve url resolution chain", func(t *testing.T) {
+		os.Unsetenv("RAMPART_API")
+		t.Setenv("RAMPART_URL", "http://proxy:7777/")
+		if got := resolveAddr(""); got != "http://proxy:7777" {
+			t.Errorf("got %q", got)
+		}
+	})
+
+	t.Run("empty addr uses config API override", func(t *testing.T) {
+		home := t.TempDir()
+		testSetHome(t, home)
+		os.Unsetenv("RAMPART_API")
+		os.Unsetenv("RAMPART_URL")
+		os.Unsetenv("RAMPART_SERVE_URL")
+		if err := os.MkdirAll(filepath.Join(home, ".rampart"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		cfgPath := filepath.Join(home, ".rampart", "config.yaml")
+		if err := os.WriteFile(cfgPath, []byte("api: http://config-api:8123\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if got := resolveAddr(""); got != "http://config-api:8123" {
+			t.Errorf("got %q", got)
+		}
+	})
+
+	t.Run("explicit addr wins", func(t *testing.T) {
+		t.Setenv("RAMPART_API", "http://custom:1234")
+		if got := resolveAddr("http://other:5678"); got != "http://other:5678" {
+			t.Errorf("got %q", got)
+		}
+	})
 }

--- a/cmd/rampart/cli/approve_test.go
+++ b/cmd/rampart/cli/approve_test.go
@@ -52,23 +52,23 @@ func TestResolveAddr(t *testing.T) {
 		os.Unsetenv("RAMPART_API")
 		os.Unsetenv("RAMPART_URL")
 		os.Unsetenv("RAMPART_SERVE_URL")
-		if got := resolveAddr(""); got != defaultAddr {
-			t.Errorf("got %q", got)
+		if got, err := resolveAddr(""); err != nil || got != defaultAddr {
+			t.Fatalf("got %q err=%v", got, err)
 		}
 	})
 
 	t.Run("empty addr uses RAMPART_API override", func(t *testing.T) {
 		t.Setenv("RAMPART_API", "http://custom:1234/")
-		if got := resolveAddr(""); got != "http://custom:1234" {
-			t.Errorf("got %q", got)
+		if got, err := resolveAddr(""); err != nil || got != "http://custom:1234" {
+			t.Fatalf("got %q err=%v", got, err)
 		}
 	})
 
 	t.Run("empty addr uses serve url resolution chain", func(t *testing.T) {
 		os.Unsetenv("RAMPART_API")
 		t.Setenv("RAMPART_URL", "http://proxy:7777/")
-		if got := resolveAddr(""); got != "http://proxy:7777" {
-			t.Errorf("got %q", got)
+		if got, err := resolveAddr(""); err != nil || got != "http://proxy:7777" {
+			t.Fatalf("got %q err=%v", got, err)
 		}
 	})
 
@@ -85,8 +85,8 @@ func TestResolveAddr(t *testing.T) {
 		if err := os.WriteFile(cfgPath, []byte("api: http://config-api:8123\n"), 0o644); err != nil {
 			t.Fatal(err)
 		}
-		if got := resolveAddr(""); got != "http://config-api:8123" {
-			t.Errorf("got %q", got)
+		if got, err := resolveAddr(""); err != nil || got != "http://config-api:8123" {
+			t.Fatalf("got %q err=%v", got, err)
 		}
 	})
 
@@ -103,15 +103,33 @@ func TestResolveAddr(t *testing.T) {
 		if err := os.WriteFile(cfgPath, []byte("serve_url: http://compat-serve:8124\n"), 0o644); err != nil {
 			t.Fatal(err)
 		}
-		if got := resolveAddr(""); got != "http://compat-serve:8124" {
-			t.Errorf("got %q", got)
+		if got, err := resolveAddr(""); err != nil || got != "http://compat-serve:8124" {
+			t.Fatalf("got %q err=%v", got, err)
 		}
 	})
 
 	t.Run("explicit addr wins", func(t *testing.T) {
 		t.Setenv("RAMPART_API", "http://custom:1234")
-		if got := resolveAddr("http://other:5678"); got != "http://other:5678" {
-			t.Errorf("got %q", got)
+		if got, err := resolveAddr("http://other:5678"); err != nil || got != "http://other:5678" {
+			t.Fatalf("got %q err=%v", got, err)
+		}
+	})
+
+	t.Run("invalid config surfaces error", func(t *testing.T) {
+		home := t.TempDir()
+		testSetHome(t, home)
+		os.Unsetenv("RAMPART_API")
+		os.Unsetenv("RAMPART_URL")
+		os.Unsetenv("RAMPART_SERVE_URL")
+		if err := os.MkdirAll(filepath.Join(home, ".rampart"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		cfgPath := filepath.Join(home, ".rampart", "config.yaml")
+		if err := os.WriteFile(cfgPath, []byte("serveUrl: http://typo\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := resolveAddr(""); err == nil {
+			t.Fatal("expected config parse error")
 		}
 	})
 }

--- a/cmd/rampart/cli/hook.go
+++ b/cmd/rampart/cli/hook.go
@@ -237,8 +237,7 @@ Cline setup: Use "rampart setup cline" to install hooks automatically.`,
 			// Resolve serve-url and serve-token from standard config/env locations.
 			serveAutoDiscovered := serveURL == ""
 			serveURL = resolveServeURL(serveURL)
-			cfg, _ := loadUserConfig()
-			serveToken := cfg.Token
+			serveToken, _ := resolveTokenValue()
 
 			if mode != "enforce" && mode != "monitor" && mode != "audit" {
 				return fmt.Errorf("hook: invalid mode %q (must be enforce, monitor, or audit)", mode)

--- a/cmd/rampart/cli/hook.go
+++ b/cmd/rampart/cli/hook.go
@@ -734,7 +734,7 @@ Cline setup: Use "rampart setup cline" to install hooks automatically.`,
 	cmd.Flags().StringVar(&mode, "mode", "enforce", "Mode: enforce | monitor | audit")
 	cmd.Flags().StringVar(&format, "format", "claude-code", "Input format: claude-code | cline")
 	cmd.Flags().StringVar(&auditDir, "audit-dir", "", "Directory for audit logs (default: ~/.rampart/audit)")
-	cmd.Flags().StringVar(&serveURL, "serve-url", "", "URL of rampart serve instance (default: auto-discover on localhost:9090, env: RAMPART_SERVE_URL)")
+	cmd.Flags().StringVar(&serveURL, "serve-url", "", "Rampart service URL override (default: auto-discover via url/config/state; env: RAMPART_URL or RAMPART_SERVE_URL)")
 	cmd.Flags().StringVar(&configDir, "config-dir", "", "Directory of additional policy YAML files (default: ~/.rampart/policies/ if it exists)")
 
 	return cmd

--- a/cmd/rampart/cli/hook.go
+++ b/cmd/rampart/cli/hook.go
@@ -234,17 +234,24 @@ Cline setup: Use "rampart setup cline" to install hooks automatically.`,
 			gitCtx := deriveGitContext()
 			hookSession := gitCtx.session
 
-			// Resolve serve-url and serve-token from standard config/env locations.
-			serveAutoDiscovered := serveURL == ""
-			serveURL = resolveServeURL(serveURL)
-			serveToken, _ := resolveTokenValue()
-
 			if mode != "enforce" && mode != "monitor" && mode != "audit" {
 				return fmt.Errorf("hook: invalid mode %q (must be enforce, monitor, or audit)", mode)
 			}
 			if format != "claude-code" && format != "cline" {
 				return fmt.Errorf("hook: invalid format %q (must be claude-code or cline)", format)
 			}
+
+			// Resolve serve-url and serve-token from standard config/env locations.
+			serveAutoDiscovered := serveURL == ""
+			resolvedServeURL, resolveErr := resolveServeURLStrict(serveURL, fmt.Sprintf("http://localhost:%d", defaultServePort))
+			if resolveErr != nil {
+				if mode == "enforce" {
+					return outputHookResult(cmd, format, hookDeny, false, "Rampart config error; refusing tool call until configuration is fixed", "")
+				}
+				return fmt.Errorf("hook: resolve serve URL: %w", resolveErr)
+			}
+			serveURL = resolvedServeURL
+			serveToken, _ := resolveTokenValue()
 
 			// Resolve audit directory
 			if auditDir == "" {
@@ -402,30 +409,14 @@ Cline setup: Use "rampart setup cline" to install hooks automatically.`,
 				}
 				decision := eng.Evaluate(failedCall)
 
-				var pendingAsk *session.PendingAsk
-				// If this failure corresponds to a stored ask decision, recover that state
-				// even when serve is unavailable so we can distinguish real Rampart blocks
-				// from ordinary tool failures.
-				if parsed.ToolUseID != "" && parsed.SessionID != "" {
-					sessionMgr := session.NewManager(sessionStateDir(), parsed.SessionID, logger)
-					if ask, dismissErr := sessionMgr.DismissAsk(parsed.ToolUseID); dismissErr == nil && ask != nil {
-						pendingAsk = ask
-						if ask.Audit && ask.AuditApprovalID != "" && serveURL != "" && isServeRunning(serveURL) {
-							approvalClient := &hookApprovalClient{
-								serveURL:       strings.TrimRight(serveURL, "/"),
-								token:          serveToken,
-								logger:         logger,
-								autoDiscovered: serveAutoDiscovered,
-								errWriter:      cmd.ErrOrStderr(),
-							}
-							resolveCtx, cancelResolve := context.WithTimeout(cmd.Context(), 400*time.Millisecond)
-							_ = approvalClient.resolveAskAuditCtx(resolveCtx, ask.AuditApprovalID, false, "hook-posttoolusefailure")
-							cancelResolve()
-						}
-					}
-				}
-
-				if pendingAsk == nil && decision.Action != engine.ActionDeny {
+				// A pending ask alone is not evidence of a denial: the user may have
+				// approved the native prompt and the tool may have failed afterward.
+				// So PostToolUseFailure must not dismiss ask state or mark mirrored serve
+				// approvals denied based solely on this hook event.
+				if decision.Action != engine.ActionDeny {
+					// For ask-mediated flows, PostToolUseFailure is ambiguous: it can mean
+					// either native-prompt denial or an approved tool that later failed.
+					// Do not inject denial guidance or mutate state based on an ambiguous event.
 					return json.NewEncoder(cmd.OutOrStdout()).Encode(hookOutput{})
 				}
 
@@ -467,12 +458,6 @@ Cline setup: Use "rampart setup cline" to install hooks automatically.`,
 						policyHint += " [Project Policy]"
 					}
 					msg = "⛔ Blocked" + policyHint + ": " + decision.Message + "\n\n" + msg
-				} else if pendingAsk != nil && pendingAsk.DecisionMessage != "" {
-					policyHint := ""
-					if pendingAsk.PolicyName != "" {
-						policyHint = " [" + pendingAsk.PolicyName + "]"
-					}
-					msg = "⛔ Approval denied" + policyHint + ": " + pendingAsk.DecisionMessage + "\n\n" + msg
 				}
 				suggestions := engine.GenerateSuggestions(failedCall)
 				if len(suggestions) > 0 {

--- a/cmd/rampart/cli/hook.go
+++ b/cmd/rampart/cli/hook.go
@@ -234,24 +234,11 @@ Cline setup: Use "rampart setup cline" to install hooks automatically.`,
 			gitCtx := deriveGitContext()
 			hookSession := gitCtx.session
 
-			// Resolve serve-url and serve-token from env if not set via flags.
-			serveAutoDiscovered := false
-			if serveURL == "" {
-				serveURL = os.Getenv("RAMPART_SERVE_URL")
-			}
-			if serveURL == "" {
-				serveURL = fmt.Sprintf("http://localhost:%d", defaultServePort)
-				serveAutoDiscovered = true
-			}
-			// Resolve token from RAMPART_TOKEN env var or ~/.rampart/token file.
-			// This means settings.json never needs to contain credentials —
-			// the hook discovers both the URL and the token from standard locations.
-			var serveToken string
-			if envToken := strings.TrimSpace(os.Getenv("RAMPART_TOKEN")); envToken != "" {
-				serveToken = envToken
-			} else if tok, err := readPersistedToken(); err == nil && tok != "" {
-				serveToken = tok
-			}
+			// Resolve serve-url and serve-token from standard config/env locations.
+			serveAutoDiscovered := serveURL == ""
+			serveURL = resolveServeURL(serveURL)
+			cfg, _ := loadUserConfig()
+			serveToken := cfg.Token
 
 			if mode != "enforce" && mode != "monitor" && mode != "audit" {
 				return fmt.Errorf("hook: invalid mode %q (must be enforce, monitor, or audit)", mode)
@@ -406,26 +393,41 @@ Cline setup: Use "rampart setup cline" to install hooks automatically.`,
 				return outputHookResult(cmd, format, hookOutcome, false, fmt.Sprintf("parse failure: %v", err), "")
 			}
 
-			// Short-circuit for PostToolUseFailure: the previous PreToolUse was denied by
-			// Rampart. Inject additionalContext telling Claude to stop retrying rather than
-			// burning 3-5 turns on workarounds.
+			// PostToolUseFailure: only inject policy guidance when the failure appears to
+			// be Rampart-mediated (a deny or a stored ask-flow decision). Ordinary tool
+			// failures should not be mislabeled as security blocks.
 			if parsed.HookEventName == "PostToolUseFailure" {
-				// If this failure corresponds to an ask+audit prompt denial, best-effort
-				// resolve the mirrored serve approval as denied for dashboard/watch sync.
-				if parsed.ToolUseID != "" && parsed.SessionID != "" && serveURL != "" && isServeRunning(serveURL) {
+				failedCall := engine.ToolCall{
+					Tool:   parsed.Tool,
+					Params: parsed.Params,
+				}
+				decision := eng.Evaluate(failedCall)
+
+				var pendingAsk *session.PendingAsk
+				// If this failure corresponds to a stored ask decision, recover that state
+				// even when serve is unavailable so we can distinguish real Rampart blocks
+				// from ordinary tool failures.
+				if parsed.ToolUseID != "" && parsed.SessionID != "" {
 					sessionMgr := session.NewManager(sessionStateDir(), parsed.SessionID, logger)
-					if ask, dismissErr := sessionMgr.DismissAsk(parsed.ToolUseID); dismissErr == nil && ask != nil && ask.Audit && ask.AuditApprovalID != "" {
-						approvalClient := &hookApprovalClient{
-							serveURL:       strings.TrimRight(serveURL, "/"),
-							token:          serveToken,
-							logger:         logger,
-							autoDiscovered: serveAutoDiscovered,
-							errWriter:      cmd.ErrOrStderr(),
+					if ask, dismissErr := sessionMgr.DismissAsk(parsed.ToolUseID); dismissErr == nil && ask != nil {
+						pendingAsk = ask
+						if ask.Audit && ask.AuditApprovalID != "" && serveURL != "" && isServeRunning(serveURL) {
+							approvalClient := &hookApprovalClient{
+								serveURL:       strings.TrimRight(serveURL, "/"),
+								token:          serveToken,
+								logger:         logger,
+								autoDiscovered: serveAutoDiscovered,
+								errWriter:      cmd.ErrOrStderr(),
+							}
+							resolveCtx, cancelResolve := context.WithTimeout(cmd.Context(), 400*time.Millisecond)
+							_ = approvalClient.resolveAskAuditCtx(resolveCtx, ask.AuditApprovalID, false, "hook-posttoolusefailure")
+							cancelResolve()
 						}
-						resolveCtx, cancelResolve := context.WithTimeout(cmd.Context(), 400*time.Millisecond)
-						_ = approvalClient.resolveAskAuditCtx(resolveCtx, ask.AuditApprovalID, false, "hook-posttoolusefailure")
-						cancelResolve()
 					}
+				}
+
+				if pendingAsk == nil && decision.Action != engine.ActionDeny {
+					return json.NewEncoder(cmd.OutOrStdout()).Encode(hookOutput{})
 				}
 
 				postToolUseFailureEvent := audit.Event{
@@ -446,15 +448,6 @@ Cline setup: Use "rampart setup cline" to install hooks automatically.`,
 					_, _ = auditFile.Write(line)
 				}
 
-				// Re-evaluate the failed call to surface the specific deny reason and
-				// matched policy name. This is a fast local operation (< 10µs) and gives
-				// the agent the exact information it needs without storing state.
-				failedCall := engine.ToolCall{
-					Tool:   parsed.Tool,
-					Params: parsed.Params,
-				}
-				denyDecision := eng.Evaluate(failedCall)
-
 				explainCmd := "rampart policy explain '" + parsed.Tool + "'"
 				msg := "This tool call failed or was blocked by a security policy. " +
 					"Do not attempt alternative approaches or workarounds — " +
@@ -466,15 +459,21 @@ Cline setup: Use "rampart setup cline" to install hooks automatically.`,
 
 				// Prepend the specific deny reason if available — gives the agent
 				// (and user) immediate context on why the call was blocked.
-				if denyDecision.Action == engine.ActionDeny && denyDecision.Message != "" {
+				if decision.Action == engine.ActionDeny && decision.Message != "" {
 					policyHint := ""
-					if len(denyDecision.MatchedPolicies) > 0 {
-						policyHint = " [" + denyDecision.MatchedPolicies[0] + "]"
+					if len(decision.MatchedPolicies) > 0 {
+						policyHint = " [" + decision.MatchedPolicies[0] + "]"
 					}
-					if denyDecision.FromProjectPolicy {
+					if decision.FromProjectPolicy {
 						policyHint += " [Project Policy]"
 					}
-					msg = "⛔ Blocked" + policyHint + ": " + denyDecision.Message + "\n\n" + msg
+					msg = "⛔ Blocked" + policyHint + ": " + decision.Message + "\n\n" + msg
+				} else if pendingAsk != nil && pendingAsk.DecisionMessage != "" {
+					policyHint := ""
+					if pendingAsk.PolicyName != "" {
+						policyHint = " [" + pendingAsk.PolicyName + "]"
+					}
+					msg = "⛔ Approval denied" + policyHint + ": " + pendingAsk.DecisionMessage + "\n\n" + msg
 				}
 				suggestions := engine.GenerateSuggestions(failedCall)
 				if len(suggestions) > 0 {

--- a/cmd/rampart/cli/hook_ask_audit_test.go
+++ b/cmd/rampart/cli/hook_ask_audit_test.go
@@ -223,3 +223,90 @@ policies:
 		t.Fatalf("resolve body = %#v, want %#v", lastResolveBody, want)
 	}
 }
+
+func TestHookActionAskAudit_PostToolUseFailure_ResolvesDenied(t *testing.T) {
+	dir := t.TempDir()
+	testSetHome(t, dir)
+
+	const policy = `version: "1"
+policies:
+  - name: test-ask-audit-deny
+    match:
+      tool: ["exec"]
+    rules:
+      - action: ask
+        ask:
+          audit: true
+        message: "approve this command?"
+`
+	configPath := filepath.Join(dir, "policy.yaml")
+	if err := os.WriteFile(configPath, []byte(policy), 0o644); err != nil {
+		t.Fatalf("write policy: %v", err)
+	}
+
+	var createCount atomic.Int32
+	var resolveCount atomic.Int32
+	var lastResolveBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/healthz":
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/approvals":
+			createCount.Add(1)
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "ap-audit-denied-1", "status": "pending"})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/approvals/ap-audit-denied-1/resolve":
+			resolveCount.Add(1)
+			_ = json.NewDecoder(r.Body).Decode(&lastResolveBody)
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "ap-audit-denied-1", "status": "denied"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	opts := &rootOptions{configPath: configPath}
+	prePayload := map[string]any{
+		"hook_event_name": "PreToolUse",
+		"session_id":      "sess-audit-deny-001",
+		"tool_use_id":     "toolu_audit_deny_001",
+		"tool_name":       "Bash",
+		"tool_input":      map[string]any{"command": "sudo apt install git"},
+	}
+	preJSON, _ := json.Marshal(prePayload)
+	if _, _, err := runHookWithStdin(t, opts, string(preJSON), "--mode", "enforce", "--serve-url", srv.URL); err != nil {
+		t.Fatalf("pre hook error: %v", err)
+	}
+	if createCount.Load() != 1 {
+		t.Fatalf("expected one create call, got %d", createCount.Load())
+	}
+
+	postPayload := map[string]any{
+		"hook_event_name": "PostToolUseFailure",
+		"session_id":      "sess-audit-deny-001",
+		"tool_use_id":     "toolu_audit_deny_001",
+		"tool_name":       "Bash",
+		"tool_input":      map[string]any{"command": "sudo apt install git"},
+	}
+	postJSON, _ := json.Marshal(postPayload)
+	stdout, _, err := runHookWithStdin(t, opts, string(postJSON), "--mode", "enforce", "--serve-url", srv.URL)
+	if err != nil {
+		t.Fatalf("post hook error: %v", err)
+	}
+	if resolveCount.Load() != 1 {
+		t.Fatalf("expected one resolve call, got %d", resolveCount.Load())
+	}
+	want := map[string]any{"approved": false, "resolved_by": "hook-posttoolusefailure"}
+	if !reflect.DeepEqual(lastResolveBody, want) {
+		t.Fatalf("resolve body = %#v, want %#v", lastResolveBody, want)
+	}
+
+	var out hookOutput
+	if err := json.Unmarshal([]byte(stdout), &out); err != nil {
+		t.Fatalf("unmarshal hook output: %v (stdout=%q)", err, stdout)
+	}
+	if out.HookSpecificOutput == nil || !strings.Contains(out.HookSpecificOutput.AdditionalContext, "Approval denied") {
+		t.Fatalf("expected approval-denied context, got %+v", out.HookSpecificOutput)
+	}
+}

--- a/cmd/rampart/cli/hook_ask_audit_test.go
+++ b/cmd/rampart/cli/hook_ask_audit_test.go
@@ -294,19 +294,18 @@ policies:
 	if err != nil {
 		t.Fatalf("post hook error: %v", err)
 	}
-	if resolveCount.Load() != 1 {
-		t.Fatalf("expected one resolve call, got %d", resolveCount.Load())
+	if resolveCount.Load() != 0 {
+		t.Fatalf("expected no resolve call for ambiguous ask failure, got %d", resolveCount.Load())
 	}
-	want := map[string]any{"approved": false, "resolved_by": "hook-posttoolusefailure"}
-	if !reflect.DeepEqual(lastResolveBody, want) {
-		t.Fatalf("resolve body = %#v, want %#v", lastResolveBody, want)
+	if lastResolveBody != nil {
+		t.Fatalf("expected no resolve body, got %#v", lastResolveBody)
 	}
 
 	var out hookOutput
 	if err := json.Unmarshal([]byte(stdout), &out); err != nil {
 		t.Fatalf("unmarshal hook output: %v (stdout=%q)", err, stdout)
 	}
-	if out.HookSpecificOutput == nil || !strings.Contains(out.HookSpecificOutput.AdditionalContext, "Approval denied") {
-		t.Fatalf("expected approval-denied context, got %+v", out.HookSpecificOutput)
+	if out.HookSpecificOutput != nil && out.HookSpecificOutput.AdditionalContext != "" {
+		t.Fatalf("expected no inferred approval-denied context, got %+v", out.HookSpecificOutput)
 	}
 }

--- a/cmd/rampart/cli/hook_posttooluse_test.go
+++ b/cmd/rampart/cli/hook_posttooluse_test.go
@@ -98,15 +98,13 @@ func TestPostToolUseFailure_DenyReasonSurfaced(t *testing.T) {
 	}
 }
 
-// TestPostToolUseFailure_NoReasonForUnknownCommand verifies that when the
-// PostToolUseFailure event is for a command that doesn't match any deny rule
-// (e.g. the policy was updated between PreToolUse and PostToolUseFailure),
-// the fallback guidance is still returned without crashing.
-func TestPostToolUseFailure_NoReasonForUnknownCommand(t *testing.T) {
+// TestPostToolUseFailure_NoContextForOrdinaryFailure verifies that ordinary
+// tool failures are not mislabeled as policy blocks.
+func TestPostToolUseFailure_NoContextForOrdinaryFailure(t *testing.T) {
 	dir := t.TempDir()
 	testSetHome(t, dir)
 
-	// Policy that allows everything — simulates policy change between events.
+	// Policy that allows everything — simulates an ordinary tool failure.
 	allowAll := `version: "1"
 default_action: allow
 policies: []
@@ -137,16 +135,66 @@ policies: []
 	if err := json.Unmarshal([]byte(stdout), &out); err != nil {
 		t.Fatalf("unmarshal hook output: %v (stdout=%q)", err, stdout)
 	}
-	if out.HookSpecificOutput == nil {
-		t.Fatal("expected non-nil HookSpecificOutput")
-	}
-	// Should still have guidance even without a matching deny rule.
-	if out.HookSpecificOutput.AdditionalContext == "" {
-		t.Fatal("additionalContext must not be empty even when no deny rule matches")
-	}
-	// Should NOT have the ⛔ prefix since re-evaluation returned allow.
-	if strings.Contains(out.HookSpecificOutput.AdditionalContext, "⛔ Blocked") {
-		t.Errorf("additionalContext should not contain ⛔ Blocked when re-evaluation returns allow; got:\n%s",
+	if out.HookSpecificOutput != nil && out.HookSpecificOutput.AdditionalContext != "" {
+		t.Errorf("expected no additionalContext for ordinary tool failure; got:\n%s",
 			out.HookSpecificOutput.AdditionalContext)
+	}
+}
+
+func TestPostToolUseFailure_AskFlowStillReturnsContext(t *testing.T) {
+	dir := t.TempDir()
+	testSetHome(t, dir)
+
+	configPath := filepath.Join(dir, "policy.yaml")
+	if err := os.WriteFile(configPath, []byte(askPolicy), 0o644); err != nil {
+		t.Fatalf("write policy: %v", err)
+	}
+
+	const sessionID = "sess-posttooluse-ask-001"
+	const toolUseID = "toolu_posttooluse_ask_001"
+
+	prePayload := map[string]any{
+		"hook_event_name": "PreToolUse",
+		"session_id":      sessionID,
+		"tool_use_id":     toolUseID,
+		"tool_name":       "Bash",
+		"tool_input":      map[string]any{"command": "sudo apt install git"},
+	}
+	preJSON, _ := json.Marshal(prePayload)
+	opts := &rootOptions{configPath: configPath}
+	stdout, _, hookErr := runHookWithStdin(t, opts, string(preJSON), "--mode", "enforce")
+	if hookErr != nil {
+		t.Fatalf("pre hook RunE error: %v", hookErr)
+	}
+	var preOut hookOutput
+	if err := json.Unmarshal([]byte(stdout), &preOut); err != nil {
+		t.Fatalf("unmarshal pre hook output: %v", err)
+	}
+	if preOut.HookSpecificOutput == nil || preOut.HookSpecificOutput.PermissionDecision != "ask" {
+		t.Fatalf("expected permissionDecision=ask, got %+v", preOut.HookSpecificOutput)
+	}
+
+	postPayload := map[string]any{
+		"hook_event_name": "PostToolUseFailure",
+		"session_id":      sessionID,
+		"tool_use_id":     toolUseID,
+		"tool_name":       "Bash",
+		"tool_input":      map[string]any{"command": "sudo apt install git"},
+	}
+	postJSON, _ := json.Marshal(postPayload)
+	stdout, _, hookErr = runHookWithStdin(t, opts, string(postJSON), "--mode", "enforce")
+	if hookErr != nil {
+		t.Fatalf("post hook RunE error: %v", hookErr)
+	}
+
+	var out hookOutput
+	if err := json.Unmarshal([]byte(stdout), &out); err != nil {
+		t.Fatalf("unmarshal hook output: %v (stdout=%q)", err, stdout)
+	}
+	if out.HookSpecificOutput == nil || out.HookSpecificOutput.AdditionalContext == "" {
+		t.Fatalf("expected additionalContext for ask-mediated denial, got %+v", out.HookSpecificOutput)
+	}
+	if !strings.Contains(out.HookSpecificOutput.AdditionalContext, "Approval denied") {
+		t.Fatalf("expected ask denial context, got:\n%s", out.HookSpecificOutput.AdditionalContext)
 	}
 }

--- a/cmd/rampart/cli/hook_posttooluse_test.go
+++ b/cmd/rampart/cli/hook_posttooluse_test.go
@@ -141,7 +141,7 @@ policies: []
 	}
 }
 
-func TestPostToolUseFailure_AskFlowStillReturnsContext(t *testing.T) {
+func TestPostToolUseFailure_AskFlowDoesNotInferDenial(t *testing.T) {
 	dir := t.TempDir()
 	testSetHome(t, dir)
 
@@ -191,10 +191,22 @@ func TestPostToolUseFailure_AskFlowStillReturnsContext(t *testing.T) {
 	if err := json.Unmarshal([]byte(stdout), &out); err != nil {
 		t.Fatalf("unmarshal hook output: %v (stdout=%q)", err, stdout)
 	}
-	if out.HookSpecificOutput == nil || out.HookSpecificOutput.AdditionalContext == "" {
-		t.Fatalf("expected additionalContext for ask-mediated denial, got %+v", out.HookSpecificOutput)
+	if out.HookSpecificOutput != nil && out.HookSpecificOutput.AdditionalContext != "" {
+		t.Fatalf("expected no inferred denial context for ambiguous ask failure, got %+v", out.HookSpecificOutput)
 	}
-	if !strings.Contains(out.HookSpecificOutput.AdditionalContext, "Approval denied") {
-		t.Fatalf("expected ask denial context, got:\n%s", out.HookSpecificOutput.AdditionalContext)
+
+	statePath := filepath.Join(dir, ".rampart", "session-state", sessionID+".json")
+	data, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatalf("read session state: %v", err)
+	}
+	var state struct {
+		PendingAsks map[string]any `json:"pending_asks"`
+	}
+	if err := json.Unmarshal(data, &state); err != nil {
+		t.Fatalf("unmarshal session state: %v", err)
+	}
+	if _, ok := state.PendingAsks[toolUseID]; !ok {
+		t.Fatalf("expected pending ask %q to remain until an explicit resolution arrives", toolUseID)
 	}
 }

--- a/cmd/rampart/cli/paths.go
+++ b/cmd/rampart/cli/paths.go
@@ -1,0 +1,24 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// rampartDir returns the path to the per-user Rampart state directory.
+func rampartDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home directory: %w", err)
+	}
+	if strings.TrimSpace(home) == "" {
+		return "", fmt.Errorf("resolve home directory: empty path")
+	}
+	return filepath.Join(home, ".rampart"), nil
+}

--- a/cmd/rampart/cli/policy.go
+++ b/cmd/rampart/cli/policy.go
@@ -483,8 +483,7 @@ file each policy came from (standard.yaml, user-overrides.yaml, auto-allowed.yam
 Requires rampart serve to be running.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			serveURL := resolveServeURL("")
-			cfg, _ := loadUserConfig()
-			token := cfg.Token
+			token, _ := resolveTokenValue()
 
 			req, _ := http.NewRequestWithContext(cmd.Context(), "GET", serveURL+"/v1/policies", nil)
 			req.Header.Set("Authorization", "Bearer "+token)

--- a/cmd/rampart/cli/policy.go
+++ b/cmd/rampart/cli/policy.go
@@ -482,14 +482,9 @@ file each policy came from (standard.yaml, user-overrides.yaml, auto-allowed.yam
 
 Requires rampart serve to be running.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			serveURL := os.Getenv("RAMPART_SERVE_URL")
-			if serveURL == "" {
-				serveURL = fmt.Sprintf("http://localhost:%d", defaultServePort)
-			}
-			token := os.Getenv("RAMPART_TOKEN")
-			if token == "" {
-				token, _ = readPersistedToken()
-			}
+			serveURL := resolveServeURL("")
+			cfg, _ := loadUserConfig()
+			token := cfg.Token
 
 			req, _ := http.NewRequestWithContext(cmd.Context(), "GET", serveURL+"/v1/policies", nil)
 			req.Header.Set("Authorization", "Bearer "+token)

--- a/cmd/rampart/cli/policy.go
+++ b/cmd/rampart/cli/policy.go
@@ -482,7 +482,10 @@ file each policy came from (standard.yaml, user-overrides.yaml, auto-allowed.yam
 
 Requires rampart serve to be running.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			serveURL := resolveServeURL("")
+			serveURL, err := resolveServeURLStrict("", fmt.Sprintf("http://localhost:%d", defaultServePort))
+			if err != nil {
+				return fmt.Errorf("policy rules: resolve serve URL: %w", err)
+			}
 			token, _ := resolveTokenValue()
 
 			req, _ := http.NewRequestWithContext(cmd.Context(), "GET", serveURL+"/v1/policies", nil)

--- a/cmd/rampart/cli/preload.go
+++ b/cmd/rampart/cli/preload.go
@@ -56,10 +56,9 @@ func newPreloadCmd(_ *rootOptions) *cobra.Command {
 				return err
 			}
 
-			cfg, _ := loadUserConfig()
-			baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
-			if cfg.URL != "" {
-				baseURL = cfg.URL
+			baseURL, err := resolvePreloadBaseURL(port)
+			if err != nil {
+				return fmt.Errorf("preload: resolve Rampart URL: %w", err)
 			}
 			if !isPreloadRuntimeReady(cmd.Context(), baseURL) {
 				fmt.Fprintf(cmd.ErrOrStderr(), "preload: warning: rampart serve is not reachable at %s/healthz; continuing\n", baseURL)
@@ -120,6 +119,10 @@ func newPreloadCmd(_ *rootOptions) *cobra.Command {
 	cmd.Flags().BoolVar(&debug, "debug", false, "Enable debug logging in the library")
 
 	return cmd
+}
+
+func resolvePreloadBaseURL(port int) (string, error) {
+	return resolveServeURLStrict("", fmt.Sprintf("http://127.0.0.1:%d", port))
 }
 
 func resolvePreloadLibrary() (string, string, error) {

--- a/cmd/rampart/cli/preload.go
+++ b/cmd/rampart/cli/preload.go
@@ -56,9 +56,10 @@ func newPreloadCmd(_ *rootOptions) *cobra.Command {
 				return err
 			}
 
+			cfg, _ := loadUserConfig()
 			baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
-			if envURL := strings.TrimSpace(os.Getenv("RAMPART_URL")); envURL != "" {
-				baseURL = strings.TrimRight(envURL, "/")
+			if cfg.URL != "" {
+				baseURL = cfg.URL
 			}
 			if !isPreloadRuntimeReady(cmd.Context(), baseURL) {
 				fmt.Fprintf(cmd.ErrOrStderr(), "preload: warning: rampart serve is not reachable at %s/healthz; continuing\n", baseURL)
@@ -66,7 +67,7 @@ func newPreloadCmd(_ *rootOptions) *cobra.Command {
 
 			resolvedToken := token
 			if resolvedToken == "" {
-				resolvedToken = os.Getenv("RAMPART_TOKEN")
+				resolvedToken = cfg.Token
 			}
 
 			sessionID := strings.TrimSpace(session)

--- a/cmd/rampart/cli/preload.go
+++ b/cmd/rampart/cli/preload.go
@@ -67,7 +67,7 @@ func newPreloadCmd(_ *rootOptions) *cobra.Command {
 
 			resolvedToken := token
 			if resolvedToken == "" {
-				resolvedToken = cfg.Token
+				resolvedToken, _ = resolveTokenValue()
 			}
 
 			sessionID := strings.TrimSpace(session)

--- a/cmd/rampart/cli/preload_test.go
+++ b/cmd/rampart/cli/preload_test.go
@@ -1,56 +1,44 @@
 package cli
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 )
 
-func TestGetEnvValue(t *testing.T) {
-	env := []string{"FOO=bar", "BAZ=qux", "EMPTY="}
-	tests := []struct {
-		key  string
-		want string
-	}{
-		{"FOO", "bar"},
-		{"BAZ", "qux"},
-		{"EMPTY", ""},
-		{"MISSING", ""},
+func TestResolvePreloadBaseURL_UsesServeURLAlias(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+	t.Setenv("RAMPART_URL", "")
+	t.Setenv("RAMPART_SERVE_URL", "")
+
+	if err := os.MkdirAll(filepath.Join(home, ".rampart"), 0o755); err != nil {
+		t.Fatal(err)
 	}
-	for _, tt := range tests {
-		if got := getEnvValue(env, tt.key); got != tt.want {
-			t.Errorf("getEnvValue(%q) = %q, want %q", tt.key, got, tt.want)
-		}
+	if err := os.WriteFile(filepath.Join(home, ".rampart", "config.yaml"), []byte("serve_url: http://compat-serve:9123\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := resolvePreloadBaseURL(9099)
+	if err != nil {
+		t.Fatalf("resolvePreloadBaseURL: %v", err)
+	}
+	if got != "http://compat-serve:9123" {
+		t.Fatalf("got %q", got)
 	}
 }
 
-func TestSetEnvValue(t *testing.T) {
-	env := []string{"FOO=bar", "BAZ=qux"}
-
-	// Override existing
-	result := setEnvValue(env, "FOO", "new")
-	if got := getEnvValue(result, "FOO"); got != "new" {
-		t.Errorf("after override FOO = %q", got)
+func TestResolvePreloadBaseURL_RejectsInvalidConfig(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+	if err := os.MkdirAll(filepath.Join(home, ".rampart"), 0o755); err != nil {
+		t.Fatal(err)
 	}
-	if got := getEnvValue(result, "BAZ"); got != "qux" {
-		t.Errorf("BAZ should be preserved, got %q", got)
+	if err := os.WriteFile(filepath.Join(home, ".rampart", "config.yaml"), []byte("serveUrl: http://typo\n"), 0o644); err != nil {
+		t.Fatal(err)
 	}
 
-	// Add new
-	result2 := setEnvValue(env, "NEW", "val")
-	if got := getEnvValue(result2, "NEW"); got != "val" {
-		t.Errorf("new key = %q", got)
-	}
-}
-
-func TestResolvePreloadLibrary(t *testing.T) {
-	// This will fail to find the library, but should return a meaningful error
-	_, _, err := resolvePreloadLibrary()
-	if err == nil {
-		// If it somehow found a library, that's fine too
-		return
-	}
-	// Should mention the library name
-	errStr := err.Error()
-	if errStr == "" {
-		t.Fatal("expected non-empty error")
+	if _, err := resolvePreloadBaseURL(9099); err == nil {
+		t.Fatal("expected config parse error")
 	}
 }

--- a/cmd/rampart/cli/rules.go
+++ b/cmd/rampart/cli/rules.go
@@ -437,7 +437,10 @@ func runRulesRemove(cmd *cobra.Command, opts *rootOptions, indexStr string, forc
 
 	// Try to reload the daemon.
 	resolvedToken := resolveToken(token)
-	resolvedAddr := resolveAddrAllow(apiAddr)
+	resolvedAddr, err := resolveAddrAllow(apiAddr)
+	if err != nil {
+		return fmt.Errorf("rules: resolve reload API address: %w", err)
+	}
 	reloaded, _ := reloadPolicy(cmd, resolvedAddr, resolvedToken)
 	if reloaded {
 		fmt.Fprintf(out, "  %s\n\n", rulesOkStyle.Render(
@@ -561,7 +564,10 @@ func runRulesReset(cmd *cobra.Command, opts *rootOptions, force bool, apiAddr, t
 
 	// Try to reload the daemon.
 	resolvedToken := resolveToken(token)
-	resolvedAddr := resolveAddrAllow(apiAddr)
+	resolvedAddr, err := resolveAddrAllow(apiAddr)
+	if err != nil {
+		return fmt.Errorf("rules: resolve reload API address: %w", err)
+	}
 	reloaded, _ := reloadPolicy(cmd, resolvedAddr, resolvedToken)
 	if reloaded {
 		fmt.Fprintf(out, "  %s\n\n", rulesOkStyle.Render(

--- a/cmd/rampart/cli/rules.go
+++ b/cmd/rampart/cli/rules.go
@@ -334,7 +334,7 @@ First run 'rampart rules' to see rule numbers, then:
 	}
 
 	cmd.Flags().BoolVar(&force, "force", false, "Skip confirmation prompt")
-	cmd.Flags().StringVar(&apiAddr, "api", "http://127.0.0.1:9090", "Rampart serve API address for reload")
+	cmd.Flags().StringVar(&apiAddr, "api", "", "Rampart API address override for reload (default: auto-discover via url/config/state)")
 	cmd.Flags().StringVar(&token, "token", "", "API auth token (or set RAMPART_TOKEN)")
 
 	// Custom error handler to catch negative numbers being parsed as flags
@@ -491,7 +491,7 @@ func newRulesResetCmd(opts *rootOptions) *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&force, "force", false, "Skip confirmation prompt")
-	cmd.Flags().StringVar(&apiAddr, "api", "http://127.0.0.1:9090", "Rampart serve API address for reload")
+	cmd.Flags().StringVar(&apiAddr, "api", "", "Rampart API address override for reload (default: auto-discover via url/config/state)")
 	cmd.Flags().StringVar(&token, "token", "", "API auth token (or set RAMPART_TOKEN)")
 	return cmd
 }

--- a/cmd/rampart/cli/serve.go
+++ b/cmd/rampart/cli/serve.go
@@ -345,8 +345,8 @@ func newServeCmd(opts *rootOptions, deps *serveDeps) *cobra.Command {
 				// Resolve token: flag > env > persisted file > generate new.
 				// Mirrors serve install behaviour so the token survives restarts.
 				{
-					if cfg, err := loadUserConfig(); err == nil && cfg.Token != "" {
-						proxyOpts = append(proxyOpts, proxy.WithToken(cfg.Token))
+					if tok, _ := resolveTokenValue(); tok != "" {
+						proxyOpts = append(proxyOpts, proxy.WithToken(tok))
 					}
 				}
 				if resolveBaseURL != "" {

--- a/cmd/rampart/cli/serve.go
+++ b/cmd/rampart/cli/serve.go
@@ -345,17 +345,8 @@ func newServeCmd(opts *rootOptions, deps *serveDeps) *cobra.Command {
 				// Resolve token: flag > env > persisted file > generate new.
 				// Mirrors serve install behaviour so the token survives restarts.
 				{
-					var tok string
-					switch {
-					case os.Getenv("RAMPART_TOKEN") != "":
-						tok = os.Getenv("RAMPART_TOKEN")
-					default:
-						if persisted, err := readPersistedToken(); err == nil && persisted != "" {
-							tok = persisted
-						}
-					}
-					if tok != "" {
-						proxyOpts = append(proxyOpts, proxy.WithToken(tok))
+					if cfg, err := loadUserConfig(); err == nil && cfg.Token != "" {
+						proxyOpts = append(proxyOpts, proxy.WithToken(cfg.Token))
 					}
 				}
 				if resolveBaseURL != "" {

--- a/cmd/rampart/cli/serve_install.go
+++ b/cmd/rampart/cli/serve_install.go
@@ -117,8 +117,8 @@ func resolveServiceToken(tokenFlag string) (string, bool, error) {
 	if tokenFlag != "" {
 		return tokenFlag, false, nil
 	}
-	if cfg, err := loadUserConfig(); err == nil && cfg.Token != "" {
-		return cfg.Token, false, nil
+	if tok, _ := resolveTokenValue(); tok != "" {
+		return tok, false, nil
 	}
 	b := make([]byte, 16)
 	if _, err := rand.Read(b); err != nil {

--- a/cmd/rampart/cli/serve_install.go
+++ b/cmd/rampart/cli/serve_install.go
@@ -17,13 +17,13 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"html/template"
 	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
-	"html/template"
 
 	"github.com/spf13/cobra"
 )
@@ -117,12 +117,8 @@ func resolveServiceToken(tokenFlag string) (string, bool, error) {
 	if tokenFlag != "" {
 		return tokenFlag, false, nil
 	}
-	if env := os.Getenv("RAMPART_TOKEN"); env != "" {
-		return env, false, nil
-	}
-	// Check persisted token file written by a previous serve install.
-	if tok, err := readPersistedToken(); err == nil && tok != "" {
-		return tok, false, nil
+	if cfg, err := loadUserConfig(); err == nil && cfg.Token != "" {
+		return cfg.Token, false, nil
 	}
 	b := make([]byte, 16)
 	if _, err := rand.Read(b); err != nil {
@@ -133,11 +129,11 @@ func resolveServiceToken(tokenFlag string) (string, bool, error) {
 
 // tokenFilePath returns the path to the persisted token file.
 func tokenFilePath() (string, error) {
-	home, err := os.UserHomeDir()
+	dir, err := rampartDir()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(home, ".rampart", "token"), nil
+	return filepath.Join(dir, "token"), nil
 }
 
 // persistToken writes the token to ~/.rampart/token with owner-only permissions.

--- a/cmd/rampart/cli/serve_state.go
+++ b/cmd/rampart/cli/serve_state.go
@@ -50,7 +50,7 @@ func removeServeState(dir string) {
 // resolveServeURL determines the serve URL using this priority:
 //  1. Explicit flag value (if non-empty)
 //  2. RAMPART_URL / config url
-//  3. RAMPART_SERVE_URL / config serve_url
+//  3. RAMPART_SERVE_URL / config serve_url (compatibility alias)
 //  4. serve.state file in ~/.rampart/
 //  5. Default port (9090)
 func resolveServeURL(flagValue string) string {

--- a/cmd/rampart/cli/serve_state.go
+++ b/cmd/rampart/cli/serve_state.go
@@ -47,24 +47,26 @@ func removeServeState(dir string) {
 	os.Remove(filepath.Join(dir, serveStateFile))
 }
 
-// resolveServeURL determines the serve URL using this priority:
+// resolveServeURLStrict determines the serve URL using this priority:
 //  1. Explicit flag value (if non-empty)
 //  2. RAMPART_URL / config url
 //  3. RAMPART_SERVE_URL / config serve_url (compatibility alias)
 //  4. serve.state file in ~/.rampart/
-//  5. Default port (9090)
-func resolveServeURL(flagValue string) string {
+//  5. Provided fallback URL
+func resolveServeURLStrict(flagValue, fallback string) (string, error) {
 	if flagValue != "" {
-		return strings.TrimRight(flagValue, "/")
+		return strings.TrimRight(flagValue, "/"), nil
 	}
 
 	if cfg, err := loadUserConfig(); err == nil {
 		if cfg.URL != "" {
-			return cfg.URL
+			return cfg.URL, nil
 		}
 		if cfg.ServeURL != "" {
-			return cfg.ServeURL
+			return cfg.ServeURL, nil
 		}
+	} else {
+		return "", err
 	}
 
 	// Try state file.
@@ -73,10 +75,20 @@ func resolveServeURL(flagValue string) string {
 		if data, err := os.ReadFile(statePath); err == nil {
 			var state serveState
 			if json.Unmarshal(data, &state) == nil && state.URL != "" {
-				return state.URL
+				return state.URL, nil
 			}
 		}
 	}
 
-	return fmt.Sprintf("http://localhost:%d", defaultServePort)
+	return fallback, nil
+}
+
+// resolveServeURL is a best-effort helper for legacy/internal call sites that
+// prefer fallback behavior over surfacing configuration errors.
+func resolveServeURL(flagValue string) string {
+	resolved, err := resolveServeURLStrict(flagValue, fmt.Sprintf("http://localhost:%d", defaultServePort))
+	if err != nil {
+		return fmt.Sprintf("http://localhost:%d", defaultServePort)
+	}
+	return resolved
 }

--- a/cmd/rampart/cli/serve_state.go
+++ b/cmd/rampart/cli/serve_state.go
@@ -49,8 +49,8 @@ func removeServeState(dir string) {
 
 // resolveServeURL determines the serve URL using this priority:
 //  1. Explicit flag value (if non-empty)
-//  2. RAMPART_URL env var
-//  3. RAMPART_SERVE_URL env var
+//  2. RAMPART_URL / config url
+//  3. RAMPART_SERVE_URL / config serve_url
 //  4. serve.state file in ~/.rampart/
 //  5. Default port (9090)
 func resolveServeURL(flagValue string) string {
@@ -58,18 +58,18 @@ func resolveServeURL(flagValue string) string {
 		return strings.TrimRight(flagValue, "/")
 	}
 
-	if u := strings.TrimSpace(os.Getenv("RAMPART_URL")); u != "" {
-		return strings.TrimRight(u, "/")
-	}
-
-	if u := strings.TrimSpace(os.Getenv("RAMPART_SERVE_URL")); u != "" {
-		return strings.TrimRight(u, "/")
+	if cfg, err := loadUserConfig(); err == nil {
+		if cfg.URL != "" {
+			return cfg.URL
+		}
+		if cfg.ServeURL != "" {
+			return cfg.ServeURL
+		}
 	}
 
 	// Try state file.
-	home, err := os.UserHomeDir()
-	if err == nil {
-		statePath := filepath.Join(home, ".rampart", serveStateFile)
+	if dir, err := rampartDir(); err == nil {
+		statePath := filepath.Join(dir, serveStateFile)
 		if data, err := os.ReadFile(statePath); err == nil {
 			var state serveState
 			if json.Unmarshal(data, &state) == nil && state.URL != "" {
@@ -80,5 +80,3 @@ func resolveServeURL(flagValue string) string {
 
 	return fmt.Sprintf("http://localhost:%d", defaultServePort)
 }
-
-

--- a/cmd/rampart/cli/setup.go
+++ b/cmd/rampart/cli/setup.go
@@ -97,7 +97,8 @@ Use --remove to uninstall the Rampart hooks from Claude Code settings.`,
 				return nil
 			}
 
-			// Build the hook config — no --serve-url needed, hook auto-discovers on localhost:9090.
+			// Build the hook config — no --serve-url needed; the hook resolves its
+			// endpoint via flag/env/config/state with localhost:9090 as the final fallback.
 			// Use absolute path so the hook works regardless of Claude Code's PATH.
 			// The hook reads RAMPART_TOKEN from ~/.rampart/token automatically, so
 			// settings.json never needs to contain credentials.
@@ -561,20 +562,20 @@ Use --remove to uninstall (preserves policies and audit logs).`,
 					fmt.Fprintln(out, "  [ ] File operations (read/write/edit/grep)       — use --patch-tools")
 				}
 				if openclawWebFetchPatched() {
-				fmt.Fprintln(out, "  [P] Network fetch (web_fetch)                    — dist patched")
-			} else {
-				fmt.Fprintln(out, "  [ ] Network fetch (web_fetch tool)               — use --patch-tools")
-			}
-			if openclawBrowserPatched() {
-				fmt.Fprintln(out, "  [P] Browser automation (browser)                 — dist patched")
-			} else {
-				fmt.Fprintln(out, "  [ ] Browser automation (browser tool)            — use --patch-tools")
-			}
-			if openclawMessagePatched() {
-				fmt.Fprintln(out, "  [P] Outbound messaging (message)                 — dist patched")
-			} else {
-				fmt.Fprintln(out, "  [ ] Outbound messaging (message tool)            — use --patch-tools")
-			}
+					fmt.Fprintln(out, "  [P] Network fetch (web_fetch)                    — dist patched")
+				} else {
+					fmt.Fprintln(out, "  [ ] Network fetch (web_fetch tool)               — use --patch-tools")
+				}
+				if openclawBrowserPatched() {
+					fmt.Fprintln(out, "  [P] Browser automation (browser)                 — dist patched")
+				} else {
+					fmt.Fprintln(out, "  [ ] Browser automation (browser tool)            — use --patch-tools")
+				}
+				if openclawMessagePatched() {
+					fmt.Fprintln(out, "  [P] Outbound messaging (message)                 — dist patched")
+				} else {
+					fmt.Fprintln(out, "  [ ] Outbound messaging (message tool)            — use --patch-tools")
+				}
 				fmt.Fprintln(out, "")
 				fmt.Fprintln(out, "Restart the OpenClaw gateway to activate:")
 				fmt.Fprintln(out, "  systemctl --user restart openclaw-gateway.service")
@@ -1833,9 +1834,10 @@ func patchMessageInDist(cmd *cobra.Command, distDir, url, tokenExpr string) bool
 // event is ever created and the Discord runtime sees an empty approval queue.
 //
 // The correct integration path is now:
-//   OpenClaw exec ask -> exec.approval.requested -> Rampart bridge evaluates ->
-//   Rampart auto-resolves allow/deny or escalates human review -> Discord sees
-//   the native OpenClaw approval request.
+//
+//	OpenClaw exec ask -> exec.approval.requested -> Rampart bridge evaluates ->
+//	Rampart auto-resolves allow/deny or escalates human review -> Discord sees
+//	the native OpenClaw approval request.
 //
 // So we intentionally no-op this dist patch for exec and rely on the bridge.
 func patchExecInDist(cmd *cobra.Command, distDir, url, tokenExpr string) bool {

--- a/cmd/rampart/cli/user_config.go
+++ b/cmd/rampart/cli/user_config.go
@@ -19,9 +19,9 @@ import (
 type UserConfig struct {
 	// URL is the primary base URL for Rampart runtime traffic. Env: RAMPART_URL.
 	URL string `yaml:"url,omitempty"`
-	// ServeURL is the explicit serve/dashboard URL. Env: RAMPART_SERVE_URL.
+	// ServeURL is a backward-compatible alias for URL. Env: RAMPART_SERVE_URL.
 	ServeURL string `yaml:"serve_url,omitempty"`
-	// APIAddr is the approval API URL for approve/deny/pending flows. Env: RAMPART_API.
+	// APIAddr is an advanced override for approval/control API flows. Env: RAMPART_API.
 	APIAddr string `yaml:"api,omitempty"`
 }
 

--- a/cmd/rampart/cli/user_config.go
+++ b/cmd/rampart/cli/user_config.go
@@ -1,0 +1,73 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package cli
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// UserConfig holds persistent user-level settings loaded from ~/.rampart/config.yaml.
+// Environment variables override file values.
+type UserConfig struct {
+	// URL is the primary base URL for Rampart runtime traffic. Env: RAMPART_URL.
+	URL string `yaml:"url,omitempty"`
+	// ServeURL is the explicit serve/dashboard URL. Env: RAMPART_SERVE_URL.
+	ServeURL string `yaml:"serve_url,omitempty"`
+	// APIAddr is the approval API URL for approve/deny/pending flows. Env: RAMPART_API.
+	APIAddr string `yaml:"api,omitempty"`
+	// Token is loaded from env or ~/.rampart/token and is never read from YAML.
+	Token string `yaml:"-"`
+}
+
+func userConfigPath() (string, error) {
+	dir, err := rampartDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "config.yaml"), nil
+}
+
+func loadUserConfig() (UserConfig, error) {
+	var cfg UserConfig
+
+	p, err := userConfigPath()
+	if err != nil {
+		return cfg, err
+	}
+	if data, err := os.ReadFile(p); err == nil {
+		if err := yaml.Unmarshal(data, &cfg); err != nil {
+			return cfg, err
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return cfg, err
+	}
+
+	if v := strings.TrimSpace(os.Getenv("RAMPART_URL")); v != "" {
+		cfg.URL = v
+	}
+	if v := strings.TrimSpace(os.Getenv("RAMPART_SERVE_URL")); v != "" {
+		cfg.ServeURL = v
+	}
+	if v := strings.TrimSpace(os.Getenv("RAMPART_API")); v != "" {
+		cfg.APIAddr = v
+	}
+
+	cfg.URL = strings.TrimRight(strings.TrimSpace(cfg.URL), "/")
+	cfg.ServeURL = strings.TrimRight(strings.TrimSpace(cfg.ServeURL), "/")
+	cfg.APIAddr = strings.TrimRight(strings.TrimSpace(cfg.APIAddr), "/")
+
+	if v := strings.TrimSpace(os.Getenv("RAMPART_TOKEN")); v != "" {
+		cfg.Token = v
+	} else if tok, err := readPersistedToken(); err == nil && tok != "" {
+		cfg.Token = tok
+	}
+
+	return cfg, nil
+}

--- a/cmd/rampart/cli/user_config.go
+++ b/cmd/rampart/cli/user_config.go
@@ -5,6 +5,7 @@
 package cli
 
 import (
+	"bytes"
 	"errors"
 	"os"
 	"path/filepath"
@@ -22,8 +23,6 @@ type UserConfig struct {
 	ServeURL string `yaml:"serve_url,omitempty"`
 	// APIAddr is the approval API URL for approve/deny/pending flows. Env: RAMPART_API.
 	APIAddr string `yaml:"api,omitempty"`
-	// Token is loaded from env or ~/.rampart/token and is never read from YAML.
-	Token string `yaml:"-"`
 }
 
 func userConfigPath() (string, error) {
@@ -42,7 +41,9 @@ func loadUserConfig() (UserConfig, error) {
 		return cfg, err
 	}
 	if data, err := os.ReadFile(p); err == nil {
-		if err := yaml.Unmarshal(data, &cfg); err != nil {
+		dec := yaml.NewDecoder(bytes.NewReader(data))
+		dec.KnownFields(true)
+		if err := dec.Decode(&cfg); err != nil {
 			return cfg, err
 		}
 	} else if !errors.Is(err, os.ErrNotExist) {
@@ -63,11 +64,15 @@ func loadUserConfig() (UserConfig, error) {
 	cfg.ServeURL = strings.TrimRight(strings.TrimSpace(cfg.ServeURL), "/")
 	cfg.APIAddr = strings.TrimRight(strings.TrimSpace(cfg.APIAddr), "/")
 
-	if v := strings.TrimSpace(os.Getenv("RAMPART_TOKEN")); v != "" {
-		cfg.Token = v
-	} else if tok, err := readPersistedToken(); err == nil && tok != "" {
-		cfg.Token = tok
-	}
-
 	return cfg, nil
+}
+
+func resolveTokenValue() (string, string) {
+	if v := strings.TrimSpace(os.Getenv("RAMPART_TOKEN")); v != "" {
+		return v, "env"
+	}
+	if tok, err := readPersistedToken(); err == nil && tok != "" {
+		return tok, "file"
+	}
+	return "", ""
 }

--- a/cmd/rampart/cli/user_config_test.go
+++ b/cmd/rampart/cli/user_config_test.go
@@ -78,3 +78,19 @@ func TestLoadUserConfig_RejectsUnknownFields(t *testing.T) {
 		t.Fatal("expected unknown-field error, got nil")
 	}
 }
+
+func TestResolveServeURLStrict_RejectsUnknownConfigFields(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+	dir := filepath.Join(home, ".rampart")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte("serveUrl: http://typo\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := resolveServeURLStrict("", "http://localhost:9090"); err == nil {
+		t.Fatal("expected resolveServeURLStrict to return config parse error")
+	}
+}

--- a/cmd/rampart/cli/user_config_test.go
+++ b/cmd/rampart/cli/user_config_test.go
@@ -1,0 +1,64 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadUserConfig_FileAndEnvPrecedence(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+
+	dir := filepath.Join(home, ".rampart")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte("url: http://config-proxy:7000\nserve_url: http://config-serve:9000\napi: http://config-api:9100\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "token"), []byte("tok-file\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("RAMPART_URL", "http://env-proxy:7001/")
+	t.Setenv("RAMPART_SERVE_URL", "")
+	t.Setenv("RAMPART_API", "http://env-api:9101/")
+	t.Setenv("RAMPART_TOKEN", "")
+
+	cfg, err := loadUserConfig()
+	if err != nil {
+		t.Fatalf("loadUserConfig: %v", err)
+	}
+	if cfg.URL != "http://env-proxy:7001" {
+		t.Fatalf("cfg.URL = %q", cfg.URL)
+	}
+	if cfg.ServeURL != "http://config-serve:9000" {
+		t.Fatalf("cfg.ServeURL = %q", cfg.ServeURL)
+	}
+	if cfg.APIAddr != "http://env-api:9101" {
+		t.Fatalf("cfg.APIAddr = %q", cfg.APIAddr)
+	}
+	if cfg.Token != "tok-file" {
+		t.Fatalf("cfg.Token = %q", cfg.Token)
+	}
+}
+
+func TestResolveServeURL_UsesConfigServeURL(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+	dir := filepath.Join(home, ".rampart")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte("serve_url: http://config-serve:9999\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("RAMPART_URL", "")
+	t.Setenv("RAMPART_SERVE_URL", "")
+
+	if got := resolveServeURL(""); got != "http://config-serve:9999" {
+		t.Fatalf("resolveServeURL() = %q", got)
+	}
+}

--- a/cmd/rampart/cli/user_config_test.go
+++ b/cmd/rampart/cli/user_config_test.go
@@ -39,8 +39,8 @@ func TestLoadUserConfig_FileAndEnvPrecedence(t *testing.T) {
 	if cfg.APIAddr != "http://env-api:9101" {
 		t.Fatalf("cfg.APIAddr = %q", cfg.APIAddr)
 	}
-	if cfg.Token != "tok-file" {
-		t.Fatalf("cfg.Token = %q", cfg.Token)
+	if tok, source := resolveTokenValue(); tok != "tok-file" || source != "file" {
+		t.Fatalf("resolveTokenValue() = %q/%q", tok, source)
 	}
 }
 
@@ -60,5 +60,21 @@ func TestResolveServeURL_UsesConfigServeURL(t *testing.T) {
 
 	if got := resolveServeURL(""); got != "http://config-serve:9999" {
 		t.Fatalf("resolveServeURL() = %q", got)
+	}
+}
+
+func TestLoadUserConfig_RejectsUnknownFields(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+	dir := filepath.Join(home, ".rampart")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte("serveUrl: http://typo\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := loadUserConfig(); err == nil {
+		t.Fatal("expected unknown-field error, got nil")
 	}
 }

--- a/cmd/rampart/cli/watch.go
+++ b/cmd/rampart/cli/watch.go
@@ -80,7 +80,7 @@ func newWatchCmd(_ *rootOptions) *cobra.Command {
 	cmd.Flags().StringVar(&agent, "agent", "all", "Filter to a single agent in view")
 	cmd.Flags().StringVar(&decision, "decision", "", "Filter by decision (allow, deny, log, webhook)")
 	cmd.Flags().StringVar(&tool, "tool", "", "Filter by tool name (e.g., exec, read, write)")
-	cmd.Flags().StringVar(&serveURL, "serve-url", "", "Serve API URL for interactive approvals")
+	cmd.Flags().StringVar(&serveURL, "serve-url", "", "Rampart service URL override for interactive approvals (default: auto-discover via url/config/state)")
 	cmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "Suppress noisy system commands (ip neigh, systemd, etc.)")
 
 	return cmd

--- a/cmd/rampart/cli/watch.go
+++ b/cmd/rampart/cli/watch.go
@@ -92,7 +92,11 @@ func resolveWatchServeConfig(cmd *cobra.Command, serveURL string) (string, strin
 	errW := cmd.ErrOrStderr()
 
 	if !cmd.Flags().Changed("serve-url") && resolvedURL == "" {
-		resolvedURL = resolveServeURL("")
+		strictURL, err := resolveServeURLStrict("", fmt.Sprintf("http://localhost:%d", defaultServePort))
+		if err != nil {
+			return "", "", fmt.Errorf("watch: resolve serve URL: %w", err)
+		}
+		resolvedURL = strictURL
 		fmt.Fprintf(errW, "Note: using serve URL %s\n", resolvedURL)
 	}
 

--- a/cmd/rampart/cli/watch.go
+++ b/cmd/rampart/cli/watch.go
@@ -96,11 +96,11 @@ func resolveWatchServeConfig(cmd *cobra.Command, serveURL string) (string, strin
 		fmt.Fprintf(errW, "Note: using serve URL %s\n", resolvedURL)
 	}
 
-	if envToken := strings.TrimSpace(os.Getenv("RAMPART_TOKEN")); envToken != "" {
-		resolvedToken = envToken
-	} else if tok, err := readPersistedToken(); err == nil && tok != "" {
-		resolvedToken = tok
-		fmt.Fprintln(errW, "Note: using auto-discovered serve token from ~/.rampart/token")
+	if cfg, err := loadUserConfig(); err == nil && cfg.Token != "" {
+		resolvedToken = cfg.Token
+		if strings.TrimSpace(os.Getenv("RAMPART_TOKEN")) == "" {
+			fmt.Fprintln(errW, "Note: using auto-discovered serve token from ~/.rampart/token")
+		}
 	}
 
 	return resolvedURL, resolvedToken, nil

--- a/cmd/rampart/cli/watch.go
+++ b/cmd/rampart/cli/watch.go
@@ -96,9 +96,9 @@ func resolveWatchServeConfig(cmd *cobra.Command, serveURL string) (string, strin
 		fmt.Fprintf(errW, "Note: using serve URL %s\n", resolvedURL)
 	}
 
-	if cfg, err := loadUserConfig(); err == nil && cfg.Token != "" {
-		resolvedToken = cfg.Token
-		if strings.TrimSpace(os.Getenv("RAMPART_TOKEN")) == "" {
+	if tok, source := resolveTokenValue(); tok != "" {
+		resolvedToken = tok
+		if source == "file" {
 			fmt.Fprintln(errW, "Note: using auto-discovered serve token from ~/.rampart/token")
 		}
 	}

--- a/cmd/rampart/cli/watch_test.go
+++ b/cmd/rampart/cli/watch_test.go
@@ -135,3 +135,31 @@ func TestResolveWatchServeConfig_ExplicitURLNoToken(t *testing.T) {
 	}
 	_ = token // token resolved from env/file (empty in test)
 }
+
+func TestResolveWatchServeConfig_UsesConfigURL(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+	t.Setenv("RAMPART_URL", "")
+	t.Setenv("RAMPART_SERVE_URL", "")
+	t.Setenv("RAMPART_TOKEN", "")
+
+	if err := os.MkdirAll(filepath.Join(home, ".rampart"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".rampart", "config.yaml"), []byte("url: http://config-primary:9095\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var errBuf bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetErr(&errBuf)
+	cmd.Flags().String("serve-url", "", "")
+
+	url, _, err := resolveWatchServeConfig(cmd, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if url != "http://config-primary:9095" {
+		t.Fatalf("unexpected URL: %s", url)
+	}
+}

--- a/internal/plugin/openclaw/openclaw.plugin.json
+++ b/internal/plugin/openclaw/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "rampart",
   "name": "Rampart",
   "description": "AI agent firewall \u2014 YAML policy-as-code for every tool call",
-  "version": "0.9.21",
+  "version": "0.9.22",
   "author": "peg",
   "homepage": "https://rampart.sh",
   "repository": "https://github.com/peg/rampart",

--- a/internal/plugin/openclaw/package.json
+++ b/internal/plugin/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rampart",
-  "version": "0.9.21",
+  "version": "0.9.22",
   "description": "Rampart AI agent firewall \u2014 OpenClaw native plugin (before_tool_call hook)",
   "type": "module",
   "main": "index.js",

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -305,6 +305,25 @@ func (m *Manager) ObserveApprovalWithAsk(toolUseID string) (*PendingAsk, *Approv
 	return &askCopy, &record, nil
 }
 
+// PeekAsk returns a pending ask without mutating session state.
+func (m *Manager) PeekAsk(toolUseID string) (*PendingAsk, error) {
+	path, err := m.statePath()
+	if err != nil {
+		return nil, err
+	}
+	s, err := m.load(path)
+	if err != nil {
+		return nil, err
+	}
+
+	ask, ok := s.PendingAsks[toolUseID]
+	if !ok {
+		return nil, fmt.Errorf("session: no pending ask for tool_use_id %q", toolUseID)
+	}
+	askCopy := ask
+	return &askCopy, nil
+}
+
 // DismissAsk removes a pending ask without recording an approval outcome.
 // This is used when a user denies the native ask prompt (PostToolUseFailure).
 func (m *Manager) DismissAsk(toolUseID string) (*PendingAsk, error) {


### PR DESCRIPTION
## Summary
- harden CLI config/API resolution and surface malformed user config in security-critical paths
- preserve approval integrity by stopping ambiguous `PostToolUseFailure` events from being inferred as denials
- unify `preload`/watch/reload endpoint resolution, polish docs, and update plugin/release metadata for v0.9.22
- migrate workflows to Node 24-safe actions and prevent prerelease Docker tags from publishing `latest`

## Why
This is the RC hardening pass for v0.9.22. It keeps the config semantics cleanup, safer hook-failure behavior, and workflow/release hardening together in one low-risk branch.

## Validation
- `go test ./cmd/rampart/cli/... -count=1`
- `go test ./... -count=1`
