### PR TITLE
docs: refresh site for v0.9.22 and runtime config

### DIFF
--- a/docs-site/getting-started/configuration.md
+++ b/docs-site/getting-started/configuration.md
@@ -1,13 +1,67 @@
 ---
 title: Configuration
-description: "Configure Rampart YAML policies to control what AI agents can execute, read, write, and fetch. Tune rules, defaults, and approvals for your workflow."
+description: "Configure Rampart runtime defaults and YAML policies. Set service URLs cleanly, then tune what AI agents can execute, read, write, and fetch."
 ---
 
 # Configuration
 
-Rampart policies are YAML files that define what your AI agent can and can't do. Policies are evaluated in microseconds and hot-reload when you edit them.
+Rampart has **two kinds of configuration**:
+
+1. **Runtime/client config** — where Rampart should find its local service
+2. **Policy config** — what agents are allowed to do once Rampart evaluates a tool call
+
+Most users only need one runtime setting:
+
+```yaml
+# ~/.rampart/config.yaml
+url: http://127.0.0.1:9090
+```
+
+## Runtime Config (`~/.rampart/config.yaml`)
+
+If you do not want to keep exporting environment variables, Rampart can load persistent local defaults from `~/.rampart/config.yaml`.
+
+```yaml
+url: http://127.0.0.1:9090
+# serve_url: http://127.0.0.1:9090   # compatibility alias for url
+# api: http://127.0.0.1:9091         # optional advanced override for daemon/split-topology API setups
+```
+
+| Setting | Use it for | Notes |
+|--------|-------------|-------|
+| `url` | Primary Rampart base URL | Canonical setting for hook, watch, plugin, and service-backed flows |
+| `serve_url` | Backwards-compatible alias for `url` | Kept for compatibility; prefer `url` in new configs |
+| `api` | Optional API base URL override for approval/control commands | Advanced only; usually unnecessary unless you split the API away from the main serve endpoint |
+
+### Resolution order
+
+Rampart resolves service addresses in this order:
+
+**flag → environment → config file → auto-discovered state → default**
+
+That means:
+
+- `--api` or `--serve-url` wins when you pass it explicitly
+- environment variables such as `RAMPART_URL`, `RAMPART_SERVE_URL`, and `RAMPART_API` override file values
+- `~/.rampart/config.yaml` is the persistent local default
+- if nothing is configured, Rampart falls back to discovered local state and then localhost defaults
+
+### Which setting should I use?
+
+Use **`url`** unless you have a specific reason not to.
+
+- `url` is the normal setting for local Rampart service discovery
+- `serve_url` exists for compatibility with older setups
+- `api` is **not** the normal `rampart serve` setting — it is an advanced client-side override for approval/control flows
+
+!!! info "Two different meanings of `--api`"
+    Client-side `--api` flags expect an **API base URL** such as `http://127.0.0.1:9091`.
+
+    Daemon/server `--api` flags refer to an **API listen address** such as `127.0.0.1:9091`.
 
 ## Policy File Location
+
+Rampart policies are YAML files that define what your AI agent can and can't do. Policies are evaluated in microseconds and hot-reload when you edit them.
 
 By default, Rampart looks for policies in `~/.rampart/policies/`. You can specify a custom location:
 

--- a/docs-site/getting-started/quickstart.md
+++ b/docs-site/getting-started/quickstart.md
@@ -45,6 +45,15 @@ This detects your agent (Claude Code, Codex, Cline, OpenClaw), installs the serv
 
 Then use your agent normally. Rampart is invisible until something needs to be blocked or approved.
 
+If you want persistent local defaults instead of exporting env vars, add this:
+
+```yaml
+# ~/.rampart/config.yaml
+url: http://127.0.0.1:9090
+```
+
+See [Configuration](configuration.md) for the full `url` / `serve_url` / `api` story.
+
 ## Other Agents
 
 === "Claude Code"

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -205,19 +205,20 @@ verify -> outcomes.approval
 
 [:octicons-arrow-right-24: See all integration guides](integrations/index.md)
 
-## What's New in v0.9.19
+## What's New in v0.9.22
 
-- **Integration hardening runway** — Codex wrapper setup is idempotent, uninstall is safer, and source builds now fail clearly when the preload library is missing. [Details →](integrations/codex-cli.md)
-- **OpenClaw degraded mode clarified** — Sensitive tools block when Rampart serve is unavailable; explicitly configured lower-risk tools can still fail open. [Details →](integrations/openclaw.md)
-- **Claude Code hook errors cleaned up** — Invalid or stale policies fail closed through structured hook responses instead of noisy shell-hook stderr.
+- **Runtime config is finally less weird** — Rampart now has a documented persistent local config file at `~/.rampart/config.yaml`, with a clear `url` / `serve_url` / `api` precedence model for hooks, approvals, reloads, and service-backed flows. [Details →](getting-started/configuration.md)
+- **Config resolution is stricter and more trustworthy** — malformed local config no longer silently falls back to the wrong endpoint during approval, hook, preload, watch, or reload paths.
+- **OpenClaw approval integrity is tighter** — ambiguous `PostToolUseFailure` events no longer get mislabeled as Rampart denials, which keeps native approval history and audit state more honest. [Details →](guides/openclaw-approval.md)
+- **OpenClaw docs are now aligned with reality** — native plugin first, single approval owner, legacy dist patching treated as compatibility-only. [Details →](integrations/openclaw.md)
 
-### v0.9.18
+### v0.9.21
 
-- **Policy explain ergonomics** — `rampart policy explain` shows winning rules, source files, durable overrides, and session/tool context.
-- **OpenClaw readiness checks** — `rampart doctor` reports native plugin readiness and approval-path state more clearly.
-- **Release hygiene** — Changelog and plugin metadata now track release state more explicitly.
+- **OpenClaw trust signals tightened** — `rampart status` is more careful about when it claims OpenClaw bridge/plugin state.
+- **Built-in self-modification policy tuned** — human-readable docs and PR text can mention Rampart commands without tripping the policy, while real self-modifying command invocations remain protected.
+- **Support contract clarified** — the published support matrix now clearly splits recommended, supported, and legacy OpenClaw integration tiers.
 
-### v0.9.17
+### v0.9.20
 
 - **OpenClaw approval trust** — Native Discord exec approvals are the supported path for Rampart's OpenClaw integration. OpenClaw owns approval UI/state, Rampart owns policy, audit, and allow-always persistence. [Details →](integrations/openclaw.md)
 - **Durable Allow Always** — OpenClaw approvals can persist safe learned rules to `user-overrides.yaml`.


### PR DESCRIPTION
## Summary
- refresh the docs site homepage from stale v0.9.19 highlights to v0.9.22/v0.9.21/v0.9.20
- document `~/.rampart/config.yaml` on the deployed docs site, including `url` / `serve_url` / `api` semantics and precedence
- add a quickstart pointer so the persistent local config story is discoverable outside the README

## Validation
- `python3 -m mkdocs build`

## Notes
- `mkdocs build` completed and wrote the site, but the existing repo still emits unrelated `mkdocs-d2-plugin` compile errors for pre-existing D2 blocks elsewhere in the docs.
