### PR TITLE
docs: tighten landing page and support matrix

### DIFF
--- a/docs-site/assets/extra.css
+++ b/docs-site/assets/extra.css
@@ -135,51 +135,93 @@
   border-radius: 8px;
 }
 
-/* Support matrix cards */
-.support-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 1rem;
+/* Support matrix */
+.support-matrix-table {
+  width: 100%;
+  table-layout: fixed;
+  border-collapse: collapse;
   margin: 1.5rem 0 2rem;
+  font-size: 0.9rem;
 }
 
-.support-card {
+.support-matrix-table th,
+.support-matrix-table td {
+  vertical-align: top;
+  padding: 0.9rem 0.8rem;
   border: 1px solid #21262d;
-  border-radius: 12px;
-  padding: 1rem 1rem 0.95rem;
-  background: rgba(255, 255, 255, 0.02);
 }
 
-.support-card h3 {
-  margin-top: 0;
-  margin-bottom: 0.75rem;
+.support-matrix-table th {
+  background: rgba(255, 99, 146, 0.1);
+  text-align: left;
+  font-family: 'Archivo', var(--md-text-font-family);
 }
 
-.support-card ul {
-  margin: 0;
-  padding-left: 1.1rem;
+.support-matrix-table td code {
+  word-break: break-word;
 }
 
-.support-card li {
-  margin-bottom: 0.5rem;
+.support-matrix-table .tier-recommended td:first-child,
+.support-matrix-table .tier-recommended td:last-child {
+  box-shadow: inset 3px 0 0 rgba(255, 99, 146, 0.65);
 }
 
-.support-card--recommended {
-  border-color: rgba(255, 99, 146, 0.32);
-  box-shadow: inset 0 0 0 1px rgba(255, 99, 146, 0.08);
-}
-
-.support-card--supported {
-  border-color: #30363d;
-}
-
-.support-card--legacy {
-  border-color: rgba(245, 158, 11, 0.35);
+.support-matrix-table .tier-legacy td:first-child,
+.support-matrix-table .tier-legacy td:last-child {
+  box-shadow: inset 3px 0 0 rgba(245, 158, 11, 0.55);
 }
 
 @media screen and (max-width: 1100px) {
-  .support-grid {
-    grid-template-columns: 1fr;
+  .support-matrix-table {
+    font-size: 0.84rem;
+  }
+}
+
+@media screen and (max-width: 760px) {
+  .support-matrix-table,
+  .support-matrix-table thead,
+  .support-matrix-table tbody,
+  .support-matrix-table tr,
+  .support-matrix-table th,
+  .support-matrix-table td {
+    display: block;
+  }
+
+  .support-matrix-table thead {
+    display: none;
+  }
+
+  .support-matrix-table tr {
+    margin-bottom: 1rem;
+    border: 1px solid #21262d;
+    border-radius: 12px;
+    overflow: hidden;
+    background: rgba(255, 255, 255, 0.02);
+  }
+
+  .support-matrix-table td {
+    border: 0;
+    border-bottom: 1px solid #21262d;
+    padding: 0.8rem 0.9rem 0.8rem 7.6rem;
+    position: relative;
+    min-height: 3rem;
+  }
+
+  .support-matrix-table td:last-child {
+    border-bottom: 0;
+  }
+
+  .support-matrix-table td::before {
+    content: attr(data-label);
+    position: absolute;
+    left: 0.9rem;
+    top: 0.8rem;
+    width: 5.8rem;
+    color: #8b949e;
+    font-size: 0.72rem;
+    font-family: 'Archivo', var(--md-text-font-family);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
   }
 }
 

--- a/docs-site/assets/extra.css
+++ b/docs-site/assets/extra.css
@@ -135,4 +135,52 @@
   border-radius: 8px;
 }
 
+/* Support matrix cards */
+.support-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+  margin: 1.5rem 0 2rem;
+}
+
+.support-card {
+  border: 1px solid #21262d;
+  border-radius: 12px;
+  padding: 1rem 1rem 0.95rem;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.support-card h3 {
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+}
+
+.support-card ul {
+  margin: 0;
+  padding-left: 1.1rem;
+}
+
+.support-card li {
+  margin-bottom: 0.5rem;
+}
+
+.support-card--recommended {
+  border-color: rgba(255, 99, 146, 0.32);
+  box-shadow: inset 0 0 0 1px rgba(255, 99, 146, 0.08);
+}
+
+.support-card--supported {
+  border-color: #30363d;
+}
+
+.support-card--legacy {
+  border-color: rgba(245, 158, 11, 0.35);
+}
+
+@media screen and (max-width: 1100px) {
+  .support-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
 /* Logo links to rampart.sh via homepage config */

--- a/docs-site/getting-started/support-matrix.md
+++ b/docs-site/getting-started/support-matrix.md
@@ -7,16 +7,97 @@ description: "Supported Rampart integration modes, coverage, approval UX, serve 
 
 Use this page as the canonical support contract for Rampart's main integration surfaces.
 
-| Surface | Integration method | `rampart serve` required? | Approval UX | Coverage summary | Support tier |
-|---------|--------------------|---------------------------|-------------|------------------|--------------|
-| Claude Code | Native hooks (`rampart setup claude-code`) | No for local hook enforcement; yes for dashboard/headless approval flows | Claude native approval prompt | Direct tool calls protected through `PreToolUse`; local policy evaluation works without serve | **Recommended** |
-| Cline | Native hooks (`rampart setup cline`) | No for local hook enforcement | No native ask UI; approval-required actions cancel with context | Native hook coverage for supported tool lifecycle events | **Supported** |
-| Codex CLI | Wrapper + preload (`rampart setup codex`) | Typically yes for service-backed evaluation path | Wrapper/preload approval semantics | Strong CLI coverage; depends on preload/wrapper path | **Recommended** |
-| OpenClaw >= 2026.4.11 | Native plugin (`rampart setup openclaw`) | Yes | OpenClaw native approval UI | Full plugin-based tool interception plus current native exec approval behavior | **Recommended** |
-| OpenClaw 2026.3.28 - 2026.4.10 | Native plugin (`rampart setup openclaw`) | Yes | Native tool enforcement; approval UX is less polished than current builds | Full plugin-based tool interception on supported builds | **Supported** |
-| OpenClaw < 2026.3.28 | Legacy shim + bridge + optional patching | Yes | Legacy bridge/shim approval behavior | Compatibility path only; more fragile and upgrade-sensitive | **Legacy compatibility** |
-| Cursor / Claude Desktop | MCP proxy (`rampart mcp --`) | Yes | MCP error / proxy-mediated behavior | MCP tool coverage only | **Supported** |
-| Custom / Python / CI | HTTP API | Yes | Caller-defined | Whatever the caller routes through Rampart | **Supported** |
+## At a glance
+
+<div class="support-grid">
+  <section class="support-card support-card--recommended">
+    <h3>Claude Code</h3>
+    <ul>
+      <li><strong>Integration:</strong> Native hooks (<code>rampart setup claude-code</code>)</li>
+      <li><strong><code>rampart serve</code>:</strong> Not required for local hook enforcement; yes for dashboard/headless approval flows</li>
+      <li><strong>Approval UX:</strong> Claude native approval prompt</li>
+      <li><strong>Coverage:</strong> Direct tool calls protected through <code>PreToolUse</code>; local policy evaluation works without serve</li>
+      <li><strong>Support tier:</strong> Recommended</li>
+    </ul>
+  </section>
+
+  <section class="support-card support-card--recommended">
+    <h3>Codex CLI</h3>
+    <ul>
+      <li><strong>Integration:</strong> Wrapper + preload (<code>rampart setup codex</code>)</li>
+      <li><strong><code>rampart serve</code>:</strong> Typically yes for the service-backed evaluation path</li>
+      <li><strong>Approval UX:</strong> Wrapper/preload approval semantics</li>
+      <li><strong>Coverage:</strong> Strong CLI coverage; depends on preload/wrapper path</li>
+      <li><strong>Support tier:</strong> Recommended</li>
+    </ul>
+  </section>
+
+  <section class="support-card support-card--supported">
+    <h3>Cline</h3>
+    <ul>
+      <li><strong>Integration:</strong> Native hooks (<code>rampart setup cline</code>)</li>
+      <li><strong><code>rampart serve</code>:</strong> Not required for local hook enforcement</li>
+      <li><strong>Approval UX:</strong> No native ask UI; approval-required actions cancel with context</li>
+      <li><strong>Coverage:</strong> Native hook coverage for supported tool lifecycle events</li>
+      <li><strong>Support tier:</strong> Supported</li>
+    </ul>
+  </section>
+
+  <section class="support-card support-card--recommended">
+    <h3>OpenClaw &gt;= 2026.4.11</h3>
+    <ul>
+      <li><strong>Integration:</strong> Native plugin (<code>rampart setup openclaw</code>)</li>
+      <li><strong><code>rampart serve</code>:</strong> Required</li>
+      <li><strong>Approval UX:</strong> OpenClaw native approval UI</li>
+      <li><strong>Coverage:</strong> Full plugin-based tool interception plus current native exec approval behavior</li>
+      <li><strong>Support tier:</strong> Recommended</li>
+    </ul>
+  </section>
+
+  <section class="support-card support-card--supported">
+    <h3>OpenClaw 2026.3.28 - 2026.4.10</h3>
+    <ul>
+      <li><strong>Integration:</strong> Native plugin (<code>rampart setup openclaw</code>)</li>
+      <li><strong><code>rampart serve</code>:</strong> Required</li>
+      <li><strong>Approval UX:</strong> Native tool enforcement; approval UX is less polished than current builds</li>
+      <li><strong>Coverage:</strong> Full plugin-based tool interception on supported builds</li>
+      <li><strong>Support tier:</strong> Supported</li>
+    </ul>
+  </section>
+
+  <section class="support-card support-card--legacy">
+    <h3>OpenClaw &lt; 2026.3.28</h3>
+    <ul>
+      <li><strong>Integration:</strong> Legacy shim + bridge + optional patching</li>
+      <li><strong><code>rampart serve</code>:</strong> Required</li>
+      <li><strong>Approval UX:</strong> Legacy bridge/shim approval behavior</li>
+      <li><strong>Coverage:</strong> Compatibility path only; more fragile and upgrade-sensitive</li>
+      <li><strong>Support tier:</strong> Legacy compatibility</li>
+    </ul>
+  </section>
+
+  <section class="support-card support-card--supported">
+    <h3>Cursor / Claude Desktop</h3>
+    <ul>
+      <li><strong>Integration:</strong> MCP proxy (<code>rampart mcp --</code>)</li>
+      <li><strong><code>rampart serve</code>:</strong> Required</li>
+      <li><strong>Approval UX:</strong> MCP error / proxy-mediated behavior</li>
+      <li><strong>Coverage:</strong> MCP tool coverage only</li>
+      <li><strong>Support tier:</strong> Supported</li>
+    </ul>
+  </section>
+
+  <section class="support-card support-card--supported">
+    <h3>Custom / Python / CI</h3>
+    <ul>
+      <li><strong>Integration:</strong> HTTP API</li>
+      <li><strong><code>rampart serve</code>:</strong> Required</li>
+      <li><strong>Approval UX:</strong> Caller-defined</li>
+      <li><strong>Coverage:</strong> Whatever the caller routes through Rampart</li>
+      <li><strong>Support tier:</strong> Supported</li>
+    </ul>
+  </section>
+</div>
 
 ## Degraded behavior notes
 

--- a/docs-site/getting-started/support-matrix.md
+++ b/docs-site/getting-started/support-matrix.md
@@ -9,95 +9,82 @@ Use this page as the canonical support contract for Rampart's main integration s
 
 ## At a glance
 
-<div class="support-grid">
-  <section class="support-card support-card--recommended">
-    <h3>Claude Code</h3>
-    <ul>
-      <li><strong>Integration:</strong> Native hooks (<code>rampart setup claude-code</code>)</li>
-      <li><strong><code>rampart serve</code>:</strong> Not required for local hook enforcement; yes for dashboard/headless approval flows</li>
-      <li><strong>Approval UX:</strong> Claude native approval prompt</li>
-      <li><strong>Coverage:</strong> Direct tool calls protected through <code>PreToolUse</code>; local policy evaluation works without serve</li>
-      <li><strong>Support tier:</strong> Recommended</li>
-    </ul>
-  </section>
+<table class="support-matrix-table">
+  <thead>
+    <tr>
+      <th>Surface</th>
+      <th>Best path</th>
+      <th><code>rampart serve</code></th>
+      <th>Approval UX</th>
+      <th>Support tier</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr class="tier-recommended">
+      <td data-label="Surface"><strong>Claude Code</strong></td>
+      <td data-label="Best path">Native hooks<br><code>rampart setup claude-code</code></td>
+      <td data-label="rampart serve">Not required for local enforcement;<br>yes for dashboard/headless approval flows</td>
+      <td data-label="Approval UX">Claude native approval prompt</td>
+      <td data-label="Support tier"><strong>Recommended</strong></td>
+    </tr>
+    <tr class="tier-recommended">
+      <td data-label="Surface"><strong>Codex CLI</strong></td>
+      <td data-label="Best path">Preload + wrapper<br><code>rampart setup codex</code></td>
+      <td data-label="rampart serve">Typically yes</td>
+      <td data-label="Approval UX">Wrapper/preload approval semantics</td>
+      <td data-label="Support tier"><strong>Recommended</strong></td>
+    </tr>
+    <tr class="tier-supported">
+      <td data-label="Surface"><strong>Cline</strong></td>
+      <td data-label="Best path">Native hooks<br><code>rampart setup cline</code></td>
+      <td data-label="rampart serve">Not required for local enforcement</td>
+      <td data-label="Approval UX">No native ask UI; approval-required actions cancel with context</td>
+      <td data-label="Support tier">Supported</td>
+    </tr>
+    <tr class="tier-recommended">
+      <td data-label="Surface"><strong>OpenClaw &gt;= 2026.4.11</strong></td>
+      <td data-label="Best path">Native plugin<br><code>rampart setup openclaw</code></td>
+      <td data-label="rampart serve">Required</td>
+      <td data-label="Approval UX">OpenClaw native approval UI</td>
+      <td data-label="Support tier"><strong>Recommended</strong></td>
+    </tr>
+    <tr class="tier-supported">
+      <td data-label="Surface"><strong>OpenClaw 2026.3.28 - 2026.4.10</strong></td>
+      <td data-label="Best path">Native plugin<br><code>rampart setup openclaw</code></td>
+      <td data-label="rampart serve">Required</td>
+      <td data-label="Approval UX">Native enforcement; approval UX less polished than current builds</td>
+      <td data-label="Support tier">Supported</td>
+    </tr>
+    <tr class="tier-legacy">
+      <td data-label="Surface"><strong>OpenClaw &lt; 2026.3.28</strong></td>
+      <td data-label="Best path">Legacy shim + bridge + patching</td>
+      <td data-label="rampart serve">Required</td>
+      <td data-label="Approval UX">Legacy bridge/shim behavior</td>
+      <td data-label="Support tier">Legacy compatibility</td>
+    </tr>
+    <tr class="tier-supported">
+      <td data-label="Surface"><strong>Cursor / Claude Desktop</strong></td>
+      <td data-label="Best path">MCP proxy<br><code>rampart mcp --</code></td>
+      <td data-label="rampart serve">Required</td>
+      <td data-label="Approval UX">MCP error / proxy-mediated behavior</td>
+      <td data-label="Support tier">Supported</td>
+    </tr>
+    <tr class="tier-supported">
+      <td data-label="Surface"><strong>Custom / Python / CI</strong></td>
+      <td data-label="Best path">HTTP API</td>
+      <td data-label="rampart serve">Required</td>
+      <td data-label="Approval UX">Caller-defined</td>
+      <td data-label="Support tier">Supported</td>
+    </tr>
+  </tbody>
+</table>
 
-  <section class="support-card support-card--recommended">
-    <h3>Codex CLI</h3>
-    <ul>
-      <li><strong>Integration:</strong> Wrapper + preload (<code>rampart setup codex</code>)</li>
-      <li><strong><code>rampart serve</code>:</strong> Typically yes for the service-backed evaluation path</li>
-      <li><strong>Approval UX:</strong> Wrapper/preload approval semantics</li>
-      <li><strong>Coverage:</strong> Strong CLI coverage; depends on preload/wrapper path</li>
-      <li><strong>Support tier:</strong> Recommended</li>
-    </ul>
-  </section>
+### Best default choices
 
-  <section class="support-card support-card--supported">
-    <h3>Cline</h3>
-    <ul>
-      <li><strong>Integration:</strong> Native hooks (<code>rampart setup cline</code>)</li>
-      <li><strong><code>rampart serve</code>:</strong> Not required for local hook enforcement</li>
-      <li><strong>Approval UX:</strong> No native ask UI; approval-required actions cancel with context</li>
-      <li><strong>Coverage:</strong> Native hook coverage for supported tool lifecycle events</li>
-      <li><strong>Support tier:</strong> Supported</li>
-    </ul>
-  </section>
-
-  <section class="support-card support-card--recommended">
-    <h3>OpenClaw &gt;= 2026.4.11</h3>
-    <ul>
-      <li><strong>Integration:</strong> Native plugin (<code>rampart setup openclaw</code>)</li>
-      <li><strong><code>rampart serve</code>:</strong> Required</li>
-      <li><strong>Approval UX:</strong> OpenClaw native approval UI</li>
-      <li><strong>Coverage:</strong> Full plugin-based tool interception plus current native exec approval behavior</li>
-      <li><strong>Support tier:</strong> Recommended</li>
-    </ul>
-  </section>
-
-  <section class="support-card support-card--supported">
-    <h3>OpenClaw 2026.3.28 - 2026.4.10</h3>
-    <ul>
-      <li><strong>Integration:</strong> Native plugin (<code>rampart setup openclaw</code>)</li>
-      <li><strong><code>rampart serve</code>:</strong> Required</li>
-      <li><strong>Approval UX:</strong> Native tool enforcement; approval UX is less polished than current builds</li>
-      <li><strong>Coverage:</strong> Full plugin-based tool interception on supported builds</li>
-      <li><strong>Support tier:</strong> Supported</li>
-    </ul>
-  </section>
-
-  <section class="support-card support-card--legacy">
-    <h3>OpenClaw &lt; 2026.3.28</h3>
-    <ul>
-      <li><strong>Integration:</strong> Legacy shim + bridge + optional patching</li>
-      <li><strong><code>rampart serve</code>:</strong> Required</li>
-      <li><strong>Approval UX:</strong> Legacy bridge/shim approval behavior</li>
-      <li><strong>Coverage:</strong> Compatibility path only; more fragile and upgrade-sensitive</li>
-      <li><strong>Support tier:</strong> Legacy compatibility</li>
-    </ul>
-  </section>
-
-  <section class="support-card support-card--supported">
-    <h3>Cursor / Claude Desktop</h3>
-    <ul>
-      <li><strong>Integration:</strong> MCP proxy (<code>rampart mcp --</code>)</li>
-      <li><strong><code>rampart serve</code>:</strong> Required</li>
-      <li><strong>Approval UX:</strong> MCP error / proxy-mediated behavior</li>
-      <li><strong>Coverage:</strong> MCP tool coverage only</li>
-      <li><strong>Support tier:</strong> Supported</li>
-    </ul>
-  </section>
-
-  <section class="support-card support-card--supported">
-    <h3>Custom / Python / CI</h3>
-    <ul>
-      <li><strong>Integration:</strong> HTTP API</li>
-      <li><strong><code>rampart serve</code>:</strong> Required</li>
-      <li><strong>Approval UX:</strong> Caller-defined</li>
-      <li><strong>Coverage:</strong> Whatever the caller routes through Rampart</li>
-      <li><strong>Support tier:</strong> Supported</li>
-    </ul>
-  </section>
-</div>
+- **Claude Code** → best overall native path
+- **Codex CLI** → best CLI path when you want strong coverage
+- **OpenClaw >= 2026.4.11** → best OpenClaw path; plugin + native approval UI
+- **Cline** → good supported path, but less polished approval UX than Claude Code
 
 ## Degraded behavior notes
 

--- a/docs-site/index.html
+++ b/docs-site/index.html
@@ -3,20 +3,20 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>AI Agent Firewall for Claude Code and Codex | Rampart</title>
-    <meta name="description" content="Open-source AI agent firewall for Claude Code, Codex, Cline, OpenClaw, and MCP. Enforce YAML policies before commands run. No cloud dependency.">
+    <title>Rampart — A Firewall for AI Coding Agents</title>
+    <meta name="description" content="Block dangerous commands before they run. Rampart enforces local YAML policies for Claude Code, Codex, Cline, OpenClaw, and MCP — no cloud, no account required.">
     <link rel="canonical" href="https://rampart.sh/">
     <meta property="og:type" content="website">
-    <meta property="og:title" content="AI Agent Firewall for Claude Code and Codex | Rampart">
-    <meta property="og:description" content="Your agent has root. Rampart blocks dangerous commands, file reads, and network calls before they run, without sandboxing away the work.">
+    <meta property="og:title" content="Rampart — A Firewall for AI Coding Agents">
+    <meta property="og:description" content="Your agent has root. Rampart blocks the dangerous stuff at the OS layer — without sandboxing away the work it actually needs to do.">
     <meta property="og:image" content="https://rampart.sh/og.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
-    <meta property="og:url" content="https://rampart.sh">
+    <meta property="og:url" content="https://rampart.sh/">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@rampart_sh">
-    <meta name="twitter:title" content="AI Agent Firewall for Claude Code and Codex | Rampart">
-    <meta name="twitter:description" content="Your agent has root. Rampart blocks dangerous commands, file reads, and network calls before they run, without sandboxing away the work.">
+    <meta name="twitter:title" content="Rampart — A Firewall for AI Coding Agents">
+    <meta name="twitter:description" content="Your agent has root. Rampart blocks the dangerous stuff at the OS layer — without sandboxing away the work it actually needs to do.">
     <meta name="twitter:image" content="https://rampart.sh/og.png">
     <script type="application/ld+json">
     {
@@ -27,7 +27,7 @@
       "url": "https://rampart.sh",
       "applicationCategory": "SecurityApplication",
       "operatingSystem": "Linux, macOS, Windows",
-      "softwareVersion": "0.9.19",
+      "softwareVersion": "0.9.22",
       "offers": {
         "@type": "Offer",
         "price": "0",
@@ -852,6 +852,8 @@
         .setup-box pre {
             margin: 0;
             overflow: auto;
+            white-space: pre-wrap;
+            word-break: break-word;
             font-family: var(--mono);
             font-size: 0.8rem;
             color: var(--text-bright);
@@ -914,6 +916,9 @@
         }
         @media (max-width: 760px) {
             .nav-links a.hide-mobile { display: none; }
+            nav .inner {
+                gap: 10px;
+            }
             .nav-links { gap: 10px; }
             .nav-btn { padding: 8px 12px; }
             .logo {
@@ -997,6 +1002,9 @@
             }
             .hero-actions { flex-direction: column; align-items: flex-start; }
             .btn { width: 100%; justify-content: center; }
+            .hero-actions .btn {
+                min-height: 48px;
+            }
             .story-panel-wrap { min-height: auto; }
             .story-panel {
                 position: relative;
@@ -1019,6 +1027,11 @@
                 flex-direction: column;
                 align-items: flex-start;
                 gap: 10px;
+            }
+            .install-inline > span:first-child {
+                width: 100%;
+                white-space: normal;
+                word-break: break-word;
             }
             .watch-shell { padding: 18px; }
             .watch-title {
@@ -1099,9 +1112,9 @@
 <section class="hero">
     <div class="container hero-grid">
         <div>
-            <div class="eyebrow"><span class="eyebrow-dot"></span>v0.9.19 · open source</div>
+            <div class="eyebrow"><span class="eyebrow-dot"></span>v0.9.22 · open source</div>
             <h1>Your agent has root.<br><span class="accent">That’s the problem.</span></h1>
-            <p class="hero-sub">Rampart sits between your agent and your system. It evaluates commands, file access, and network requests against your YAML policy before they run. Local-first. No cloud dependency.</p>
+            <p class="hero-sub">Rampart sits in the execution path. Install it, run <code>rampart quickstart</code>, and it wires the right protection path for Claude Code, Codex, Cline, or OpenClaw before risky tool calls run.</p>
             <div class="install-cluster">
                 <div class="install-inline" onclick="copyCode(this)" title="Click to copy">
                     <span class="prompt">$</span>
@@ -1110,11 +1123,11 @@
                 </div>
                 <div class="hero-meta">
                     <span>Installs to <code>~/.local/bin</code> by default on macOS/Linux. Usually no sudo required.</span>
-                    <span>Claude Code · Codex CLI · OpenClaw · MCP</span>
+                    <span>Claude Code · Codex CLI · Cline · OpenClaw · MCP</span>
                 </div>
                 <div class="hero-actions">
-                    <a href="#install" class="btn btn-primary">Install Rampart</a>
-                    <a href="#watch" class="btn btn-ghost">See it work</a>
+                    <a href="#install" class="btn btn-primary">Quickstart</a>
+                    <a href="https://docs.rampart.sh/getting-started/support-matrix/" class="btn btn-ghost">Support matrix</a>
                 </div>
             </div>
         </div>
@@ -1241,16 +1254,17 @@
     <div class="container reveal">
         <div class="section-label">Works with your agent</div>
         <h2 class="section-title">Claude Code, Codex CLI, Cline, OpenClaw, MCP.</h2>
-        <p class="section-desc">Use the native setup where Rampart knows the agent. Use wrapping or the MCP proxy everywhere else.</p>
+        <p class="section-desc">Use the native path where Rampart knows the agent. Use preload, wrapping, MCP proxy, or the HTTP API everywhere else. For exact support tiers, approval UX, and whether <code>rampart serve</code> is required, check the support matrix.</p>
         <div class="integrations-grid">
             <div class="integration-row header"><span>Agent</span><span>Setup</span><span>Enforcement path</span><span>Status</span></div>
-            <div class="integration-row interactive"><span class="integration-agent">Claude Code</span><span class="integration-code">rampart setup claude-code</span><span class="integration-path">hooks + bridge</span><span class="integration-status">native</span></div>
-            <div class="integration-row interactive"><span class="integration-agent">Codex CLI</span><span class="integration-code">rampart setup codex</span><span class="integration-path">wrapper + preload</span><span class="integration-status">native</span></div>
-            <div class="integration-row interactive"><span class="integration-agent">Cline</span><span class="integration-code">rampart setup cline</span><span class="integration-path">hooks</span><span class="integration-status">native</span></div>
+            <div class="integration-row interactive"><span class="integration-agent">Claude Code</span><span class="integration-code">rampart setup claude-code</span><span class="integration-path">native hooks</span><span class="integration-status">native</span></div>
+            <div class="integration-row interactive"><span class="integration-agent">Codex CLI</span><span class="integration-code">rampart setup codex</span><span class="integration-path">preload + wrapper</span><span class="integration-status">native</span></div>
+            <div class="integration-row interactive"><span class="integration-agent">Cline</span><span class="integration-code">rampart setup cline</span><span class="integration-path">native hooks</span><span class="integration-status">native</span></div>
             <div class="integration-row interactive"><span class="integration-agent">OpenClaw</span><span class="integration-code">rampart setup openclaw</span><span class="integration-path">native plugin</span><span class="integration-status">native</span></div>
             <div class="integration-row interactive"><span class="integration-agent">Any agent</span><span class="integration-code">rampart wrap -- &lt;cmd&gt;</span><span class="integration-path">shim</span><span class="integration-status">universal</span></div>
             <div class="integration-row interactive"><span class="integration-agent">MCP servers</span><span class="integration-code">rampart mcp -- &lt;server&gt;</span><span class="integration-path">proxy</span><span class="integration-status">universal</span></div>
         </div>
+        <p style="margin-top:16px;color:var(--text-dim);font-size:0.9rem;">OpenClaw’s native plugin path depends on <code>rampart serve</code>. Claude Code and Cline can still enforce locally without it. <a href="https://docs.rampart.sh/getting-started/support-matrix/" style="color:var(--accent);text-decoration:none;">Read the canonical support matrix →</a></p>
     </div>
 </section>
 
@@ -1309,8 +1323,8 @@
 <section class="section install-section" id="install">
     <div class="container reveal">
         <div class="section-label">Quickstart</div>
-        <h2 class="section-title">Start protecting your agents.</h2>
-        <p class="section-desc" style="margin:0 auto;">Install locally. No account, no API key, no cloud dependency.</p>
+        <h2 class="section-title">Install, then run <code>rampart quickstart</code>.</h2>
+        <p class="section-desc" style="margin:0 auto;">That is the default path now. It detects your agent, installs what it needs, wires the right integration path, and verifies the setup without making you memorize the matrix first.</p>
 
         <div class="install-tabs">
             <button id="tab-unix" class="install-tab active" onclick="switchTab('unix')">macOS / Linux</button>
@@ -1349,9 +1363,27 @@
         </div>
 
         <div class="setup-box panel">
-            <p style="color:var(--heading);font-weight:700;margin-bottom:12px;text-align:center;">Then connect your agent:</p>
-            <pre><span style="color:var(--accent)">$</span> rampart setup          <span style="color:var(--text-dim)"># auto-detects all your agents</span>
-<span style="color:var(--text-dim)"># or target one: rampart setup claude-code / codex / cline / openclaw</span></pre>
+            <p style="color:var(--heading);font-weight:700;margin-bottom:12px;text-align:center;">Then do the part that actually wires protection:</p>
+            <pre><span style="color:var(--accent)">$</span> rampart quickstart     <span style="color:var(--text-dim)"># detect agent, install service, wire integration, verify setup</span>
+
+<span style="color:var(--text-dim)"># Want the manual path instead?</span>
+<span style="color:var(--accent)">$</span> rampart setup claude-code
+<span style="color:var(--accent)">$</span> rampart setup codex
+<span style="color:var(--accent)">$</span> rampart setup cline
+<span style="color:var(--accent)">$</span> rampart setup openclaw</pre>
+        </div>
+
+        <div class="setup-box panel" style="margin-top:16px;">
+            <p style="color:var(--heading);font-weight:700;margin-bottom:12px;text-align:center;">Persistent local defaults live here:</p>
+            <pre># ~/.rampart/config.yaml
+url: http://127.0.0.1:9090</pre>
+            <p style="margin-top:12px;color:var(--text-dim);font-size:0.86rem;text-align:center;">Use <code>url</code> for the normal local service address. <code>serve_url</code> is legacy compatibility. <code>api</code> is advanced. <a href="https://docs.rampart.sh/getting-started/configuration/" style="color:var(--accent);text-decoration:none;">Configuration docs →</a></p>
+        </div>
+
+        <div class="install-links" style="margin-top:18px;">
+            <a href="https://docs.rampart.sh/getting-started/quickstart/">Quick Start guide</a>
+            <a href="https://docs.rampart.sh/getting-started/support-matrix/">Support matrix</a>
+            <a href="https://docs.rampart.sh/integrations/openclaw/">OpenClaw guide</a>
         </div>
     </div>
 </section>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,20 +3,20 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>AI Agent Firewall for Claude Code and Codex | Rampart</title>
-    <meta name="description" content="Open-source AI agent firewall for Claude Code, Codex, Cline, OpenClaw, and MCP. Enforce YAML policies before commands run. No cloud dependency.">
+    <title>Rampart — A Firewall for AI Coding Agents</title>
+    <meta name="description" content="Block dangerous commands before they run. Rampart enforces local YAML policies for Claude Code, Codex, Cline, OpenClaw, and MCP — no cloud, no account required.">
     <link rel="canonical" href="https://rampart.sh/">
     <meta property="og:type" content="website">
-    <meta property="og:title" content="AI Agent Firewall for Claude Code and Codex | Rampart">
-    <meta property="og:description" content="Your agent has root. Rampart blocks dangerous commands, file reads, and network calls before they run, without sandboxing away the work.">
+    <meta property="og:title" content="Rampart — A Firewall for AI Coding Agents">
+    <meta property="og:description" content="Your agent has root. Rampart blocks the dangerous stuff at the OS layer — without sandboxing away the work it actually needs to do.">
     <meta property="og:image" content="https://rampart.sh/og.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
-    <meta property="og:url" content="https://rampart.sh">
+    <meta property="og:url" content="https://rampart.sh/">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@rampart_sh">
-    <meta name="twitter:title" content="AI Agent Firewall for Claude Code and Codex | Rampart">
-    <meta name="twitter:description" content="Your agent has root. Rampart blocks dangerous commands, file reads, and network calls before they run, without sandboxing away the work.">
+    <meta name="twitter:title" content="Rampart — A Firewall for AI Coding Agents">
+    <meta name="twitter:description" content="Your agent has root. Rampart blocks the dangerous stuff at the OS layer — without sandboxing away the work it actually needs to do.">
     <meta name="twitter:image" content="https://rampart.sh/og.png">
     <script type="application/ld+json">
     {
@@ -27,7 +27,7 @@
       "url": "https://rampart.sh",
       "applicationCategory": "SecurityApplication",
       "operatingSystem": "Linux, macOS, Windows",
-      "softwareVersion": "0.9.19",
+      "softwareVersion": "0.9.22",
       "offers": {
         "@type": "Offer",
         "price": "0",
@@ -852,6 +852,8 @@
         .setup-box pre {
             margin: 0;
             overflow: auto;
+            white-space: pre-wrap;
+            word-break: break-word;
             font-family: var(--mono);
             font-size: 0.8rem;
             color: var(--text-bright);
@@ -914,6 +916,9 @@
         }
         @media (max-width: 760px) {
             .nav-links a.hide-mobile { display: none; }
+            nav .inner {
+                gap: 10px;
+            }
             .nav-links { gap: 10px; }
             .nav-btn { padding: 8px 12px; }
             .logo {
@@ -997,6 +1002,9 @@
             }
             .hero-actions { flex-direction: column; align-items: flex-start; }
             .btn { width: 100%; justify-content: center; }
+            .hero-actions .btn {
+                min-height: 48px;
+            }
             .story-panel-wrap { min-height: auto; }
             .story-panel {
                 position: relative;
@@ -1019,6 +1027,11 @@
                 flex-direction: column;
                 align-items: flex-start;
                 gap: 10px;
+            }
+            .install-inline > span:first-child {
+                width: 100%;
+                white-space: normal;
+                word-break: break-word;
             }
             .watch-shell { padding: 18px; }
             .watch-title {
@@ -1099,9 +1112,9 @@
 <section class="hero">
     <div class="container hero-grid">
         <div>
-            <div class="eyebrow"><span class="eyebrow-dot"></span>v0.9.19 · open source</div>
+            <div class="eyebrow"><span class="eyebrow-dot"></span>v0.9.22 · open source</div>
             <h1>Your agent has root.<br><span class="accent">That’s the problem.</span></h1>
-            <p class="hero-sub">Rampart sits between your agent and your system. It evaluates commands, file access, and network requests against your YAML policy before they run. Local-first. No cloud dependency.</p>
+            <p class="hero-sub">Rampart sits in the execution path. Install it, run <code>rampart quickstart</code>, and it wires the right protection path for Claude Code, Codex, Cline, or OpenClaw before risky tool calls run.</p>
             <div class="install-cluster">
                 <div class="install-inline" onclick="copyCode(this)" title="Click to copy">
                     <span class="prompt">$</span>
@@ -1110,11 +1123,11 @@
                 </div>
                 <div class="hero-meta">
                     <span>Installs to <code>~/.local/bin</code> by default on macOS/Linux. Usually no sudo required.</span>
-                    <span>Claude Code · Codex CLI · OpenClaw · MCP</span>
+                    <span>Claude Code · Codex CLI · Cline · OpenClaw · MCP</span>
                 </div>
                 <div class="hero-actions">
-                    <a href="#install" class="btn btn-primary">Install Rampart</a>
-                    <a href="#watch" class="btn btn-ghost">See it work</a>
+                    <a href="#install" class="btn btn-primary">Quickstart</a>
+                    <a href="https://docs.rampart.sh/getting-started/support-matrix/" class="btn btn-ghost">Support matrix</a>
                 </div>
             </div>
         </div>
@@ -1241,16 +1254,17 @@
     <div class="container reveal">
         <div class="section-label">Works with your agent</div>
         <h2 class="section-title">Claude Code, Codex CLI, Cline, OpenClaw, MCP.</h2>
-        <p class="section-desc">Use the native setup where Rampart knows the agent. Use wrapping or the MCP proxy everywhere else.</p>
+        <p class="section-desc">Use the native path where Rampart knows the agent. Use preload, wrapping, MCP proxy, or the HTTP API everywhere else. For exact support tiers, approval UX, and whether <code>rampart serve</code> is required, check the support matrix.</p>
         <div class="integrations-grid">
             <div class="integration-row header"><span>Agent</span><span>Setup</span><span>Enforcement path</span><span>Status</span></div>
-            <div class="integration-row interactive"><span class="integration-agent">Claude Code</span><span class="integration-code">rampart setup claude-code</span><span class="integration-path">hooks + bridge</span><span class="integration-status">native</span></div>
-            <div class="integration-row interactive"><span class="integration-agent">Codex CLI</span><span class="integration-code">rampart setup codex</span><span class="integration-path">wrapper + preload</span><span class="integration-status">native</span></div>
-            <div class="integration-row interactive"><span class="integration-agent">Cline</span><span class="integration-code">rampart setup cline</span><span class="integration-path">hooks</span><span class="integration-status">native</span></div>
+            <div class="integration-row interactive"><span class="integration-agent">Claude Code</span><span class="integration-code">rampart setup claude-code</span><span class="integration-path">native hooks</span><span class="integration-status">native</span></div>
+            <div class="integration-row interactive"><span class="integration-agent">Codex CLI</span><span class="integration-code">rampart setup codex</span><span class="integration-path">preload + wrapper</span><span class="integration-status">native</span></div>
+            <div class="integration-row interactive"><span class="integration-agent">Cline</span><span class="integration-code">rampart setup cline</span><span class="integration-path">native hooks</span><span class="integration-status">native</span></div>
             <div class="integration-row interactive"><span class="integration-agent">OpenClaw</span><span class="integration-code">rampart setup openclaw</span><span class="integration-path">native plugin</span><span class="integration-status">native</span></div>
             <div class="integration-row interactive"><span class="integration-agent">Any agent</span><span class="integration-code">rampart wrap -- &lt;cmd&gt;</span><span class="integration-path">shim</span><span class="integration-status">universal</span></div>
             <div class="integration-row interactive"><span class="integration-agent">MCP servers</span><span class="integration-code">rampart mcp -- &lt;server&gt;</span><span class="integration-path">proxy</span><span class="integration-status">universal</span></div>
         </div>
+        <p style="margin-top:16px;color:var(--text-dim);font-size:0.9rem;">OpenClaw’s native plugin path depends on <code>rampart serve</code>. Claude Code and Cline can still enforce locally without it. <a href="https://docs.rampart.sh/getting-started/support-matrix/" style="color:var(--accent);text-decoration:none;">Read the canonical support matrix →</a></p>
     </div>
 </section>
 
@@ -1309,8 +1323,8 @@
 <section class="section install-section" id="install">
     <div class="container reveal">
         <div class="section-label">Quickstart</div>
-        <h2 class="section-title">Start protecting your agents.</h2>
-        <p class="section-desc" style="margin:0 auto;">Install locally. No account, no API key, no cloud dependency.</p>
+        <h2 class="section-title">Install, then run <code>rampart quickstart</code>.</h2>
+        <p class="section-desc" style="margin:0 auto;">That is the default path now. It detects your agent, installs what it needs, wires the right integration path, and verifies the setup without making you memorize the matrix first.</p>
 
         <div class="install-tabs">
             <button id="tab-unix" class="install-tab active" onclick="switchTab('unix')">macOS / Linux</button>
@@ -1349,9 +1363,27 @@
         </div>
 
         <div class="setup-box panel">
-            <p style="color:var(--heading);font-weight:700;margin-bottom:12px;text-align:center;">Then connect your agent:</p>
-            <pre><span style="color:var(--accent)">$</span> rampart setup          <span style="color:var(--text-dim)"># auto-detects all your agents</span>
-<span style="color:var(--text-dim)"># or target one: rampart setup claude-code / codex / cline / openclaw</span></pre>
+            <p style="color:var(--heading);font-weight:700;margin-bottom:12px;text-align:center;">Then do the part that actually wires protection:</p>
+            <pre><span style="color:var(--accent)">$</span> rampart quickstart     <span style="color:var(--text-dim)"># detect agent, install service, wire integration, verify setup</span>
+
+<span style="color:var(--text-dim)"># Want the manual path instead?</span>
+<span style="color:var(--accent)">$</span> rampart setup claude-code
+<span style="color:var(--accent)">$</span> rampart setup codex
+<span style="color:var(--accent)">$</span> rampart setup cline
+<span style="color:var(--accent)">$</span> rampart setup openclaw</pre>
+        </div>
+
+        <div class="setup-box panel" style="margin-top:16px;">
+            <p style="color:var(--heading);font-weight:700;margin-bottom:12px;text-align:center;">Persistent local defaults live here:</p>
+            <pre># ~/.rampart/config.yaml
+url: http://127.0.0.1:9090</pre>
+            <p style="margin-top:12px;color:var(--text-dim);font-size:0.86rem;text-align:center;">Use <code>url</code> for the normal local service address. <code>serve_url</code> is legacy compatibility. <code>api</code> is advanced. <a href="https://docs.rampart.sh/getting-started/configuration/" style="color:var(--accent);text-decoration:none;">Configuration docs →</a></p>
+        </div>
+
+        <div class="install-links" style="margin-top:18px;">
+            <a href="https://docs.rampart.sh/getting-started/quickstart/">Quick Start guide</a>
+            <a href="https://docs.rampart.sh/getting-started/support-matrix/">Support matrix</a>
+            <a href="https://docs.rampart.sh/integrations/openclaw/">OpenClaw guide</a>
         </div>
     </div>
 </section>


### PR DESCRIPTION
## Summary
- align rampart.sh landing copy with the current docs and v0.9.22 product state
- make the support matrix readable on laptop/mobile by replacing the wide table with responsive cards
- tighten mobile wrapping and wording on the landing page quickstart/install sections

## What changed
- update landing SEO/meta/version copy and quickstart messaging
- add clearer support-matrix/configuration/OpenClaw links from the landing page
- make landing install/setup blocks wrap cleanly on smaller screens
- restyle `getting-started/support-matrix.md` into responsive support cards

## Verification
- reviewed local landing preview at laptop/mobile widths
- reviewed local support matrix preview at laptop/mobile widths
- `mkdocs build` completes (existing d2 warnings/errors still present in unrelated docs build paths)