### PR TITLE
fix: preserve OpenClaw approval ownership

### DIFF
--- a/cmd/rampart/cli/serve.go
+++ b/cmd/rampart/cli/serve.go
@@ -453,13 +453,14 @@ func newServeCmd(opts *rootOptions, deps *serveDeps) *cobra.Command {
 			// Auto-start OpenClaw bridge if gateway is discoverable.
 			var openclawBridge *bridge.OpenClawBridge
 			if !noOpenClawBridge {
-				gwURL, gwToken, discoverErr := bridge.DiscoverGatewayConfig()
+				gwURL, gwToken, autoResolveAllowDecisions, discoverErr := bridge.DiscoverGatewayConfigForBridge()
 				if discoverErr == nil {
 					openclawBridge = bridge.NewOpenClawBridge(eng, bridge.Config{
-						GatewayURL:   gwURL,
-						GatewayToken: gwToken,
-						Logger:       logger,
-						AuditSink:    sink,
+						GatewayURL:                gwURL,
+						GatewayToken:              gwToken,
+						Logger:                    logger,
+						AuditSink:                 sink,
+						AutoResolveAllowDecisions: &autoResolveAllowDecisions,
 					})
 					bridgeCtx, bridgeCancel := context.WithCancel(cmd.Context())
 					defer bridgeCancel()

--- a/docs/design/openclaw-approval-ownership.md
+++ b/docs/design/openclaw-approval-ownership.md
@@ -27,10 +27,13 @@ For **OpenClaw-hosted workflows**, OpenClaw owns the operator-facing pending app
 Rampart owns:
 
 - policy evaluation
-- auto-resolution for allow/deny
+- deny enforcement
+- approval creation when Rampart itself returns `ask`
 - persistent rule writeback for `allow-always`
 - audit trail
 - diagnostics
+
+In legacy bridge-first mode, Rampart may also auto-resolve policy-allowed OpenClaw exec approvals as `allow-once`. In native OpenClaw plugin mode, Rampart must not auto-resolve allow/watch decisions for an approval OpenClaw already created; `allow` only means “Rampart does not object.”
 
 Rampart does **not** create a second human-facing approval object for the same OpenClaw-hosted tool call.
 
@@ -45,9 +48,9 @@ For **non-OpenClaw workflows**, Rampart's native approval store remains canonica
 3. Discord/native approval surfaces read that native record.
 4. Rampart bridge/plugin evaluates the request.
 5. Rampart may:
-   - auto-resolve allow
    - auto-resolve deny
    - leave the native approval pending for human review
+   - auto-resolve allow only in legacy bridge-first mode
 6. If a human resolves it:
    - `allow-once` resolves the native approval only
    - `allow-always` resolves the native approval and writes a persistent Rampart rule
@@ -90,8 +93,9 @@ Supporting metadata, audit events, and persistence helpers are fine. A second hu
 
 - receive `exec.approval.requested`
 - evaluate with Rampart engine
-- auto-resolve allow/deny where possible
-- leave native approval pending for human review
+- auto-resolve deny where possible
+- auto-resolve allow only in legacy bridge-first mode
+- leave native approval pending for human review in native plugin mode
 - persist allow-always after human resolution
 
 ### 2. Remove legacy exec short-circuiting

--- a/docs/guides/openclaw-approval.md
+++ b/docs/guides/openclaw-approval.md
@@ -51,8 +51,9 @@ Rampart also supports OpenClaw native exec approval events as a **secondary seam
 This is useful for host-exec/native approval flows that already produce OpenClaw approval events. In that mode:
 
 - OpenClaw still owns the pending approval UI/state
-- Rampart may auto-resolve allow/deny
-- if human review is needed, the approval remains pending in OpenClaw
+- Rampart may auto-resolve deny decisions
+- in native plugin mode, Rampart leaves allow/watch decisions pending because they mean “Rampart does not object,” not “the human approved”
+- in legacy bridge-first mode, Rampart may still auto-resolve allow/watch decisions for compatibility
 - Rampart writes `allow-always` persistence after native resolution
 
 This native exec approval path is supported and remains the reference UX for exec approval behavior. The plugin path should match its single-queue ownership model and, where possible, its native approval UX.

--- a/internal/bridge/openclaw.go
+++ b/internal/bridge/openclaw.go
@@ -53,12 +53,13 @@ import (
 // OpenClawBridge connects to the OpenClaw gateway and handles exec approval
 // routing through Rampart's policy engine.
 type OpenClawBridge struct {
-	engine     *engine.Engine
-	gatewayURL string
-	token      string
-	serveURL   string
-	sink       audit.AuditSink
-	logger     *slog.Logger
+	engine                    *engine.Engine
+	gatewayURL                string
+	token                     string
+	serveURL                  string
+	sink                      audit.AuditSink
+	logger                    *slog.Logger
+	autoResolveAllowDecisions bool
 
 	reconnectInterval time.Duration
 
@@ -90,6 +91,17 @@ type Config struct {
 
 	// Logger is the structured logger.
 	Logger *slog.Logger
+
+	// AutoResolveAllowDecisions controls whether Rampart allow/watch decisions
+	// resolve an existing OpenClaw exec approval as allow-once.
+	//
+	// Legacy bridge-first installs use true: OpenClaw creates approval objects for
+	// unknown execs, then Rampart auto-resolves policy-safe commands.
+	// Native plugin installs use false: Rampart has already evaluated the tool
+	// call before execution, so any remaining OpenClaw approval belongs to
+	// OpenClaw's own/manual approval layer and must stay human-owned unless
+	// Rampart explicitly denies it.
+	AutoResolveAllowDecisions *bool
 }
 
 // NewOpenClawBridge creates a new bridge.
@@ -103,17 +115,22 @@ func NewOpenClawBridge(eng *engine.Engine, cfg Config) *OpenClawBridge {
 	if cfg.ServeURL == "" {
 		cfg.ServeURL = discoverServeURL()
 	}
+	autoResolveAllowDecisions := true
+	if cfg.AutoResolveAllowDecisions != nil {
+		autoResolveAllowDecisions = *cfg.AutoResolveAllowDecisions
+	}
 
 	return &OpenClawBridge{
-		engine:            eng,
-		gatewayURL:        cfg.GatewayURL,
-		token:             cfg.GatewayToken,
-		serveURL:          cfg.ServeURL,
-		sink:              cfg.AuditSink,
-		logger:            cfg.Logger,
-		reconnectInterval: cfg.ReconnectInterval,
-		pending:           make(map[string]chan struct{}),
-		pendingCommands:   make(map[string]string),
+		engine:                    eng,
+		gatewayURL:                cfg.GatewayURL,
+		token:                     cfg.GatewayToken,
+		serveURL:                  cfg.ServeURL,
+		sink:                      cfg.AuditSink,
+		logger:                    cfg.Logger,
+		autoResolveAllowDecisions: autoResolveAllowDecisions,
+		reconnectInterval:         cfg.ReconnectInterval,
+		pending:                   make(map[string]chan struct{}),
+		pendingCommands:           make(map[string]string),
 	}
 }
 
@@ -406,6 +423,10 @@ func (b *OpenClawBridge) handleApprovalRequested(ctx context.Context, conn *webs
 
 	switch decision.Action {
 	case engine.ActionAllow, engine.ActionWatch:
+		if !b.autoResolveAllowDecisions {
+			b.leavePendingForOpenClawReview(req, decision)
+			return
+		}
 		b.resolveApproval(conn, req.ID, "allow-once")
 		b.cleanPendingCommand(req.ID)
 
@@ -484,6 +505,19 @@ func (b *OpenClawBridge) leavePendingForHumanReview(req approvalRequestParams, d
 		"command", req.command(),
 		"agent", req.agentID(),
 		"message", decision.Message,
+	)
+}
+
+// leavePendingForOpenClawReview keeps an already-created OpenClaw approval
+// pending when Rampart is running in native plugin ownership mode. In that
+// mode a Rampart allow decision only means "Rampart does not object"; it must
+// not silently satisfy a manual or host-policy approval that OpenClaw created.
+func (b *OpenClawBridge) leavePendingForOpenClawReview(req approvalRequestParams, decision engine.Decision) {
+	b.logger.Info("bridge: Rampart allowed approval request; leaving native OpenClaw approval pending",
+		"id", req.ID,
+		"command", req.command(),
+		"agent", req.agentID(),
+		"action", decision.Action.String(),
 	)
 }
 
@@ -641,29 +675,94 @@ func DiscoverGatewayConfig() (string, string, error) {
 	return ReadGatewayConfig(configPath)
 }
 
+// DiscoverGatewayConfigForBridge reads the OpenClaw gateway connection details
+// and the approval-ownership mode Rampart should use for this install.
+func DiscoverGatewayConfigForBridge() (string, string, bool, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", "", false, fmt.Errorf("resolve home directory: %w", err)
+	}
+
+	configPath := filepath.Join(home, ".openclaw", "openclaw.json")
+	return ReadGatewayConfigForBridge(configPath)
+}
+
 // ReadGatewayConfig reads gateway URL and token from the specified openclaw.json path.
 func ReadGatewayConfig(path string) (string, string, error) {
+	cfg, err := readOpenClawConfig(path)
+	if err != nil {
+		return "", "", err
+	}
+	token, err := cfg.gatewayToken(path)
+	if err != nil {
+		return "", "", err
+	}
+	return cfg.gatewayURL(), token, nil
+}
+
+// ReadGatewayConfigForBridge reads gateway URL/token plus whether the bridge
+// should auto-resolve Rampart allow/watch decisions. In native plugin mode we
+// leave existing OpenClaw approvals pending so explicit/manual approval intent
+// is preserved.
+func ReadGatewayConfigForBridge(path string) (string, string, bool, error) {
+	cfg, err := readOpenClawConfig(path)
+	if err != nil {
+		return "", "", false, err
+	}
+	url := cfg.gatewayURL()
+	token, err := cfg.gatewayToken(path)
+	if err != nil {
+		return "", "", false, err
+	}
+	return url, token, cfg.autoResolveAllowDecisions(), nil
+}
+
+func readOpenClawConfig(path string) (openclawConfig, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return "", "", fmt.Errorf("read openclaw config: %w", err)
+		return openclawConfig{}, fmt.Errorf("read openclaw config: %w", err)
 	}
 
 	var cfg openclawConfig
 	if err := json.Unmarshal(data, &cfg); err != nil {
-		return "", "", fmt.Errorf("parse openclaw config: %w", err)
+		return openclawConfig{}, fmt.Errorf("parse openclaw config: %w", err)
 	}
+	return cfg, nil
+}
 
+func (cfg openclawConfig) gatewayToken(path string) (string, error) {
 	token := cfg.Gateway.Auth.Token
 	if token == "" {
-		return "", "", fmt.Errorf("no gateway.auth.token in %s", path)
+		return "", fmt.Errorf("no gateway.auth.token in %s", path)
 	}
+	return token, nil
+}
 
+func (cfg openclawConfig) gatewayURL() string {
 	url := cfg.Gateway.URL
 	if url == "" {
 		url = "ws://127.0.0.1:18789/ws"
 	}
+	return url
+}
 
-	return url, token, nil
+func (cfg openclawConfig) autoResolveAllowDecisions() bool {
+	return !cfg.rampartPluginEnabled()
+}
+
+func (cfg openclawConfig) rampartPluginEnabled() bool {
+	if entry, ok := cfg.Plugins.Entries["rampart"]; ok {
+		return entry.Enabled == nil || *entry.Enabled
+	}
+	for _, id := range cfg.Plugins.Allow {
+		if id == "rampart" {
+			return true
+		}
+	}
+	if entry, ok := cfg.Hooks.Internal.Entries["rampart"]; ok {
+		return entry.Enabled == nil || *entry.Enabled
+	}
+	return false
 }
 
 // discoverServeURL finds the Rampart serve URL from serve.state or environment.
@@ -696,4 +795,17 @@ type openclawConfig struct {
 			Token string `json:"token"`
 		} `json:"auth"`
 	} `json:"gateway"`
+	Plugins struct {
+		Allow   []string                 `json:"allow"`
+		Entries map[string]openclawEntry `json:"entries"`
+	} `json:"plugins"`
+	Hooks struct {
+		Internal struct {
+			Entries map[string]openclawEntry `json:"entries"`
+		} `json:"internal"`
+	} `json:"hooks"`
+}
+
+type openclawEntry struct {
+	Enabled *bool `json:"enabled"`
 }

--- a/internal/bridge/openclaw_test.go
+++ b/internal/bridge/openclaw_test.go
@@ -16,6 +16,8 @@ package bridge
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -155,6 +157,24 @@ func (mg *mockGateway) readResponse() map[string]any {
 	return frame
 }
 
+func (mg *mockGateway) readResponseWithin(timeout time.Duration) (map[string]any, bool) {
+	require.NoError(mg.t, mg.conn.SetReadDeadline(time.Now().Add(timeout)))
+	defer mg.conn.SetReadDeadline(time.Time{}) //nolint:errcheck
+
+	_, msg, err := mg.conn.ReadMessage()
+	if err != nil {
+		var netErr net.Error
+		if errors.As(err, &netErr) && netErr.Timeout() {
+			return nil, false
+		}
+		require.NoError(mg.t, err)
+	}
+
+	var frame map[string]any
+	json.Unmarshal(msg, &frame)
+	return frame, true
+}
+
 func (mg *mockGateway) close() {
 	mg.writeMu.Lock()
 	conn := mg.conn
@@ -271,6 +291,79 @@ func TestBridgeAutoResolveDeny(t *testing.T) {
 	cancel()
 }
 
+func TestBridgeNativePluginModeLeavesAllowApprovalPending(t *testing.T) {
+	mg := newMockGateway(t)
+	defer mg.close()
+
+	tmpDir := t.TempDir()
+	policyPath := writeTestPolicy(t, tmpDir)
+	eng := newTestEngine(t, policyPath)
+	autoResolve := false
+
+	bridge := NewOpenClawBridge(eng, Config{
+		GatewayURL:                mg.url(),
+		GatewayToken:              "test-token",
+		ReconnectInterval:         100 * time.Millisecond,
+		AutoResolveAllowDecisions: &autoResolve,
+	})
+	defer bridge.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	go func() { bridge.Start(ctx) }() //nolint:errcheck
+
+	time.Sleep(500 * time.Millisecond)
+
+	mg.sendApprovalRequest("approval-safe-native", "git status", "openclaw")
+	if resp, ok := mg.readResponseWithin(300 * time.Millisecond); ok {
+		t.Fatalf("expected safe approval to remain pending in native plugin mode, got response: %#v", resp)
+	}
+
+	bridge.pendingMu.Lock()
+	_, stillStored := bridge.pendingCommands["approval-safe-native"]
+	bridge.pendingMu.Unlock()
+	if !stillStored {
+		t.Fatalf("expected pending command to stay stored for later human allow-always writeback")
+	}
+
+	cancel()
+}
+
+func TestBridgeNativePluginModeStillAutoResolvesDeny(t *testing.T) {
+	mg := newMockGateway(t)
+	defer mg.close()
+
+	tmpDir := t.TempDir()
+	policyPath := writeTestPolicy(t, tmpDir)
+	eng := newTestEngine(t, policyPath)
+	autoResolve := false
+
+	bridge := NewOpenClawBridge(eng, Config{
+		GatewayURL:                mg.url(),
+		GatewayToken:              "test-token",
+		ReconnectInterval:         100 * time.Millisecond,
+		AutoResolveAllowDecisions: &autoResolve,
+	})
+	defer bridge.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	go func() { bridge.Start(ctx) }() //nolint:errcheck
+
+	time.Sleep(500 * time.Millisecond)
+
+	mg.sendApprovalRequest("approval-danger-native", "rm -rf /", "openclaw")
+	time.Sleep(200 * time.Millisecond)
+
+	resp := mg.readResponse()
+	params, ok := resp["params"].(map[string]any)
+	require.True(t, ok, "expected params in response")
+	assert.Equal(t, "approval-danger-native", params["id"])
+	assert.Equal(t, "deny", params["decision"])
+
+	cancel()
+}
+
 func TestBridgeReconnect(t *testing.T) {
 	mg := newMockGateway(t)
 
@@ -360,6 +453,68 @@ func TestDiscoverGatewayConfigDefaultURL(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "ws://127.0.0.1:18789/ws", url)
 	assert.Equal(t, "tok", token)
+}
+
+func TestReadGatewayConfigForBridgeDetectsNativePluginOwnership(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	tests := []struct {
+		name string
+		ask  any
+	}{
+		{name: "explicit ask off", ask: "off"},
+		{name: "forced openclaw approvals", ask: "always"},
+		{name: "openclaw on miss approvals", ask: "on-miss"},
+		{name: "omitted ask defaults to off", ask: nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configPath := filepath.Join(tmpDir, tt.name+".json")
+			config := map[string]any{
+				"gateway": map[string]any{
+					"auth": map[string]any{"token": "tok"},
+				},
+				"plugins": map[string]any{
+					"entries": map[string]any{
+						"rampart": map[string]any{"enabled": true},
+					},
+				},
+			}
+			if tt.ask != nil {
+				config["tools"] = map[string]any{
+					"exec": map[string]any{"ask": tt.ask},
+				}
+			}
+			data, err := json.Marshal(config)
+			require.NoError(t, err)
+			require.NoError(t, os.WriteFile(configPath, data, 0o644))
+
+			_, _, autoResolve, err := ReadGatewayConfigForBridge(configPath)
+			require.NoError(t, err)
+			assert.False(t, autoResolve, "native plugin mode must not auto-consume OpenClaw approvals")
+		})
+	}
+}
+
+func TestReadGatewayConfigForBridgeKeepsLegacyBridgeAutoResolve(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "openclaw.json")
+
+	config := map[string]any{
+		"gateway": map[string]any{
+			"auth": map[string]any{"token": "tok"},
+		},
+		"tools": map[string]any{
+			"exec": map[string]any{"ask": "on-miss"},
+		},
+	}
+	data, err := json.Marshal(config)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(configPath, data, 0o644))
+
+	_, _, autoResolve, err := ReadGatewayConfigForBridge(configPath)
+	require.NoError(t, err)
+	assert.True(t, autoResolve, "legacy bridge-first mode should still auto-resolve Rampart-allowed approvals")
 }
 
 func TestDiscoverGatewayConfigMissingToken(t *testing.T) {


### PR DESCRIPTION
## Summary
- stop Rampart bridge from auto-consuming OpenClaw approvals when the native Rampart plugin is installed
- keep deny enforcement automatic while leaving OpenClaw/manual approval records human-owned
- preserve legacy bridge-first auto-allow behavior when the Rampart plugin is not installed
- document the ownership split and add regression coverage for forced/OpenClaw approval modes

## Tests
- `go test ./internal/bridge ./cmd/rampart/cli ./internal/proxy -count=1`
- `go test ./... -count=1`
- `go vet ./...`
- `go build ./cmd/rampart`
