### PR TITLE
fix: detect latest OpenClaw approval bundles

### DIFF
--- a/internal/openclaw/hardening/hardening.go
+++ b/internal/openclaw/hardening/hardening.go
@@ -52,11 +52,11 @@ type openClawConfig struct {
 
 func Inspect(home string, distCandidates []string) (State, error) {
 	state := State{ConfigPath: filepath.Join(home, ".openclaw", "openclaw.json")}
-	if path, ok := findDistFile(distCandidates, "exec-approvals-*.js"); ok {
+	if path, ok := findDistFileByShape(distCandidates, "exec-approvals-*.js", supportsExecApprovalsShape); ok {
 		state.ExecApprovalsPath = path
 		state.DistDir = filepath.Dir(path)
 	}
-	if path, ok := findDistFile(distCandidates, "bash-tools-*.js"); ok {
+	if path, ok := findDistFileByShape(distCandidates, "bash-tools-*.js", supportsBashToolsShape); ok {
 		state.BashToolsPath = path
 		if state.DistDir == "" {
 			state.DistDir = filepath.Dir(path)
@@ -148,6 +148,24 @@ func findDistFile(candidates []string, pattern string) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+func findDistFileByShape(candidates []string, pattern string, supports func(string) bool) (string, bool) {
+	fallback, fallbackOK := findDistFile(candidates, pattern)
+	for _, dir := range candidates {
+		matches, _ := filepath.Glob(filepath.Join(dir, pattern))
+		sort.Strings(matches)
+		for _, path := range matches {
+			data, err := os.ReadFile(path)
+			if err != nil {
+				continue
+			}
+			if supports(string(data)) {
+				return path, true
+			}
+		}
+	}
+	return fallback, fallbackOK
 }
 
 func supportsExecApprovalsShape(text string) bool {

--- a/internal/openclaw/hardening/hardening_test.go
+++ b/internal/openclaw/hardening/hardening_test.go
@@ -63,6 +63,26 @@ func TestInspectPrePatch(t *testing.T) {
 	}
 }
 
+func TestInspectSkipsNonApprovalBundles(t *testing.T) {
+	home, dist := setupFixture(t, execApprovalsPre, bashToolsPre, "{}\n")
+	writeFile(t, filepath.Join(dist, "exec-approvals-allowlist-test.js"), `export const allowlist = true;`)
+	writeFile(t, filepath.Join(dist, "bash-tools-helper-test.js"), `export const helper = true;`)
+
+	state, err := Inspect(home, []string{dist})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !state.Supported {
+		t.Fatal("expected supported build shape despite adjacent helper bundles")
+	}
+	if filepath.Base(state.ExecApprovalsPath) != "exec-approvals-test.js" {
+		t.Fatalf("expected approval runtime bundle, got %s", state.ExecApprovalsPath)
+	}
+	if filepath.Base(state.BashToolsPath) != "bash-tools-test.js" {
+		t.Fatalf("expected bash tools runtime bundle, got %s", state.BashToolsPath)
+	}
+}
+
 func TestApplyPatchesAndAlignsConfig(t *testing.T) {
 	home, dist := setupFixture(t, execApprovalsPre, bashToolsPre, "{\"plugins\":{\"entries\":{\"rampart\":{\"config\":{\"approvalTimeoutMs\":300000}}}}}\n")
 	result, err := Apply(home, []string{dist})


### PR DESCRIPTION
## Summary
- update OpenClaw approval hardening detection to skip adjacent helper bundles like `exec-approvals-allowlist-*`
- select the actual approval runtime bundle by supported markers instead of the first lexicographic match
- add regression coverage for latest OpenClaw dist layouts with multiple matching bundles

## Why
OpenClaw 2026.4.29 ships several `exec-approvals-*.js` bundles. Rampart was picking the allowlist helper first, deciding the build shape was unsupported, and refusing approval hardening. This restores support for the latest client layout without blind patching.

## Tests
- `go test ./internal/openclaw/hardening ./cmd/rampart/cli -count=1`
- `go test ./... -count=1`
- `go vet ./...`
- `go build ./cmd/rampart`
