### PR TITLE
fix: make durable user overrides authoritative

### DIFF
--- a/cmd/rampart/cli/test_cmd.go
+++ b/cmd/rampart/cli/test_cmd.go
@@ -290,7 +290,8 @@ func runTest(w, errW io.Writer, opts *rootOptions, arg, toolName string, noColor
 
 	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
 
-	store := engine.NewFileStore(policyPath)
+	includeHomePolicyDir := opts.configPath == "" || opts.configPath == "rampart.yaml"
+	store := newTestPolicyStore(policyPath, includeHomePolicyDir, nil)
 	eng, err := engine.New(store, nil)
 	if err != nil {
 		return fmt.Errorf("test: create engine: %w", err)
@@ -334,6 +335,19 @@ func runTest(w, errW io.Writer, opts *rootOptions, arg, toolName string, noColor
 		return exitCodeError{code: 1}
 	}
 	return nil
+}
+
+func newTestPolicyStore(policyPath string, includeHomePolicyDir bool, logger *slog.Logger) engine.PolicyStore {
+	if !includeHomePolicyDir {
+		return engine.NewFileStore(policyPath)
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		policyDir := filepath.Join(home, ".rampart", "policies")
+		if _, statErr := os.Stat(policyDir); statErr == nil {
+			return engine.NewMultiStore(policyPath, policyDir, logger)
+		}
+	}
+	return engine.NewFileStore(policyPath)
 }
 
 func resolveTestPolicyPath(path string) (string, func(), error) {

--- a/cmd/rampart/cli/test_cmd_test.go
+++ b/cmd/rampart/cli/test_cmd_test.go
@@ -15,6 +15,7 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -72,6 +73,66 @@ policies:
 	}
 	if !strings.Contains(output, "block-destructive") {
 		t.Errorf("expected policy name in output, got: %s", output)
+	}
+}
+
+func TestRunTestIncludesDurableUserOverrides(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("USERPROFILE", tmpHome)
+	policyDir := filepath.Join(tmpHome, ".rampart", "policies")
+	if err := os.MkdirAll(policyDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(policyDir, "standard.yaml"), []byte(`
+version: "1"
+default_action: deny
+policies:
+  - name: block-destructive
+    match:
+      tool: exec
+    rules:
+      - action: ask
+        message: Secure delete requires approval
+        when:
+          command_matches: ["shred **"]
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(policyDir, "user-overrides.yaml"), []byte(`
+version: "1"
+default_action: deny
+policies:
+  - name: user-allow-shred-help
+    match:
+      tool: exec
+    rules:
+      - action: allow
+        message: User allow (always) via openclaw-approval
+        when:
+          command_matches: ["shred --help"]
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	opts := &rootOptions{configPath: "rampart.yaml"}
+
+	runErr := runTest(&out, &errOut, opts, "shred --help", "exec", true, true)
+	if runErr != nil {
+		t.Fatalf("expected no error for durable override, got: %v", runErr)
+	}
+
+	var got bareCmdJSONResult
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("parse json output: %v\n%s", err, out.String())
+	}
+	if got.Action != "allow" {
+		t.Fatalf("expected durable override to make rampart test return allow, got %#v", got)
+	}
+	if len(got.MatchedPolicies) != 1 || got.MatchedPolicies[0] != "user-allow-shred-help" {
+		t.Fatalf("expected only durable override policy, got %#v", got.MatchedPolicies)
 	}
 }
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -116,12 +116,22 @@ func (e *Engine) EvaluateWith(call ToolCall, opts EvalOptions) Decision {
 	// Collect matching policies, sorted by priority.
 	matching := e.collectMatching(cfg, call)
 
-	// Apply policy filter if set (per-agent token scoping).
+	// Durable human allow rules are not ordinary policy allows. They are explicit
+	// operator carve-outs written by approval/allow workflows. They bypass broader
+	// ask/approval policies, but hard deny policies still win.
+	durableAllow, hasDurableAllow := e.evaluateDurableAllowOverride(matching, call, start)
+
+	// Apply policy filter if set (per-agent token scoping). Durable operator
+	// overrides are intentionally checked before this filter so human-approved
+	// carve-outs stay global rather than disappearing under token profile scoping.
 	if opts.PolicyFilter != "" {
 		matching = filterByProfile(matching, opts.PolicyFilter)
 	}
 
 	if len(matching) == 0 {
+		if hasDurableAllow {
+			return durableAllow
+		}
 		return Decision{
 			Action:       defaultAction,
 			Message:      "no matching policy; using default action",
@@ -133,16 +143,16 @@ func (e *Engine) EvaluateWith(call ToolCall, opts EvalOptions) Decision {
 	// Deny wins. Then log. Then allow.
 	// If policies match scope but no rules fire, fall through to default action.
 	var (
-		finalAction           = ActionAllow
-		finalMessage          string
-		finalAudit            bool
-		finalHeadlessOnly     bool
-		finalFromProject      bool
-		matched               []string
-		anyRuleFired          bool
-		consumedOnce          bool
-		consumedPolicy        string
-		consumedRuleIdx       int
+		finalAction       = ActionAllow
+		finalMessage      string
+		finalAudit        bool
+		finalHeadlessOnly bool
+		finalFromProject  bool
+		matched           []string
+		anyRuleFired      bool
+		consumedOnce      bool
+		consumedPolicy    string
+		consumedRuleIdx   int
 	)
 
 	var finalWebhookConfig *WebhookActionConfig
@@ -225,6 +235,10 @@ func (e *Engine) EvaluateWith(call ToolCall, opts EvalOptions) Decision {
 		}
 	}
 
+	if hasDurableAllow {
+		return durableAllow
+	}
+
 	// If policies matched scope but no rules actually fired,
 	// fall through to the configured default action.
 	if !anyRuleFired {
@@ -248,6 +262,120 @@ func (e *Engine) EvaluateWith(call ToolCall, opts EvalOptions) Decision {
 		ConsumedRulePolicy: consumedPolicy,
 		ConsumedRuleIndex:  consumedRuleIdx,
 	}
+}
+
+func (e *Engine) evaluateDurableAllowOverride(matching []Policy, call ToolCall, start time.Time) (Decision, bool) {
+	for _, p := range matching {
+		if !isDurableAllowPolicy(p) {
+			continue
+		}
+
+		res := e.evaluateDurableAllowPolicy(p, call)
+		if !res.matched || res.action != ActionAllow {
+			continue
+		}
+
+		message := res.message
+		if message == "" {
+			message = durableAllowMessage(p)
+		}
+
+		decision := Decision{
+			Action:          ActionAllow,
+			MatchedPolicies: []string{p.Name},
+			Message:         message,
+			EvalDuration:    time.Since(start),
+		}
+		if res.rule != nil && res.rule.Once {
+			decision.ConsumedOnce = true
+			decision.ConsumedRulePolicy = p.Name
+			decision.ConsumedRuleIndex = res.ruleIndex
+		}
+		return decision, true
+	}
+
+	return Decision{}, false
+}
+
+func (e *Engine) evaluateDurableAllowPolicy(p Policy, call ToolCall) evaluatePolicyResult {
+	for i, rule := range p.Rules {
+		if rule.IsExpired() || !matchDurableAllowCondition(rule.When, call, e.callCounter) {
+			continue
+		}
+		action, err := rule.ParseAction()
+		if err != nil {
+			e.logger.Error("engine: invalid durable allow action", "policy", p.Name, "action", rule.Action, "error", err)
+			return evaluatePolicyResult{ActionDeny, "invalid rule action; failing closed", nil, i, true}
+		}
+		return evaluatePolicyResult{action, rule.Message, &p.Rules[i], i, true}
+	}
+	return evaluatePolicyResult{matched: false}
+}
+
+func matchDurableAllowCondition(cond Condition, call ToolCall, counter CallCounter) bool {
+	if cond.Default || cond.IsEmpty() {
+		return true
+	}
+	if len(cond.CommandMatches) == 0 && len(cond.CommandContains) == 0 {
+		return matchCondition(cond, call, counter)
+	}
+	if !matchStrictCommandCondition(cond, call) {
+		return false
+	}
+	cond.CommandMatches = nil
+	cond.CommandContains = nil
+	cond.CommandNotMatches = nil
+	if cond.IsEmpty() {
+		return true
+	}
+	return matchCondition(cond, call, counter)
+}
+
+func matchStrictCommandCondition(cond Condition, call ToolCall) bool {
+	cmd := call.Command()
+	if cmd == "" {
+		return false
+	}
+	cmdMatch := false
+	if len(cond.CommandMatches) > 0 {
+		cmdMatch = matchAny(cond.CommandMatches, cmd)
+		if norm := NormalizeCommand(cmd); !cmdMatch && norm != cmd {
+			cmdMatch = matchAny(cond.CommandMatches, norm)
+		}
+	}
+	if !cmdMatch {
+		cmdLower := strings.ToLower(cmd)
+		for _, sub := range cond.CommandContains {
+			if strings.Contains(cmdLower, strings.ToLower(sub)) {
+				cmdMatch = true
+				break
+			}
+		}
+	}
+	if !cmdMatch {
+		return false
+	}
+	return !matchAny(cond.CommandNotMatches, cmd) && !matchAny(cond.CommandNotMatches, NormalizeCommand(cmd))
+}
+
+// isDurableAllowPolicy reports whether a policy came from Rampart's durable
+// human allow files. These are intentional operator carve-outs created by
+// `rampart allow`, approval persist/Always Allow, or legacy auto-allow flows.
+// Policy names alone are not trusted here: project or custom policy files must
+// not be able to self-declare high-precedence operator overrides.
+func isDurableAllowPolicy(p Policy) bool {
+	profile := strings.ToLower(profileNameFromPath(p.FilePath))
+	return profile == "user-overrides" || profile == "auto-allowed"
+}
+
+// durableAllowMessage returns the default audit/test message for a durable
+// human allow policy when the matching rule did not provide one.
+func durableAllowMessage(p Policy) string {
+	profile := strings.ToLower(profileNameFromPath(p.FilePath))
+	if profile == "auto-allowed" {
+		return "auto-allowed by user rule"
+	}
+	return "allowed by durable user override"
 }
 
 // EvaluateResponse runs response-side evaluation against matching policies.

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -133,6 +133,77 @@ policies:
 	}
 }
 
+func TestEvaluate_DurableUserOverrideWinsBeforeAsk(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "standard.yaml"), []byte(`
+version: "1"
+default_action: deny
+policies:
+  - name: block-destructive
+    match:
+      tool: exec
+    rules:
+      - action: deny
+        when:
+          command_matches: ["rm -rf *"]
+        message: "Destructive command blocked"
+      - action: ask
+        when:
+          command_matches: ["shred **"]
+        message: "Secure delete requires approval"
+  - name: user-allow-name-alone-is-not-durable
+    match:
+      tool: exec
+    rules:
+      - action: allow
+        when:
+          command_matches: ["shred --version"]
+        message: "ordinary allow"
+`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "user-overrides.yaml"), []byte(`
+version: "1"
+default_action: deny
+policies:
+  - name: user-allow-shred-help
+    match:
+      tool: exec
+    rules:
+      - action: allow
+        when:
+          command_matches: ["shred --help"]
+        message: "User allow (always) via openclaw-approval"
+  - name: user-allow-rm-root
+    match:
+      tool: exec
+    rules:
+      - action: allow
+        when:
+          command_matches: ["rm -rf /"]
+        message: "User allow (always) via openclaw-approval"
+`), 0o644))
+
+	eng, err := New(NewDirStore(dir, nil), nil)
+	require.NoError(t, err)
+
+	got := eng.Evaluate(execCall("main", "shred --help"))
+	require.Equal(t, ActionAllow, got.Action)
+	assert.Equal(t, []string{"user-allow-shred-help"}, got.MatchedPolicies)
+	assert.Equal(t, "User allow (always) via openclaw-approval", got.Message)
+
+	stillAsk := eng.Evaluate(execCall("main", "shred --help | head -n 1"))
+	require.Equal(t, ActionAsk, stillAsk.Action)
+	assert.Contains(t, stillAsk.MatchedPolicies, "block-destructive")
+
+	nameAloneIsNotDurable := eng.Evaluate(execCall("main", "shred --version"))
+	require.Equal(t, ActionAsk, nameAloneIsNotDurable.Action)
+	assert.Contains(t, nameAloneIsNotDurable.MatchedPolicies, "user-allow-name-alone-is-not-durable")
+	assert.Contains(t, nameAloneIsNotDurable.MatchedPolicies, "block-destructive")
+
+	denyStillWins := eng.Evaluate(execCall("main", "rm -rf /"))
+	require.Equal(t, ActionDeny, denyStillWins.Action)
+	assert.Contains(t, denyStillWins.MatchedPolicies, "block-destructive")
+}
+
 func TestEvaluate_DefaultDeny(t *testing.T) {
 	e := setupEngine(t, `
 version: "1"

--- a/internal/plugin/openclaw/degraded-mode-test.mjs
+++ b/internal/plugin/openclaw/degraded-mode-test.mjs
@@ -65,6 +65,18 @@ const serverErrorWrite = await runScenario({
 assert(serverErrorWrite.result?.block === true, 'write on serve 5xx must block');
 assert(serverErrorWrite.result.blockReason.includes('service error 503'), 'write 5xx reason should include status');
 
+const timeoutEdit = await runScenario({
+  name: 'timeout-edit',
+  toolName: 'edit',
+  fetchImpl: async () => {
+    const err = new Error('aborted');
+    err.name = 'AbortError';
+    throw err;
+  },
+});
+assert(timeoutEdit.result?.block === true, 'edit on timeout must block');
+assert(timeoutEdit.result.blockReason.includes('timed out'), 'edit timeout reason should mention timeout');
+
 const serverErrorReadWithStrictConfig = await runScenario({
   name: 'server-error-read-strict',
   toolName: 'read',
@@ -73,4 +85,4 @@ const serverErrorReadWithStrictConfig = await runScenario({
 });
 assert(serverErrorReadWithStrictConfig.result?.block === true, 'read should block when failOpenTools is empty');
 
-console.log(JSON.stringify({ ok: true, scenarios: ['unreachable-exec', 'unreachable-read', 'server-error-write', 'server-error-read-strict'] }, null, 2));
+console.log(JSON.stringify({ ok: true, scenarios: ['unreachable-exec', 'unreachable-read', 'server-error-write', 'timeout-edit', 'server-error-read-strict'] }, null, 2));

--- a/internal/proxy/eval_handlers.go
+++ b/internal/proxy/eval_handlers.go
@@ -142,35 +142,6 @@ func (s *Server) handleToolCall(w http.ResponseWriter, r *http.Request) {
 		resp["suggestions"] = []string{}
 	}
 
-	// Explicit durable human carve-outs should bypass normal deny/ask precedence.
-	// They are not ordinary policy rules, they are operator-approved overrides.
-	if s.mode == "enforce" {
-		policyName := ""
-		message := ""
-		if engine.MatchesAutoAllowFile(engine.DefaultAutoAllowedPath(), call) {
-			policyName = "auto-allowed"
-			message = "auto-allowed by user rule"
-		} else if engine.MatchesAutoAllowFile(engine.DefaultUserOverridesPath(), call) {
-			policyName = "user-overrides"
-			message = "allowed by durable user override"
-		}
-		if policyName != "" {
-			s.logger.Debug("proxy: user override matched, bypassing normal policy decision", "tool", toolName, "policy", policyName)
-			decision.Action = engine.ActionAllow
-			decision.Message = message
-			decision.MatchedPolicies = []string{policyName}
-			decision.Suggestions = nil
-			resp["allowed"] = true
-			resp["decision"] = decision.Action.String()
-			resp["message"] = decision.Message
-			resp["policy"] = policyName
-			resp["suggestions"] = []string{}
-			s.writeAudit(req, toolName, decision)
-			writeJSON(w, http.StatusOK, resp)
-			return
-		}
-	}
-
 	if s.mode == "enforce" && decision.Action == engine.ActionDeny {
 		writeJSON(w, http.StatusForbidden, resp)
 		return
@@ -205,7 +176,6 @@ func (s *Server) handleToolCall(w http.ResponseWriter, r *http.Request) {
 					"decision", decision.Action.String(),
 					"session", call.Session,
 				)
-				s.writeAudit(req, toolName, decision)
 				writeJSON(w, http.StatusOK, resp)
 				return
 			}

--- a/internal/proxy/server_test.go
+++ b/internal/proxy/server_test.go
@@ -136,7 +136,11 @@ func setupTestServerWithHome(t *testing.T, configYAML, mode, homeDir string) (*S
 	policyPath := filepath.Join(dir, "policy.yaml")
 	require.NoError(t, os.WriteFile(policyPath, []byte(configYAML), 0o644))
 
-	store := engine.NewFileStore(policyPath)
+	store := engine.PolicyStore(engine.NewFileStore(policyPath))
+	policyDir := filepath.Join(homeDir, ".rampart", "policies")
+	if _, err := os.Stat(policyDir); err == nil {
+		store = engine.NewMultiStore(policyPath, policyDir, slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil)))
+	}
 	eng, err := engine.New(store, slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil)))
 	require.NoError(t, err)
 
@@ -676,7 +680,7 @@ policies:
 	_, hasApprovalID := got["approval_id"]
 	assert.False(t, hasApprovalID, "trusted OpenClaw-hosted evaluation should not create Rampart approval_id")
 	assert.Len(t, srv.approvals.List(), 0, "trusted OpenClaw-hosted evaluation should not enqueue Rampart approvals")
-	require.GreaterOrEqual(t, srv.sink.(*mockSink).count(), 1, "trusted OpenClaw-hosted evaluation should still write an audit event")
+	require.Equal(t, 1, srv.sink.(*mockSink).count(), "trusted OpenClaw-hosted evaluation should write one audit event")
 	ev := srv.sink.(*mockSink).lastEvent()
 	assert.Equal(t, "ask", ev.Decision.Action)
 	assert.Equal(t, "exec", ev.Tool)
@@ -760,7 +764,7 @@ policies:
         message: "needs approval"
 `
 
-	srv, token, _ := setupTestServerWithHome(t, configYAML, "enforce", tmpHome)
+	srv, token, sink := setupTestServerWithHome(t, configYAML, "enforce", tmpHome)
 	ts := httptest.NewServer(srv.handler())
 	defer ts.Close()
 
@@ -778,8 +782,10 @@ policies:
 	var got map[string]any
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&got))
 	assert.Equal(t, "allow", got["decision"])
-	assert.Equal(t, "user-overrides", got["policy"])
+	assert.Equal(t, "user-allow-local-api", got["policy"])
 	assert.Len(t, srv.approvals.List(), 0, "durable user overrides should bypass approval queue")
+	assert.Equal(t, 1, sink.count(), "durable user override should write exactly one audit event")
+	assert.Equal(t, "allow", sink.lastEvent().Decision.Action)
 }
 
 func TestResolveApproval_AuditTrail(t *testing.T) {


### PR DESCRIPTION
## Summary
- make durable user allow files (`user-overrides.yaml`, `auto-allowed.yaml`) first-class engine overrides for broader ask/approval decisions while preserving hard deny-wins
- make durable command allows match only the full raw/normalized command, not compound-command segments
- remove proxy-only post-processing override and fix duplicate OpenClaw-hosted ask audit rows
- make bare `rampart test` include the default policy directory so dry-runs agree with live serve
- extend degraded-mode coverage for edit timeout handling

## Verification
- `go test ./internal/engine ./internal/proxy ./cmd/rampart/cli -run 'TestEvaluate_DurableUserOverrideWinsBeforeAsk|TestUserOverridesBypassApprovalQueue|TestRunTestIncludesDurableUserOverrides|TestOpenClawHostedAskSkipsPendingApprovalCreationForAdmin' -count=1`
- `go test ./... -count=1`
- `go vet ./...`
- `node internal/plugin/openclaw/degraded-mode-test.mjs`
- `node internal/plugin/openclaw/approval-regression.mjs`
