### PR TITLE
fix: avoid prerelease downgrade update hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-rc.2] - 2026-05-04
+
+### Fixed
+
+- **Doctor no longer suggests downgrading prerelease builds** — `rampart doctor` now uses SemVer-aware prerelease comparison for update hints, so `v1.0.0-rc.1`/`v1.0.0-rc.2` do not report stable `v0.9.22` as an available upgrade.
+
+### Changed
+
+- **OpenClaw plugin metadata now matches the RC.2 release** — The embedded plugin manifest, runtime export, and package metadata are versioned as `1.0.0-rc.2`.
+
 ## [1.0.0-rc.1] - 2026-05-03
 
 ### Added

--- a/cmd/rampart/cli/doctor.go
+++ b/cmd/rampart/cli/doctor.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -1297,10 +1298,7 @@ func doctorVersionCheck(w io.Writer, silent bool, emit emitFn) int {
 		return 0
 	}
 
-	latest := strings.TrimPrefix(release.TagName, "v")
-	currentClean := strings.TrimPrefix(current, "v")
-
-	if latest == currentClean {
+	if !isNewerReleaseVersion(current, release.TagName) {
 		return 0
 	}
 
@@ -1319,6 +1317,130 @@ func doctorVersionCheck(w io.Writer, silent bool, emit emitFn) int {
 		fmt.Fprintf(w, "  ⚠ Update available: %s → %s\n%s\n", current, release.TagName, hint)
 	}
 	return 0 // informational, not an issue
+}
+
+type releaseVersion struct {
+	major      int
+	minor      int
+	patch      int
+	prerelease []string
+}
+
+func isNewerReleaseVersion(current, latest string) bool {
+	cmp, ok := compareReleaseVersions(current, latest)
+	if !ok {
+		return false
+	}
+	return cmp < 0
+}
+
+func compareReleaseVersions(a, b string) (int, bool) {
+	av, okA := parseReleaseVersion(a)
+	bv, okB := parseReleaseVersion(b)
+	if !okA || !okB {
+		return 0, false
+	}
+	for _, pair := range [][2]int{{av.major, bv.major}, {av.minor, bv.minor}, {av.patch, bv.patch}} {
+		if pair[0] < pair[1] {
+			return -1, true
+		}
+		if pair[0] > pair[1] {
+			return 1, true
+		}
+	}
+	return comparePrerelease(av.prerelease, bv.prerelease), true
+}
+
+func parseReleaseVersion(v string) (releaseVersion, bool) {
+	var out releaseVersion
+	v = strings.TrimPrefix(strings.TrimSpace(v), "v")
+	if v == "" || v == "dev" || v == "unknown" || strings.Contains(v, "dirty") || strings.Contains(v, "staging") || strings.HasPrefix(v, "0.0.0-") || isGoPseudoVersion(v) {
+		return out, false
+	}
+	v = strings.SplitN(v, "+", 2)[0]
+	base, prerelease, hasPrerelease := strings.Cut(v, "-")
+	parts := strings.Split(base, ".")
+	if len(parts) != 3 {
+		return out, false
+	}
+	parsed := []*int{&out.major, &out.minor, &out.patch}
+	for i, part := range parts {
+		n, err := strconv.Atoi(part)
+		if err != nil || n < 0 {
+			return out, false
+		}
+		*parsed[i] = n
+	}
+	if hasPrerelease {
+		if prerelease == "" {
+			return out, false
+		}
+		out.prerelease = strings.Split(prerelease, ".")
+		for _, id := range out.prerelease {
+			if id == "" {
+				return out, false
+			}
+		}
+	}
+	return out, true
+}
+
+func comparePrerelease(a, b []string) int {
+	if len(a) == 0 && len(b) == 0 {
+		return 0
+	}
+	if len(a) == 0 {
+		return 1
+	}
+	if len(b) == 0 {
+		return -1
+	}
+	for i := 0; i < len(a) && i < len(b); i++ {
+		cmp := comparePrereleaseIdentifier(a[i], b[i])
+		if cmp != 0 {
+			return cmp
+		}
+	}
+	if len(a) < len(b) {
+		return -1
+	}
+	if len(a) > len(b) {
+		return 1
+	}
+	return 0
+}
+
+func comparePrereleaseIdentifier(a, b string) int {
+	ai, aNum := parseNumericPrereleaseIdentifier(a)
+	bi, bNum := parseNumericPrereleaseIdentifier(b)
+	switch {
+	case aNum && bNum:
+		if ai < bi {
+			return -1
+		}
+		if ai > bi {
+			return 1
+		}
+		return 0
+	case aNum:
+		return -1
+	case bNum:
+		return 1
+	case a < b:
+		return -1
+	case a > b:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func parseNumericPrereleaseIdentifier(v string) (int, bool) {
+	if v == "" || (len(v) > 1 && v[0] == '0') {
+		return 0, false
+	}
+	n, err := strconv.Atoi(v)
+	return n, err == nil
 }
 
 // doctorProjectPolicy checks if the current git repo has a .rampart/policy.yaml project policy.

--- a/cmd/rampart/cli/doctor_test.go
+++ b/cmd/rampart/cli/doctor_test.go
@@ -617,6 +617,35 @@ func TestPluginVersionMatchesBuildVersion(t *testing.T) {
 	}
 }
 
+func TestIsNewerReleaseVersion(t *testing.T) {
+	tests := []struct {
+		current string
+		latest  string
+		want    bool
+	}{
+		{"v0.9.21", "v0.9.22", true},
+		{"v0.9.22", "v0.9.22", false},
+		{"0.9.22", "v0.9.22", false},
+		{"v0.9.23", "v0.9.22", false},
+		{"v1.0.0-rc.1", "v0.9.22", false},
+		{"1.0.0-rc.1", "v0.9.22", false},
+		{"v0.9.22", "v1.0.0-rc.1", true},
+		{"v1.0.0-rc.1", "v1.0.0-rc.2", true},
+		{"v1.0.0-rc.2", "v1.0.0-rc.1", false},
+		{"v1.0.0-rc.1", "v1.0.0", true},
+		{"v1.0.0", "v1.0.0-rc.1", false},
+		{"v1.0.0-rc.10", "v1.0.0-rc.2", false},
+		{"v1.0.0-alpha", "v1.0.0-beta", true},
+		{"v0.9.22-staging-47fa0cf", "v0.9.22", false},
+		{"v0.9.22-0.20260503052103-a72c3452fe38", "v0.9.22", false},
+	}
+	for _, tt := range tests {
+		if got := isNewerReleaseVersion(tt.current, tt.latest); got != tt.want {
+			t.Fatalf("isNewerReleaseVersion(%q, %q) = %v, want %v", tt.current, tt.latest, got, tt.want)
+		}
+	}
+}
+
 func TestOpenClawDiscordNativeApprovalsConfigured(t *testing.T) {
 	tmp := t.TempDir()
 	bin := filepath.Join(tmp, "openclaw")

--- a/cmd/rampart/cli/setup_openclaw_plugin_test.go
+++ b/cmd/rampart/cli/setup_openclaw_plugin_test.go
@@ -9,10 +9,10 @@ import (
 
 func TestExtractOpenClawPluginRuntimeVersion(t *testing.T) {
 	got := extractOpenClawPluginRuntimeVersion(`export const id = "rampart";
-export const version = "1.0.0-rc.1";
+export const version = "1.0.0-rc.2";
 `)
-	if got != "1.0.0-rc.1" {
-		t.Fatalf("runtime version = %q, want 1.0.0-rc.1", got)
+	if got != "1.0.0-rc.2" {
+		t.Fatalf("runtime version = %q, want 1.0.0-rc.2", got)
 	}
 }
 

--- a/docs-site/index.html
+++ b/docs-site/index.html
@@ -27,7 +27,7 @@
       "url": "https://rampart.sh",
       "applicationCategory": "SecurityApplication",
       "operatingSystem": "Linux, macOS, Windows",
-      "softwareVersion": "1.0.0-rc.1",
+      "softwareVersion": "1.0.0-rc.2",
       "offers": {
         "@type": "Offer",
         "price": "0",
@@ -1112,7 +1112,7 @@
 <section class="hero">
     <div class="container hero-grid">
         <div>
-            <div class="eyebrow"><span class="eyebrow-dot"></span>v1.0.0-rc.1 · release candidate</div>
+            <div class="eyebrow"><span class="eyebrow-dot"></span>v1.0.0-rc.2 · release candidate</div>
             <h1>Your agent has root.<br><span class="accent">That’s the problem.</span></h1>
             <p class="hero-sub">Rampart sits in the execution path. Install it, run <code>rampart quickstart</code>, and it wires the right protection path for Claude Code, Codex, Cline, or OpenClaw before risky tool calls run.</p>
             <div class="install-cluster">

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -205,8 +205,9 @@ verify -> outcomes.approval
 
 [:octicons-arrow-right-24: See all integration guides](integrations/index.md)
 
-## What's New in v1.0.0-rc.1
+## What's New in v1.0.0-rc.2
 
+- **Prerelease update checks are sane** — `rampart doctor` no longer suggests downgrading from the 1.0 RC line to the older stable `v0.9.22` release.
 - **OpenClaw 2026.5.2 is the RC baseline** — Rampart now uses OpenClaw's first-class plugin approval path as the single human-approval owner, with Rampart handling policy, audit, and durable allow-always persistence. [Details →](integrations/openclaw.md)
 - **Degraded mode is explicit** — sensitive OpenClaw tools block when `rampart serve` is unavailable, while only configured lower-risk `failOpenTools` may proceed.
 - **Setup and doctor are release-candidate strict** — `rampart setup openclaw` installs the native plugin cleanly, repairs approval-hardening drift, and `rampart doctor` checks plugin state, serve reachability, approval timeout alignment, and version coherence.

--- a/docs-site/reference/threat-model.md
+++ b/docs-site/reference/threat-model.md
@@ -1,6 +1,6 @@
 # Threat Model
 
-> Last reviewed: 2026-04-30 | Applies to: v1.0.0-rc.1+
+> Last reviewed: 2026-04-30 | Applies to: v1.0.0-rc.2+
 
 Rampart is a policy engine for AI agents — not a sandbox, not a hypervisor, not a full isolation boundary. This document describes what Rampart protects against, what it doesn't, and why.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -45,7 +45,7 @@ What's coming next for Rampart. Priorities shift based on feedback — [open an 
 
 ## Current Focus
 
-### `v1.0.0-rc.1`
+### `v1.0.0-rc.2`
 - Keep the integration support story boring and evidence-backed: hooks, plugins, preload/wrapper, MCP, and HTTP API should each say what is protected and what happens when policy evaluation is unavailable.
 - Treat OpenClaw `2026.5.2+` as the recommended RC baseline for native plugin approvals.
 - Keep `rampart doctor`, setup output, and docs aligned so users can answer "am I protected, how, and what breaks if serve is down?" without reading source.

--- a/docs/index.html
+++ b/docs/index.html
@@ -27,7 +27,7 @@
       "url": "https://rampart.sh",
       "applicationCategory": "SecurityApplication",
       "operatingSystem": "Linux, macOS, Windows",
-      "softwareVersion": "1.0.0-rc.1",
+      "softwareVersion": "1.0.0-rc.2",
       "offers": {
         "@type": "Offer",
         "price": "0",
@@ -1112,7 +1112,7 @@
 <section class="hero">
     <div class="container hero-grid">
         <div>
-            <div class="eyebrow"><span class="eyebrow-dot"></span>v1.0.0-rc.1 · release candidate</div>
+            <div class="eyebrow"><span class="eyebrow-dot"></span>v1.0.0-rc.2 · release candidate</div>
             <h1>Your agent has root.<br><span class="accent">That’s the problem.</span></h1>
             <p class="hero-sub">Rampart sits in the execution path. Install it, run <code>rampart quickstart</code>, and it wires the right protection path for Claude Code, Codex, Cline, or OpenClaw before risky tool calls run.</p>
             <div class="install-cluster">

--- a/internal/plugin/openclaw/index.js
+++ b/internal/plugin/openclaw/index.js
@@ -212,7 +212,7 @@ async function auditLog(toolName, params, ctx, outcome, config) {
 export const id = "rampart";
 export const name = "Rampart";
 export const description = "AI agent firewall — YAML policy-as-code for every tool call";
-export const version = "1.0.0-rc.1";
+export const version = "1.0.0-rc.2";
 
 export function register(api) {
   const pluginConfig = api.pluginConfig ?? {};

--- a/internal/plugin/openclaw/openclaw.plugin.json
+++ b/internal/plugin/openclaw/openclaw.plugin.json
@@ -8,7 +8,7 @@
       "hook"
     ]
   },
-  "version": "1.0.0-rc.1",
+  "version": "1.0.0-rc.2",
   "author": "peg",
   "homepage": "https://rampart.sh",
   "repository": "https://github.com/peg/rampart",

--- a/internal/plugin/openclaw/package.json
+++ b/internal/plugin/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rampart",
-  "version": "1.0.0-rc.1",
+  "version": "1.0.0-rc.2",
   "description": "Rampart AI agent firewall — OpenClaw native plugin (before_tool_call hook)",
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
## Summary
- avoid treating the latest stable GitHub release as an update when the installed version is a newer prerelease
- normalize `v` prefixes and use semver-aware comparison for update hints
- keep prerelease/stable update messaging from suggesting a downgrade like `1.0.0-rc.1 → v0.9.22`

## Verification
- `go test ./... -count=1`
- `go vet ./...`
