### PR TITLE
fix: keep durable override reporting strict

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -158,7 +158,7 @@ func (e *Engine) EvaluateWith(call ToolCall, opts EvalOptions) Decision {
 	var finalWebhookConfig *WebhookActionConfig
 
 	for _, p := range matching {
-		res := e.evaluatePolicy(p, call)
+		res := e.evaluateMatchingPolicy(p, call)
 		if !res.matched {
 			continue // no rule matched within this policy
 		}
@@ -262,6 +262,13 @@ func (e *Engine) EvaluateWith(call ToolCall, opts EvalOptions) Decision {
 		ConsumedRulePolicy: consumedPolicy,
 		ConsumedRuleIndex:  consumedRuleIdx,
 	}
+}
+
+func (e *Engine) evaluateMatchingPolicy(p Policy, call ToolCall) evaluatePolicyResult {
+	if isDurableAllowPolicy(p) {
+		return e.evaluateDurableAllowPolicy(p, call)
+	}
+	return e.evaluatePolicy(p, call)
 }
 
 func (e *Engine) evaluateDurableAllowOverride(matching []Policy, call ToolCall, start time.Time) (Decision, bool) {

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -193,6 +193,7 @@ policies:
 	stillAsk := eng.Evaluate(execCall("main", "shred --help | head -n 1"))
 	require.Equal(t, ActionAsk, stillAsk.Action)
 	assert.Contains(t, stillAsk.MatchedPolicies, "block-destructive")
+	assert.NotContains(t, stillAsk.MatchedPolicies, "user-allow-shred-help")
 
 	nameAloneIsNotDurable := eng.Evaluate(execCall("main", "shred --version"))
 	require.Equal(t, ActionAsk, nameAloneIsNotDurable.Action)


### PR DESCRIPTION
## Summary
- evaluate durable allow files with the same strict command matching in normal policy reporting as in the override pre-pass
- prevent negative compound commands like `shred --help | head -n 1` from reporting the exact durable allow policy as matched when the final decision is still `ask`

## Verification
- `go test ./internal/engine ./cmd/rampart/cli -run 'TestEvaluate_DurableUserOverrideWinsBeforeAsk|TestRunTestIncludesDurableUserOverrides' -count=1`
- `go test ./... -count=1`
- `go vet ./...`
- `git diff --check`
