### PR TITLE
fix: warn on permissive OpenClaw policy layering

### DIFF
--- a/cmd/rampart/cli/doctor.go
+++ b/cmd/rampart/cli/doctor.go
@@ -203,6 +203,9 @@ func runDoctor(w io.Writer, jsonOut bool) error {
 
 	// 4. Policy files
 	issues += doctorPolicies(emit)
+	if n := doctorOpenClawPolicyLayering(emit); n > 0 {
+		warnings += n
+	}
 
 	// 5. Hook binary path
 	issues += doctorHookBinary(emit)
@@ -578,6 +581,49 @@ func doctorPolicies(emit emitFn) int {
 		issues++
 	}
 	return issues
+}
+
+func doctorOpenClawPolicyLayering(emit emitFn) (warnings int) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return 0
+	}
+	policyDir := filepath.Join(home, ".rampart", "policies")
+	openclawPath := filepath.Join(policyDir, "openclaw.yaml")
+	standardPath := filepath.Join(policyDir, "standard.yaml")
+	openclawCfg, err := engine.NewFileStore(openclawPath).Load()
+	if err != nil || strings.ToLower(strings.TrimSpace(openclawCfg.DefaultAction)) != "ask" {
+		return 0
+	}
+	standardCfg, err := engine.NewFileStore(standardPath).Load()
+	if err != nil || !hasPermissiveAllowUnmatched(standardCfg) {
+		return 0
+	}
+	emit("OpenClaw policy layering", "warn",
+		"standard.yaml allow-unmatched can silently allow OpenClaw tool calls that openclaw.yaml intended to send to approval"+
+			hintSep+"remove standard.yaml for strict OpenClaw dogfood, or add explicit ask/deny rules for unmatched OpenClaw tools")
+	return 1
+}
+
+func hasPermissiveAllowUnmatched(cfg *engine.Config) bool {
+	if cfg == nil {
+		return false
+	}
+	for _, p := range cfg.Policies {
+		if p.Name != "allow-unmatched" || !p.IsEnabled() {
+			continue
+		}
+		for _, r := range p.Rules {
+			action, err := r.ParseAction()
+			if err != nil || action != engine.ActionAllow || r.IsExpired() {
+				continue
+			}
+			if r.When.Default || r.When.IsEmpty() {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // doctorServer checks if rampart serve is running on defaultServePort.

--- a/cmd/rampart/cli/doctor_test.go
+++ b/cmd/rampart/cli/doctor_test.go
@@ -321,6 +321,84 @@ func TestDoctorPolicies_CustomizedBuiltInIsReportedClearly(t *testing.T) {
 	}
 }
 
+func TestDoctorOpenClawPolicyLayeringWarnsOnStandardAllowUnmatched(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+	policyDir := filepath.Join(home, ".rampart", "policies")
+	requireNoErr(t, os.MkdirAll(policyDir, 0o755))
+	requireNoErr(t, os.WriteFile(filepath.Join(policyDir, "openclaw.yaml"), []byte(`version: "1"
+default_action: ask
+policies:
+  - name: openclaw-safe
+    match:
+      tool: [exec]
+    rules:
+      - action: allow
+        when:
+          command_matches: ["echo *"]
+`), 0o644))
+	requireNoErr(t, os.WriteFile(filepath.Join(policyDir, "standard.yaml"), []byte(`version: "1"
+default_action: deny
+policies:
+  - name: allow-unmatched
+    priority: 10000
+    rules:
+      - action: allow
+        when:
+          default: true
+        message: "No matching standard policy rule"
+`), 0o644))
+
+	var results []checkResult
+	warnings := doctorOpenClawPolicyLayering(func(name, status, msg string) {
+		results = append(results, checkResult{Name: name, Status: status, Message: msg})
+	})
+
+	if warnings != 1 {
+		t.Fatalf("expected one warning, got %d (%+v)", warnings, results)
+	}
+	if len(results) != 1 || results[0].Status != "warn" {
+		t.Fatalf("expected warn result, got %+v", results)
+	}
+	if !strings.Contains(results[0].Message, "allow-unmatched") {
+		t.Fatalf("expected allow-unmatched warning, got %q", results[0].Message)
+	}
+}
+
+func TestDoctorOpenClawPolicyLayeringSkipsStrictStandard(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+	policyDir := filepath.Join(home, ".rampart", "policies")
+	requireNoErr(t, os.MkdirAll(policyDir, 0o755))
+	requireNoErr(t, os.WriteFile(filepath.Join(policyDir, "openclaw.yaml"), []byte(`version: "1"
+default_action: ask
+policies:
+  - name: openclaw-safe
+    rules:
+      - action: allow
+        when:
+          command_matches: ["echo *"]
+`), 0o644))
+	requireNoErr(t, os.WriteFile(filepath.Join(policyDir, "standard.yaml"), []byte(`version: "1"
+default_action: deny
+policies:
+  - name: ask-unmatched
+    rules:
+      - action: ask
+        when:
+          default: true
+`), 0o644))
+
+	var results []checkResult
+	warnings := doctorOpenClawPolicyLayering(func(name, status, msg string) {
+		results = append(results, checkResult{Name: name, Status: status, Message: msg})
+	})
+
+	if warnings != 0 || len(results) != 0 {
+		t.Fatalf("expected no warning, got warnings=%d results=%+v", warnings, results)
+	}
+}
+
 // TestDoctorHooks_ClaudeBinaryNoDir verifies that doctorHooks flags a missing hook
 // when the claude binary is in PATH but ~/.claude/ has never been created.
 func TestDoctorHooks_ClaudeBinaryNoDir(t *testing.T) {


### PR DESCRIPTION
## Summary
- add a `rampart doctor` warning when `openclaw.yaml` uses `default_action: ask` but `standard.yaml` still has the permissive `allow-unmatched` catch-all
- document the operational risk directly in the health check: unknown OpenClaw tool calls may be silently allowed instead of surfacing for approval
- add focused tests for the warning and no-warning cases

## Verification
- `go test ./cmd/rampart/cli -run 'TestDoctorOpenClawPolicyLayering|TestRunDoctor_JSON' -count=1`
- `go test ./... -count=1`
- `go vet ./...`
- `git diff --check`
