### PR TITLE
ci: use Go 1.25.9 in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Vulnerability check
         continue-on-error: true
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest && govulncheck ./...
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4 && govulncheck ./...
 
       - name: Benchmark
         if: runner.os != 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go-version: ['1.24.13']
+        go-version: ['1.25.9']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5
@@ -58,7 +58,7 @@ jobs:
 
       - name: Vulnerability check
         continue-on-error: true
-        run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4 && govulncheck ./...
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.3.0 && govulncheck ./...
 
       - name: Benchmark
         if: runner.os != 'Windows'
@@ -84,7 +84,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24.13'
+          go-version: '1.25.9'
 
       - name: GoReleaser snapshot (all platforms, no publish)
         uses: goreleaser/goreleaser-action@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.24.13"
+          go-version: "1.25.9"
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7


### PR DESCRIPTION
## Summary
- update CI and release workflows from Go `1.24.13` to Go `1.25.9`
- pin CI govulncheck to `v1.3.0` instead of floating `@latest`
- restore vuln scanning under the same patched Go toolchain used by CI/release

## Context
The staging failure email came from the #295 staging push: Windows tests passed, then `actions/upload-artifact` hit `ECONNRESET`. Current staging is green.

While checking the logs, I found the vuln step had become noisy/broken because `govulncheck@latest` now resolves to a release requiring Go 1.25 while CI was pinned to Go 1.24.13. Running current govulncheck under Go 1.25.9 reports no vulnerabilities.

## Verification
- `GOTOOLCHAIN=go1.25.9 go test ./... -count=1`
- `GOTOOLCHAIN=go1.25.9 go vet ./...`
- `GOTOOLCHAIN=go1.25.9 govulncheck@v1.3.0 ./...` → no vulnerabilities found
- `git diff --check`
