### PR TITLE
fix: update root installer for release archives

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,6 +3,7 @@
 # Usage: curl -fsSL https://rampart.sh/install | sh
 #        curl -fsSL https://rampart.sh/install | sh -s -- --version v0.1.0
 #        curl -fsSL https://rampart.sh/install | sh -s -- --auto-setup
+#        RAMPART_INSTALL_DRY_RUN=1 sh install.sh --version v1.0.0-rc.2
 set -e
 
 REPO="peg/rampart"
@@ -10,6 +11,7 @@ INSTALL_DIR="/usr/local/bin"
 BINARY="rampart"
 VERSION=""
 AUTO_SETUP="${RAMPART_AUTO_SETUP:-0}"
+DRY_RUN="${RAMPART_INSTALL_DRY_RUN:-0}"
 
 # Colors (if terminal supports them).
 if [ -t 1 ]; then
@@ -32,6 +34,7 @@ while [ $# -gt 0 ]; do
         --version) VERSION="$2"; shift 2 ;;
         --version=*) VERSION="${1#--version=}"; shift ;;
         --auto-setup) AUTO_SETUP=1; shift ;;
+        --dry-run) DRY_RUN=1; shift ;;
         *) error "Unknown option: $1" ;;
     esac
 done
@@ -64,54 +67,82 @@ if [ -z "$VERSION" ]; then
     fi
 fi
 
+# Normalise version: release tags include a leading "v".
+case "$VERSION" in
+    v*) ;;
+    *)  VERSION="v${VERSION}" ;;
+esac
+
 info "Installing ${BOLD}rampart ${VERSION}${RESET}"
+
+if [ "$(id -u)" -eq 0 ]; then
+    INSTALL_DIR="/usr/local/bin"
+elif [ -d "$HOME/.local/bin" ]; then
+    INSTALL_DIR="$HOME/.local/bin"
+elif [ "$DRY_RUN" = "1" ]; then
+    INSTALL_DIR="$HOME/.local/bin"
+elif mkdir -p "$HOME/.local/bin" 2>/dev/null; then
+    INSTALL_DIR="$HOME/.local/bin"
+else
+    INSTALL_DIR="/usr/local/bin"
+fi
 
 # Build download URLs.
 BASE_URL="https://github.com/${REPO}/releases/download/${VERSION}"
-BINARY_URL="${BASE_URL}/rampart-${OS}-${ARCH}"
-CHECKSUM_URL="${BASE_URL}/rampart-${OS}-${ARCH}.sha256"
+TARBALL="rampart_${VERSION#v}_${OS}_${ARCH}.tar.gz"
+TARBALL_URL="${BASE_URL}/${TARBALL}"
+CHECKSUM_URL="${BASE_URL}/checksums.txt"
+
+if [ "$DRY_RUN" = "1" ]; then
+    info "Dry-run — no changes will be made"
+    info "Would download: ${TARBALL_URL}"
+    info "Would verify:  ${CHECKSUM_URL}"
+    info "Would install: ${INSTALL_DIR}/${BINARY}"
+    exit 0
+fi
 
 # Create temp directory.
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
-# Download binary.
-info "Downloading binary..."
-if ! curl -fsSL -o "${TMP_DIR}/${BINARY}" "$BINARY_URL"; then
-    error "Download failed. Check that ${VERSION} exists at:\n  ${BINARY_URL}"
+# Download archive.
+info "Downloading archive..."
+if ! curl -fsSL -o "${TMP_DIR}/${TARBALL}" "$TARBALL_URL"; then
+    error "Download failed. Check that ${VERSION} exists at:\n  ${TARBALL_URL}"
 fi
 
 # Download and verify checksum.
 info "Verifying checksum..."
-if curl -fsSL -o "${TMP_DIR}/${BINARY}.sha256" "$CHECKSUM_URL" 2>/dev/null; then
-    EXPECTED=$(awk '{print $1}' "${TMP_DIR}/${BINARY}.sha256")
+if curl -fsSL -o "${TMP_DIR}/checksums.txt" "$CHECKSUM_URL" 2>/dev/null; then
+    EXPECTED=$(grep "${TARBALL}" "${TMP_DIR}/checksums.txt" | awk '{print $1}')
     if command -v sha256sum >/dev/null 2>&1; then
-        ACTUAL=$(sha256sum "${TMP_DIR}/${BINARY}" | awk '{print $1}')
+        ACTUAL=$(sha256sum "${TMP_DIR}/${TARBALL}" | awk '{print $1}')
     elif command -v shasum >/dev/null 2>&1; then
-        ACTUAL=$(shasum -a 256 "${TMP_DIR}/${BINARY}" | awk '{print $1}')
+        ACTUAL=$(shasum -a 256 "${TMP_DIR}/${TARBALL}" | awk '{print $1}')
     else
         warn "No sha256sum or shasum found — skipping verification"
         ACTUAL="$EXPECTED"
     fi
 
-    if [ "$EXPECTED" != "$ACTUAL" ]; then
+    if [ -z "$EXPECTED" ]; then
+        warn "No checksum entry found for ${TARBALL} — skipping verification"
+    elif [ "$EXPECTED" != "$ACTUAL" ]; then
         error "Checksum mismatch!\n  Expected: ${EXPECTED}\n  Got:      ${ACTUAL}"
+    else
+        info "Checksum verified ✓"
     fi
-    info "Checksum verified ✓"
 else
-    warn "No checksum file found — skipping verification"
+    warn "No checksums.txt found — skipping verification"
+fi
+
+tar -xzf "${TMP_DIR}/${TARBALL}" -C "$TMP_DIR"
+
+if [ ! -f "${TMP_DIR}/${BINARY}" ]; then
+    error "Archive did not contain ${BINARY}"
 fi
 
 # Install.
 chmod +x "${TMP_DIR}/${BINARY}"
-
-if [ "$(id -u)" -eq 0 ]; then
-    INSTALL_DIR="/usr/local/bin"
-elif [ -d "$HOME/.local/bin" ] || mkdir -p "$HOME/.local/bin" 2>/dev/null; then
-    INSTALL_DIR="$HOME/.local/bin"
-else
-    INSTALL_DIR="/usr/local/bin"
-fi
 
 if [ -w "$INSTALL_DIR" ]; then
     mv "${TMP_DIR}/${BINARY}" "${INSTALL_DIR}/${BINARY}"
@@ -123,14 +154,20 @@ fi
 info "Installed to ${BOLD}${INSTALL_DIR}/${BINARY}${RESET}"
 
 # Verify.
-if command -v rampart >/dev/null 2>&1; then
+RAMPART_BIN="${INSTALL_DIR}/${BINARY}"
+if [ -x "$RAMPART_BIN" ]; then
     printf "\n"
-    rampart version 2>/dev/null || true
-    printf "\n${GREEN}${BOLD}Ready!${RESET} Run ${BOLD}rampart quickstart${RESET} to get started.\n"
+    "$RAMPART_BIN" version 2>/dev/null || true
+
+    if echo ":${PATH}:" | grep -q ":${INSTALL_DIR}:"; then
+        printf "\n${GREEN}${BOLD}Ready!${RESET} Run ${BOLD}rampart quickstart${RESET} to get started.\n"
+    else
+        printf "\n${YELLOW}Note:${RESET} ${INSTALL_DIR} may not be in your PATH.\n"
+        printf "Add it: ${BOLD}export PATH=\"${INSTALL_DIR}:\$PATH\"${RESET}\n"
+        printf "Then run: ${BOLD}rampart quickstart${RESET}\n"
+    fi
 else
-    printf "\n${YELLOW}Note:${RESET} ${INSTALL_DIR} may not be in your PATH.\n"
-    printf "Add it: ${BOLD}export PATH=\"${INSTALL_DIR}:\$PATH\"${RESET}\n"
-    printf "Then run: ${BOLD}rampart quickstart${RESET}\n"
+    warn "Could not verify installed binary at ${INSTALL_DIR}/${BINARY}"
 fi
 
 # Detect AI agents and suggest setup commands.
@@ -160,7 +197,7 @@ detect_agents_and_suggest() {
     if [ "$OPENCLAW_FOUND" -eq 1 ]; then
         if [ "$AUTO_SETUP" = "1" ]; then
             printf "${GREEN}▸${RESET} Auto-setup: protecting OpenClaw...\n"
-            rampart setup openclaw 2>&1 || printf "${YELLOW}  ↳ Auto-setup failed — run manually: rampart setup openclaw${RESET}\n"
+            "$RAMPART_BIN" setup openclaw 2>&1 || printf "${YELLOW}  ↳ Auto-setup failed — run manually: rampart setup openclaw${RESET}\n"
         else
             printf "  Run this to protect your OpenClaw agent:\n"
             printf "    ${BOLD}rampart setup openclaw${RESET}\n"
@@ -171,7 +208,7 @@ detect_agents_and_suggest() {
     if [ "$CLAUDE_FOUND" -eq 1 ]; then
         if [ "$AUTO_SETUP" = "1" ]; then
             printf "${GREEN}▸${RESET} Auto-setup: protecting Claude Code...\n"
-            rampart setup claude-code 2>&1 || printf "${YELLOW}  ↳ Auto-setup failed — run manually: rampart setup claude-code${RESET}\n"
+            "$RAMPART_BIN" setup claude-code 2>&1 || printf "${YELLOW}  ↳ Auto-setup failed — run manually: rampart setup claude-code${RESET}\n"
         else
             printf "  Run this to protect Claude Code:\n"
             printf "    ${BOLD}rampart setup claude-code${RESET}\n"
@@ -187,6 +224,6 @@ detect_agents_and_suggest() {
     fi
 }
 
-if command -v rampart >/dev/null 2>&1; then
+if [ -x "$RAMPART_BIN" ]; then
     detect_agents_and_suggest
 fi


### PR DESCRIPTION
## Summary
- update install.sh to download GoReleaser tarball assets instead of legacy raw binaries
- verify release archives via checksums.txt
- prefer user-local install paths when not root
- add dry-run support for validating future release URLs without making changes

## Validation
- `sh -n ./install.sh`
- `RAMPART_INSTALL_DRY_RUN=1 sh ./install.sh --version v1.0.0-rc.2`

Needed before cutting v1.0.0-rc.2 so the public install script matches the current release artifact shape.
