### PR TITLE
fix(openclaw): run Rampart tool hook last

### DIFF
--- a/internal/plugin/openclaw/approval-regression.mjs
+++ b/internal/plugin/openclaw/approval-regression.mjs
@@ -2,9 +2,11 @@ import plugin from './index.js';
 
 function createApi() {
   const handlers = {};
+  const hookOpts = {};
   const logs = [];
   return {
     handlers,
+    hookOpts,
     logs,
     api: {
       pluginConfig: {},
@@ -13,7 +15,7 @@ function createApi() {
         warn: (...a) => logs.push(['warn', a.join(' ')]),
         debug: (...a) => logs.push(['debug', a.join(' ')]),
       },
-      on: (name, fn) => { handlers[name] = fn; },
+      on: (name, fn, opts) => { handlers[name] = fn; hookOpts[name] = opts; },
       registerGatewayMethod: () => {},
     },
   };
@@ -24,7 +26,7 @@ function assert(condition, message) {
 }
 
 async function runScenario({ name, toolResult, toolName = 'exec', params = { command: 'sudo true' }, resolution }) {
-  const { api, handlers } = createApi();
+  const { api, handlers, hookOpts } = createApi();
   const fetchCalls = [];
   const originalFetch = global.fetch;
   global.fetch = async (url, opts = {}) => {
@@ -51,7 +53,7 @@ async function runScenario({ name, toolResult, toolName = 'exec', params = { com
     if (resolution && result?.requireApproval?.onResolution) {
       await result.requireApproval.onResolution(resolution);
     }
-    return { name, result, fetchCalls };
+    return { name, result, fetchCalls, hookOpts };
   } finally {
     global.fetch = originalFetch;
   }
@@ -64,6 +66,7 @@ const ask = await runScenario({
 assert(ask.result?.requireApproval, 'ask-exec: requireApproval missing');
 assert(!ask.result?.params?.ask, 'ask-exec: legacy ask param mutation still present');
 assert(ask.result.requireApproval.title.includes('exec approval required'), 'ask-exec: wrong title');
+assert(ask.hookOpts.before_tool_call?.priority < 0, 'ask-exec: Rampart should run as a late before_tool_call hook');
 
 const deny = await runScenario({
   name: 'deny-exec',

--- a/internal/plugin/openclaw/index.js
+++ b/internal/plugin/openclaw/index.js
@@ -214,6 +214,12 @@ export const name = "Rampart";
 export const description = "AI agent firewall — YAML policy-as-code for every tool call";
 export const version = "1.0.0-rc.2";
 
+// OpenClaw runs higher-priority before_tool_call hooks first. Rampart should
+// act as the final normal plugin gate so it evaluates the params that will
+// actually execute, rather than letting another plugin mutate them after the
+// policy check.
+const RAMPART_TOOL_HOOK_PRIORITY = -1000;
+
 export function register(api) {
   const pluginConfig = api.pluginConfig ?? {};
 
@@ -367,12 +373,11 @@ export function register(api) {
         }
         return; // void = allow as-is
     }
-  });
+  }, { priority: RAMPART_TOOL_HOOK_PRIORITY });
 
   // ── after_tool_call (audit trail) ──────────────────────────────────────────
-  // Register a gateway method so OpenClaw classifies this as a "hybrid-capability"
-  // plugin rather than "hook-only". The rampart.status endpoint proxies Rampart
-  // serve status through the OpenClaw gateway for dashboard integrations.
+  // Expose a small status endpoint for dashboard integrations. Tool enforcement
+  // still lives entirely in the typed before_tool_call / after_tool_call hooks.
   api.registerGatewayMethod("rampart.status", async ({ respond }) => {
     try {
       const token = await loadToken();


### PR DESCRIPTION
## Summary
- run the Rampart OpenClaw `before_tool_call` hook at low priority so policy evaluates final tool params after other normal plugin rewrites
- keep the gateway status method comment aligned with current native-plugin behavior
- add regression coverage that asserts Rampart registers as a late tool hook

## Tests
- `node internal/plugin/openclaw/approval-regression.mjs`
- `node internal/plugin/openclaw/degraded-mode-test.mjs`
- `go test ./internal/openclaw/... ./cmd/rampart/cli -run 'TestOpenClaw|TestInspect|TestApply|TestPlugin|TestDoctor' -count=1`
- `go test ./... -count=1`
- `go vet ./...`

## Notes
- No changes under `/cmd/rampart`, `/internal/engine/`, or `/internal/engine`.
- Target: `staging` only; no `staging` → `main` merge.
