### PR TITLE
chore: promote staging for v1.0.0 rc review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Vulnerability check
         continue-on-error: true
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest && govulncheck ./...
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4 && govulncheck ./...
 
       - name: Benchmark
         if: runner.os != 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go-version: ['1.24.13']
+        go-version: ['1.25.9']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5
@@ -58,7 +58,7 @@ jobs:
 
       - name: Vulnerability check
         continue-on-error: true
-        run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4 && govulncheck ./...
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.3.0 && govulncheck ./...
 
       - name: Benchmark
         if: runner.os != 'Windows'
@@ -84,7 +84,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24.13'
+          go-version: '1.25.9'
 
       - name: GoReleaser snapshot (all platforms, no publish)
         uses: goreleaser/goreleaser-action@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.24.13"
+          go-version: "1.25.9"
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-rc.2] - 2026-05-04
+
+### Fixed
+
+- **Doctor no longer suggests downgrading prerelease builds** — `rampart doctor` now uses SemVer-aware prerelease comparison for update hints, so `v1.0.0-rc.1`/`v1.0.0-rc.2` do not report stable `v0.9.22` as an available upgrade.
+
+### Changed
+
+- **OpenClaw plugin metadata now matches the RC.2 release** — The embedded plugin manifest, runtime export, and package metadata are versioned as `1.0.0-rc.2`.
+
 ## [1.0.0-rc.1] - 2026-05-03
 
 ### Added

--- a/cmd/rampart/cli/doctor.go
+++ b/cmd/rampart/cli/doctor.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -1297,10 +1298,7 @@ func doctorVersionCheck(w io.Writer, silent bool, emit emitFn) int {
 		return 0
 	}
 
-	latest := strings.TrimPrefix(release.TagName, "v")
-	currentClean := strings.TrimPrefix(current, "v")
-
-	if latest == currentClean {
+	if !isNewerReleaseVersion(current, release.TagName) {
 		return 0
 	}
 
@@ -1319,6 +1317,130 @@ func doctorVersionCheck(w io.Writer, silent bool, emit emitFn) int {
 		fmt.Fprintf(w, "  ⚠ Update available: %s → %s\n%s\n", current, release.TagName, hint)
 	}
 	return 0 // informational, not an issue
+}
+
+type releaseVersion struct {
+	major      int
+	minor      int
+	patch      int
+	prerelease []string
+}
+
+func isNewerReleaseVersion(current, latest string) bool {
+	cmp, ok := compareReleaseVersions(current, latest)
+	if !ok {
+		return false
+	}
+	return cmp < 0
+}
+
+func compareReleaseVersions(a, b string) (int, bool) {
+	av, okA := parseReleaseVersion(a)
+	bv, okB := parseReleaseVersion(b)
+	if !okA || !okB {
+		return 0, false
+	}
+	for _, pair := range [][2]int{{av.major, bv.major}, {av.minor, bv.minor}, {av.patch, bv.patch}} {
+		if pair[0] < pair[1] {
+			return -1, true
+		}
+		if pair[0] > pair[1] {
+			return 1, true
+		}
+	}
+	return comparePrerelease(av.prerelease, bv.prerelease), true
+}
+
+func parseReleaseVersion(v string) (releaseVersion, bool) {
+	var out releaseVersion
+	v = strings.TrimPrefix(strings.TrimSpace(v), "v")
+	if v == "" || v == "dev" || v == "unknown" || strings.Contains(v, "dirty") || strings.Contains(v, "staging") || strings.HasPrefix(v, "0.0.0-") || isGoPseudoVersion(v) {
+		return out, false
+	}
+	v = strings.SplitN(v, "+", 2)[0]
+	base, prerelease, hasPrerelease := strings.Cut(v, "-")
+	parts := strings.Split(base, ".")
+	if len(parts) != 3 {
+		return out, false
+	}
+	parsed := []*int{&out.major, &out.minor, &out.patch}
+	for i, part := range parts {
+		n, err := strconv.Atoi(part)
+		if err != nil || n < 0 {
+			return out, false
+		}
+		*parsed[i] = n
+	}
+	if hasPrerelease {
+		if prerelease == "" {
+			return out, false
+		}
+		out.prerelease = strings.Split(prerelease, ".")
+		for _, id := range out.prerelease {
+			if id == "" {
+				return out, false
+			}
+		}
+	}
+	return out, true
+}
+
+func comparePrerelease(a, b []string) int {
+	if len(a) == 0 && len(b) == 0 {
+		return 0
+	}
+	if len(a) == 0 {
+		return 1
+	}
+	if len(b) == 0 {
+		return -1
+	}
+	for i := 0; i < len(a) && i < len(b); i++ {
+		cmp := comparePrereleaseIdentifier(a[i], b[i])
+		if cmp != 0 {
+			return cmp
+		}
+	}
+	if len(a) < len(b) {
+		return -1
+	}
+	if len(a) > len(b) {
+		return 1
+	}
+	return 0
+}
+
+func comparePrereleaseIdentifier(a, b string) int {
+	ai, aNum := parseNumericPrereleaseIdentifier(a)
+	bi, bNum := parseNumericPrereleaseIdentifier(b)
+	switch {
+	case aNum && bNum:
+		if ai < bi {
+			return -1
+		}
+		if ai > bi {
+			return 1
+		}
+		return 0
+	case aNum:
+		return -1
+	case bNum:
+		return 1
+	case a < b:
+		return -1
+	case a > b:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func parseNumericPrereleaseIdentifier(v string) (int, bool) {
+	if v == "" || (len(v) > 1 && v[0] == '0') {
+		return 0, false
+	}
+	n, err := strconv.Atoi(v)
+	return n, err == nil
 }
 
 // doctorProjectPolicy checks if the current git repo has a .rampart/policy.yaml project policy.

--- a/cmd/rampart/cli/doctor.go
+++ b/cmd/rampart/cli/doctor.go
@@ -203,6 +203,9 @@ func runDoctor(w io.Writer, jsonOut bool) error {
 
 	// 4. Policy files
 	issues += doctorPolicies(emit)
+	if n := doctorOpenClawPolicyLayering(emit); n > 0 {
+		warnings += n
+	}
 
 	// 5. Hook binary path
 	issues += doctorHookBinary(emit)
@@ -578,6 +581,49 @@ func doctorPolicies(emit emitFn) int {
 		issues++
 	}
 	return issues
+}
+
+func doctorOpenClawPolicyLayering(emit emitFn) (warnings int) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return 0
+	}
+	policyDir := filepath.Join(home, ".rampart", "policies")
+	openclawPath := filepath.Join(policyDir, "openclaw.yaml")
+	standardPath := filepath.Join(policyDir, "standard.yaml")
+	openclawCfg, err := engine.NewFileStore(openclawPath).Load()
+	if err != nil || strings.ToLower(strings.TrimSpace(openclawCfg.DefaultAction)) != "ask" {
+		return 0
+	}
+	standardCfg, err := engine.NewFileStore(standardPath).Load()
+	if err != nil || !hasPermissiveAllowUnmatched(standardCfg) {
+		return 0
+	}
+	emit("OpenClaw policy layering", "warn",
+		"standard.yaml allow-unmatched can silently allow OpenClaw tool calls that openclaw.yaml intended to send to approval"+
+			hintSep+"remove standard.yaml for strict OpenClaw dogfood, or add explicit ask/deny rules for unmatched OpenClaw tools")
+	return 1
+}
+
+func hasPermissiveAllowUnmatched(cfg *engine.Config) bool {
+	if cfg == nil {
+		return false
+	}
+	for _, p := range cfg.Policies {
+		if p.Name != "allow-unmatched" || !p.IsEnabled() {
+			continue
+		}
+		for _, r := range p.Rules {
+			action, err := r.ParseAction()
+			if err != nil || action != engine.ActionAllow || r.IsExpired() {
+				continue
+			}
+			if r.When.Default || r.When.IsEmpty() {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // doctorServer checks if rampart serve is running on defaultServePort.

--- a/cmd/rampart/cli/doctor_test.go
+++ b/cmd/rampart/cli/doctor_test.go
@@ -617,6 +617,35 @@ func TestPluginVersionMatchesBuildVersion(t *testing.T) {
 	}
 }
 
+func TestIsNewerReleaseVersion(t *testing.T) {
+	tests := []struct {
+		current string
+		latest  string
+		want    bool
+	}{
+		{"v0.9.21", "v0.9.22", true},
+		{"v0.9.22", "v0.9.22", false},
+		{"0.9.22", "v0.9.22", false},
+		{"v0.9.23", "v0.9.22", false},
+		{"v1.0.0-rc.1", "v0.9.22", false},
+		{"1.0.0-rc.1", "v0.9.22", false},
+		{"v0.9.22", "v1.0.0-rc.1", true},
+		{"v1.0.0-rc.1", "v1.0.0-rc.2", true},
+		{"v1.0.0-rc.2", "v1.0.0-rc.1", false},
+		{"v1.0.0-rc.1", "v1.0.0", true},
+		{"v1.0.0", "v1.0.0-rc.1", false},
+		{"v1.0.0-rc.10", "v1.0.0-rc.2", false},
+		{"v1.0.0-alpha", "v1.0.0-beta", true},
+		{"v0.9.22-staging-47fa0cf", "v0.9.22", false},
+		{"v0.9.22-0.20260503052103-a72c3452fe38", "v0.9.22", false},
+	}
+	for _, tt := range tests {
+		if got := isNewerReleaseVersion(tt.current, tt.latest); got != tt.want {
+			t.Fatalf("isNewerReleaseVersion(%q, %q) = %v, want %v", tt.current, tt.latest, got, tt.want)
+		}
+	}
+}
+
 func TestOpenClawDiscordNativeApprovalsConfigured(t *testing.T) {
 	tmp := t.TempDir()
 	bin := filepath.Join(tmp, "openclaw")

--- a/cmd/rampart/cli/doctor_test.go
+++ b/cmd/rampart/cli/doctor_test.go
@@ -321,6 +321,84 @@ func TestDoctorPolicies_CustomizedBuiltInIsReportedClearly(t *testing.T) {
 	}
 }
 
+func TestDoctorOpenClawPolicyLayeringWarnsOnStandardAllowUnmatched(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+	policyDir := filepath.Join(home, ".rampart", "policies")
+	requireNoErr(t, os.MkdirAll(policyDir, 0o755))
+	requireNoErr(t, os.WriteFile(filepath.Join(policyDir, "openclaw.yaml"), []byte(`version: "1"
+default_action: ask
+policies:
+  - name: openclaw-safe
+    match:
+      tool: [exec]
+    rules:
+      - action: allow
+        when:
+          command_matches: ["echo *"]
+`), 0o644))
+	requireNoErr(t, os.WriteFile(filepath.Join(policyDir, "standard.yaml"), []byte(`version: "1"
+default_action: deny
+policies:
+  - name: allow-unmatched
+    priority: 10000
+    rules:
+      - action: allow
+        when:
+          default: true
+        message: "No matching standard policy rule"
+`), 0o644))
+
+	var results []checkResult
+	warnings := doctorOpenClawPolicyLayering(func(name, status, msg string) {
+		results = append(results, checkResult{Name: name, Status: status, Message: msg})
+	})
+
+	if warnings != 1 {
+		t.Fatalf("expected one warning, got %d (%+v)", warnings, results)
+	}
+	if len(results) != 1 || results[0].Status != "warn" {
+		t.Fatalf("expected warn result, got %+v", results)
+	}
+	if !strings.Contains(results[0].Message, "allow-unmatched") {
+		t.Fatalf("expected allow-unmatched warning, got %q", results[0].Message)
+	}
+}
+
+func TestDoctorOpenClawPolicyLayeringSkipsStrictStandard(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+	policyDir := filepath.Join(home, ".rampart", "policies")
+	requireNoErr(t, os.MkdirAll(policyDir, 0o755))
+	requireNoErr(t, os.WriteFile(filepath.Join(policyDir, "openclaw.yaml"), []byte(`version: "1"
+default_action: ask
+policies:
+  - name: openclaw-safe
+    rules:
+      - action: allow
+        when:
+          command_matches: ["echo *"]
+`), 0o644))
+	requireNoErr(t, os.WriteFile(filepath.Join(policyDir, "standard.yaml"), []byte(`version: "1"
+default_action: deny
+policies:
+  - name: ask-unmatched
+    rules:
+      - action: ask
+        when:
+          default: true
+`), 0o644))
+
+	var results []checkResult
+	warnings := doctorOpenClawPolicyLayering(func(name, status, msg string) {
+		results = append(results, checkResult{Name: name, Status: status, Message: msg})
+	})
+
+	if warnings != 0 || len(results) != 0 {
+		t.Fatalf("expected no warning, got warnings=%d results=%+v", warnings, results)
+	}
+}
+
 // TestDoctorHooks_ClaudeBinaryNoDir verifies that doctorHooks flags a missing hook
 // when the claude binary is in PATH but ~/.claude/ has never been created.
 func TestDoctorHooks_ClaudeBinaryNoDir(t *testing.T) {

--- a/cmd/rampart/cli/setup_openclaw_plugin_test.go
+++ b/cmd/rampart/cli/setup_openclaw_plugin_test.go
@@ -9,10 +9,10 @@ import (
 
 func TestExtractOpenClawPluginRuntimeVersion(t *testing.T) {
 	got := extractOpenClawPluginRuntimeVersion(`export const id = "rampart";
-export const version = "1.0.0-rc.1";
+export const version = "1.0.0-rc.2";
 `)
-	if got != "1.0.0-rc.1" {
-		t.Fatalf("runtime version = %q, want 1.0.0-rc.1", got)
+	if got != "1.0.0-rc.2" {
+		t.Fatalf("runtime version = %q, want 1.0.0-rc.2", got)
 	}
 }
 

--- a/cmd/rampart/cli/test_cmd.go
+++ b/cmd/rampart/cli/test_cmd.go
@@ -290,7 +290,8 @@ func runTest(w, errW io.Writer, opts *rootOptions, arg, toolName string, noColor
 
 	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
 
-	store := engine.NewFileStore(policyPath)
+	includeHomePolicyDir := opts.configPath == "" || opts.configPath == "rampart.yaml"
+	store := newTestPolicyStore(policyPath, includeHomePolicyDir, nil)
 	eng, err := engine.New(store, nil)
 	if err != nil {
 		return fmt.Errorf("test: create engine: %w", err)
@@ -334,6 +335,19 @@ func runTest(w, errW io.Writer, opts *rootOptions, arg, toolName string, noColor
 		return exitCodeError{code: 1}
 	}
 	return nil
+}
+
+func newTestPolicyStore(policyPath string, includeHomePolicyDir bool, logger *slog.Logger) engine.PolicyStore {
+	if !includeHomePolicyDir {
+		return engine.NewFileStore(policyPath)
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		policyDir := filepath.Join(home, ".rampart", "policies")
+		if _, statErr := os.Stat(policyDir); statErr == nil {
+			return engine.NewMultiStore(policyPath, policyDir, logger)
+		}
+	}
+	return engine.NewFileStore(policyPath)
 }
 
 func resolveTestPolicyPath(path string) (string, func(), error) {

--- a/cmd/rampart/cli/test_cmd_test.go
+++ b/cmd/rampart/cli/test_cmd_test.go
@@ -15,6 +15,7 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -72,6 +73,66 @@ policies:
 	}
 	if !strings.Contains(output, "block-destructive") {
 		t.Errorf("expected policy name in output, got: %s", output)
+	}
+}
+
+func TestRunTestIncludesDurableUserOverrides(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("USERPROFILE", tmpHome)
+	policyDir := filepath.Join(tmpHome, ".rampart", "policies")
+	if err := os.MkdirAll(policyDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(policyDir, "standard.yaml"), []byte(`
+version: "1"
+default_action: deny
+policies:
+  - name: block-destructive
+    match:
+      tool: exec
+    rules:
+      - action: ask
+        message: Secure delete requires approval
+        when:
+          command_matches: ["shred **"]
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(policyDir, "user-overrides.yaml"), []byte(`
+version: "1"
+default_action: deny
+policies:
+  - name: user-allow-shred-help
+    match:
+      tool: exec
+    rules:
+      - action: allow
+        message: User allow (always) via openclaw-approval
+        when:
+          command_matches: ["shred --help"]
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	opts := &rootOptions{configPath: "rampart.yaml"}
+
+	runErr := runTest(&out, &errOut, opts, "shred --help", "exec", true, true)
+	if runErr != nil {
+		t.Fatalf("expected no error for durable override, got: %v", runErr)
+	}
+
+	var got bareCmdJSONResult
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("parse json output: %v\n%s", err, out.String())
+	}
+	if got.Action != "allow" {
+		t.Fatalf("expected durable override to make rampart test return allow, got %#v", got)
+	}
+	if len(got.MatchedPolicies) != 1 || got.MatchedPolicies[0] != "user-allow-shred-help" {
+		t.Fatalf("expected only durable override policy, got %#v", got.MatchedPolicies)
 	}
 }
 

--- a/docs-site/index.html
+++ b/docs-site/index.html
@@ -27,7 +27,7 @@
       "url": "https://rampart.sh",
       "applicationCategory": "SecurityApplication",
       "operatingSystem": "Linux, macOS, Windows",
-      "softwareVersion": "1.0.0-rc.1",
+      "softwareVersion": "1.0.0-rc.2",
       "offers": {
         "@type": "Offer",
         "price": "0",
@@ -1112,7 +1112,7 @@
 <section class="hero">
     <div class="container hero-grid">
         <div>
-            <div class="eyebrow"><span class="eyebrow-dot"></span>v1.0.0-rc.1 · release candidate</div>
+            <div class="eyebrow"><span class="eyebrow-dot"></span>v1.0.0-rc.2 · release candidate</div>
             <h1>Your agent has root.<br><span class="accent">That’s the problem.</span></h1>
             <p class="hero-sub">Rampart sits in the execution path. Install it, run <code>rampart quickstart</code>, and it wires the right protection path for Claude Code, Codex, Cline, or OpenClaw before risky tool calls run.</p>
             <div class="install-cluster">

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -205,8 +205,9 @@ verify -> outcomes.approval
 
 [:octicons-arrow-right-24: See all integration guides](integrations/index.md)
 
-## What's New in v1.0.0-rc.1
+## What's New in v1.0.0-rc.2
 
+- **Prerelease update checks are sane** — `rampart doctor` no longer suggests downgrading from the 1.0 RC line to the older stable `v0.9.22` release.
 - **OpenClaw 2026.5.2 is the RC baseline** — Rampart now uses OpenClaw's first-class plugin approval path as the single human-approval owner, with Rampart handling policy, audit, and durable allow-always persistence. [Details →](integrations/openclaw.md)
 - **Degraded mode is explicit** — sensitive OpenClaw tools block when `rampart serve` is unavailable, while only configured lower-risk `failOpenTools` may proceed.
 - **Setup and doctor are release-candidate strict** — `rampart setup openclaw` installs the native plugin cleanly, repairs approval-hardening drift, and `rampart doctor` checks plugin state, serve reachability, approval timeout alignment, and version coherence.

--- a/docs-site/reference/threat-model.md
+++ b/docs-site/reference/threat-model.md
@@ -1,6 +1,6 @@
 # Threat Model
 
-> Last reviewed: 2026-04-30 | Applies to: v1.0.0-rc.1+
+> Last reviewed: 2026-04-30 | Applies to: v1.0.0-rc.2+
 
 Rampart is a policy engine for AI agents — not a sandbox, not a hypervisor, not a full isolation boundary. This document describes what Rampart protects against, what it doesn't, and why.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -45,7 +45,7 @@ What's coming next for Rampart. Priorities shift based on feedback — [open an 
 
 ## Current Focus
 
-### `v1.0.0-rc.1`
+### `v1.0.0-rc.2`
 - Keep the integration support story boring and evidence-backed: hooks, plugins, preload/wrapper, MCP, and HTTP API should each say what is protected and what happens when policy evaluation is unavailable.
 - Treat OpenClaw `2026.5.2+` as the recommended RC baseline for native plugin approvals.
 - Keep `rampart doctor`, setup output, and docs aligned so users can answer "am I protected, how, and what breaks if serve is down?" without reading source.

--- a/docs/index.html
+++ b/docs/index.html
@@ -27,7 +27,7 @@
       "url": "https://rampart.sh",
       "applicationCategory": "SecurityApplication",
       "operatingSystem": "Linux, macOS, Windows",
-      "softwareVersion": "1.0.0-rc.1",
+      "softwareVersion": "1.0.0-rc.2",
       "offers": {
         "@type": "Offer",
         "price": "0",
@@ -1112,7 +1112,7 @@
 <section class="hero">
     <div class="container hero-grid">
         <div>
-            <div class="eyebrow"><span class="eyebrow-dot"></span>v1.0.0-rc.1 · release candidate</div>
+            <div class="eyebrow"><span class="eyebrow-dot"></span>v1.0.0-rc.2 · release candidate</div>
             <h1>Your agent has root.<br><span class="accent">That’s the problem.</span></h1>
             <p class="hero-sub">Rampart sits in the execution path. Install it, run <code>rampart quickstart</code>, and it wires the right protection path for Claude Code, Codex, Cline, or OpenClaw before risky tool calls run.</p>
             <div class="install-cluster">

--- a/install.sh
+++ b/install.sh
@@ -3,6 +3,7 @@
 # Usage: curl -fsSL https://rampart.sh/install | sh
 #        curl -fsSL https://rampart.sh/install | sh -s -- --version v0.1.0
 #        curl -fsSL https://rampart.sh/install | sh -s -- --auto-setup
+#        RAMPART_INSTALL_DRY_RUN=1 sh install.sh --version v1.0.0-rc.2
 set -e
 
 REPO="peg/rampart"
@@ -10,6 +11,7 @@ INSTALL_DIR="/usr/local/bin"
 BINARY="rampart"
 VERSION=""
 AUTO_SETUP="${RAMPART_AUTO_SETUP:-0}"
+DRY_RUN="${RAMPART_INSTALL_DRY_RUN:-0}"
 
 # Colors (if terminal supports them).
 if [ -t 1 ]; then
@@ -32,6 +34,7 @@ while [ $# -gt 0 ]; do
         --version) VERSION="$2"; shift 2 ;;
         --version=*) VERSION="${1#--version=}"; shift ;;
         --auto-setup) AUTO_SETUP=1; shift ;;
+        --dry-run) DRY_RUN=1; shift ;;
         *) error "Unknown option: $1" ;;
     esac
 done
@@ -64,54 +67,82 @@ if [ -z "$VERSION" ]; then
     fi
 fi
 
+# Normalise version: release tags include a leading "v".
+case "$VERSION" in
+    v*) ;;
+    *)  VERSION="v${VERSION}" ;;
+esac
+
 info "Installing ${BOLD}rampart ${VERSION}${RESET}"
+
+if [ "$(id -u)" -eq 0 ]; then
+    INSTALL_DIR="/usr/local/bin"
+elif [ -d "$HOME/.local/bin" ]; then
+    INSTALL_DIR="$HOME/.local/bin"
+elif [ "$DRY_RUN" = "1" ]; then
+    INSTALL_DIR="$HOME/.local/bin"
+elif mkdir -p "$HOME/.local/bin" 2>/dev/null; then
+    INSTALL_DIR="$HOME/.local/bin"
+else
+    INSTALL_DIR="/usr/local/bin"
+fi
 
 # Build download URLs.
 BASE_URL="https://github.com/${REPO}/releases/download/${VERSION}"
-BINARY_URL="${BASE_URL}/rampart-${OS}-${ARCH}"
-CHECKSUM_URL="${BASE_URL}/rampart-${OS}-${ARCH}.sha256"
+TARBALL="rampart_${VERSION#v}_${OS}_${ARCH}.tar.gz"
+TARBALL_URL="${BASE_URL}/${TARBALL}"
+CHECKSUM_URL="${BASE_URL}/checksums.txt"
+
+if [ "$DRY_RUN" = "1" ]; then
+    info "Dry-run — no changes will be made"
+    info "Would download: ${TARBALL_URL}"
+    info "Would verify:  ${CHECKSUM_URL}"
+    info "Would install: ${INSTALL_DIR}/${BINARY}"
+    exit 0
+fi
 
 # Create temp directory.
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
-# Download binary.
-info "Downloading binary..."
-if ! curl -fsSL -o "${TMP_DIR}/${BINARY}" "$BINARY_URL"; then
-    error "Download failed. Check that ${VERSION} exists at:\n  ${BINARY_URL}"
+# Download archive.
+info "Downloading archive..."
+if ! curl -fsSL -o "${TMP_DIR}/${TARBALL}" "$TARBALL_URL"; then
+    error "Download failed. Check that ${VERSION} exists at:\n  ${TARBALL_URL}"
 fi
 
 # Download and verify checksum.
 info "Verifying checksum..."
-if curl -fsSL -o "${TMP_DIR}/${BINARY}.sha256" "$CHECKSUM_URL" 2>/dev/null; then
-    EXPECTED=$(awk '{print $1}' "${TMP_DIR}/${BINARY}.sha256")
+if curl -fsSL -o "${TMP_DIR}/checksums.txt" "$CHECKSUM_URL" 2>/dev/null; then
+    EXPECTED=$(grep "${TARBALL}" "${TMP_DIR}/checksums.txt" | awk '{print $1}')
     if command -v sha256sum >/dev/null 2>&1; then
-        ACTUAL=$(sha256sum "${TMP_DIR}/${BINARY}" | awk '{print $1}')
+        ACTUAL=$(sha256sum "${TMP_DIR}/${TARBALL}" | awk '{print $1}')
     elif command -v shasum >/dev/null 2>&1; then
-        ACTUAL=$(shasum -a 256 "${TMP_DIR}/${BINARY}" | awk '{print $1}')
+        ACTUAL=$(shasum -a 256 "${TMP_DIR}/${TARBALL}" | awk '{print $1}')
     else
         warn "No sha256sum or shasum found — skipping verification"
         ACTUAL="$EXPECTED"
     fi
 
-    if [ "$EXPECTED" != "$ACTUAL" ]; then
+    if [ -z "$EXPECTED" ]; then
+        warn "No checksum entry found for ${TARBALL} — skipping verification"
+    elif [ "$EXPECTED" != "$ACTUAL" ]; then
         error "Checksum mismatch!\n  Expected: ${EXPECTED}\n  Got:      ${ACTUAL}"
+    else
+        info "Checksum verified ✓"
     fi
-    info "Checksum verified ✓"
 else
-    warn "No checksum file found — skipping verification"
+    warn "No checksums.txt found — skipping verification"
+fi
+
+tar -xzf "${TMP_DIR}/${TARBALL}" -C "$TMP_DIR"
+
+if [ ! -f "${TMP_DIR}/${BINARY}" ]; then
+    error "Archive did not contain ${BINARY}"
 fi
 
 # Install.
 chmod +x "${TMP_DIR}/${BINARY}"
-
-if [ "$(id -u)" -eq 0 ]; then
-    INSTALL_DIR="/usr/local/bin"
-elif [ -d "$HOME/.local/bin" ] || mkdir -p "$HOME/.local/bin" 2>/dev/null; then
-    INSTALL_DIR="$HOME/.local/bin"
-else
-    INSTALL_DIR="/usr/local/bin"
-fi
 
 if [ -w "$INSTALL_DIR" ]; then
     mv "${TMP_DIR}/${BINARY}" "${INSTALL_DIR}/${BINARY}"
@@ -123,14 +154,20 @@ fi
 info "Installed to ${BOLD}${INSTALL_DIR}/${BINARY}${RESET}"
 
 # Verify.
-if command -v rampart >/dev/null 2>&1; then
+RAMPART_BIN="${INSTALL_DIR}/${BINARY}"
+if [ -x "$RAMPART_BIN" ]; then
     printf "\n"
-    rampart version 2>/dev/null || true
-    printf "\n${GREEN}${BOLD}Ready!${RESET} Run ${BOLD}rampart quickstart${RESET} to get started.\n"
+    "$RAMPART_BIN" version 2>/dev/null || true
+
+    if echo ":${PATH}:" | grep -q ":${INSTALL_DIR}:"; then
+        printf "\n${GREEN}${BOLD}Ready!${RESET} Run ${BOLD}rampart quickstart${RESET} to get started.\n"
+    else
+        printf "\n${YELLOW}Note:${RESET} ${INSTALL_DIR} may not be in your PATH.\n"
+        printf "Add it: ${BOLD}export PATH=\"${INSTALL_DIR}:\$PATH\"${RESET}\n"
+        printf "Then run: ${BOLD}rampart quickstart${RESET}\n"
+    fi
 else
-    printf "\n${YELLOW}Note:${RESET} ${INSTALL_DIR} may not be in your PATH.\n"
-    printf "Add it: ${BOLD}export PATH=\"${INSTALL_DIR}:\$PATH\"${RESET}\n"
-    printf "Then run: ${BOLD}rampart quickstart${RESET}\n"
+    warn "Could not verify installed binary at ${INSTALL_DIR}/${BINARY}"
 fi
 
 # Detect AI agents and suggest setup commands.
@@ -160,7 +197,7 @@ detect_agents_and_suggest() {
     if [ "$OPENCLAW_FOUND" -eq 1 ]; then
         if [ "$AUTO_SETUP" = "1" ]; then
             printf "${GREEN}▸${RESET} Auto-setup: protecting OpenClaw...\n"
-            rampart setup openclaw 2>&1 || printf "${YELLOW}  ↳ Auto-setup failed — run manually: rampart setup openclaw${RESET}\n"
+            "$RAMPART_BIN" setup openclaw 2>&1 || printf "${YELLOW}  ↳ Auto-setup failed — run manually: rampart setup openclaw${RESET}\n"
         else
             printf "  Run this to protect your OpenClaw agent:\n"
             printf "    ${BOLD}rampart setup openclaw${RESET}\n"
@@ -171,7 +208,7 @@ detect_agents_and_suggest() {
     if [ "$CLAUDE_FOUND" -eq 1 ]; then
         if [ "$AUTO_SETUP" = "1" ]; then
             printf "${GREEN}▸${RESET} Auto-setup: protecting Claude Code...\n"
-            rampart setup claude-code 2>&1 || printf "${YELLOW}  ↳ Auto-setup failed — run manually: rampart setup claude-code${RESET}\n"
+            "$RAMPART_BIN" setup claude-code 2>&1 || printf "${YELLOW}  ↳ Auto-setup failed — run manually: rampart setup claude-code${RESET}\n"
         else
             printf "  Run this to protect Claude Code:\n"
             printf "    ${BOLD}rampart setup claude-code${RESET}\n"
@@ -187,6 +224,6 @@ detect_agents_and_suggest() {
     fi
 }
 
-if command -v rampart >/dev/null 2>&1; then
+if [ -x "$RAMPART_BIN" ]; then
     detect_agents_and_suggest
 fi

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -158,7 +158,7 @@ func (e *Engine) EvaluateWith(call ToolCall, opts EvalOptions) Decision {
 	var finalWebhookConfig *WebhookActionConfig
 
 	for _, p := range matching {
-		res := e.evaluatePolicy(p, call)
+		res := e.evaluateMatchingPolicy(p, call)
 		if !res.matched {
 			continue // no rule matched within this policy
 		}
@@ -262,6 +262,13 @@ func (e *Engine) EvaluateWith(call ToolCall, opts EvalOptions) Decision {
 		ConsumedRulePolicy: consumedPolicy,
 		ConsumedRuleIndex:  consumedRuleIdx,
 	}
+}
+
+func (e *Engine) evaluateMatchingPolicy(p Policy, call ToolCall) evaluatePolicyResult {
+	if isDurableAllowPolicy(p) {
+		return e.evaluateDurableAllowPolicy(p, call)
+	}
+	return e.evaluatePolicy(p, call)
 }
 
 func (e *Engine) evaluateDurableAllowOverride(matching []Policy, call ToolCall, start time.Time) (Decision, bool) {

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -116,12 +116,22 @@ func (e *Engine) EvaluateWith(call ToolCall, opts EvalOptions) Decision {
 	// Collect matching policies, sorted by priority.
 	matching := e.collectMatching(cfg, call)
 
-	// Apply policy filter if set (per-agent token scoping).
+	// Durable human allow rules are not ordinary policy allows. They are explicit
+	// operator carve-outs written by approval/allow workflows. They bypass broader
+	// ask/approval policies, but hard deny policies still win.
+	durableAllow, hasDurableAllow := e.evaluateDurableAllowOverride(matching, call, start)
+
+	// Apply policy filter if set (per-agent token scoping). Durable operator
+	// overrides are intentionally checked before this filter so human-approved
+	// carve-outs stay global rather than disappearing under token profile scoping.
 	if opts.PolicyFilter != "" {
 		matching = filterByProfile(matching, opts.PolicyFilter)
 	}
 
 	if len(matching) == 0 {
+		if hasDurableAllow {
+			return durableAllow
+		}
 		return Decision{
 			Action:       defaultAction,
 			Message:      "no matching policy; using default action",
@@ -133,16 +143,16 @@ func (e *Engine) EvaluateWith(call ToolCall, opts EvalOptions) Decision {
 	// Deny wins. Then log. Then allow.
 	// If policies match scope but no rules fire, fall through to default action.
 	var (
-		finalAction           = ActionAllow
-		finalMessage          string
-		finalAudit            bool
-		finalHeadlessOnly     bool
-		finalFromProject      bool
-		matched               []string
-		anyRuleFired          bool
-		consumedOnce          bool
-		consumedPolicy        string
-		consumedRuleIdx       int
+		finalAction       = ActionAllow
+		finalMessage      string
+		finalAudit        bool
+		finalHeadlessOnly bool
+		finalFromProject  bool
+		matched           []string
+		anyRuleFired      bool
+		consumedOnce      bool
+		consumedPolicy    string
+		consumedRuleIdx   int
 	)
 
 	var finalWebhookConfig *WebhookActionConfig
@@ -225,6 +235,10 @@ func (e *Engine) EvaluateWith(call ToolCall, opts EvalOptions) Decision {
 		}
 	}
 
+	if hasDurableAllow {
+		return durableAllow
+	}
+
 	// If policies matched scope but no rules actually fired,
 	// fall through to the configured default action.
 	if !anyRuleFired {
@@ -248,6 +262,120 @@ func (e *Engine) EvaluateWith(call ToolCall, opts EvalOptions) Decision {
 		ConsumedRulePolicy: consumedPolicy,
 		ConsumedRuleIndex:  consumedRuleIdx,
 	}
+}
+
+func (e *Engine) evaluateDurableAllowOverride(matching []Policy, call ToolCall, start time.Time) (Decision, bool) {
+	for _, p := range matching {
+		if !isDurableAllowPolicy(p) {
+			continue
+		}
+
+		res := e.evaluateDurableAllowPolicy(p, call)
+		if !res.matched || res.action != ActionAllow {
+			continue
+		}
+
+		message := res.message
+		if message == "" {
+			message = durableAllowMessage(p)
+		}
+
+		decision := Decision{
+			Action:          ActionAllow,
+			MatchedPolicies: []string{p.Name},
+			Message:         message,
+			EvalDuration:    time.Since(start),
+		}
+		if res.rule != nil && res.rule.Once {
+			decision.ConsumedOnce = true
+			decision.ConsumedRulePolicy = p.Name
+			decision.ConsumedRuleIndex = res.ruleIndex
+		}
+		return decision, true
+	}
+
+	return Decision{}, false
+}
+
+func (e *Engine) evaluateDurableAllowPolicy(p Policy, call ToolCall) evaluatePolicyResult {
+	for i, rule := range p.Rules {
+		if rule.IsExpired() || !matchDurableAllowCondition(rule.When, call, e.callCounter) {
+			continue
+		}
+		action, err := rule.ParseAction()
+		if err != nil {
+			e.logger.Error("engine: invalid durable allow action", "policy", p.Name, "action", rule.Action, "error", err)
+			return evaluatePolicyResult{ActionDeny, "invalid rule action; failing closed", nil, i, true}
+		}
+		return evaluatePolicyResult{action, rule.Message, &p.Rules[i], i, true}
+	}
+	return evaluatePolicyResult{matched: false}
+}
+
+func matchDurableAllowCondition(cond Condition, call ToolCall, counter CallCounter) bool {
+	if cond.Default || cond.IsEmpty() {
+		return true
+	}
+	if len(cond.CommandMatches) == 0 && len(cond.CommandContains) == 0 {
+		return matchCondition(cond, call, counter)
+	}
+	if !matchStrictCommandCondition(cond, call) {
+		return false
+	}
+	cond.CommandMatches = nil
+	cond.CommandContains = nil
+	cond.CommandNotMatches = nil
+	if cond.IsEmpty() {
+		return true
+	}
+	return matchCondition(cond, call, counter)
+}
+
+func matchStrictCommandCondition(cond Condition, call ToolCall) bool {
+	cmd := call.Command()
+	if cmd == "" {
+		return false
+	}
+	cmdMatch := false
+	if len(cond.CommandMatches) > 0 {
+		cmdMatch = matchAny(cond.CommandMatches, cmd)
+		if norm := NormalizeCommand(cmd); !cmdMatch && norm != cmd {
+			cmdMatch = matchAny(cond.CommandMatches, norm)
+		}
+	}
+	if !cmdMatch {
+		cmdLower := strings.ToLower(cmd)
+		for _, sub := range cond.CommandContains {
+			if strings.Contains(cmdLower, strings.ToLower(sub)) {
+				cmdMatch = true
+				break
+			}
+		}
+	}
+	if !cmdMatch {
+		return false
+	}
+	return !matchAny(cond.CommandNotMatches, cmd) && !matchAny(cond.CommandNotMatches, NormalizeCommand(cmd))
+}
+
+// isDurableAllowPolicy reports whether a policy came from Rampart's durable
+// human allow files. These are intentional operator carve-outs created by
+// `rampart allow`, approval persist/Always Allow, or legacy auto-allow flows.
+// Policy names alone are not trusted here: project or custom policy files must
+// not be able to self-declare high-precedence operator overrides.
+func isDurableAllowPolicy(p Policy) bool {
+	profile := strings.ToLower(profileNameFromPath(p.FilePath))
+	return profile == "user-overrides" || profile == "auto-allowed"
+}
+
+// durableAllowMessage returns the default audit/test message for a durable
+// human allow policy when the matching rule did not provide one.
+func durableAllowMessage(p Policy) string {
+	profile := strings.ToLower(profileNameFromPath(p.FilePath))
+	if profile == "auto-allowed" {
+		return "auto-allowed by user rule"
+	}
+	return "allowed by durable user override"
 }
 
 // EvaluateResponse runs response-side evaluation against matching policies.

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -133,6 +133,77 @@ policies:
 	}
 }
 
+func TestEvaluate_DurableUserOverrideWinsBeforeAsk(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "standard.yaml"), []byte(`
+version: "1"
+default_action: deny
+policies:
+  - name: block-destructive
+    match:
+      tool: exec
+    rules:
+      - action: deny
+        when:
+          command_matches: ["rm -rf *"]
+        message: "Destructive command blocked"
+      - action: ask
+        when:
+          command_matches: ["shred **"]
+        message: "Secure delete requires approval"
+  - name: user-allow-name-alone-is-not-durable
+    match:
+      tool: exec
+    rules:
+      - action: allow
+        when:
+          command_matches: ["shred --version"]
+        message: "ordinary allow"
+`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "user-overrides.yaml"), []byte(`
+version: "1"
+default_action: deny
+policies:
+  - name: user-allow-shred-help
+    match:
+      tool: exec
+    rules:
+      - action: allow
+        when:
+          command_matches: ["shred --help"]
+        message: "User allow (always) via openclaw-approval"
+  - name: user-allow-rm-root
+    match:
+      tool: exec
+    rules:
+      - action: allow
+        when:
+          command_matches: ["rm -rf /"]
+        message: "User allow (always) via openclaw-approval"
+`), 0o644))
+
+	eng, err := New(NewDirStore(dir, nil), nil)
+	require.NoError(t, err)
+
+	got := eng.Evaluate(execCall("main", "shred --help"))
+	require.Equal(t, ActionAllow, got.Action)
+	assert.Equal(t, []string{"user-allow-shred-help"}, got.MatchedPolicies)
+	assert.Equal(t, "User allow (always) via openclaw-approval", got.Message)
+
+	stillAsk := eng.Evaluate(execCall("main", "shred --help | head -n 1"))
+	require.Equal(t, ActionAsk, stillAsk.Action)
+	assert.Contains(t, stillAsk.MatchedPolicies, "block-destructive")
+
+	nameAloneIsNotDurable := eng.Evaluate(execCall("main", "shred --version"))
+	require.Equal(t, ActionAsk, nameAloneIsNotDurable.Action)
+	assert.Contains(t, nameAloneIsNotDurable.MatchedPolicies, "user-allow-name-alone-is-not-durable")
+	assert.Contains(t, nameAloneIsNotDurable.MatchedPolicies, "block-destructive")
+
+	denyStillWins := eng.Evaluate(execCall("main", "rm -rf /"))
+	require.Equal(t, ActionDeny, denyStillWins.Action)
+	assert.Contains(t, denyStillWins.MatchedPolicies, "block-destructive")
+}
+
 func TestEvaluate_DefaultDeny(t *testing.T) {
 	e := setupEngine(t, `
 version: "1"

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -193,6 +193,7 @@ policies:
 	stillAsk := eng.Evaluate(execCall("main", "shred --help | head -n 1"))
 	require.Equal(t, ActionAsk, stillAsk.Action)
 	assert.Contains(t, stillAsk.MatchedPolicies, "block-destructive")
+	assert.NotContains(t, stillAsk.MatchedPolicies, "user-allow-shred-help")
 
 	nameAloneIsNotDurable := eng.Evaluate(execCall("main", "shred --version"))
 	require.Equal(t, ActionAsk, nameAloneIsNotDurable.Action)

--- a/internal/plugin/openclaw/approval-regression.mjs
+++ b/internal/plugin/openclaw/approval-regression.mjs
@@ -2,9 +2,11 @@ import plugin from './index.js';
 
 function createApi() {
   const handlers = {};
+  const hookOpts = {};
   const logs = [];
   return {
     handlers,
+    hookOpts,
     logs,
     api: {
       pluginConfig: {},
@@ -13,7 +15,7 @@ function createApi() {
         warn: (...a) => logs.push(['warn', a.join(' ')]),
         debug: (...a) => logs.push(['debug', a.join(' ')]),
       },
-      on: (name, fn) => { handlers[name] = fn; },
+      on: (name, fn, opts) => { handlers[name] = fn; hookOpts[name] = opts; },
       registerGatewayMethod: () => {},
     },
   };
@@ -24,7 +26,7 @@ function assert(condition, message) {
 }
 
 async function runScenario({ name, toolResult, toolName = 'exec', params = { command: 'sudo true' }, resolution }) {
-  const { api, handlers } = createApi();
+  const { api, handlers, hookOpts } = createApi();
   const fetchCalls = [];
   const originalFetch = global.fetch;
   global.fetch = async (url, opts = {}) => {
@@ -51,7 +53,7 @@ async function runScenario({ name, toolResult, toolName = 'exec', params = { com
     if (resolution && result?.requireApproval?.onResolution) {
       await result.requireApproval.onResolution(resolution);
     }
-    return { name, result, fetchCalls };
+    return { name, result, fetchCalls, hookOpts };
   } finally {
     global.fetch = originalFetch;
   }
@@ -64,6 +66,7 @@ const ask = await runScenario({
 assert(ask.result?.requireApproval, 'ask-exec: requireApproval missing');
 assert(!ask.result?.params?.ask, 'ask-exec: legacy ask param mutation still present');
 assert(ask.result.requireApproval.title.includes('exec approval required'), 'ask-exec: wrong title');
+assert(ask.hookOpts.before_tool_call?.priority < 0, 'ask-exec: Rampart should run as a late before_tool_call hook');
 
 const deny = await runScenario({
   name: 'deny-exec',

--- a/internal/plugin/openclaw/degraded-mode-test.mjs
+++ b/internal/plugin/openclaw/degraded-mode-test.mjs
@@ -65,6 +65,18 @@ const serverErrorWrite = await runScenario({
 assert(serverErrorWrite.result?.block === true, 'write on serve 5xx must block');
 assert(serverErrorWrite.result.blockReason.includes('service error 503'), 'write 5xx reason should include status');
 
+const timeoutEdit = await runScenario({
+  name: 'timeout-edit',
+  toolName: 'edit',
+  fetchImpl: async () => {
+    const err = new Error('aborted');
+    err.name = 'AbortError';
+    throw err;
+  },
+});
+assert(timeoutEdit.result?.block === true, 'edit on timeout must block');
+assert(timeoutEdit.result.blockReason.includes('timed out'), 'edit timeout reason should mention timeout');
+
 const serverErrorReadWithStrictConfig = await runScenario({
   name: 'server-error-read-strict',
   toolName: 'read',
@@ -73,4 +85,4 @@ const serverErrorReadWithStrictConfig = await runScenario({
 });
 assert(serverErrorReadWithStrictConfig.result?.block === true, 'read should block when failOpenTools is empty');
 
-console.log(JSON.stringify({ ok: true, scenarios: ['unreachable-exec', 'unreachable-read', 'server-error-write', 'server-error-read-strict'] }, null, 2));
+console.log(JSON.stringify({ ok: true, scenarios: ['unreachable-exec', 'unreachable-read', 'server-error-write', 'timeout-edit', 'server-error-read-strict'] }, null, 2));

--- a/internal/plugin/openclaw/index.js
+++ b/internal/plugin/openclaw/index.js
@@ -212,7 +212,7 @@ async function auditLog(toolName, params, ctx, outcome, config) {
 export const id = "rampart";
 export const name = "Rampart";
 export const description = "AI agent firewall — YAML policy-as-code for every tool call";
-export const version = "1.0.0-rc.1";
+export const version = "1.0.0-rc.2";
 
 export function register(api) {
   const pluginConfig = api.pluginConfig ?? {};

--- a/internal/plugin/openclaw/index.js
+++ b/internal/plugin/openclaw/index.js
@@ -214,6 +214,12 @@ export const name = "Rampart";
 export const description = "AI agent firewall — YAML policy-as-code for every tool call";
 export const version = "1.0.0-rc.2";
 
+// OpenClaw runs higher-priority before_tool_call hooks first. Rampart should
+// act as the final normal plugin gate so it evaluates the params that will
+// actually execute, rather than letting another plugin mutate them after the
+// policy check.
+const RAMPART_TOOL_HOOK_PRIORITY = -1000;
+
 export function register(api) {
   const pluginConfig = api.pluginConfig ?? {};
 
@@ -367,12 +373,11 @@ export function register(api) {
         }
         return; // void = allow as-is
     }
-  });
+  }, { priority: RAMPART_TOOL_HOOK_PRIORITY });
 
   // ── after_tool_call (audit trail) ──────────────────────────────────────────
-  // Register a gateway method so OpenClaw classifies this as a "hybrid-capability"
-  // plugin rather than "hook-only". The rampart.status endpoint proxies Rampart
-  // serve status through the OpenClaw gateway for dashboard integrations.
+  // Expose a small status endpoint for dashboard integrations. Tool enforcement
+  // still lives entirely in the typed before_tool_call / after_tool_call hooks.
   api.registerGatewayMethod("rampart.status", async ({ respond }) => {
     try {
       const token = await loadToken();

--- a/internal/plugin/openclaw/openclaw.plugin.json
+++ b/internal/plugin/openclaw/openclaw.plugin.json
@@ -8,7 +8,7 @@
       "hook"
     ]
   },
-  "version": "1.0.0-rc.1",
+  "version": "1.0.0-rc.2",
   "author": "peg",
   "homepage": "https://rampart.sh",
   "repository": "https://github.com/peg/rampart",

--- a/internal/plugin/openclaw/package.json
+++ b/internal/plugin/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rampart",
-  "version": "1.0.0-rc.1",
+  "version": "1.0.0-rc.2",
   "description": "Rampart AI agent firewall — OpenClaw native plugin (before_tool_call hook)",
   "type": "module",
   "main": "index.js",

--- a/internal/proxy/eval_handlers.go
+++ b/internal/proxy/eval_handlers.go
@@ -142,35 +142,6 @@ func (s *Server) handleToolCall(w http.ResponseWriter, r *http.Request) {
 		resp["suggestions"] = []string{}
 	}
 
-	// Explicit durable human carve-outs should bypass normal deny/ask precedence.
-	// They are not ordinary policy rules, they are operator-approved overrides.
-	if s.mode == "enforce" {
-		policyName := ""
-		message := ""
-		if engine.MatchesAutoAllowFile(engine.DefaultAutoAllowedPath(), call) {
-			policyName = "auto-allowed"
-			message = "auto-allowed by user rule"
-		} else if engine.MatchesAutoAllowFile(engine.DefaultUserOverridesPath(), call) {
-			policyName = "user-overrides"
-			message = "allowed by durable user override"
-		}
-		if policyName != "" {
-			s.logger.Debug("proxy: user override matched, bypassing normal policy decision", "tool", toolName, "policy", policyName)
-			decision.Action = engine.ActionAllow
-			decision.Message = message
-			decision.MatchedPolicies = []string{policyName}
-			decision.Suggestions = nil
-			resp["allowed"] = true
-			resp["decision"] = decision.Action.String()
-			resp["message"] = decision.Message
-			resp["policy"] = policyName
-			resp["suggestions"] = []string{}
-			s.writeAudit(req, toolName, decision)
-			writeJSON(w, http.StatusOK, resp)
-			return
-		}
-	}
-
 	if s.mode == "enforce" && decision.Action == engine.ActionDeny {
 		writeJSON(w, http.StatusForbidden, resp)
 		return
@@ -205,7 +176,6 @@ func (s *Server) handleToolCall(w http.ResponseWriter, r *http.Request) {
 					"decision", decision.Action.String(),
 					"session", call.Session,
 				)
-				s.writeAudit(req, toolName, decision)
 				writeJSON(w, http.StatusOK, resp)
 				return
 			}

--- a/internal/proxy/server_test.go
+++ b/internal/proxy/server_test.go
@@ -136,7 +136,11 @@ func setupTestServerWithHome(t *testing.T, configYAML, mode, homeDir string) (*S
 	policyPath := filepath.Join(dir, "policy.yaml")
 	require.NoError(t, os.WriteFile(policyPath, []byte(configYAML), 0o644))
 
-	store := engine.NewFileStore(policyPath)
+	store := engine.PolicyStore(engine.NewFileStore(policyPath))
+	policyDir := filepath.Join(homeDir, ".rampart", "policies")
+	if _, err := os.Stat(policyDir); err == nil {
+		store = engine.NewMultiStore(policyPath, policyDir, slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil)))
+	}
 	eng, err := engine.New(store, slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil)))
 	require.NoError(t, err)
 
@@ -676,7 +680,7 @@ policies:
 	_, hasApprovalID := got["approval_id"]
 	assert.False(t, hasApprovalID, "trusted OpenClaw-hosted evaluation should not create Rampart approval_id")
 	assert.Len(t, srv.approvals.List(), 0, "trusted OpenClaw-hosted evaluation should not enqueue Rampart approvals")
-	require.GreaterOrEqual(t, srv.sink.(*mockSink).count(), 1, "trusted OpenClaw-hosted evaluation should still write an audit event")
+	require.Equal(t, 1, srv.sink.(*mockSink).count(), "trusted OpenClaw-hosted evaluation should write one audit event")
 	ev := srv.sink.(*mockSink).lastEvent()
 	assert.Equal(t, "ask", ev.Decision.Action)
 	assert.Equal(t, "exec", ev.Tool)
@@ -760,7 +764,7 @@ policies:
         message: "needs approval"
 `
 
-	srv, token, _ := setupTestServerWithHome(t, configYAML, "enforce", tmpHome)
+	srv, token, sink := setupTestServerWithHome(t, configYAML, "enforce", tmpHome)
 	ts := httptest.NewServer(srv.handler())
 	defer ts.Close()
 
@@ -778,8 +782,10 @@ policies:
 	var got map[string]any
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&got))
 	assert.Equal(t, "allow", got["decision"])
-	assert.Equal(t, "user-overrides", got["policy"])
+	assert.Equal(t, "user-allow-local-api", got["policy"])
 	assert.Len(t, srv.approvals.List(), 0, "durable user overrides should bypass approval queue")
+	assert.Equal(t, 1, sink.count(), "durable user override should write exactly one audit event")
+	assert.Equal(t, "allow", sink.lastEvent().Decision.Action)
 }
 
 func TestResolveApproval_AuditTrail(t *testing.T) {


### PR DESCRIPTION
## Summary
Promote current `staging` to `main` for Trevor review ahead of a possible `v1.0.0-rc.3` cut.

Included highlights:
- OpenClaw native plugin integration hardening and diagnostics
- durable user override / strict reporting fixes in `/internal/engine/`
- RC update-check and CI/govulncheck fixes
- root installer release-archive fixes
- OpenClaw hook priority cleanup from PR #301 so Rampart evaluates final tool params

## Review gate
Do **not** merge without Trevor's manual approval. This PR is intentionally opened for review only.

## Validation so far
- PR #301 CI: Ubuntu/macOS/Windows + goreleaser snapshot all green
- Local on latest hook-priority branch:
  - `node internal/plugin/openclaw/approval-regression.mjs`
  - `node internal/plugin/openclaw/degraded-mode-test.mjs`
  - `go test ./internal/openclaw/... ./cmd/rampart/cli -run 'TestOpenClaw|TestInspect|TestApply|TestPlugin|TestDoctor' -count=1`
  - `go test ./... -count=1`
  - `go vet ./...`
- RC2 dogfood already passed on OpenClaw `2026.5.4` + Rampart `1.0.0-rc.2` before the hook-priority cleanup.

## Notes
- Base: `main` (`2fd1fd8`)
- Head: `staging` (`3bba7e1`)
- Key paths touched include `/cmd/rampart`, `/internal/engine/`, `/internal/engine`, and `internal/plugin/openclaw`.
