### PR TITLE
ci: smoke test Docker before releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,10 +76,64 @@ jobs:
         run: go test -bench=. -benchmem ./internal/engine/ ./internal/audit/
 
       - name: Upload coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-${{ matrix.os }}
           path: coverage.out
+
+  docker-smoke:
+    name: docker smoke (amd64 runtime + arm64 build)
+    runs-on: ubuntu-latest
+    needs: test
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Build amd64 image
+        run: |
+          set -euo pipefail
+          docker buildx build \
+            --platform linux/amd64 \
+            --load \
+            --build-arg VERSION=ci-smoke \
+            --build-arg COMMIT=${GITHUB_SHA::12} \
+            --build-arg DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ) \
+            -t rampart:ci-smoke \
+            .
+
+      - name: Smoke test amd64 image
+        run: |
+          set -euo pipefail
+
+          docker run --rm rampart:ci-smoke version | tee /tmp/rampart-docker-version.txt
+          grep -F "rampart ci-smoke" /tmp/rampart-docker-version.txt
+
+          cid="$(docker run -d -p 19090:9090 rampart:ci-smoke)"
+          trap 'docker rm -f "$cid" >/dev/null 2>&1 || true' EXIT
+
+          for _ in $(seq 1 20); do
+            if curl -fsS http://127.0.0.1:19090/healthz >/dev/null 2>&1; then
+              exit 0
+            fi
+            sleep 1
+          done
+
+          docker logs "$cid"
+          exit 1
+
+      - name: Build arm64 image
+        run: |
+          set -euo pipefail
+          docker buildx build \
+            --platform linux/arm64 \
+            --build-arg VERSION=ci-smoke \
+            --build-arg COMMIT=${GITHUB_SHA::12} \
+            --build-arg DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ) \
+            --output=type=cacheonly \
+            .
 
   release-dry-run:
     name: goreleaser snapshot (cross-platform build check)

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,15 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: docker/setup-qemu-action@v4
-
       - uses: docker/setup-buildx-action@v4
-
-      - uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: docker/metadata-action@v6
         id: meta
@@ -43,7 +35,50 @@ jobs:
           echo "commit=${GITHUB_SHA::12}" >> "$GITHUB_OUTPUT"
           echo "date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
-      - uses: docker/build-push-action@v7
+      - name: Build local image for smoke test
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64
+          load: true
+          tags: rampart:release-smoke
+          build-args: |
+            VERSION=${{ steps.build.outputs.version }}
+            COMMIT=${{ steps.build.outputs.commit }}
+            DATE=${{ steps.build.outputs.date }}
+          cache-from: type=gha
+
+      - name: Smoke test local Docker image
+        env:
+          IMAGE: rampart:release-smoke
+          VERSION: ${{ steps.build.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          docker run --rm "$IMAGE" version | tee /tmp/rampart-docker-version.txt
+          grep -F "rampart ${VERSION}" /tmp/rampart-docker-version.txt
+
+          cid="$(docker run -d -p 19090:9090 "$IMAGE")"
+          trap 'docker rm -f "$cid" >/dev/null 2>&1 || true' EXIT
+
+          for _ in $(seq 1 20); do
+            if curl -fsS http://127.0.0.1:19090/healthz >/dev/null 2>&1; then
+              exit 0
+            fi
+            sleep 1
+          done
+
+          docker logs "$cid"
+          exit 1
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push multi-arch image
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -56,29 +91,6 @@ jobs:
             DATE=${{ steps.build.outputs.date }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-      - name: Smoke test Docker image
-        env:
-          IMAGE: ghcr.io/peg/rampart:${{ steps.build.outputs.version }}
-          VERSION: ${{ steps.build.outputs.version }}
-        run: |
-          set -euo pipefail
-
-          docker run --rm "$IMAGE" version | tee /tmp/rampart-docker-version.txt
-          grep -F "rampart ${VERSION}" /tmp/rampart-docker-version.txt
-
-          cid="$(docker run -d -p 19090:9090 "$IMAGE")"
-          trap 'docker rm -f "$cid" >/dev/null 2>&1 || true' EXIT
-
-          for _ in $(seq 1 20); do
-            if curl -fsS http://127.0.0.1:19090/healthz >/dev/null; then
-              exit 0
-            fi
-            sleep 1
-          done
-
-          docker logs "$cid"
-          exit 1
 
       - name: Verify multi-arch manifest
         env:


### PR DESCRIPTION
## Summary

Follow-up polish after the 1.0 release packaging fix:

- add a CI Docker smoke job that builds and boots the linux/amd64 image on PRs/pushes
- add a linux/arm64 Docker build probe in CI so cross-compile regressions are caught before tag day
- smoke the release Docker image locally before logging in/pushing to GHCR
- remove the now-unnecessary QEMU setup from the Docker release workflow
- update `actions/upload-artifact` to `v7` to clear the Node20 deprecation annotation
- quiet expected health-probe retry noise in Docker smoke loops

## Validation

- `git diff --check` ✅
- YAML parse for `.github/workflows/ci.yml` and `.github/workflows/docker.yml` ✅
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/ci.yml .github/workflows/docker.yml` ✅
- local Docker buildx linux/amd64 build with release ldflags ✅
- local Docker `version` smoke ✅
- local Docker default `serve` + `/healthz` smoke ✅
- local Docker buildx linux/arm64 build probe with `--output=type=cacheonly` ✅
