### PR TITLE
fix: align OpenClaw plugin license metadata

### DIFF
--- a/internal/plugin/openclaw/embed_test.go
+++ b/internal/plugin/openclaw/embed_test.go
@@ -40,6 +40,7 @@ func TestPackageDeclaresInstallHostFloor(t *testing.T) {
 	}
 	var pkg struct {
 		Version  string `json:"version"`
+		License  string `json:"license"`
 		OpenClaw struct {
 			Install struct {
 				MinHostVersion string `json:"minHostVersion"`
@@ -54,6 +55,9 @@ func TestPackageDeclaresInstallHostFloor(t *testing.T) {
 	}
 	if got, want := pkg.Version, Version(); got != want {
 		t.Fatalf("package.json version = %q, want Version() %q", got, want)
+	}
+	if got, want := pkg.License, "Apache-2.0"; got != want {
+		t.Fatalf("package.json license = %q, want %q", got, want)
 	}
 }
 

--- a/internal/plugin/openclaw/package.json
+++ b/internal/plugin/openclaw/package.json
@@ -11,7 +11,7 @@
     "security",
     "plugin"
   ],
-  "license": "MIT",
+  "license": "Apache-2.0",
   "openclaw": {
     "extensions": [
       "./index.js"


### PR DESCRIPTION
## Summary

- Set the embedded OpenClaw plugin package license to Apache-2.0 to match the repository/release metadata.
- Add an embedded package metadata regression assertion.

## Verification

- `git diff --check`
- `go test ./internal/plugin/openclaw -count=1`
- `node internal/plugin/openclaw/smoke-test.mjs`
