### PR TITLE
docs: update 1.0 security support metadata

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,9 +4,9 @@
 
 | Version | Supported          |
 |---------|--------------------|
-| 0.7.x   | ✅ Current release |
-| 0.6.x   | ⚠️ Critical fixes only |
-| < 0.6   | ❌ No longer supported |
+| 1.0.x   | ✅ Current release |
+| 0.9.x   | ⚠️ Critical fixes only |
+| < 0.9   | ❌ No longer supported |
 
 ## Reporting a Vulnerability
 

--- a/docs-site/integrations/openclaw.md
+++ b/docs-site/integrations/openclaw.md
@@ -157,7 +157,7 @@ Or check plugin status directly:
 
 ```bash
 openclaw plugins list
-# rampart  v0.9.18  active
+# rampart  v1.0.0  active
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary

- Update SECURITY.md supported-version policy for the 1.0 release line.
- Refresh the OpenClaw plugin status example from v0.9.x to v1.0.0.

## Verification

- `git diff --check`
