### PR TITLE
feat: add observability schema foundations

### DIFF
--- a/cmd/rampart/cli/status.go
+++ b/cmd/rampart/cli/status.go
@@ -30,30 +30,144 @@ import (
 )
 
 func newStatusCmd() *cobra.Command {
-	return &cobra.Command{
+	var jsonOut bool
+
+	cmd := &cobra.Command{
 		Use:   "status",
 		Short: "Show Rampart protection status",
 		Long:  "Display a quick dashboard of Rampart protection status, mode, and today's events.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runStatus(cmd.OutOrStdout())
+			return runStatus(cmd.OutOrStdout(), jsonOut)
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output status as JSON")
+	return cmd
 }
 
-func runStatus(w io.Writer) error {
-	protected := detectProtectedAgents()
-	mode, defaultAction := detectMode()
-	allow, deny, pending, lastDeny := todayEvents()
-	serverRunning := isServeRunningLocal()
-	hookOnly := isHookBasedOnly(protected)
+const statusSchemaVersion = "rampart.status.v1"
+
+type statusSnapshot struct {
+	generatedAt   time.Time
+	buildVersion  string
+	protected     []string
+	mode          string
+	defaultAction string
+	serverRunning bool
+	hookOnly      bool
+	allow         int
+	deny          int
+	pending       int
+	lastDeny      *audit.Event
+}
+
+type statusJSONOutput struct {
+	SchemaVersion string              `json:"schema_version"`
+	GeneratedAt   time.Time           `json:"generated_at"`
+	BuildVersion  string              `json:"build_version"`
+	Protected     []string            `json:"protected_agents"`
+	Mode          string              `json:"mode"`
+	DefaultAction string              `json:"default_action"`
+	ServerRunning bool                `json:"server_running"`
+	HookOnly      bool                `json:"hook_only"`
+	Today         statusTodayJSON     `json:"today"`
+	LastDeny      *statusLastDenyJSON `json:"last_deny,omitempty"`
+}
+
+type statusTodayJSON struct {
+	Allow   int `json:"allow"`
+	Deny    int `json:"deny"`
+	Pending int `json:"pending"`
+}
+
+type statusLastDenyJSON struct {
+	Timestamp time.Time `json:"timestamp"`
+	Tool      string    `json:"tool"`
+	Command   string    `json:"command,omitempty"`
+}
+
+func runStatus(w io.Writer, jsonOut bool) error {
+	snapshot := collectStatusSnapshot(time.Now().UTC())
+	if jsonOut {
+		return writeStatusJSON(w, snapshot)
+	}
 
 	useColor := !noColor() && isTerminal(os.Stdout)
 
-	box := buildStatusBox(protected, mode, defaultAction, allow, deny, pending, serverRunning, hookOnly, lastDeny, useColor)
+	box := buildStatusBox(
+		snapshot.protected,
+		snapshot.mode,
+		snapshot.defaultAction,
+		snapshot.allow,
+		snapshot.deny,
+		snapshot.pending,
+		snapshot.serverRunning,
+		snapshot.hookOnly,
+		snapshot.lastDeny,
+		useColor,
+	)
 	fmt.Fprintln(w, box)
 
-	printStatusHints(w, serverRunning, protected, allow, deny, pending)
+	printStatusHints(w, snapshot.serverRunning, snapshot.protected, snapshot.allow, snapshot.deny, snapshot.pending)
 	return nil
+}
+
+func collectStatusSnapshot(generatedAt time.Time) statusSnapshot {
+	if generatedAt.IsZero() {
+		generatedAt = time.Now().UTC()
+	}
+	protected := detectProtectedAgents()
+	mode, defaultAction := detectMode()
+	allow, deny, pending, lastDeny := todayEventsAt(generatedAt)
+	return statusSnapshot{
+		generatedAt:   generatedAt,
+		buildVersion:  build.Version,
+		protected:     protected,
+		mode:          mode,
+		defaultAction: defaultAction,
+		serverRunning: isServeRunningLocal(),
+		hookOnly:      isHookBasedOnly(protected),
+		allow:         allow,
+		deny:          deny,
+		pending:       pending,
+		lastDeny:      lastDeny,
+	}
+}
+
+func writeStatusJSON(w io.Writer, snapshot statusSnapshot) error {
+	protected := snapshot.protected
+	if protected == nil {
+		protected = []string{}
+	}
+
+	out := statusJSONOutput{
+		SchemaVersion: statusSchemaVersion,
+		GeneratedAt:   snapshot.generatedAt,
+		BuildVersion:  snapshot.buildVersion,
+		Protected:     protected,
+		Mode:          snapshot.mode,
+		DefaultAction: snapshot.defaultAction,
+		ServerRunning: snapshot.serverRunning,
+		HookOnly:      snapshot.hookOnly,
+		Today: statusTodayJSON{
+			Allow:   snapshot.allow,
+			Deny:    snapshot.deny,
+			Pending: snapshot.pending,
+		},
+	}
+
+	if snapshot.lastDeny != nil {
+		last := &statusLastDenyJSON{
+			Timestamp: snapshot.lastDeny.Timestamp,
+			Tool:      snapshot.lastDeny.Tool,
+		}
+		if command := extractEventCommand(snapshot.lastDeny); !isUnknownOrEmpty(command) {
+			last.Command = command
+		}
+		out.LastDeny = last
+	}
+
+	enc := json.NewEncoder(w)
+	return enc.Encode(out)
 }
 
 // Box dimensions.
@@ -339,13 +453,20 @@ func detectMode() (string, string) {
 // todayEvents returns today's allow/deny/pending counts and the most recent deny event.
 // "pending" counts require_approval and webhook actions.
 func todayEvents() (allow, deny, pending int, lastDeny *audit.Event) {
+	return todayEventsAt(time.Now().UTC())
+}
+
+func todayEventsAt(now time.Time) (allow, deny, pending int, lastDeny *audit.Event) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return
 	}
 	auditDir := filepath.Join(home, ".rampart", "audit")
 
-	today := time.Now().UTC().Format("2006-01-02")
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	today := now.UTC().Format("2006-01-02")
 
 	seen := make(map[string]bool)
 	var candidates []string

--- a/cmd/rampart/cli/status_test.go
+++ b/cmd/rampart/cli/status_test.go
@@ -15,17 +15,19 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/peg/rampart/internal/audit"
 )
 
 func TestRunStatus(t *testing.T) {
 	var buf bytes.Buffer
-	err := runStatus(&buf)
+	err := runStatus(&buf, false)
 	if err != nil {
 		t.Fatalf("runStatus returned error: %v", err)
 	}
@@ -37,6 +39,111 @@ func TestRunStatus(t *testing.T) {
 	// Verify the status line is present.
 	if !strings.Contains(out, "Status") {
 		t.Error("missing Status row in status output")
+	}
+}
+
+func TestStatusCmdDefaultHumanOutput(t *testing.T) {
+	stdout, _, err := runCLI(t, "status")
+	if err != nil {
+		t.Fatalf("status returned error: %v", err)
+	}
+	if !strings.Contains(stdout, "RAMPART") {
+		t.Fatalf("expected human status box output, got: %s", stdout)
+	}
+	var payload map[string]any
+	if jsonErr := json.Unmarshal([]byte(stdout), &payload); jsonErr == nil {
+		t.Fatal("default status output should not be JSON")
+	}
+}
+
+func TestStatusCmdJSONOutput(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+
+	policyDir := filepath.Join(home, ".rampart", "policies")
+	if err := os.MkdirAll(policyDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(policyDir, "status.yaml"), []byte("version: \"1\"\ndefault_action: allow\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	auditDir := filepath.Join(home, ".rampart", "audit")
+	if err := os.MkdirAll(auditDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	allowEvent := audit.Event{
+		ID:        "01JTEST000000000000000001",
+		Timestamp: now.Add(-1 * time.Minute),
+		Agent:     "agent-1",
+		Session:   "session-1",
+		Tool:      "exec",
+		Request:   map[string]any{"command": "echo ok"},
+		Decision:  audit.EventDecision{Action: "allow", EvalTimeUS: 1},
+		Hash:      "sha256:allow",
+	}
+	denyEvent := audit.Event{
+		ID:        "01JTEST000000000000000002",
+		Timestamp: now,
+		Agent:     "agent-1",
+		Session:   "session-1",
+		Tool:      "exec",
+		Request:   map[string]any{"command": "rm -rf /tmp/demo"},
+		Decision:  audit.EventDecision{Action: "deny", EvalTimeUS: 1},
+		PrevHash:  allowEvent.Hash,
+		Hash:      "sha256:deny",
+	}
+	allowLine, err := json.Marshal(allowEvent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	denyLine, err := json.Marshal(denyEvent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	logPath := filepath.Join(auditDir, now.Format("2006-01-02")+".jsonl")
+	content := string(allowLine) + "\n" + string(denyLine) + "\n"
+	if err := os.WriteFile(logPath, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, _, err := runCLI(t, "status", "--json")
+	if err != nil {
+		t.Fatalf("status --json returned error: %v", err)
+	}
+
+	var got statusJSONOutput
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("status --json output is not valid JSON: %v\noutput: %s", err, stdout)
+	}
+
+	if got.SchemaVersion != statusSchemaVersion {
+		t.Fatalf("schema_version=%q, want %q", got.SchemaVersion, statusSchemaVersion)
+	}
+	if got.GeneratedAt.IsZero() {
+		t.Fatal("generated_at should be set")
+	}
+	if got.BuildVersion == "" {
+		t.Fatal("build_version should be set")
+	}
+	if got.Mode != "monitor" {
+		t.Fatalf("mode=%q, want monitor", got.Mode)
+	}
+	if got.DefaultAction != "allow" {
+		t.Fatalf("default_action=%q, want allow", got.DefaultAction)
+	}
+	if got.Today.Allow != 1 || got.Today.Deny != 1 || got.Today.Pending != 0 {
+		t.Fatalf("today counts mismatch: %+v", got.Today)
+	}
+	if got.LastDeny == nil {
+		t.Fatal("last_deny should be present")
+	}
+	if got.LastDeny.Tool != "exec" {
+		t.Fatalf("last_deny.tool=%q, want exec", got.LastDeny.Tool)
+	}
+	if !strings.Contains(got.LastDeny.Command, "rm -rf") {
+		t.Fatalf("last_deny.command=%q, want command summary", got.LastDeny.Command)
 	}
 }
 

--- a/docs-site/reference/cli-commands.md
+++ b/docs-site/reference/cli-commands.md
@@ -262,7 +262,10 @@ Quick dashboard showing protected agents, enforcement mode, and today's event co
 
 ```bash
 rampart status
+rampart status --json      # Machine-readable snapshot
 ```
+
+`--json` emits a stable status payload (`schema_version: "rampart.status.v1"`) with mode, protection state, server flags, today's counts, and optional last deny details.
 
 ### `rampart test`
 

--- a/internal/audit/cef.go
+++ b/internal/audit/cef.go
@@ -177,6 +177,7 @@ func (m *MultiSink) drain() {
 
 // Write writes to the primary sink and enqueues to secondary sinks (non-blocking).
 func (m *MultiSink) Write(event Event) error {
+	event = applyEventDefaults(event)
 	err := m.primary.Write(event)
 	// Non-blocking send to secondary sinks.
 	select {

--- a/internal/audit/defaults.go
+++ b/internal/audit/defaults.go
@@ -1,0 +1,74 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package audit
+
+import (
+	"os"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+)
+
+var (
+	hostContextOnce   sync.Once
+	cachedHostContext HostContext
+)
+
+func applyEventDefaults(event Event) Event {
+	if strings.TrimSpace(event.SchemaVersion) == "" {
+		event.SchemaVersion = EventSchemaVersion
+	}
+	if event.ID == "" {
+		event.ID = NewEventID()
+	}
+	if event.Timestamp.IsZero() {
+		event.Timestamp = time.Now().UTC()
+	}
+	if event.Host == nil {
+		event.Host = &HostContext{}
+	}
+	host := defaultHostContext(*event.Host)
+	event.Host = &host
+	return event
+}
+
+func defaultHostContext(host HostContext) HostContext {
+	defaults := localHostContext()
+	if strings.TrimSpace(host.Hostname) == "" {
+		host.Hostname = defaults.Hostname
+	}
+	if strings.TrimSpace(host.OS) == "" {
+		host.OS = defaults.OS
+	}
+	if strings.TrimSpace(host.Arch) == "" {
+		host.Arch = defaults.Arch
+	}
+	return host
+}
+
+func localHostContext() HostContext {
+	hostContextOnce.Do(func() {
+		hostname, err := os.Hostname()
+		if err != nil || strings.TrimSpace(hostname) == "" {
+			hostname = "unknown"
+		}
+		cachedHostContext = HostContext{
+			Hostname: hostname,
+			OS:       runtime.GOOS,
+			Arch:     runtime.GOARCH,
+		}
+	})
+	return cachedHostContext
+}

--- a/internal/audit/event.go
+++ b/internal/audit/event.go
@@ -31,12 +31,17 @@ import (
 	"time"
 )
 
+const EventSchemaVersion = "rampart.audit.v1"
+
 // Event represents a single audited tool call.
 //
 // Events are written to the audit trail in JSONL format, one per line.
 // The hash chain ensures integrity: modifying any event breaks the chain
 // for all subsequent events.
 type Event struct {
+	// SchemaVersion identifies the stable JSON event schema.
+	SchemaVersion string `json:"schema_version,omitempty"`
+
 	// ID is a ULID — time-ordered, lexicographically sortable, globally unique.
 	ID string `json:"id"`
 
@@ -48,6 +53,9 @@ type Event struct {
 
 	// Session identifies the agent's session (git repo/branch or RAMPART_SESSION).
 	Session string `json:"session"`
+
+	// Host records local, non-sensitive host context.
+	Host *HostContext `json:"host,omitempty"`
 
 	// RunID groups events from the same orchestration run.
 	// Sourced from Claude Code's session_id field, RAMPART_RUN env override,
@@ -74,6 +82,13 @@ type Event struct {
 	// Hash is the SHA-256 hash of this event (excluding the hash field itself).
 	// Computed by ComputeHash after all other fields are set.
 	Hash string `json:"hash"`
+}
+
+// HostContext contains non-sensitive local host identifiers.
+type HostContext struct {
+	Hostname string `json:"hostname"`
+	OS       string `json:"os"`
+	Arch     string `json:"arch"`
 }
 
 // EventDecision is the policy engine's verdict, recorded in the audit event.

--- a/internal/audit/event_compat_test.go
+++ b/internal/audit/event_compat_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package audit
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifyHash_LegacyEventWithoutSchemaAndHost(t *testing.T) {
+	type legacyEvent struct {
+		ID        string         `json:"id"`
+		Timestamp time.Time      `json:"timestamp"`
+		Agent     string         `json:"agent"`
+		Session   string         `json:"session"`
+		Tool      string         `json:"tool"`
+		Request   map[string]any `json:"request"`
+		Decision  EventDecision  `json:"decision"`
+		PrevHash  string         `json:"prev_hash"`
+		Hash      string         `json:"hash"`
+	}
+
+	legacy := legacyEvent{
+		ID:        "01JTEST000000000000000100",
+		Timestamp: time.Date(2026, 2, 12, 10, 0, 0, 0, time.UTC),
+		Agent:     "agent-1",
+		Session:   "session-1",
+		Tool:      "exec",
+		Request:   map[string]any{"command": "echo hello"},
+		Decision:  EventDecision{Action: "allow", EvalTimeUS: 7},
+		PrevHash:  "",
+	}
+
+	forHash := legacy
+	forHash.Hash = ""
+	data, err := json.Marshal(forHash)
+	require.NoError(t, err)
+
+	sum := sha256.Sum256(append([]byte(legacy.PrevHash), data...))
+	legacy.Hash = "sha256:" + hex.EncodeToString(sum[:])
+
+	line, err := json.Marshal(legacy)
+	require.NoError(t, err)
+
+	var parsed Event
+	require.NoError(t, json.Unmarshal(line, &parsed))
+	require.Empty(t, parsed.SchemaVersion)
+	require.Nil(t, parsed.Host)
+
+	ok, err := parsed.VerifyHash()
+	require.NoError(t, err)
+	require.True(t, ok)
+}

--- a/internal/audit/jsonl.go
+++ b/internal/audit/jsonl.go
@@ -190,12 +190,7 @@ func (s *JSONLSink) Write(event Event) error {
 	if s.closed {
 		return fmt.Errorf("audit: write on closed sink")
 	}
-	if event.ID == "" {
-		event.ID = NewEventID()
-	}
-	if event.Timestamp.IsZero() {
-		event.Timestamp = time.Now().UTC()
-	}
+	event = applyEventDefaults(event)
 
 	event.PrevHash = s.lastHash
 	if err := event.ComputeHash(); err != nil {

--- a/internal/audit/jsonl_test.go
+++ b/internal/audit/jsonl_test.go
@@ -18,9 +18,9 @@ import (
 	"encoding/json"
 	"io"
 	"log/slog"
-	"sort"
 	"os"
 	"path/filepath"
+	"sort"
 	"sync"
 	"testing"
 	"time"
@@ -61,6 +61,69 @@ func TestJSONLSinkWrite_ValidJSONLine(t *testing.T) {
 			assert.Equal(t, "exec", parsed.Tool)
 		})
 	}
+}
+
+func TestJSONLSinkWrite_AppliesDefaults(t *testing.T) {
+	dir := t.TempDir()
+	sink, err := NewJSONLSink(dir, WithFsync(false))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sink.Close() })
+
+	event := sampleEvent("exec")
+	event.ID = ""
+	event.Timestamp = time.Time{}
+	event.SchemaVersion = ""
+	event.Host = nil
+
+	require.NoError(t, sink.Write(event))
+
+	lines := readJSONLLines(t, sink.filePath())
+	require.Len(t, lines, 1)
+
+	var parsed Event
+	require.NoError(t, json.Unmarshal([]byte(lines[0]), &parsed))
+	assert.NotEmpty(t, parsed.ID)
+	assert.False(t, parsed.Timestamp.IsZero())
+	assert.Equal(t, EventSchemaVersion, parsed.SchemaVersion)
+	require.NotNil(t, parsed.Host)
+	assert.NotEmpty(t, parsed.Host.Hostname)
+	assert.NotEmpty(t, parsed.Host.OS)
+	assert.NotEmpty(t, parsed.Host.Arch)
+}
+
+func TestJSONLSinkWrite_HashCoversDefaultedFields(t *testing.T) {
+	dir := t.TempDir()
+	sink, err := NewJSONLSink(dir, WithFsync(false))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sink.Close() })
+
+	event := sampleEvent("exec")
+	event.ID = ""
+	event.Timestamp = time.Time{}
+	event.SchemaVersion = ""
+	event.Host = nil
+	require.NoError(t, sink.Write(event))
+
+	lines := readJSONLLines(t, sink.filePath())
+	require.Len(t, lines, 1)
+
+	var parsed Event
+	require.NoError(t, json.Unmarshal([]byte(lines[0]), &parsed))
+
+	mutated := parsed
+	mutated.SchemaVersion = "rampart.audit.v2"
+	ok, verifyErr := mutated.VerifyHash()
+	require.NoError(t, verifyErr)
+	assert.False(t, ok)
+
+	mutated = parsed
+	require.NotNil(t, mutated.Host)
+	mutatedHost := *mutated.Host
+	mutatedHost.Hostname = "tampered-host"
+	mutated.Host = &mutatedHost
+	ok, verifyErr = mutated.VerifyHash()
+	require.NoError(t, verifyErr)
+	assert.False(t, ok)
 }
 
 func TestJSONLSinkWrite_HashChainValid(t *testing.T) {

--- a/internal/audit/reader_test.go
+++ b/internal/audit/reader_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package audit
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadEventsFromOffset_BackwardCompatibleMissingFields(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "legacy.jsonl")
+	line := `{"id":"01JTEST000000000000000000","timestamp":"2026-02-12T00:00:00Z","agent":"agent-1","session":"session-1","tool":"exec","request":{"command":"echo hello"},"decision":{"action":"allow","evaluation_time_us":10},"prev_hash":"","hash":"sha256:abc"}` + "\n"
+	require.NoError(t, os.WriteFile(path, []byte(line), 0o600))
+
+	events, _, err := ReadEventsFromOffset(path, 0)
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+
+	require.Empty(t, events[0].SchemaVersion)
+	require.Nil(t, events[0].Host)
+}

--- a/internal/audit/rotate.go
+++ b/internal/audit/rotate.go
@@ -25,7 +25,7 @@ import (
 const anchorFilename = "audit-anchor.json"
 
 func (s *JSONLSink) shouldRotateLocked(incoming int) bool {
-	if s.rotateSize <= 0 {
+	if s.rotateSize <= 0 || s.currentSize == 0 {
 		return false
 	}
 	return s.currentSize+int64(incoming) > s.rotateSize

--- a/internal/audit/syslog_test.go
+++ b/internal/audit/syslog_test.go
@@ -144,6 +144,63 @@ func TestMultiSink_FanOut(t *testing.T) {
 	}
 }
 
+func TestMultiSink_FanOutUsesDefaultedEvent(t *testing.T) {
+	var primaryEvents []Event
+	primary := &mockSink{writeFn: func(e Event) error {
+		primaryEvents = append(primaryEvents, e)
+		return nil
+	}}
+	syslogSink := &mockSyslogSender{}
+
+	ms := NewMultiSink(primary, syslogSink, nil, nil)
+	e := Event{
+		Agent:   "test-agent",
+		Session: "sess-1",
+		Tool:    "exec",
+		Request: map[string]any{"command": "echo hello"},
+		Decision: EventDecision{
+			Action:     "allow",
+			EvalTimeUS: 42,
+		},
+	}
+
+	if err := ms.Write(e); err != nil {
+		t.Fatal(err)
+	}
+	if err := ms.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(primaryEvents) != 1 {
+		t.Fatalf("expected 1 primary write, got %d", len(primaryEvents))
+	}
+	if len(syslogSink.events) != 1 {
+		t.Fatalf("expected 1 secondary write, got %d", len(syslogSink.events))
+	}
+
+	primaryEvent := primaryEvents[0]
+	secondaryEvent := syslogSink.events[0]
+
+	if primaryEvent.SchemaVersion != EventSchemaVersion {
+		t.Fatalf("primary schema_version=%q, want %q", primaryEvent.SchemaVersion, EventSchemaVersion)
+	}
+	if secondaryEvent.SchemaVersion != EventSchemaVersion {
+		t.Fatalf("secondary schema_version=%q, want %q", secondaryEvent.SchemaVersion, EventSchemaVersion)
+	}
+	if primaryEvent.ID == "" || secondaryEvent.ID == "" {
+		t.Fatalf("expected defaulted id in both sinks")
+	}
+	if primaryEvent.Timestamp.IsZero() || secondaryEvent.Timestamp.IsZero() {
+		t.Fatalf("expected defaulted timestamp in both sinks")
+	}
+	if secondaryEvent.Host == nil {
+		t.Fatalf("expected defaulted host context in secondary sink")
+	}
+	if secondaryEvent.Host.Hostname == "" || secondaryEvent.Host.OS == "" || secondaryEvent.Host.Arch == "" {
+		t.Fatalf("expected defaulted host context in secondary sink: %+v", *secondaryEvent.Host)
+	}
+}
+
 func TestCEFFileSink_Write(t *testing.T) {
 	dir := t.TempDir()
 	path := dir + "/cef.log"
@@ -170,6 +227,16 @@ type mockSink struct {
 func (m *mockSink) Write(e Event) error { return m.writeFn(e) }
 func (m *mockSink) Flush() error        { return nil }
 func (m *mockSink) Close() error        { return nil }
+
+type mockSyslogSender struct {
+	events []Event
+}
+
+func (m *mockSyslogSender) Send(e Event) {
+	m.events = append(m.events, e)
+}
+
+func (m *mockSyslogSender) Close() error { return nil }
 
 func readFileBytes(path string) ([]byte, error) {
 	return os.ReadFile(path)


### PR DESCRIPTION
## Summary
- add `rampart.audit.v1` audit event schema version defaults
- add local non-sensitive host context to newly written audit events
- add `rampart.status.v1` output via `rampart status --json`
- document the new status JSON flag

## Testing
- `go test ./internal/audit ./cmd/rampart/cli -count=1`
- `go test ./... -count=1`
- `go vet ./...`
- `make build`
- `./rampart status --json | python3 -m json.tool`
