### PR TITLE
feat: harden doctor json contract

### DIFF
--- a/cmd/rampart/cli/doctor.go
+++ b/cmd/rampart/cli/doctor.go
@@ -49,6 +49,33 @@ type checkResult struct {
 	Hint    string `json:"hint,omitempty"` // actionable suggestion on failure/warn
 }
 
+const doctorJSONSchemaVersion = "rampart.doctor.v1"
+
+// doctorSummary carries stable machine-readable counts for doctor checks.
+type doctorSummary struct {
+	Checks   int `json:"checks"`
+	OK       int `json:"ok"`
+	Info     int `json:"info"`
+	Warnings int `json:"warnings"`
+	Issues   int `json:"issues"`
+}
+
+// doctorJSONReport is the machine-readable contract for `rampart doctor --json`.
+type doctorJSONReport struct {
+	SchemaVersion string        `json:"schema_version"`
+	GeneratedAt   string        `json:"generated_at"`
+	BuildVersion  string        `json:"build_version"`
+	Summary       doctorSummary `json:"summary"`
+	Checks        []checkResult `json:"checks"`
+
+	// warnings and issues preserve the pre-v1 JSON count fields.
+	Warnings int `json:"warnings"`
+	Issues   int `json:"issues"`
+
+	WarningChecks []checkResult `json:"warning_checks"`
+	IssueChecks   []checkResult `json:"issue_checks"`
+}
+
 // hintSep is the separator embedded in doctor messages to carry a hint.
 // Format: "<msg>\n" + hintSep + "<hint>"
 const hintSep = "\n  💡 "
@@ -306,26 +333,13 @@ func runDoctor(w io.Writer, jsonOut bool) error {
 	}
 
 	if collect {
-		// JSON output
-		issueCount := 0
-		warnCount := 0
-		for _, r := range results {
-			switch r.Status {
-			case "fail":
-				issueCount++
-			case "warn":
-				warnCount++
-			}
-		}
-		out := map[string]any{
-			"checks":   results,
-			"issues":   issueCount,
-			"warnings": warnCount,
-		}
+		out := buildDoctorJSONReport(results, time.Now())
 		enc := json.NewEncoder(w)
 		enc.SetIndent("", "  ")
-		_ = enc.Encode(out)
-		if issueCount > 0 {
+		if err := enc.Encode(out); err != nil {
+			return fmt.Errorf("doctor: encode json output: %w", err)
+		}
+		if out.Summary.Issues > 0 {
 			return exitCodeError{code: 1}
 		}
 		return nil
@@ -353,6 +367,41 @@ func runDoctor(w io.Writer, jsonOut bool) error {
 		return exitCodeError{code: 1}
 	}
 	return nil
+}
+
+func buildDoctorJSONReport(results []checkResult, generatedAt time.Time) doctorJSONReport {
+	report := doctorJSONReport{
+		SchemaVersion: doctorJSONSchemaVersion,
+		GeneratedAt:   generatedAt.UTC().Format(time.RFC3339),
+		BuildVersion:  build.Version,
+		Checks:        make([]checkResult, 0, len(results)),
+		WarningChecks: make([]checkResult, 0),
+		IssueChecks:   make([]checkResult, 0),
+	}
+
+	for _, result := range results {
+		report.Checks = append(report.Checks, result)
+		report.Summary.Checks++
+
+		switch result.Status {
+		case "ok":
+			report.Summary.OK++
+		case "warn":
+			report.Summary.Warnings++
+			report.WarningChecks = append(report.WarningChecks, result)
+		case "fail":
+			report.Summary.Issues++
+			report.IssueChecks = append(report.IssueChecks, result)
+		default:
+			// WHY: Unrecognized statuses should still be counted but must not
+			// affect issue/warning tallies used for exit behavior.
+			report.Summary.Info++
+		}
+	}
+
+	report.Warnings = report.Summary.Warnings
+	report.Issues = report.Summary.Issues
+	return report
 }
 
 // printDoctorSummary prints an encouraging all-clear summary with next steps.

--- a/cmd/rampart/cli/doctor_test.go
+++ b/cmd/rampart/cli/doctor_test.go
@@ -92,7 +92,7 @@ func TestCountClaudeHookMatchers(t *testing.T) {
 	}
 }
 
-func TestRunDoctor_JSON(t *testing.T) {
+func TestRunDoctor_JSONContract(t *testing.T) {
 	var buf bytes.Buffer
 	err := runDoctor(&buf, true)
 	// May return exitCodeError if issues found — that's expected in test env.
@@ -102,15 +102,55 @@ func TestRunDoctor_JSON(t *testing.T) {
 			t.Fatalf("unexpected error type: %v", err)
 		}
 	}
-	var result map[string]any
-	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+
+	var report doctorJSONReport
+	if err := json.Unmarshal(buf.Bytes(), &report); err != nil {
 		t.Fatalf("JSON output invalid: %v\noutput: %s", err, buf.String())
 	}
-	if _, ok := result["checks"]; !ok {
-		t.Error("JSON output missing 'checks' field")
+	if report.SchemaVersion != doctorJSONSchemaVersion {
+		t.Fatalf("schema_version = %q, want %q", report.SchemaVersion, doctorJSONSchemaVersion)
 	}
-	if _, ok := result["issues"]; !ok {
-		t.Error("JSON output missing 'issues' field")
+	if report.BuildVersion != build.Version {
+		t.Fatalf("build_version = %q, want %q", report.BuildVersion, build.Version)
+	}
+	if _, err := time.Parse(time.RFC3339, report.GeneratedAt); err != nil {
+		t.Fatalf("generated_at is not RFC3339: %q (%v)", report.GeneratedAt, err)
+	}
+	if len(report.Checks) == 0 {
+		t.Fatal("expected at least one doctor check in JSON output")
+	}
+	if report.WarningChecks == nil {
+		t.Fatal("warning_checks must be an array, got nil")
+	}
+	if report.IssueChecks == nil {
+		t.Fatal("issue_checks must be an array, got nil")
+	}
+	if report.Summary.Checks != len(report.Checks) {
+		t.Fatalf("summary.checks = %d, want %d", report.Summary.Checks, len(report.Checks))
+	}
+	if report.Summary.Warnings != len(report.WarningChecks) {
+		t.Fatalf("summary.warnings = %d, want %d", report.Summary.Warnings, len(report.WarningChecks))
+	}
+	if report.Summary.Issues != len(report.IssueChecks) {
+		t.Fatalf("summary.issues = %d, want %d", report.Summary.Issues, len(report.IssueChecks))
+	}
+	if report.Warnings != len(report.WarningChecks) {
+		t.Fatalf("warnings = %d, want %d", report.Warnings, len(report.WarningChecks))
+	}
+	if report.Issues != len(report.IssueChecks) {
+		t.Fatalf("issues = %d, want %d", report.Issues, len(report.IssueChecks))
+	}
+
+	for i, check := range report.Checks {
+		if check.Name == "" {
+			t.Fatalf("checks[%d].name is empty", i)
+		}
+		if check.Status == "" {
+			t.Fatalf("checks[%d].status is empty", i)
+		}
+		if check.Message == "" {
+			t.Fatalf("checks[%d].message is empty", i)
+		}
 	}
 }
 
@@ -132,6 +172,117 @@ func TestRunDoctor_ExitCode(t *testing.T) {
 		if exitErr.code != 1 {
 			t.Errorf("expected exit code 1, got %d", exitErr.code)
 		}
+	}
+}
+
+func TestRunDoctor_DefaultOutputIsHumanReadable(t *testing.T) {
+	var buf bytes.Buffer
+	err := runDoctor(&buf, false)
+	if err != nil {
+		var exitErr exitCodeError
+		if !errors.As(err, &exitErr) {
+			t.Fatalf("expected exitCodeError, got %T %v", err, err)
+		}
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "🩺 Rampart Doctor") {
+		t.Fatal("missing doctor header in default output")
+	}
+
+	var asJSON map[string]any
+	if json.Unmarshal(buf.Bytes(), &asJSON) == nil {
+		t.Fatalf("expected human-readable default output, got valid JSON: %s", out)
+	}
+}
+
+func TestBuildDoctorJSONReport(t *testing.T) {
+	generatedAt := time.Date(2026, time.May, 11, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name         string
+		results      []checkResult
+		wantSummary  doctorSummary
+		wantWarnings int
+		wantIssues   int
+	}{
+		{
+			name: "ok and info only",
+			results: []checkResult{
+				{Name: "Version", Status: "ok", Message: "v1"},
+				{Name: "Policy suggestions", Status: "info", Message: "none"},
+			},
+			wantSummary:  doctorSummary{Checks: 2, OK: 1, Info: 1, Warnings: 0, Issues: 0},
+			wantWarnings: 0,
+			wantIssues:   0,
+		},
+		{
+			name: "warn and fail included in dedicated arrays",
+			results: []checkResult{
+				{Name: "PATH", Status: "warn", Message: "warn"},
+				{Name: "Token", Status: "fail", Message: "fail"},
+				{Name: "System", Status: "ok", Message: "ok"},
+			},
+			wantSummary:  doctorSummary{Checks: 3, OK: 1, Info: 0, Warnings: 1, Issues: 1},
+			wantWarnings: 1,
+			wantIssues:   1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			report := buildDoctorJSONReport(tt.results, generatedAt)
+			if report.SchemaVersion != doctorJSONSchemaVersion {
+				t.Fatalf("schema_version = %q, want %q", report.SchemaVersion, doctorJSONSchemaVersion)
+			}
+			if report.GeneratedAt != generatedAt.Format(time.RFC3339) {
+				t.Fatalf("generated_at = %q, want %q", report.GeneratedAt, generatedAt.Format(time.RFC3339))
+			}
+			if report.BuildVersion != build.Version {
+				t.Fatalf("build_version = %q, want %q", report.BuildVersion, build.Version)
+			}
+			if report.Summary != tt.wantSummary {
+				t.Fatalf("summary = %+v, want %+v", report.Summary, tt.wantSummary)
+			}
+			if len(report.WarningChecks) != tt.wantWarnings {
+				t.Fatalf("len(warning_checks) = %d, want %d", len(report.WarningChecks), tt.wantWarnings)
+			}
+			if len(report.IssueChecks) != tt.wantIssues {
+				t.Fatalf("len(issue_checks) = %d, want %d", len(report.IssueChecks), tt.wantIssues)
+			}
+			if report.WarningChecks == nil {
+				t.Fatal("warning_checks must always encode as an array")
+			}
+			if report.IssueChecks == nil {
+				t.Fatal("issue_checks must always encode as an array")
+			}
+			if report.Warnings != tt.wantSummary.Warnings {
+				t.Fatalf("warnings = %d, want %d", report.Warnings, tt.wantSummary.Warnings)
+			}
+			if report.Issues != tt.wantSummary.Issues {
+				t.Fatalf("issues = %d, want %d", report.Issues, tt.wantSummary.Issues)
+			}
+
+			encoded, err := json.Marshal(report)
+			if err != nil {
+				t.Fatalf("marshal report: %v", err)
+			}
+			var raw map[string]any
+			if err := json.Unmarshal(encoded, &raw); err != nil {
+				t.Fatalf("unmarshal report: %v", err)
+			}
+			if _, ok := raw["warnings"].(float64); !ok {
+				t.Fatalf("warnings should preserve numeric count, got %T", raw["warnings"])
+			}
+			if _, ok := raw["issues"].(float64); !ok {
+				t.Fatalf("issues should preserve numeric count, got %T", raw["issues"])
+			}
+			if _, ok := raw["warning_checks"].([]any); !ok {
+				t.Fatalf("warning_checks should encode as JSON array, got %T", raw["warning_checks"])
+			}
+			if _, ok := raw["issue_checks"].([]any); !ok {
+				t.Fatalf("issue_checks should encode as JSON array, got %T", raw["issue_checks"])
+			}
+		})
 	}
 }
 

--- a/docs-site/reference/cli-commands.md
+++ b/docs-site/reference/cli-commands.md
@@ -245,6 +245,9 @@ Health check — verifies installation, policies, server, hooks, audit trail, an
 rampart doctor
 ```
 
+For automation, `rampart doctor --json` emits schema `rampart.doctor.v1` with top-level fields:
+`schema_version`, `generated_at`, `build_version`, `summary`, `checks`, numeric `warnings`/`issues`, and `warning_checks`/`issue_checks` arrays.
+
 When the OpenClaw native plugin is installed, doctor shows:
 ```
 ✓ OpenClaw plugin: installed (before_tool_call hook active)


### PR DESCRIPTION
## Summary
- harden `rampart doctor --json` behind an explicit `rampart.doctor.v1` schema contract
- add generated/build metadata plus normalized summary/check result fields
- preserve compatibility with existing numeric `warnings` and `issues`, while exposing detailed `warning_checks` / `issue_checks`
- document the stable JSON contract in the CLI reference

## Validation
- `go test ./... -count=1`
- `go vet ./...`
- `make build`
- `git diff --check`
