### PR TITLE
feat: add inventory json command

### DIFF
--- a/cmd/rampart/cli/inventory.go
+++ b/cmd/rampart/cli/inventory.go
@@ -1,0 +1,488 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/peg/rampart/internal/audit"
+	"github.com/peg/rampart/internal/build"
+	"github.com/peg/rampart/internal/engine"
+	"github.com/spf13/cobra"
+)
+
+const inventorySchemaVersion = "rampart.inventory.v1"
+
+type inventorySnapshot struct {
+	SchemaVersion   string                   `json:"schema_version"`
+	GeneratedAt     string                   `json:"generated_at"`
+	BuildVersion    string                   `json:"build_version"`
+	ProtectedAgents []string                 `json:"protected_agents"`
+	PolicyInventory inventoryPolicyInventory `json:"policy_inventory"`
+	AuditInventory  inventoryAuditInventory  `json:"audit_inventory"`
+	Runtime         inventoryRuntime         `json:"runtime"`
+}
+
+type inventoryPolicyInventory struct {
+	Files        []inventoryPolicyFile `json:"files"`
+	LoadedCount  int                   `json:"loaded_count"`
+	InvalidCount int                   `json:"invalid_count"`
+}
+
+type inventoryPolicyFile struct {
+	FileName      string `json:"file_name"`
+	Path          string `json:"path"`
+	Valid         bool   `json:"valid"`
+	LoadStatus    string `json:"load_status"`
+	DefaultAction string `json:"default_action,omitempty"`
+	PolicyCount   int    `json:"policy_count"`
+	Error         string `json:"error,omitempty"`
+}
+
+type inventoryAuditInventory struct {
+	Directory          string                   `json:"directory"`
+	DirectoryAvailable bool                     `json:"directory_available"`
+	LogFileCount       int                      `json:"log_file_count"`
+	LogFileBytes       int64                    `json:"log_file_bytes"`
+	TodayEvents        inventoryAuditEventCount `json:"today_events"`
+	Error              string                   `json:"error,omitempty"`
+}
+
+type inventoryAuditEventCount struct {
+	Allow   int `json:"allow"`
+	Deny    int `json:"deny"`
+	Watch   int `json:"watch"`
+	Pending int `json:"pending"`
+	Total   int `json:"total"`
+}
+
+type inventoryRuntime struct {
+	Server inventoryServer `json:"server"`
+}
+
+type inventoryServer struct {
+	Reachable bool `json:"reachable"`
+}
+
+func newInventoryCmd(opts *rootOptions) *cobra.Command {
+	var jsonOut bool
+
+	cmd := &cobra.Command{
+		Use:   "inventory",
+		Short: "Show local Rampart inventory",
+		Long: `Collect a local-only inventory snapshot of Rampart state.
+
+Includes protected agents, policy file load status, audit footprint, and
+whether local rampart serve appears reachable.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			snapshot := collectInventorySnapshot(opts.configPath)
+			if jsonOut {
+				return writeInventoryJSON(cmd.OutOrStdout(), snapshot)
+			}
+			return writeInventoryHuman(cmd.OutOrStdout(), snapshot)
+		},
+	}
+
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output inventory as JSON")
+	return cmd
+}
+
+func collectInventorySnapshot(configPath string) inventorySnapshot {
+	protectedAgents := detectProtectedAgents()
+	sort.Strings(protectedAgents)
+
+	version := strings.TrimSpace(build.Version)
+	if version == "" {
+		version = "dev"
+	}
+
+	return inventorySnapshot{
+		SchemaVersion:   inventorySchemaVersion,
+		GeneratedAt:     time.Now().UTC().Format(time.RFC3339),
+		BuildVersion:    version,
+		ProtectedAgents: protectedAgents,
+		PolicyInventory: collectPolicyInventory(configPath),
+		AuditInventory:  collectAuditInventory(),
+		Runtime: inventoryRuntime{
+			Server: inventoryServer{Reachable: detectLocalServeReachable()},
+		},
+	}
+}
+
+func collectPolicyInventory(configPath string) inventoryPolicyInventory {
+	paths := collectPolicyPaths(configPath)
+	files := make([]inventoryPolicyFile, 0, len(paths))
+	loadedCount := 0
+	invalidCount := 0
+
+	for _, path := range paths {
+		fileInv := inspectPolicyFile(path)
+		if fileInv.Valid {
+			loadedCount++
+		} else if fileInv.LoadStatus == "invalid" || fileInv.LoadStatus == "unreadable" {
+			invalidCount++
+		}
+		files = append(files, fileInv)
+	}
+
+	return inventoryPolicyInventory{
+		Files:        files,
+		LoadedCount:  loadedCount,
+		InvalidCount: invalidCount,
+	}
+}
+
+func collectPolicyPaths(configPath string) []string {
+	set := map[string]struct{}{}
+	addPath := func(path string) {
+		trimmed := strings.TrimSpace(path)
+		if trimmed == "" {
+			return
+		}
+		abs, err := filepath.Abs(trimmed)
+		if err != nil {
+			set[filepath.Clean(trimmed)] = struct{}{}
+			return
+		}
+		set[abs] = struct{}{}
+	}
+
+	addPath(configPath)
+
+	policyDir, err := policyInventoryDir()
+	if err == nil {
+		entries, readErr := os.ReadDir(policyDir)
+		if readErr == nil {
+			for _, entry := range entries {
+				if entry.IsDir() || !isPolicyYAMLFile(entry.Name()) {
+					continue
+				}
+				addPath(filepath.Join(policyDir, entry.Name()))
+			}
+		}
+	}
+
+	paths := make([]string, 0, len(set))
+	for path := range set {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+func policyInventoryDir() (string, error) {
+	dir, err := rampartDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "policies"), nil
+}
+
+func inspectPolicyFile(path string) inventoryPolicyFile {
+	entry := inventoryPolicyFile{
+		FileName:   filepath.Base(path),
+		Path:       inventoryDisplayPath(path),
+		LoadStatus: "missing",
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			entry.Error = "file not found"
+			return entry
+		}
+		entry.LoadStatus = "unreadable"
+		entry.Error = sanitizeInventoryError(err)
+		return entry
+	}
+
+	if info.IsDir() {
+		entry.LoadStatus = "invalid"
+		entry.Error = "path is a directory"
+		return entry
+	}
+
+	cfg, err := engine.NewFileStore(path).Load()
+	if err != nil {
+		entry.LoadStatus = "invalid"
+		entry.Error = sanitizeInventoryError(err)
+		return entry
+	}
+
+	entry.Valid = true
+	entry.LoadStatus = "loaded"
+	entry.PolicyCount = len(cfg.Policies)
+	if strings.TrimSpace(cfg.DefaultAction) == "" {
+		entry.DefaultAction = "deny"
+	} else {
+		entry.DefaultAction = strings.ToLower(strings.TrimSpace(cfg.DefaultAction))
+	}
+	return entry
+}
+
+func collectAuditInventory() inventoryAuditInventory {
+	dir, err := rampartDir()
+	if err != nil {
+		return inventoryAuditInventory{
+			Directory: filepath.ToSlash(filepath.Join("~", ".rampart", "audit")),
+			Error:     sanitizeInventoryError(err),
+		}
+	}
+
+	auditDir := filepath.Join(dir, "audit")
+	inv := inventoryAuditInventory{Directory: inventoryDisplayPath(auditDir)}
+
+	entries, err := os.ReadDir(auditDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return inv
+		}
+		inv.Error = sanitizeInventoryError(err)
+		return inv
+	}
+
+	inv.DirectoryAvailable = true
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".jsonl") {
+			continue
+		}
+		info, infoErr := entry.Info()
+		if infoErr != nil {
+			continue
+		}
+		inv.LogFileCount++
+		inv.LogFileBytes += info.Size()
+	}
+
+	inv.TodayEvents = collectTodayAuditCounts(auditDir)
+	return inv
+}
+
+func collectTodayAuditCounts(auditDir string) inventoryAuditEventCount {
+	today := time.Now().UTC().Format("2006-01-02")
+	entries, err := os.ReadDir(auditDir)
+	if err != nil {
+		return inventoryAuditEventCount{}
+	}
+
+	candidates := make([]string, 0)
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".jsonl") || !strings.Contains(name, today) {
+			continue
+		}
+		candidates = append(candidates, filepath.Join(auditDir, name))
+	}
+	sort.Strings(candidates)
+
+	counts := inventoryAuditEventCount{}
+	for _, path := range candidates {
+		events, _, readErr := audit.ReadEventsFromOffset(path, 0)
+		if readErr != nil {
+			continue
+		}
+		for _, event := range events {
+			switch strings.ToLower(strings.TrimSpace(event.Decision.Action)) {
+			case "allow":
+				counts.Allow++
+			case "deny":
+				counts.Deny++
+			case "watch", "log":
+				counts.Watch++
+			case "ask", "require_approval", "webhook":
+				counts.Pending++
+			}
+		}
+	}
+	counts.Total = counts.Allow + counts.Deny + counts.Watch + counts.Pending
+	return counts
+}
+
+func detectLocalServeReachable() bool {
+	for _, serveURL := range localServeCandidates() {
+		if isServeRunning(serveURL) {
+			return true
+		}
+	}
+	return false
+}
+
+func localServeCandidates() []string {
+	candidates := make([]string, 0, 8)
+	seen := map[string]struct{}{}
+	add := func(raw string) {
+		trimmed := strings.TrimSpace(raw)
+		if trimmed == "" || !isLoopbackURL(trimmed) {
+			return
+		}
+		trimmed = strings.TrimRight(trimmed, "/")
+		if _, ok := seen[trimmed]; ok {
+			return
+		}
+		seen[trimmed] = struct{}{}
+		candidates = append(candidates, trimmed)
+	}
+
+	// Only probe local loopback endpoints to keep inventory strictly local-only.
+	if cfg, err := loadUserConfig(); err == nil {
+		add(cfg.URL)
+		add(cfg.ServeURL)
+	}
+
+	if dir, err := rampartDir(); err == nil {
+		statePath := filepath.Join(dir, serveStateFile)
+		if data, readErr := os.ReadFile(statePath); readErr == nil {
+			var state serveState
+			if json.Unmarshal(data, &state) == nil {
+				add(state.URL)
+			}
+		}
+	}
+
+	for _, port := range []int{defaultServePort, 9091, 8090} {
+		add(fmt.Sprintf("http://localhost:%d", port))
+		add(fmt.Sprintf("http://127.0.0.1:%d", port))
+	}
+
+	return candidates
+}
+
+func isLoopbackURL(raw string) bool {
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Host == "" {
+		return false
+	}
+	host := parsed.Hostname()
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+func writeInventoryJSON(w io.Writer, snapshot inventorySnapshot) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(snapshot); err != nil {
+		return fmt.Errorf("inventory: write JSON output: %w", err)
+	}
+	return nil
+}
+
+func writeInventoryHuman(w io.Writer, snapshot inventorySnapshot) error {
+	if _, err := fmt.Fprintf(w, "Rampart inventory (%s)\n", snapshot.GeneratedAt); err != nil {
+		return fmt.Errorf("inventory: write output: %w", err)
+	}
+	if _, err := fmt.Fprintf(w, "Build: %s\n", snapshot.BuildVersion); err != nil {
+		return fmt.Errorf("inventory: write output: %w", err)
+	}
+	if _, err := fmt.Fprintf(w, "Protected agents: %d\n", len(snapshot.ProtectedAgents)); err != nil {
+		return fmt.Errorf("inventory: write output: %w", err)
+	}
+	if _, err := fmt.Fprintf(
+		w,
+		"Policy files: %d (loaded: %d, invalid: %d)\n",
+		len(snapshot.PolicyInventory.Files),
+		snapshot.PolicyInventory.LoadedCount,
+		snapshot.PolicyInventory.InvalidCount,
+	); err != nil {
+		return fmt.Errorf("inventory: write output: %w", err)
+	}
+
+	auditState := "unavailable"
+	if snapshot.AuditInventory.DirectoryAvailable {
+		auditState = "available"
+	}
+	if _, err := fmt.Fprintf(
+		w,
+		"Audit logs: %s (%d files, %d bytes) today=%d/%d/%d/%d\n",
+		auditState,
+		snapshot.AuditInventory.LogFileCount,
+		snapshot.AuditInventory.LogFileBytes,
+		snapshot.AuditInventory.TodayEvents.Allow,
+		snapshot.AuditInventory.TodayEvents.Deny,
+		snapshot.AuditInventory.TodayEvents.Watch,
+		snapshot.AuditInventory.TodayEvents.Pending,
+	); err != nil {
+		return fmt.Errorf("inventory: write output: %w", err)
+	}
+	if _, err := fmt.Fprintf(w, "Serve reachable: %t\n", snapshot.Runtime.Server.Reachable); err != nil {
+		return fmt.Errorf("inventory: write output: %w", err)
+	}
+	return nil
+}
+
+func inventoryDisplayPath(path string) string {
+	cleaned := filepath.Clean(path)
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return filepath.ToSlash(cleaned)
+	}
+
+	rampartRoot := filepath.Join(home, ".rampart")
+	if rel, ok := relativePathInside(rampartRoot, cleaned); ok {
+		if rel == "." {
+			return "~/.rampart"
+		}
+		return filepath.ToSlash(filepath.Join("~/.rampart", rel))
+	}
+	if rel, ok := relativePathInside(home, cleaned); ok {
+		if rel == "." {
+			return "~"
+		}
+		return filepath.ToSlash(filepath.Join("~", rel))
+	}
+	return filepath.ToSlash(cleaned)
+}
+
+func relativePathInside(base, target string) (string, bool) {
+	rel, err := filepath.Rel(base, target)
+	if err != nil {
+		return "", false
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", false
+	}
+	return rel, true
+}
+
+func sanitizeInventoryError(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := strings.Join(strings.Fields(strings.TrimSpace(err.Error())), " ")
+	home, homeErr := os.UserHomeDir()
+	if homeErr == nil && home != "" {
+		msg = strings.ReplaceAll(msg, home, "~")
+	}
+	if len(msg) > 160 {
+		msg = msg[:157] + "..."
+	}
+	return msg
+}
+
+func isPolicyYAMLFile(name string) bool {
+	ext := strings.ToLower(filepath.Ext(name))
+	return ext == ".yaml" || ext == ".yml"
+}

--- a/cmd/rampart/cli/inventory_test.go
+++ b/cmd/rampart/cli/inventory_test.go
@@ -1,0 +1,199 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/peg/rampart/internal/audit"
+)
+
+func TestInventoryJSONKeyFields(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+
+	configPath := filepath.Join(home, "rampart.yaml")
+	writeTestPolicyFile(t, configPath)
+
+	auditDir := filepath.Join(home, ".rampart", "audit")
+	writeTestAuditEvents(t, auditDir, []audit.Event{
+		{ID: "evt-1", Timestamp: time.Now().UTC(), Tool: "exec", Decision: audit.EventDecision{Action: "allow"}},
+		{ID: "evt-2", Timestamp: time.Now().UTC(), Tool: "exec", Decision: audit.EventDecision{Action: "deny"}},
+		{ID: "evt-3", Timestamp: time.Now().UTC(), Tool: "exec", Decision: audit.EventDecision{Action: "watch"}},
+		{ID: "evt-4", Timestamp: time.Now().UTC(), Tool: "exec", Decision: audit.EventDecision{Action: "ask"}},
+	})
+
+	stdout, _, err := runCLI(t, "--config", configPath, "inventory", "--json")
+	if err != nil {
+		t.Fatalf("inventory --json failed: %v", err)
+	}
+
+	var got inventorySnapshot
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("inventory --json output is not valid JSON: %v\nOutput:\n%s", err, stdout)
+	}
+
+	if got.SchemaVersion != inventorySchemaVersion {
+		t.Fatalf("schema_version = %q, want %q", got.SchemaVersion, inventorySchemaVersion)
+	}
+	if _, err := time.Parse(time.RFC3339, got.GeneratedAt); err != nil {
+		t.Fatalf("generated_at is not RFC3339: %q (%v)", got.GeneratedAt, err)
+	}
+	if strings.TrimSpace(got.BuildVersion) == "" {
+		t.Fatal("build_version is empty")
+	}
+
+	if len(got.PolicyInventory.Files) == 0 {
+		t.Fatal("expected at least one policy inventory entry")
+	}
+	policyEntry, found := findPolicyEntry(got.PolicyInventory.Files, filepath.Base(configPath))
+	if !found {
+		t.Fatalf("missing policy inventory entry for %s", filepath.Base(configPath))
+	}
+	if !policyEntry.Valid || policyEntry.LoadStatus != "loaded" {
+		t.Fatalf("expected loaded policy entry, got valid=%v status=%q", policyEntry.Valid, policyEntry.LoadStatus)
+	}
+	if policyEntry.DefaultAction != "deny" {
+		t.Fatalf("default_action = %q, want %q", policyEntry.DefaultAction, "deny")
+	}
+	if policyEntry.PolicyCount != 1 {
+		t.Fatalf("policy_count = %d, want 1", policyEntry.PolicyCount)
+	}
+	if strings.Contains(policyEntry.Path, home) {
+		t.Fatalf("policy path leaked full home path: %q", policyEntry.Path)
+	}
+
+	if !got.AuditInventory.DirectoryAvailable {
+		t.Fatal("expected audit directory to be available")
+	}
+	if got.AuditInventory.TodayEvents.Allow != 1 || got.AuditInventory.TodayEvents.Deny != 1 || got.AuditInventory.TodayEvents.Watch != 1 || got.AuditInventory.TodayEvents.Pending != 1 {
+		t.Fatalf("unexpected today event counts: %+v", got.AuditInventory.TodayEvents)
+	}
+	if got.AuditInventory.TodayEvents.Total != 4 {
+		t.Fatalf("today total = %d, want 4", got.AuditInventory.TodayEvents.Total)
+	}
+}
+
+func TestInventoryJSONPolicyInvalidHandling(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+
+	configPath := filepath.Join(home, "rampart.yaml")
+	writeTestPolicyFile(t, configPath)
+
+	policyDir := filepath.Join(home, ".rampart", "policies")
+	if err := os.MkdirAll(policyDir, 0o755); err != nil {
+		t.Fatalf("mkdir policy dir: %v", err)
+	}
+	invalidPath := filepath.Join(policyDir, "invalid.yaml")
+	if err := os.WriteFile(invalidPath, []byte("version: \"1\"\npolicies:\n  - name: broken\n    rules: [\n"), 0o644); err != nil {
+		t.Fatalf("write invalid policy: %v", err)
+	}
+
+	stdout, _, err := runCLI(t, "--config", configPath, "inventory", "--json")
+	if err != nil {
+		t.Fatalf("inventory --json failed: %v", err)
+	}
+
+	var got inventorySnapshot
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("inventory --json output is not valid JSON: %v\nOutput:\n%s", err, stdout)
+	}
+
+	invalidEntry, found := findPolicyEntry(got.PolicyInventory.Files, "invalid.yaml")
+	if !found {
+		t.Fatalf("missing inventory entry for invalid policy file: %+v", got.PolicyInventory.Files)
+	}
+	if invalidEntry.Valid {
+		t.Fatalf("invalid policy unexpectedly marked valid: %+v", invalidEntry)
+	}
+	if invalidEntry.LoadStatus != "invalid" {
+		t.Fatalf("load_status = %q, want %q", invalidEntry.LoadStatus, "invalid")
+	}
+	if strings.TrimSpace(invalidEntry.Error) == "" {
+		t.Fatal("expected invalid policy error message")
+	}
+	if invalidEntry.PolicyCount != 0 {
+		t.Fatalf("invalid policy_count = %d, want 0", invalidEntry.PolicyCount)
+	}
+	if strings.Contains(invalidEntry.Path, home) {
+		t.Fatalf("invalid policy path leaked full home path: %q", invalidEntry.Path)
+	}
+	if got.PolicyInventory.InvalidCount < 1 {
+		t.Fatalf("invalid_count = %d, want at least 1", got.PolicyInventory.InvalidCount)
+	}
+}
+
+func writeTestPolicyFile(t *testing.T, path string) {
+	t.Helper()
+	content := `version: "1"
+default_action: deny
+policies:
+  - name: test-allow
+    match:
+      tool: exec
+    rules:
+      - action: allow
+        when:
+          command_matches: ["echo *"]
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write test policy: %v", err)
+	}
+}
+
+func writeTestAuditEvents(t *testing.T, auditDir string, events []audit.Event) {
+	t.Helper()
+	if err := os.MkdirAll(auditDir, 0o755); err != nil {
+		t.Fatalf("mkdir audit dir: %v", err)
+	}
+
+	path := filepath.Join(auditDir, time.Now().UTC().Format("2006-01-02")+".jsonl")
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create audit file: %v", err)
+	}
+	defer file.Close()
+
+	for i, event := range events {
+		if event.ID == "" {
+			event.ID = fmt.Sprintf("evt-%d", i+1)
+		}
+		if event.Timestamp.IsZero() {
+			event.Timestamp = time.Now().UTC()
+		}
+		data, err := json.Marshal(event)
+		if err != nil {
+			t.Fatalf("marshal audit event: %v", err)
+		}
+		if _, err := file.Write(append(data, '\n')); err != nil {
+			t.Fatalf("write audit event: %v", err)
+		}
+	}
+}
+
+func findPolicyEntry(entries []inventoryPolicyFile, fileName string) (inventoryPolicyFile, bool) {
+	for _, entry := range entries {
+		if entry.FileName == fileName {
+			return entry, true
+		}
+	}
+	return inventoryPolicyFile{}, false
+}

--- a/cmd/rampart/cli/root.go
+++ b/cmd/rampart/cli/root.go
@@ -123,6 +123,7 @@ func NewRootCmd(ctx context.Context, outWriter, errWriter io.Writer) *cobra.Comm
 	setupCmd := newSetupCmd(opts)
 	doctorCmd := newDoctorCmd()
 	statusCmd := newStatusCmd()
+	inventoryCmd := newInventoryCmd(opts)
 	tokenCmd := newTokenShowCmd()
 	testCmd := newTestCmd(opts)
 	// benchCmd removed in v0.9 cleanup — use `go test -bench` instead
@@ -152,6 +153,7 @@ func NewRootCmd(ctx context.Context, outWriter, errWriter io.Writer) *cobra.Comm
 	serveCmd.GroupID = groupRuntime
 	tokenCmd.GroupID = groupRuntime
 	statusCmd.GroupID = groupRuntime
+	inventoryCmd.GroupID = groupRuntime
 	logCmd.GroupID = groupRuntime
 
 	approveCmd.GroupID = groupApprovals
@@ -190,6 +192,7 @@ func NewRootCmd(ctx context.Context, outWriter, errWriter io.Writer) *cobra.Comm
 	cmd.AddCommand(setupCmd)
 	cmd.AddCommand(doctorCmd)
 	cmd.AddCommand(statusCmd)
+	cmd.AddCommand(inventoryCmd)
 	cmd.AddCommand(tokenCmd)
 	cmd.AddCommand(testCmd)
 	// cmd.AddCommand(benchCmd)

--- a/docs-site/reference/cli-commands.md
+++ b/docs-site/reference/cli-commands.md
@@ -270,6 +270,17 @@ rampart status --json      # Machine-readable snapshot
 
 `--json` emits a stable status payload (`schema_version: "rampart.status.v1"`) with mode, protection state, server flags, today's counts, and optional last deny details.
 
+### `rampart inventory`
+
+Local observability snapshot for automation and debugging.
+
+Use `--json` for a stable machine-readable contract (`rampart.inventory.v1`) that includes protected agents, policy file load status, audit footprint, and local `rampart serve` reachability.
+
+```bash
+rampart inventory
+rampart inventory --json
+```
+
 ### `rampart test`
 
 Dry-run commands against your policies or run a declarative test suite.


### PR DESCRIPTION
## Summary
- add `rampart inventory` for local observability/debugging snapshots
- add `--json` output with schema `rampart.inventory.v1`
- include protected agents, policy file load status, audit footprint, and local `rampart serve` reachability
- document the new command in the CLI reference

## Validation
- `go test ./... -count=1`
- `go vet ./...`
- `make build`
- `git diff --check`
