### PR TITLE
fix: support OpenClaw gateway protocol v4

### DIFF
--- a/internal/bridge/openclaw.go
+++ b/internal/bridge/openclaw.go
@@ -50,6 +50,8 @@ import (
 	"github.com/peg/rampart/internal/engine"
 )
 
+const openClawGatewayProtocolVersion = 4
+
 // OpenClawBridge connects to the OpenClaw gateway and handles exec approval
 // routing through Rampart's policy engine.
 type OpenClawBridge struct {
@@ -264,8 +266,8 @@ func (b *OpenClawBridge) sendConnect(conn *websocket.Conn) error {
 		ID:     reqID,
 		Method: "connect",
 		Params: map[string]any{
-			"minProtocol": 3,
-			"maxProtocol": 3,
+			"minProtocol": openClawGatewayProtocolVersion,
+			"maxProtocol": openClawGatewayProtocolVersion,
 			"client": map[string]any{
 				"id":          "gateway-client",
 				"displayName": "Rampart Bridge",
@@ -309,6 +311,9 @@ func (b *OpenClawBridge) sendConnect(conn *websocket.Conn) error {
 	}
 	if resFrame.Type != "res" {
 		return fmt.Errorf("unexpected connect response type: %s", resFrame.Type)
+	}
+	if resFrame.OK != nil && !*resFrame.OK {
+		return fmt.Errorf("connect rejected: %s", string(resFrame.Error))
 	}
 
 	return nil
@@ -642,6 +647,7 @@ type gatewayFrame struct {
 	Event   string          `json:"event,omitempty"`
 	Payload json.RawMessage `json:"payload,omitempty"`
 	Result  json.RawMessage `json:"result,omitempty"`
+	OK      *bool           `json:"ok,omitempty"`
 	Error   json.RawMessage `json:"error,omitempty"`
 	Seq     int             `json:"seq,omitempty"`
 }

--- a/internal/bridge/openclaw_test.go
+++ b/internal/bridge/openclaw_test.go
@@ -86,6 +86,10 @@ func (mg *mockGateway) handleConnection(conn *websocket.Conn) {
 	}
 	var req gatewayRequest
 	json.Unmarshal(msg, &req)
+	params, ok := req.Params.(map[string]any)
+	assert.True(mg.t, ok)
+	assert.Equal(mg.t, float64(openClawGatewayProtocolVersion), params["minProtocol"])
+	assert.Equal(mg.t, float64(openClawGatewayProtocolVersion), params["maxProtocol"])
 
 	// Step 3: respond with hello-ok.
 	resp := map[string]any{

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -36,6 +36,8 @@ import (
 	"github.com/peg/rampart/internal/engine"
 )
 
+const openClawGatewayProtocolVersion = 4
+
 // Config holds the daemon configuration.
 type Config struct {
 	// GatewayURL is the OpenClaw Gateway WebSocket URL (e.g., ws://127.0.0.1:18789).
@@ -214,8 +216,8 @@ type wsMessage struct {
 
 // approvalRequest is the payload of an exec.approval.requested event.
 type approvalRequest struct {
-	ID      string                `json:"id"`
-	Request approvalRequestInner  `json:"request"`
+	ID      string               `json:"id"`
+	Request approvalRequestInner `json:"request"`
 }
 
 // approvalRequestInner contains the nested request fields from OpenClaw.
@@ -249,8 +251,8 @@ func (d *Daemon) handshake(ctx context.Context) error {
 		"id":     d.nextID(),
 		"method": "connect",
 		"params": map[string]any{
-			"minProtocol": 3,
-			"maxProtocol": 3,
+			"minProtocol": openClawGatewayProtocolVersion,
+			"maxProtocol": openClawGatewayProtocolVersion,
 			"client": map[string]any{
 				"id":       "gateway-client",
 				"version":  "0.1.0",

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -88,6 +88,10 @@ func (mg *mockGateway) handleConnection(conn *websocket.Conn) {
 
 	var connectReq map[string]any
 	json.Unmarshal(msg, &connectReq)
+	params, paramsOK := connectReq["params"].(map[string]any)
+	assert.True(mg.t, paramsOK)
+	assert.Equal(mg.t, float64(openClawGatewayProtocolVersion), params["minProtocol"])
+	assert.Equal(mg.t, float64(openClawGatewayProtocolVersion), params["maxProtocol"])
 	mg.received = append(mg.received, connectReq)
 
 	// Send hello-ok.
@@ -96,7 +100,7 @@ func (mg *mockGateway) handleConnection(conn *websocket.Conn) {
 		Type:    "res",
 		ID:      connectReq["id"].(string),
 		OK:      &ok,
-		Payload: json.RawMessage(`{"type":"hello-ok","protocol":3}`),
+		Payload: json.RawMessage(`{"type":"hello-ok","protocol":4}`),
 	}
 	data, _ := json.Marshal(hello)
 	conn.WriteMessage(websocket.TextMessage, data)


### PR DESCRIPTION
## Summary

- Update the OpenClaw bridge and daemon handshake to use gateway protocol v4.
- Treat unsuccessful bridge connect responses as rejected handshakes.
- Add bridge and daemon test coverage for the negotiated protocol fields.

## Tests

- `go test ./internal/bridge ./internal/daemon`
- `go test ./...`
