### PR TITLE
fix: normalize OpenClaw exec tool aliases

### DIFF
--- a/internal/plugin/openclaw/README.md
+++ b/internal/plugin/openclaw/README.md
@@ -14,6 +14,7 @@ From the repo root:
 node internal/plugin/openclaw/smoke-test.mjs
 node internal/plugin/openclaw/approval-regression.mjs
 node internal/plugin/openclaw/degraded-mode-test.mjs
+node internal/plugin/openclaw/tool-alias-test.mjs
 ```
 
 Default behavior simulates:
@@ -48,6 +49,7 @@ Arguments:
 - there is no legacy `params.ask = "always"` mutation path
 - degraded mode blocks sensitive tools (`exec`, `write`) when serve is unreachable or returns 5xx
 - configured fail-open tools (`read`, `web_fetch`, `web_search`, `image` by default) remain explicit and test-covered
+- command-execution aliases such as OpenClaw `bash` map to Rampart `exec` for policy checks, learning, and audit events
 
 This is a deterministic harness for the highest-leverage regression: approval-path behavior without depending on model tool selection.
 

--- a/internal/plugin/openclaw/index.js
+++ b/internal/plugin/openclaw/index.js
@@ -98,6 +98,53 @@ function truncateForApprovalDescription(text, max = 220) {
   return `${normalized.slice(0, Math.max(0, max - 1)).trimEnd()}…`;
 }
 
+// OpenClaw has exposed command execution through more than one tool name over
+// time. Rampart policy is intentionally written against the stable "exec"
+// class, so command-style aliases must be normalized before policy evaluation.
+// Otherwise a host exposing a tool as "bash" can bypass exec policies and land
+// in allow-unmatched/default handling.
+const EXEC_TOOL_ALIASES = new Set(["bash", "shell", "terminal"]);
+
+function normalizeExecParams(params) {
+  if (!params || typeof params !== "object") return {};
+  const normalized = { ...params };
+  const command =
+    params.command ??
+    params.input?.command ??
+    params.script ??
+    params.cmd ??
+    params.args?.command;
+  if (typeof command === "string" && !normalized.command) {
+    normalized.command = command;
+  }
+  return normalized;
+}
+
+function normalizeToolCall(toolName, params) {
+  const originalToolName = typeof toolName === "string" && toolName ? toolName : "unknown";
+  const canonical = originalToolName.toLowerCase();
+  if (EXEC_TOOL_ALIASES.has(canonical)) {
+    return {
+      toolName: "exec",
+      params: normalizeExecParams(params),
+      originalToolName,
+      mapped: true,
+    };
+  }
+  return {
+    toolName: originalToolName,
+    params: params ?? {},
+    originalToolName,
+    mapped: false,
+  };
+}
+
+function toolDisplayName(toolName, originalToolName) {
+  return originalToolName && originalToolName !== toolName
+    ? `${originalToolName}→${toolName}`
+    : toolName;
+}
+
 // ─── Rampart API client ───────────────────────────────────────────────────────
 
 /**
@@ -237,7 +284,12 @@ export function register(api) {
 
   // ── before_tool_call ────────────────────────────────────────────────────────
   api.on("before_tool_call", async (event, ctx) => {
-    const { toolName, params } = event;
+    const normalized = normalizeToolCall(event?.toolName, event?.params);
+    const { toolName, params, originalToolName, mapped } = normalized;
+    const displayToolName = toolDisplayName(toolName, originalToolName);
+    if (mapped) {
+      api.logger.info(`[rampart] mapped OpenClaw tool ${originalToolName} to Rampart ${toolName}`);
+    }
 
     const result = await checkWithRampart(toolName, params, ctx, pluginConfig);
 
@@ -248,7 +300,7 @@ export function register(api) {
         : ["read", "web_fetch", "web_search", "image"];
     const failOpenTools = new Set(configuredFailOpenTools);
     const shouldFailOpen = failOpenTools.has(toolName);
-    const unreachableReason = `[rampart] serve unavailable for ${toolName} at ${serveUrl}`;
+    const unreachableReason = `[rampart] serve unavailable for ${displayToolName} at ${serveUrl}`;
 
     // Serve unreachable → explicit degraded-state handling
     if (result?._unreachable) {
@@ -256,42 +308,42 @@ export function register(api) {
       if (shouldFailOpen) return;
       return {
         block: true,
-        blockReason: `rampart: unavailable (${toolName}) — policy service down, refusing sensitive tool call`,
+        blockReason: `rampart: unavailable (${displayToolName}) — policy service down, refusing sensitive tool call`,
       };
     }
 
     // null (timeout/unknown error) → explicit degraded-state handling
     if (result === null) {
-      api.logger.warn(`[rampart] check timed out or failed for ${toolName} (${shouldFailOpen ? "configured fail-open" : "blocking tool call"})`);
+      api.logger.warn(`[rampart] check timed out or failed for ${displayToolName} (${shouldFailOpen ? "configured fail-open" : "blocking tool call"})`);
       if (shouldFailOpen) return;
       return {
         block: true,
-        blockReason: `rampart: unavailable (${toolName}) — policy check timed out, refusing sensitive tool call`,
+        blockReason: `rampart: unavailable (${displayToolName}) — policy check timed out, refusing sensitive tool call`,
       };
     }
 
     // Serve returned an error status → explicit degraded-state handling
     if (result?._serveError) {
-      api.logger.warn(`[rampart] serve returned HTTP ${result._status} for ${toolName} (${shouldFailOpen ? "configured fail-open" : "blocking tool call"})`);
+      api.logger.warn(`[rampart] serve returned HTTP ${result._status} for ${displayToolName} (${shouldFailOpen ? "configured fail-open" : "blocking tool call"})`);
       if (shouldFailOpen) return;
       return {
         block: true,
-        blockReason: `rampart: unavailable (${toolName}) — policy service error ${result._status}, refusing sensitive tool call`,
+        blockReason: `rampart: unavailable (${displayToolName}) — policy service error ${result._status}, refusing sensitive tool call`,
       };
     }
 
     const decision = result.decision ?? (result.allowed === false ? "deny" : "allow");
 
     // Debug log every decision (not just blocks/approvals)
-    api.logger.debug(`[rampart] ${toolName} → ${decision}${result.policy ? ` (policy: ${result.policy})` : ""}`);
+    api.logger.debug(`[rampart] ${displayToolName} → ${decision}${result.policy ? ` (policy: ${result.policy})` : ""}`);
     if (Object.prototype.hasOwnProperty.call(result, "approval_id")) {
-      api.logger.warn(`[rampart] unexpected approval_id from Rampart eval for OpenClaw-hosted ${toolName}; this would create dual-queue ownership`);
+      api.logger.warn(`[rampart] unexpected approval_id from Rampart eval for OpenClaw-hosted ${displayToolName}; this would create dual-queue ownership`);
     }
 
     switch (decision) {
       case "deny": {
         const reason = result.message ?? result.reason ?? "policy violation";
-        api.logger.warn(`[rampart] BLOCKED ${toolName}: ${reason}${result.policy ? ` [${result.policy}]` : ""}`);
+        api.logger.warn(`[rampart] BLOCKED ${displayToolName}: ${reason}${result.policy ? ` [${result.policy}]` : ""}`);
         return {
           block: true,
           blockReason: `rampart: ${reason}`,
@@ -304,10 +356,10 @@ export function register(api) {
         const severity = result.severity ?? "warning";
         const emoji = severityEmoji[severity] ?? "⚠️";
 
-        api.logger.info(`[rampart] returning requireApproval for ${toolName} (subject: ${subjectPreview})`);
+        api.logger.info(`[rampart] returning requireApproval for ${displayToolName} (subject: ${subjectPreview})`);
         return {
           requireApproval: {
-            title: `🛡️ Rampart — ${toolName} approval required`,
+            title: `🛡️ Rampart — ${displayToolName} approval required`,
             description: [
               `**Command:** \`${subjectPreview}\``,
               result.policy  ? `**Policy:** ${truncateForApprovalDescription(result.policy, 64)}` : null,
@@ -317,7 +369,7 @@ export function register(api) {
             timeoutMs: pluginConfig.approvalTimeoutMs ?? 120_000,
             timeoutBehavior: "deny",
             onResolution: async (resolution) => {
-              api.logger.info(`[rampart] plugin approval resolved: ${toolName} → ${resolution} (toolCallId: ${ctx.toolCallId ?? "none"}, session: ${ctx.sessionKey ?? "none"})`);
+              api.logger.info(`[rampart] plugin approval resolved: ${displayToolName} → ${resolution} (toolCallId: ${ctx.toolCallId ?? "none"}, session: ${ctx.sessionKey ?? "none"})`);
 
               if (resolution === "allow-always") {
                 const learnPayload = {
@@ -326,7 +378,7 @@ export function register(api) {
                   decision: "allow",
                   source: "openclaw-approval",
                 };
-                api.logger.info(`[rampart] attempting always-allow persistence via /v1/rules/learn: ${JSON.stringify({ ...learnPayload, session: ctx.sessionKey ?? null, toolCallId: ctx.toolCallId ?? null })}`);
+                api.logger.info(`[rampart] attempting always-allow persistence via /v1/rules/learn: ${JSON.stringify({ ...learnPayload, originalToolName: mapped ? originalToolName : undefined, session: ctx.sessionKey ?? null, toolCallId: ctx.toolCallId ?? null })}`);
 
                 // Write a persistent allow rule via /v1/rules/learn.
                 // This works regardless of whether an approval_id exists.
@@ -390,12 +442,14 @@ export function register(api) {
   });
 
   api.on("after_tool_call", async (event, ctx) => {
-    const { toolName, params, error, durationMs } = event;
+    const normalized = normalizeToolCall(event?.toolName, event?.params);
+    const { toolName, params, originalToolName } = normalized;
+    const { error, durationMs } = event;
 
     // Fire-and-forget — do not block the tool result
     Promise.resolve().then(async () => {
       try {
-        api.logger.debug(`[rampart] tool completed: ${toolName} (${durationMs ?? "?"}ms)`);
+        api.logger.debug(`[rampart] tool completed: ${toolDisplayName(toolName, originalToolName)} (${durationMs ?? "?"}ms)`);
 
         // Best-effort audit POST — Rampart serve already logs via before_tool_call path
         await auditLog(

--- a/internal/plugin/openclaw/tool-alias-test.mjs
+++ b/internal/plugin/openclaw/tool-alias-test.mjs
@@ -1,0 +1,148 @@
+import plugin from './index.js';
+
+function createApi(pluginConfig = {}) {
+  const handlers = {};
+  const logs = [];
+  return {
+    handlers,
+    logs,
+    api: {
+      pluginConfig,
+      logger: {
+        info: (...a) => logs.push(['info', a.join(' ')]),
+        warn: (...a) => logs.push(['warn', a.join(' ')]),
+        debug: (...a) => logs.push(['debug', a.join(' ')]),
+      },
+      on: (name, fn) => { handlers[name] = fn; },
+      registerGatewayMethod: () => {},
+    },
+  };
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function parseBody(call) {
+  return JSON.parse(call.opts.body);
+}
+
+async function runWithFetch({ name, fetchImpl, pluginConfig = {}, invoke }) {
+  const { api, handlers, logs } = createApi(pluginConfig);
+  const originalFetch = global.fetch;
+  global.fetch = fetchImpl;
+  try {
+    plugin.register(api);
+    return await invoke({ handlers, logs });
+  } catch (err) {
+    err.message = `${name}: ${err.message}`;
+    throw err;
+  } finally {
+    global.fetch = originalFetch;
+  }
+}
+
+const calls = [];
+const allowResult = await runWithFetch({
+  name: 'bash-allow-maps-to-exec',
+  fetchImpl: async (url, opts = {}) => {
+    calls.push({ url: String(url), opts });
+    assert(String(url).includes('/v1/tool/exec'), `expected exec endpoint, got ${url}`);
+    return { ok: true, json: async () => ({ decision: 'allow' }) };
+  },
+  invoke: async ({ handlers, logs }) => {
+    const before = handlers.before_tool_call;
+    assert(typeof before === 'function', 'before_tool_call handler missing');
+    const result = await before({ toolName: 'bash', params: { cmd: 'echo hi' } }, {
+      agentId: 'main',
+      sessionKey: 'agent:main:test',
+      runId: 'bash-allow-run',
+    });
+    assert(logs.some((entry) => entry.join(' ').includes('mapped OpenClaw tool bash to Rampart exec')), 'mapping log missing');
+    return result;
+  },
+});
+assert(allowResult === undefined, 'allow decision should pass through');
+assert(calls.length === 1, `expected one policy call, got ${calls.length}`);
+const allowBody = parseBody(calls[0]);
+assert(allowBody.params.command === 'echo hi', `expected cmd promoted to command, got ${JSON.stringify(allowBody.params)}`);
+assert(allowBody.openclaw_hosted === true, 'expected openclaw_hosted=true');
+assert(allowBody.skip_pending_approval === true, 'expected skip_pending_approval=true');
+
+const learnCalls = [];
+const askResult = await runWithFetch({
+  name: 'bash-ask-learns-canonical-exec',
+  fetchImpl: async (url, opts = {}) => {
+    learnCalls.push({ url: String(url), opts });
+    if (String(url).includes('/v1/tool/exec')) {
+      return { ok: true, json: async () => ({ decision: 'ask', policy: 'test-policy', message: 'needs approval' }) };
+    }
+    if (String(url).includes('/v1/rules/learn')) {
+      return { ok: true, status: 200, text: async () => '{"ok":true}' };
+    }
+    throw new Error(`unexpected fetch ${url}`);
+  },
+  invoke: async ({ handlers }) => {
+    const before = handlers.before_tool_call;
+    const result = await before({ toolName: 'bash', params: { script: 'sudo true' } }, {
+      agentId: 'main',
+      sessionKey: 'agent:main:test',
+      runId: 'bash-ask-run',
+    });
+    assert(result?.requireApproval, 'expected requireApproval for ask');
+    assert(result.requireApproval.title.includes('bash→exec approval required'), `unexpected title: ${result.requireApproval.title}`);
+    await result.requireApproval.onResolution('allow-always');
+    return result;
+  },
+});
+assert(askResult.requireApproval.description.includes('sudo true'), 'approval description should include normalized command');
+const learnCall = learnCalls.find((call) => call.url.includes('/v1/rules/learn'));
+assert(learnCall, 'learn endpoint not called');
+const learnBody = parseBody(learnCall);
+assert(learnBody.tool === 'exec', `learn tool = ${learnBody.tool}, want exec`);
+assert(learnBody.args === 'sudo true', `learn args = ${learnBody.args}, want sudo true`);
+
+const unreachableResult = await runWithFetch({
+  name: 'bash-unreachable-blocks-as-exec',
+  fetchImpl: async () => { throw new TypeError('fetch failed', { cause: { code: 'ECONNREFUSED' } }); },
+  invoke: async ({ handlers }) => handlers.before_tool_call(
+    { toolName: 'bash', params: { command: 'echo hi' } },
+    { agentId: 'main', sessionKey: 'agent:main:test', runId: 'bash-unreachable-run' },
+  ),
+});
+assert(unreachableResult?.block === true, 'bash/exec alias should fail closed when Rampart is unreachable');
+assert(unreachableResult.blockReason.includes('bash→exec'), `block reason should show alias mapping: ${unreachableResult.blockReason}`);
+
+const auditCalls = [];
+await runWithFetch({
+  name: 'bash-after-audit-canonical-exec',
+  fetchImpl: async (url, opts = {}) => {
+    auditCalls.push({ url: String(url), opts });
+    return { ok: true, status: 200, json: async () => ({ ok: true }) };
+  },
+  invoke: async ({ handlers }) => {
+    const after = handlers.after_tool_call;
+    assert(typeof after === 'function', 'after_tool_call handler missing');
+    await after({ toolName: 'bash', params: { command: 'echo hi' }, durationMs: 7 }, {
+      agentId: 'main',
+      sessionKey: 'agent:main:test',
+      runId: 'bash-after-run',
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  },
+});
+const auditCall = auditCalls.find((call) => call.url.includes('/v1/audit'));
+assert(auditCall, 'audit endpoint not called');
+const auditBody = parseBody(auditCall);
+assert(auditBody.tool === 'exec', `audit tool = ${auditBody.tool}, want exec`);
+assert(auditBody.params.command === 'echo hi', `audit command missing: ${JSON.stringify(auditBody.params)}`);
+
+console.log(JSON.stringify({
+  ok: true,
+  scenarios: [
+    'bash-allow-maps-to-exec',
+    'bash-ask-learns-canonical-exec',
+    'bash-unreachable-blocks-as-exec',
+    'bash-after-audit-canonical-exec',
+  ],
+}, null, 2));


### PR DESCRIPTION
## Summary
- Normalize OpenClaw command-execution aliases such as `bash`, `shell`, and `terminal` to Rampart `exec` before policy evaluation.
- Preserve canonical `exec` behavior for approval descriptions, learned allow rules, and audit payloads while logging alias mappings.
- Add deterministic plugin regression coverage for alias mapping, fail-closed degraded mode, learning, and after-tool audit events.

## Tests
- `node internal/plugin/openclaw/smoke-test.mjs`
- `node internal/plugin/openclaw/approval-regression.mjs`
- `node internal/plugin/openclaw/degraded-mode-test.mjs`
- `node internal/plugin/openclaw/tool-alias-test.mjs`
- `git diff --check`
- `go test ./internal/plugin/openclaw`
- `go test ./...`
