### PR TITLE
chore: prepare v1.1.0 release metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-2022]
-        go-version: ['1.25.9']
+        go-version: ['1.25.10']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -65,7 +65,6 @@ jobs:
         run: go run ./cmd/rampart policy check --config policies/yolo.yaml
 
       - name: Vulnerability check
-        continue-on-error: true
         run: go install golang.org/x/vuln/cmd/govulncheck@v1.3.0 && govulncheck ./...
 
       - name: Benchmark
@@ -146,7 +145,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.9'
+          go-version: '1.25.10'
 
       - name: GoReleaser snapshot (all platforms, no publish)
         uses: goreleaser/goreleaser-action@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-05-24
+
+### Added
+
+- **Machine-readable diagnostics for automation** — `rampart status --json`, `rampart doctor --json`, and `rampart inventory --json` expose structured runtime, policy, and integration state for scripts and CI systems.
+- **Enterprise observability foundation** — Runtime status now includes schema-versioned health and integration details that downstream dashboards can consume without parsing human output.
+- **OpenClaw/Codex native audit regression coverage** — The release gate now includes an opt-in live regression that verifies Codex native shell calls are correlated with Rampart audit events.
+
+### Changed
+
+- **OpenClaw gateway protocol v4 is the bundled baseline** — The embedded plugin now speaks the current gateway/status response contract while preserving Rampart's native approval and audit ownership.
+- **Bundled OpenClaw plugin metadata is aligned for v1.1.0** — The plugin package manifest, OpenClaw manifest, runtime export, and user-facing examples now report `1.1.0`.
+- **Release builds use Go 1.25.10** — CI, release, and Docker builds now use the patched Go toolchain that resolves the called standard-library vulnerabilities reported against Go 1.25.9.
+
+### Fixed
+
+- **Codex native shell calls stay visible in Rampart audit** — OpenClaw tool-alias handling now preserves canonical `exec` audit correlation for Codex app-server native shell sessions.
+
 ## [1.0.0] - 2026-05-06
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # requested image platform so linux/arm64 releases don't depend on slow QEMU
 # emulation for the Go build itself.
 ARG BUILDPLATFORM
-FROM --platform=$BUILDPLATFORM golang:1.25.9-bookworm AS build
+FROM --platform=$BUILDPLATFORM golang:1.25.10-bookworm AS build
 WORKDIR /src
 
 ARG TARGETOS

--- a/docs-site/getting-started/installation.md
+++ b/docs-site/getting-started/installation.md
@@ -97,7 +97,7 @@ volumes:
   rampart-audit:
 ```
 
-Available tags include full versions such as `1.0.0`, minor versions such as `1.0`, and `latest` for the current stable release. Prereleases use their full tag, for example `1.0.0-rc.3`, and do not move `latest`. Pin to a specific version tag for reproducibility. Images are published on [GitHub Container Registry](https://github.com/peg/rampart/pkgs/container/rampart).
+Available tags include full versions such as `1.1.0`, minor versions such as `1.1`, and `latest` for the current stable release. Prereleases use their full tag, for example `1.1.0-rc.1`, and do not move `latest`. Pin to a specific version tag for reproducibility. Images are published on [GitHub Container Registry](https://github.com/peg/rampart/pkgs/container/rampart).
 
 ## Build from Source
 

--- a/docs-site/getting-started/troubleshooting.md
+++ b/docs-site/getting-started/troubleshooting.md
@@ -165,7 +165,7 @@ rampart test --tool read "/etc/shadow"
 
 ```bash
 openclaw plugins list
-# Should show: rampart  1.0.0  ✓ active
+# Should show: rampart  1.1.0  ✓ active
 
 rampart doctor
 # Should show: ✓ OpenClaw plugin: installed (before_tool_call hook active)

--- a/docs-site/index.html
+++ b/docs-site/index.html
@@ -27,7 +27,7 @@
       "url": "https://rampart.sh",
       "applicationCategory": "SecurityApplication",
       "operatingSystem": "Linux, macOS, Windows",
-      "softwareVersion": "1.0.0",
+      "softwareVersion": "1.1.0",
       "offers": {
         "@type": "Offer",
         "price": "0",
@@ -1112,7 +1112,7 @@
 <section class="hero">
     <div class="container hero-grid">
         <div>
-            <div class="eyebrow"><span class="eyebrow-dot"></span>v1.0.0 · launch-ready</div>
+            <div class="eyebrow"><span class="eyebrow-dot"></span>v1.1.0 · release-ready</div>
             <h1>Your agent has root.<br><span class="accent">That’s the problem.</span></h1>
             <p class="hero-sub">Rampart sits in the execution path. Install it, run <code>rampart quickstart</code>, and it wires the right protection path for Claude Code, Codex, Cline, or OpenClaw before risky tool calls run.</p>
             <div class="install-cluster">

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -205,7 +205,14 @@ verify -> outcomes.approval
 
 [:octicons-arrow-right-24: See all integration guides](integrations/index.md)
 
-## What's New in v1.0
+## What's New in v1.1
+
+- **Machine-readable diagnostics** — `rampart status --json`, `rampart doctor --json`, and `rampart inventory --json` expose structured runtime and integration state for automation.
+- **OpenClaw gateway v4 support** — the bundled plugin speaks the current gateway/status response contract while preserving native approval and audit ownership.
+- **Codex native shell audit coverage** — the release gate now proves Codex app-server native shell calls correlate with canonical Rampart `exec` audit events.
+- **Patched release toolchain** — CI, release, and Docker builds now use Go 1.25.10.
+
+### v1.0
 
 - **Update checks are sane** — `rampart doctor` understands the 1.0 release line and no longer suggests downgrading release candidates to the older stable `v0.9.22` release.
 - **OpenClaw 2026.5.6 verified for launch** — Rampart uses OpenClaw's first-class plugin approval path as the single human-approval owner, with Rampart handling policy, audit, and durable allow-always persistence. [Details →](integrations/openclaw.md)

--- a/docs-site/integrations/openclaw.md
+++ b/docs-site/integrations/openclaw.md
@@ -157,7 +157,7 @@ Or check plugin status directly:
 
 ```bash
 openclaw plugins list
-# rampart  v1.0.0  active
+# rampart  v1.1.0  active
 ```
 
 ## Troubleshooting

--- a/docs-site/reference/threat-model.md
+++ b/docs-site/reference/threat-model.md
@@ -1,6 +1,6 @@
 # Threat Model
 
-> Last reviewed: 2026-04-30 | Applies to: v1.0.0
+> Last reviewed: 2026-05-24 | Applies to: v1.1.0
 
 Rampart is a policy engine for AI agents — not a sandbox, not a hypervisor, not a full isolation boundary. This document describes what Rampart protects against, what it doesn't, and why.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -45,12 +45,12 @@ What's coming next for Rampart. Priorities shift based on feedback — [open an 
 
 ## Current Focus
 
-### `v1.0.0`
-- Keep the integration support story boring and evidence-backed: hooks, plugins, preload/wrapper, MCP, and HTTP API should each say what is protected and what happens when policy evaluation is unavailable.
-- Treat OpenClaw `2026.5.2+` as the recommended 1.0 path for native plugin approvals, with launch dogfood verified on OpenClaw `2026.5.6`.
-- Keep `rampart doctor`, setup output, plugin metadata, and docs aligned so users can answer "am I protected, how, and what breaks if serve is down?" without reading source.
+### `v1.1.0`
+- Keep structured diagnostics boring and automation-friendly: `status --json`, `doctor --json`, and `inventory --json` should remain stable enough for scripts without replacing human-readable output.
+- Treat current OpenClaw gateway protocol support and Codex native shell audit correlation as release-gated integrations, with live regression proof before tagging.
+- Keep the release toolchain, plugin metadata, setup output, and docs aligned so users can answer "am I protected, how, and what version is active?" without reading source.
 
-### After 1.0
+### After 1.1
 - Collect feedback from real OpenClaw, Claude Code, Cline, Codex, and MCP users.
 - Fix integration bugs without widening the public API unless the tradeoff is explicit.
 - Keep the support matrix and threat model honest as agent runtimes evolve.

--- a/docs/index.html
+++ b/docs/index.html
@@ -27,7 +27,7 @@
       "url": "https://rampart.sh",
       "applicationCategory": "SecurityApplication",
       "operatingSystem": "Linux, macOS, Windows",
-      "softwareVersion": "1.0.0",
+      "softwareVersion": "1.1.0",
       "offers": {
         "@type": "Offer",
         "price": "0",
@@ -1112,7 +1112,7 @@
 <section class="hero">
     <div class="container hero-grid">
         <div>
-            <div class="eyebrow"><span class="eyebrow-dot"></span>v1.0.0 · launch-ready</div>
+            <div class="eyebrow"><span class="eyebrow-dot"></span>v1.1.0 · release-ready</div>
             <h1>Your agent has root.<br><span class="accent">That’s the problem.</span></h1>
             <p class="hero-sub">Rampart sits in the execution path. Install it, run <code>rampart quickstart</code>, and it wires the right protection path for Claude Code, Codex, Cline, or OpenClaw before risky tool calls run.</p>
             <div class="install-cluster">

--- a/docs/install
+++ b/docs/install
@@ -7,8 +7,8 @@
 # Usage: curl -fsSL https://rampart.sh/install | sh
 #        curl -fsSL https://rampart.sh/install | sh -s -- --version v0.1.0
 #        curl -fsSL https://rampart.sh/install | sh -s -- --auto-setup
-#        RAMPART_INSTALL_DRY_RUN=1 sh install.sh --version v1.0.0
-#        RAMPART_VERSION=v1.0.0 RAMPART_INSTALL_DIR=$HOME/.local/bin sh install.sh
+#        RAMPART_INSTALL_DRY_RUN=1 sh install.sh --version v1.1.0
+#        RAMPART_VERSION=v1.1.0 RAMPART_INSTALL_DIR=$HOME/.local/bin sh install.sh
 set -e
 
 REPO="peg/rampart"

--- a/docs/install.sh
+++ b/docs/install.sh
@@ -7,8 +7,8 @@
 # Usage: curl -fsSL https://rampart.sh/install | sh
 #        curl -fsSL https://rampart.sh/install | sh -s -- --version v0.1.0
 #        curl -fsSL https://rampart.sh/install | sh -s -- --auto-setup
-#        RAMPART_INSTALL_DRY_RUN=1 sh install.sh --version v1.0.0
-#        RAMPART_VERSION=v1.0.0 RAMPART_INSTALL_DIR=$HOME/.local/bin sh install.sh
+#        RAMPART_INSTALL_DRY_RUN=1 sh install.sh --version v1.1.0
+#        RAMPART_VERSION=v1.1.0 RAMPART_INSTALL_DIR=$HOME/.local/bin sh install.sh
 set -e
 
 REPO="peg/rampart"

--- a/install.sh
+++ b/install.sh
@@ -7,8 +7,8 @@
 # Usage: curl -fsSL https://rampart.sh/install | sh
 #        curl -fsSL https://rampart.sh/install | sh -s -- --version v0.1.0
 #        curl -fsSL https://rampart.sh/install | sh -s -- --auto-setup
-#        RAMPART_INSTALL_DRY_RUN=1 sh install.sh --version v1.0.0
-#        RAMPART_VERSION=v1.0.0 RAMPART_INSTALL_DIR=$HOME/.local/bin sh install.sh
+#        RAMPART_INSTALL_DRY_RUN=1 sh install.sh --version v1.1.0
+#        RAMPART_VERSION=v1.1.0 RAMPART_INSTALL_DIR=$HOME/.local/bin sh install.sh
 set -e
 
 REPO="peg/rampart"

--- a/internal/plugin/openclaw/index.js
+++ b/internal/plugin/openclaw/index.js
@@ -5,7 +5,7 @@
  * Replaces brittle dist-file patching with the official OpenClaw plugin API.
  *
  * @see https://github.com/peg/rampart
- * @version 1.0.0
+ * @version 1.1.0
  */
 
 import { readFile } from "fs/promises";
@@ -259,7 +259,7 @@ async function auditLog(toolName, params, ctx, outcome, config) {
 export const id = "rampart";
 export const name = "Rampart";
 export const description = "AI agent firewall — YAML policy-as-code for every tool call";
-export const version = "1.0.0";
+export const version = "1.1.0";
 
 // OpenClaw runs higher-priority before_tool_call hooks first. Rampart should
 // act as the final normal plugin gate so it evaluates the params that will

--- a/internal/plugin/openclaw/openclaw.plugin.json
+++ b/internal/plugin/openclaw/openclaw.plugin.json
@@ -8,7 +8,7 @@
       "hook"
     ]
   },
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": "peg",
   "homepage": "https://rampart.sh",
   "repository": "https://github.com/peg/rampart",

--- a/internal/plugin/openclaw/package.json
+++ b/internal/plugin/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rampart",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Rampart AI agent firewall — OpenClaw native plugin (before_tool_call hook)",
   "type": "module",
   "main": "index.js",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,8 +7,8 @@
 # Usage: curl -fsSL https://rampart.sh/install | sh
 #        curl -fsSL https://rampart.sh/install | sh -s -- --version v0.1.0
 #        curl -fsSL https://rampart.sh/install | sh -s -- --auto-setup
-#        RAMPART_INSTALL_DRY_RUN=1 sh install.sh --version v1.0.0
-#        RAMPART_VERSION=v1.0.0 RAMPART_INSTALL_DIR=$HOME/.local/bin sh install.sh
+#        RAMPART_INSTALL_DRY_RUN=1 sh install.sh --version v1.1.0
+#        RAMPART_VERSION=v1.1.0 RAMPART_INSTALL_DIR=$HOME/.local/bin sh install.sh
 set -e
 
 REPO="peg/rampart"


### PR DESCRIPTION
## Summary
- Update CI, release, and Docker builds to Go 1.25.10 and make `govulncheck` blocking now that the patched toolchain is available.
- Document the v1.1.0 release train in the changelog and refresh release-facing docs/examples.
- Align bundled OpenClaw plugin metadata and runtime-reported version with v1.1.0.

## Tests
- `git diff --check`
- `GOTOOLCHAIN=go1.25.10 go vet ./...`
- `GOTOOLCHAIN=go1.25.10 go test -race -coverprofile=coverage.out ./...`
- `GOTOOLCHAIN=go1.25.10 go run golang.org/x/vuln/cmd/govulncheck@v1.3.0 ./...`
- `node internal/plugin/openclaw/smoke-test.mjs`
- `node internal/plugin/openclaw/approval-regression.mjs`
- `node internal/plugin/openclaw/degraded-mode-test.mjs`
- `GOTOOLCHAIN=go1.25.10 go run ./cmd/rampart policy check --config policies/standard.yaml`
- `GOTOOLCHAIN=go1.25.10 go run ./cmd/rampart policy check --config policies/paranoid.yaml`
- `GOTOOLCHAIN=go1.25.10 go run ./cmd/rampart policy check --config policies/yolo.yaml`
- `docker buildx build --build-arg VERSION=v1.1.0-snapshot --build-arg COMMIT=$(git rev-parse --short HEAD) --build-arg DATE=<utc> --output=type=cacheonly .`
