### PR TITLE
chore: promote staging for v1.1.0 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-2022]
-        go-version: ['1.25.9']
+        go-version: ['1.25.10']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -65,7 +65,6 @@ jobs:
         run: go run ./cmd/rampart policy check --config policies/yolo.yaml
 
       - name: Vulnerability check
-        continue-on-error: true
         run: go install golang.org/x/vuln/cmd/govulncheck@v1.3.0 && govulncheck ./...
 
       - name: Benchmark
@@ -146,7 +145,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.9'
+          go-version: '1.25.10'
 
       - name: GoReleaser snapshot (all platforms, no publish)
         uses: goreleaser/goreleaser-action@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-05-24
+
+### Added
+
+- **Machine-readable diagnostics for automation** — `rampart status --json`, `rampart doctor --json`, and `rampart inventory --json` expose structured runtime, policy, and integration state for scripts and CI systems.
+- **Enterprise observability foundation** — Runtime status now includes schema-versioned health and integration details that downstream dashboards can consume without parsing human output.
+- **OpenClaw/Codex native audit regression coverage** — The release gate now includes an opt-in live regression that verifies Codex native shell calls are correlated with Rampart audit events.
+
+### Changed
+
+- **OpenClaw gateway protocol v4 is the bundled baseline** — The embedded plugin now speaks the current gateway/status response contract while preserving Rampart's native approval and audit ownership.
+- **Bundled OpenClaw plugin metadata is aligned for v1.1.0** — The plugin package manifest, OpenClaw manifest, runtime export, and user-facing examples now report `1.1.0`.
+- **Release builds use Go 1.25.10** — CI, release, and Docker builds now use the patched Go toolchain that resolves the called standard-library vulnerabilities reported against Go 1.25.9.
+
+### Fixed
+
+- **Codex native shell calls stay visible in Rampart audit** — OpenClaw tool-alias handling now preserves canonical `exec` audit correlation for Codex app-server native shell sessions.
+
 ## [1.0.0] - 2026-05-06
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # requested image platform so linux/arm64 releases don't depend on slow QEMU
 # emulation for the Go build itself.
 ARG BUILDPLATFORM
-FROM --platform=$BUILDPLATFORM golang:1.25.9-bookworm AS build
+FROM --platform=$BUILDPLATFORM golang:1.25.10-bookworm AS build
 WORKDIR /src
 
 ARG TARGETOS

--- a/cmd/rampart/cli/doctor.go
+++ b/cmd/rampart/cli/doctor.go
@@ -49,6 +49,33 @@ type checkResult struct {
 	Hint    string `json:"hint,omitempty"` // actionable suggestion on failure/warn
 }
 
+const doctorJSONSchemaVersion = "rampart.doctor.v1"
+
+// doctorSummary carries stable machine-readable counts for doctor checks.
+type doctorSummary struct {
+	Checks   int `json:"checks"`
+	OK       int `json:"ok"`
+	Info     int `json:"info"`
+	Warnings int `json:"warnings"`
+	Issues   int `json:"issues"`
+}
+
+// doctorJSONReport is the machine-readable contract for `rampart doctor --json`.
+type doctorJSONReport struct {
+	SchemaVersion string        `json:"schema_version"`
+	GeneratedAt   string        `json:"generated_at"`
+	BuildVersion  string        `json:"build_version"`
+	Summary       doctorSummary `json:"summary"`
+	Checks        []checkResult `json:"checks"`
+
+	// warnings and issues preserve the pre-v1 JSON count fields.
+	Warnings int `json:"warnings"`
+	Issues   int `json:"issues"`
+
+	WarningChecks []checkResult `json:"warning_checks"`
+	IssueChecks   []checkResult `json:"issue_checks"`
+}
+
 // hintSep is the separator embedded in doctor messages to carry a hint.
 // Format: "<msg>\n" + hintSep + "<hint>"
 const hintSep = "\n  💡 "
@@ -306,26 +333,13 @@ func runDoctor(w io.Writer, jsonOut bool) error {
 	}
 
 	if collect {
-		// JSON output
-		issueCount := 0
-		warnCount := 0
-		for _, r := range results {
-			switch r.Status {
-			case "fail":
-				issueCount++
-			case "warn":
-				warnCount++
-			}
-		}
-		out := map[string]any{
-			"checks":   results,
-			"issues":   issueCount,
-			"warnings": warnCount,
-		}
+		out := buildDoctorJSONReport(results, time.Now())
 		enc := json.NewEncoder(w)
 		enc.SetIndent("", "  ")
-		_ = enc.Encode(out)
-		if issueCount > 0 {
+		if err := enc.Encode(out); err != nil {
+			return fmt.Errorf("doctor: encode json output: %w", err)
+		}
+		if out.Summary.Issues > 0 {
 			return exitCodeError{code: 1}
 		}
 		return nil
@@ -353,6 +367,41 @@ func runDoctor(w io.Writer, jsonOut bool) error {
 		return exitCodeError{code: 1}
 	}
 	return nil
+}
+
+func buildDoctorJSONReport(results []checkResult, generatedAt time.Time) doctorJSONReport {
+	report := doctorJSONReport{
+		SchemaVersion: doctorJSONSchemaVersion,
+		GeneratedAt:   generatedAt.UTC().Format(time.RFC3339),
+		BuildVersion:  build.Version,
+		Checks:        make([]checkResult, 0, len(results)),
+		WarningChecks: make([]checkResult, 0),
+		IssueChecks:   make([]checkResult, 0),
+	}
+
+	for _, result := range results {
+		report.Checks = append(report.Checks, result)
+		report.Summary.Checks++
+
+		switch result.Status {
+		case "ok":
+			report.Summary.OK++
+		case "warn":
+			report.Summary.Warnings++
+			report.WarningChecks = append(report.WarningChecks, result)
+		case "fail":
+			report.Summary.Issues++
+			report.IssueChecks = append(report.IssueChecks, result)
+		default:
+			// WHY: Unrecognized statuses should still be counted but must not
+			// affect issue/warning tallies used for exit behavior.
+			report.Summary.Info++
+		}
+	}
+
+	report.Warnings = report.Summary.Warnings
+	report.Issues = report.Summary.Issues
+	return report
 }
 
 // printDoctorSummary prints an encouraging all-clear summary with next steps.

--- a/cmd/rampart/cli/doctor_test.go
+++ b/cmd/rampart/cli/doctor_test.go
@@ -92,7 +92,7 @@ func TestCountClaudeHookMatchers(t *testing.T) {
 	}
 }
 
-func TestRunDoctor_JSON(t *testing.T) {
+func TestRunDoctor_JSONContract(t *testing.T) {
 	var buf bytes.Buffer
 	err := runDoctor(&buf, true)
 	// May return exitCodeError if issues found — that's expected in test env.
@@ -102,15 +102,55 @@ func TestRunDoctor_JSON(t *testing.T) {
 			t.Fatalf("unexpected error type: %v", err)
 		}
 	}
-	var result map[string]any
-	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+
+	var report doctorJSONReport
+	if err := json.Unmarshal(buf.Bytes(), &report); err != nil {
 		t.Fatalf("JSON output invalid: %v\noutput: %s", err, buf.String())
 	}
-	if _, ok := result["checks"]; !ok {
-		t.Error("JSON output missing 'checks' field")
+	if report.SchemaVersion != doctorJSONSchemaVersion {
+		t.Fatalf("schema_version = %q, want %q", report.SchemaVersion, doctorJSONSchemaVersion)
 	}
-	if _, ok := result["issues"]; !ok {
-		t.Error("JSON output missing 'issues' field")
+	if report.BuildVersion != build.Version {
+		t.Fatalf("build_version = %q, want %q", report.BuildVersion, build.Version)
+	}
+	if _, err := time.Parse(time.RFC3339, report.GeneratedAt); err != nil {
+		t.Fatalf("generated_at is not RFC3339: %q (%v)", report.GeneratedAt, err)
+	}
+	if len(report.Checks) == 0 {
+		t.Fatal("expected at least one doctor check in JSON output")
+	}
+	if report.WarningChecks == nil {
+		t.Fatal("warning_checks must be an array, got nil")
+	}
+	if report.IssueChecks == nil {
+		t.Fatal("issue_checks must be an array, got nil")
+	}
+	if report.Summary.Checks != len(report.Checks) {
+		t.Fatalf("summary.checks = %d, want %d", report.Summary.Checks, len(report.Checks))
+	}
+	if report.Summary.Warnings != len(report.WarningChecks) {
+		t.Fatalf("summary.warnings = %d, want %d", report.Summary.Warnings, len(report.WarningChecks))
+	}
+	if report.Summary.Issues != len(report.IssueChecks) {
+		t.Fatalf("summary.issues = %d, want %d", report.Summary.Issues, len(report.IssueChecks))
+	}
+	if report.Warnings != len(report.WarningChecks) {
+		t.Fatalf("warnings = %d, want %d", report.Warnings, len(report.WarningChecks))
+	}
+	if report.Issues != len(report.IssueChecks) {
+		t.Fatalf("issues = %d, want %d", report.Issues, len(report.IssueChecks))
+	}
+
+	for i, check := range report.Checks {
+		if check.Name == "" {
+			t.Fatalf("checks[%d].name is empty", i)
+		}
+		if check.Status == "" {
+			t.Fatalf("checks[%d].status is empty", i)
+		}
+		if check.Message == "" {
+			t.Fatalf("checks[%d].message is empty", i)
+		}
 	}
 }
 
@@ -132,6 +172,117 @@ func TestRunDoctor_ExitCode(t *testing.T) {
 		if exitErr.code != 1 {
 			t.Errorf("expected exit code 1, got %d", exitErr.code)
 		}
+	}
+}
+
+func TestRunDoctor_DefaultOutputIsHumanReadable(t *testing.T) {
+	var buf bytes.Buffer
+	err := runDoctor(&buf, false)
+	if err != nil {
+		var exitErr exitCodeError
+		if !errors.As(err, &exitErr) {
+			t.Fatalf("expected exitCodeError, got %T %v", err, err)
+		}
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "🩺 Rampart Doctor") {
+		t.Fatal("missing doctor header in default output")
+	}
+
+	var asJSON map[string]any
+	if json.Unmarshal(buf.Bytes(), &asJSON) == nil {
+		t.Fatalf("expected human-readable default output, got valid JSON: %s", out)
+	}
+}
+
+func TestBuildDoctorJSONReport(t *testing.T) {
+	generatedAt := time.Date(2026, time.May, 11, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name         string
+		results      []checkResult
+		wantSummary  doctorSummary
+		wantWarnings int
+		wantIssues   int
+	}{
+		{
+			name: "ok and info only",
+			results: []checkResult{
+				{Name: "Version", Status: "ok", Message: "v1"},
+				{Name: "Policy suggestions", Status: "info", Message: "none"},
+			},
+			wantSummary:  doctorSummary{Checks: 2, OK: 1, Info: 1, Warnings: 0, Issues: 0},
+			wantWarnings: 0,
+			wantIssues:   0,
+		},
+		{
+			name: "warn and fail included in dedicated arrays",
+			results: []checkResult{
+				{Name: "PATH", Status: "warn", Message: "warn"},
+				{Name: "Token", Status: "fail", Message: "fail"},
+				{Name: "System", Status: "ok", Message: "ok"},
+			},
+			wantSummary:  doctorSummary{Checks: 3, OK: 1, Info: 0, Warnings: 1, Issues: 1},
+			wantWarnings: 1,
+			wantIssues:   1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			report := buildDoctorJSONReport(tt.results, generatedAt)
+			if report.SchemaVersion != doctorJSONSchemaVersion {
+				t.Fatalf("schema_version = %q, want %q", report.SchemaVersion, doctorJSONSchemaVersion)
+			}
+			if report.GeneratedAt != generatedAt.Format(time.RFC3339) {
+				t.Fatalf("generated_at = %q, want %q", report.GeneratedAt, generatedAt.Format(time.RFC3339))
+			}
+			if report.BuildVersion != build.Version {
+				t.Fatalf("build_version = %q, want %q", report.BuildVersion, build.Version)
+			}
+			if report.Summary != tt.wantSummary {
+				t.Fatalf("summary = %+v, want %+v", report.Summary, tt.wantSummary)
+			}
+			if len(report.WarningChecks) != tt.wantWarnings {
+				t.Fatalf("len(warning_checks) = %d, want %d", len(report.WarningChecks), tt.wantWarnings)
+			}
+			if len(report.IssueChecks) != tt.wantIssues {
+				t.Fatalf("len(issue_checks) = %d, want %d", len(report.IssueChecks), tt.wantIssues)
+			}
+			if report.WarningChecks == nil {
+				t.Fatal("warning_checks must always encode as an array")
+			}
+			if report.IssueChecks == nil {
+				t.Fatal("issue_checks must always encode as an array")
+			}
+			if report.Warnings != tt.wantSummary.Warnings {
+				t.Fatalf("warnings = %d, want %d", report.Warnings, tt.wantSummary.Warnings)
+			}
+			if report.Issues != tt.wantSummary.Issues {
+				t.Fatalf("issues = %d, want %d", report.Issues, tt.wantSummary.Issues)
+			}
+
+			encoded, err := json.Marshal(report)
+			if err != nil {
+				t.Fatalf("marshal report: %v", err)
+			}
+			var raw map[string]any
+			if err := json.Unmarshal(encoded, &raw); err != nil {
+				t.Fatalf("unmarshal report: %v", err)
+			}
+			if _, ok := raw["warnings"].(float64); !ok {
+				t.Fatalf("warnings should preserve numeric count, got %T", raw["warnings"])
+			}
+			if _, ok := raw["issues"].(float64); !ok {
+				t.Fatalf("issues should preserve numeric count, got %T", raw["issues"])
+			}
+			if _, ok := raw["warning_checks"].([]any); !ok {
+				t.Fatalf("warning_checks should encode as JSON array, got %T", raw["warning_checks"])
+			}
+			if _, ok := raw["issue_checks"].([]any); !ok {
+				t.Fatalf("issue_checks should encode as JSON array, got %T", raw["issue_checks"])
+			}
+		})
 	}
 }
 

--- a/cmd/rampart/cli/inventory.go
+++ b/cmd/rampart/cli/inventory.go
@@ -1,0 +1,488 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/peg/rampart/internal/audit"
+	"github.com/peg/rampart/internal/build"
+	"github.com/peg/rampart/internal/engine"
+	"github.com/spf13/cobra"
+)
+
+const inventorySchemaVersion = "rampart.inventory.v1"
+
+type inventorySnapshot struct {
+	SchemaVersion   string                   `json:"schema_version"`
+	GeneratedAt     string                   `json:"generated_at"`
+	BuildVersion    string                   `json:"build_version"`
+	ProtectedAgents []string                 `json:"protected_agents"`
+	PolicyInventory inventoryPolicyInventory `json:"policy_inventory"`
+	AuditInventory  inventoryAuditInventory  `json:"audit_inventory"`
+	Runtime         inventoryRuntime         `json:"runtime"`
+}
+
+type inventoryPolicyInventory struct {
+	Files        []inventoryPolicyFile `json:"files"`
+	LoadedCount  int                   `json:"loaded_count"`
+	InvalidCount int                   `json:"invalid_count"`
+}
+
+type inventoryPolicyFile struct {
+	FileName      string `json:"file_name"`
+	Path          string `json:"path"`
+	Valid         bool   `json:"valid"`
+	LoadStatus    string `json:"load_status"`
+	DefaultAction string `json:"default_action,omitempty"`
+	PolicyCount   int    `json:"policy_count"`
+	Error         string `json:"error,omitempty"`
+}
+
+type inventoryAuditInventory struct {
+	Directory          string                   `json:"directory"`
+	DirectoryAvailable bool                     `json:"directory_available"`
+	LogFileCount       int                      `json:"log_file_count"`
+	LogFileBytes       int64                    `json:"log_file_bytes"`
+	TodayEvents        inventoryAuditEventCount `json:"today_events"`
+	Error              string                   `json:"error,omitempty"`
+}
+
+type inventoryAuditEventCount struct {
+	Allow   int `json:"allow"`
+	Deny    int `json:"deny"`
+	Watch   int `json:"watch"`
+	Pending int `json:"pending"`
+	Total   int `json:"total"`
+}
+
+type inventoryRuntime struct {
+	Server inventoryServer `json:"server"`
+}
+
+type inventoryServer struct {
+	Reachable bool `json:"reachable"`
+}
+
+func newInventoryCmd(opts *rootOptions) *cobra.Command {
+	var jsonOut bool
+
+	cmd := &cobra.Command{
+		Use:   "inventory",
+		Short: "Show local Rampart inventory",
+		Long: `Collect a local-only inventory snapshot of Rampart state.
+
+Includes protected agents, policy file load status, audit footprint, and
+whether local rampart serve appears reachable.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			snapshot := collectInventorySnapshot(opts.configPath)
+			if jsonOut {
+				return writeInventoryJSON(cmd.OutOrStdout(), snapshot)
+			}
+			return writeInventoryHuman(cmd.OutOrStdout(), snapshot)
+		},
+	}
+
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output inventory as JSON")
+	return cmd
+}
+
+func collectInventorySnapshot(configPath string) inventorySnapshot {
+	protectedAgents := detectProtectedAgents()
+	sort.Strings(protectedAgents)
+
+	version := strings.TrimSpace(build.Version)
+	if version == "" {
+		version = "dev"
+	}
+
+	return inventorySnapshot{
+		SchemaVersion:   inventorySchemaVersion,
+		GeneratedAt:     time.Now().UTC().Format(time.RFC3339),
+		BuildVersion:    version,
+		ProtectedAgents: protectedAgents,
+		PolicyInventory: collectPolicyInventory(configPath),
+		AuditInventory:  collectAuditInventory(),
+		Runtime: inventoryRuntime{
+			Server: inventoryServer{Reachable: detectLocalServeReachable()},
+		},
+	}
+}
+
+func collectPolicyInventory(configPath string) inventoryPolicyInventory {
+	paths := collectPolicyPaths(configPath)
+	files := make([]inventoryPolicyFile, 0, len(paths))
+	loadedCount := 0
+	invalidCount := 0
+
+	for _, path := range paths {
+		fileInv := inspectPolicyFile(path)
+		if fileInv.Valid {
+			loadedCount++
+		} else if fileInv.LoadStatus == "invalid" || fileInv.LoadStatus == "unreadable" {
+			invalidCount++
+		}
+		files = append(files, fileInv)
+	}
+
+	return inventoryPolicyInventory{
+		Files:        files,
+		LoadedCount:  loadedCount,
+		InvalidCount: invalidCount,
+	}
+}
+
+func collectPolicyPaths(configPath string) []string {
+	set := map[string]struct{}{}
+	addPath := func(path string) {
+		trimmed := strings.TrimSpace(path)
+		if trimmed == "" {
+			return
+		}
+		abs, err := filepath.Abs(trimmed)
+		if err != nil {
+			set[filepath.Clean(trimmed)] = struct{}{}
+			return
+		}
+		set[abs] = struct{}{}
+	}
+
+	addPath(configPath)
+
+	policyDir, err := policyInventoryDir()
+	if err == nil {
+		entries, readErr := os.ReadDir(policyDir)
+		if readErr == nil {
+			for _, entry := range entries {
+				if entry.IsDir() || !isPolicyYAMLFile(entry.Name()) {
+					continue
+				}
+				addPath(filepath.Join(policyDir, entry.Name()))
+			}
+		}
+	}
+
+	paths := make([]string, 0, len(set))
+	for path := range set {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+func policyInventoryDir() (string, error) {
+	dir, err := rampartDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "policies"), nil
+}
+
+func inspectPolicyFile(path string) inventoryPolicyFile {
+	entry := inventoryPolicyFile{
+		FileName:   filepath.Base(path),
+		Path:       inventoryDisplayPath(path),
+		LoadStatus: "missing",
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			entry.Error = "file not found"
+			return entry
+		}
+		entry.LoadStatus = "unreadable"
+		entry.Error = sanitizeInventoryError(err)
+		return entry
+	}
+
+	if info.IsDir() {
+		entry.LoadStatus = "invalid"
+		entry.Error = "path is a directory"
+		return entry
+	}
+
+	cfg, err := engine.NewFileStore(path).Load()
+	if err != nil {
+		entry.LoadStatus = "invalid"
+		entry.Error = sanitizeInventoryError(err)
+		return entry
+	}
+
+	entry.Valid = true
+	entry.LoadStatus = "loaded"
+	entry.PolicyCount = len(cfg.Policies)
+	if strings.TrimSpace(cfg.DefaultAction) == "" {
+		entry.DefaultAction = "deny"
+	} else {
+		entry.DefaultAction = strings.ToLower(strings.TrimSpace(cfg.DefaultAction))
+	}
+	return entry
+}
+
+func collectAuditInventory() inventoryAuditInventory {
+	dir, err := rampartDir()
+	if err != nil {
+		return inventoryAuditInventory{
+			Directory: filepath.ToSlash(filepath.Join("~", ".rampart", "audit")),
+			Error:     sanitizeInventoryError(err),
+		}
+	}
+
+	auditDir := filepath.Join(dir, "audit")
+	inv := inventoryAuditInventory{Directory: inventoryDisplayPath(auditDir)}
+
+	entries, err := os.ReadDir(auditDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return inv
+		}
+		inv.Error = sanitizeInventoryError(err)
+		return inv
+	}
+
+	inv.DirectoryAvailable = true
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".jsonl") {
+			continue
+		}
+		info, infoErr := entry.Info()
+		if infoErr != nil {
+			continue
+		}
+		inv.LogFileCount++
+		inv.LogFileBytes += info.Size()
+	}
+
+	inv.TodayEvents = collectTodayAuditCounts(auditDir)
+	return inv
+}
+
+func collectTodayAuditCounts(auditDir string) inventoryAuditEventCount {
+	today := time.Now().UTC().Format("2006-01-02")
+	entries, err := os.ReadDir(auditDir)
+	if err != nil {
+		return inventoryAuditEventCount{}
+	}
+
+	candidates := make([]string, 0)
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".jsonl") || !strings.Contains(name, today) {
+			continue
+		}
+		candidates = append(candidates, filepath.Join(auditDir, name))
+	}
+	sort.Strings(candidates)
+
+	counts := inventoryAuditEventCount{}
+	for _, path := range candidates {
+		events, _, readErr := audit.ReadEventsFromOffset(path, 0)
+		if readErr != nil {
+			continue
+		}
+		for _, event := range events {
+			switch strings.ToLower(strings.TrimSpace(event.Decision.Action)) {
+			case "allow":
+				counts.Allow++
+			case "deny":
+				counts.Deny++
+			case "watch", "log":
+				counts.Watch++
+			case "ask", "require_approval", "webhook":
+				counts.Pending++
+			}
+		}
+	}
+	counts.Total = counts.Allow + counts.Deny + counts.Watch + counts.Pending
+	return counts
+}
+
+func detectLocalServeReachable() bool {
+	for _, serveURL := range localServeCandidates() {
+		if isServeRunning(serveURL) {
+			return true
+		}
+	}
+	return false
+}
+
+func localServeCandidates() []string {
+	candidates := make([]string, 0, 8)
+	seen := map[string]struct{}{}
+	add := func(raw string) {
+		trimmed := strings.TrimSpace(raw)
+		if trimmed == "" || !isLoopbackURL(trimmed) {
+			return
+		}
+		trimmed = strings.TrimRight(trimmed, "/")
+		if _, ok := seen[trimmed]; ok {
+			return
+		}
+		seen[trimmed] = struct{}{}
+		candidates = append(candidates, trimmed)
+	}
+
+	// Only probe local loopback endpoints to keep inventory strictly local-only.
+	if cfg, err := loadUserConfig(); err == nil {
+		add(cfg.URL)
+		add(cfg.ServeURL)
+	}
+
+	if dir, err := rampartDir(); err == nil {
+		statePath := filepath.Join(dir, serveStateFile)
+		if data, readErr := os.ReadFile(statePath); readErr == nil {
+			var state serveState
+			if json.Unmarshal(data, &state) == nil {
+				add(state.URL)
+			}
+		}
+	}
+
+	for _, port := range []int{defaultServePort, 9091, 8090} {
+		add(fmt.Sprintf("http://localhost:%d", port))
+		add(fmt.Sprintf("http://127.0.0.1:%d", port))
+	}
+
+	return candidates
+}
+
+func isLoopbackURL(raw string) bool {
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Host == "" {
+		return false
+	}
+	host := parsed.Hostname()
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+func writeInventoryJSON(w io.Writer, snapshot inventorySnapshot) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(snapshot); err != nil {
+		return fmt.Errorf("inventory: write JSON output: %w", err)
+	}
+	return nil
+}
+
+func writeInventoryHuman(w io.Writer, snapshot inventorySnapshot) error {
+	if _, err := fmt.Fprintf(w, "Rampart inventory (%s)\n", snapshot.GeneratedAt); err != nil {
+		return fmt.Errorf("inventory: write output: %w", err)
+	}
+	if _, err := fmt.Fprintf(w, "Build: %s\n", snapshot.BuildVersion); err != nil {
+		return fmt.Errorf("inventory: write output: %w", err)
+	}
+	if _, err := fmt.Fprintf(w, "Protected agents: %d\n", len(snapshot.ProtectedAgents)); err != nil {
+		return fmt.Errorf("inventory: write output: %w", err)
+	}
+	if _, err := fmt.Fprintf(
+		w,
+		"Policy files: %d (loaded: %d, invalid: %d)\n",
+		len(snapshot.PolicyInventory.Files),
+		snapshot.PolicyInventory.LoadedCount,
+		snapshot.PolicyInventory.InvalidCount,
+	); err != nil {
+		return fmt.Errorf("inventory: write output: %w", err)
+	}
+
+	auditState := "unavailable"
+	if snapshot.AuditInventory.DirectoryAvailable {
+		auditState = "available"
+	}
+	if _, err := fmt.Fprintf(
+		w,
+		"Audit logs: %s (%d files, %d bytes) today=%d/%d/%d/%d\n",
+		auditState,
+		snapshot.AuditInventory.LogFileCount,
+		snapshot.AuditInventory.LogFileBytes,
+		snapshot.AuditInventory.TodayEvents.Allow,
+		snapshot.AuditInventory.TodayEvents.Deny,
+		snapshot.AuditInventory.TodayEvents.Watch,
+		snapshot.AuditInventory.TodayEvents.Pending,
+	); err != nil {
+		return fmt.Errorf("inventory: write output: %w", err)
+	}
+	if _, err := fmt.Fprintf(w, "Serve reachable: %t\n", snapshot.Runtime.Server.Reachable); err != nil {
+		return fmt.Errorf("inventory: write output: %w", err)
+	}
+	return nil
+}
+
+func inventoryDisplayPath(path string) string {
+	cleaned := filepath.Clean(path)
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return filepath.ToSlash(cleaned)
+	}
+
+	rampartRoot := filepath.Join(home, ".rampart")
+	if rel, ok := relativePathInside(rampartRoot, cleaned); ok {
+		if rel == "." {
+			return "~/.rampart"
+		}
+		return filepath.ToSlash(filepath.Join("~/.rampart", rel))
+	}
+	if rel, ok := relativePathInside(home, cleaned); ok {
+		if rel == "." {
+			return "~"
+		}
+		return filepath.ToSlash(filepath.Join("~", rel))
+	}
+	return filepath.ToSlash(cleaned)
+}
+
+func relativePathInside(base, target string) (string, bool) {
+	rel, err := filepath.Rel(base, target)
+	if err != nil {
+		return "", false
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", false
+	}
+	return rel, true
+}
+
+func sanitizeInventoryError(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := strings.Join(strings.Fields(strings.TrimSpace(err.Error())), " ")
+	home, homeErr := os.UserHomeDir()
+	if homeErr == nil && home != "" {
+		msg = strings.ReplaceAll(msg, home, "~")
+	}
+	if len(msg) > 160 {
+		msg = msg[:157] + "..."
+	}
+	return msg
+}
+
+func isPolicyYAMLFile(name string) bool {
+	ext := strings.ToLower(filepath.Ext(name))
+	return ext == ".yaml" || ext == ".yml"
+}

--- a/cmd/rampart/cli/inventory_test.go
+++ b/cmd/rampart/cli/inventory_test.go
@@ -1,0 +1,199 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/peg/rampart/internal/audit"
+)
+
+func TestInventoryJSONKeyFields(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+
+	configPath := filepath.Join(home, "rampart.yaml")
+	writeTestPolicyFile(t, configPath)
+
+	auditDir := filepath.Join(home, ".rampart", "audit")
+	writeTestAuditEvents(t, auditDir, []audit.Event{
+		{ID: "evt-1", Timestamp: time.Now().UTC(), Tool: "exec", Decision: audit.EventDecision{Action: "allow"}},
+		{ID: "evt-2", Timestamp: time.Now().UTC(), Tool: "exec", Decision: audit.EventDecision{Action: "deny"}},
+		{ID: "evt-3", Timestamp: time.Now().UTC(), Tool: "exec", Decision: audit.EventDecision{Action: "watch"}},
+		{ID: "evt-4", Timestamp: time.Now().UTC(), Tool: "exec", Decision: audit.EventDecision{Action: "ask"}},
+	})
+
+	stdout, _, err := runCLI(t, "--config", configPath, "inventory", "--json")
+	if err != nil {
+		t.Fatalf("inventory --json failed: %v", err)
+	}
+
+	var got inventorySnapshot
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("inventory --json output is not valid JSON: %v\nOutput:\n%s", err, stdout)
+	}
+
+	if got.SchemaVersion != inventorySchemaVersion {
+		t.Fatalf("schema_version = %q, want %q", got.SchemaVersion, inventorySchemaVersion)
+	}
+	if _, err := time.Parse(time.RFC3339, got.GeneratedAt); err != nil {
+		t.Fatalf("generated_at is not RFC3339: %q (%v)", got.GeneratedAt, err)
+	}
+	if strings.TrimSpace(got.BuildVersion) == "" {
+		t.Fatal("build_version is empty")
+	}
+
+	if len(got.PolicyInventory.Files) == 0 {
+		t.Fatal("expected at least one policy inventory entry")
+	}
+	policyEntry, found := findPolicyEntry(got.PolicyInventory.Files, filepath.Base(configPath))
+	if !found {
+		t.Fatalf("missing policy inventory entry for %s", filepath.Base(configPath))
+	}
+	if !policyEntry.Valid || policyEntry.LoadStatus != "loaded" {
+		t.Fatalf("expected loaded policy entry, got valid=%v status=%q", policyEntry.Valid, policyEntry.LoadStatus)
+	}
+	if policyEntry.DefaultAction != "deny" {
+		t.Fatalf("default_action = %q, want %q", policyEntry.DefaultAction, "deny")
+	}
+	if policyEntry.PolicyCount != 1 {
+		t.Fatalf("policy_count = %d, want 1", policyEntry.PolicyCount)
+	}
+	if strings.Contains(policyEntry.Path, home) {
+		t.Fatalf("policy path leaked full home path: %q", policyEntry.Path)
+	}
+
+	if !got.AuditInventory.DirectoryAvailable {
+		t.Fatal("expected audit directory to be available")
+	}
+	if got.AuditInventory.TodayEvents.Allow != 1 || got.AuditInventory.TodayEvents.Deny != 1 || got.AuditInventory.TodayEvents.Watch != 1 || got.AuditInventory.TodayEvents.Pending != 1 {
+		t.Fatalf("unexpected today event counts: %+v", got.AuditInventory.TodayEvents)
+	}
+	if got.AuditInventory.TodayEvents.Total != 4 {
+		t.Fatalf("today total = %d, want 4", got.AuditInventory.TodayEvents.Total)
+	}
+}
+
+func TestInventoryJSONPolicyInvalidHandling(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+
+	configPath := filepath.Join(home, "rampart.yaml")
+	writeTestPolicyFile(t, configPath)
+
+	policyDir := filepath.Join(home, ".rampart", "policies")
+	if err := os.MkdirAll(policyDir, 0o755); err != nil {
+		t.Fatalf("mkdir policy dir: %v", err)
+	}
+	invalidPath := filepath.Join(policyDir, "invalid.yaml")
+	if err := os.WriteFile(invalidPath, []byte("version: \"1\"\npolicies:\n  - name: broken\n    rules: [\n"), 0o644); err != nil {
+		t.Fatalf("write invalid policy: %v", err)
+	}
+
+	stdout, _, err := runCLI(t, "--config", configPath, "inventory", "--json")
+	if err != nil {
+		t.Fatalf("inventory --json failed: %v", err)
+	}
+
+	var got inventorySnapshot
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("inventory --json output is not valid JSON: %v\nOutput:\n%s", err, stdout)
+	}
+
+	invalidEntry, found := findPolicyEntry(got.PolicyInventory.Files, "invalid.yaml")
+	if !found {
+		t.Fatalf("missing inventory entry for invalid policy file: %+v", got.PolicyInventory.Files)
+	}
+	if invalidEntry.Valid {
+		t.Fatalf("invalid policy unexpectedly marked valid: %+v", invalidEntry)
+	}
+	if invalidEntry.LoadStatus != "invalid" {
+		t.Fatalf("load_status = %q, want %q", invalidEntry.LoadStatus, "invalid")
+	}
+	if strings.TrimSpace(invalidEntry.Error) == "" {
+		t.Fatal("expected invalid policy error message")
+	}
+	if invalidEntry.PolicyCount != 0 {
+		t.Fatalf("invalid policy_count = %d, want 0", invalidEntry.PolicyCount)
+	}
+	if strings.Contains(invalidEntry.Path, home) {
+		t.Fatalf("invalid policy path leaked full home path: %q", invalidEntry.Path)
+	}
+	if got.PolicyInventory.InvalidCount < 1 {
+		t.Fatalf("invalid_count = %d, want at least 1", got.PolicyInventory.InvalidCount)
+	}
+}
+
+func writeTestPolicyFile(t *testing.T, path string) {
+	t.Helper()
+	content := `version: "1"
+default_action: deny
+policies:
+  - name: test-allow
+    match:
+      tool: exec
+    rules:
+      - action: allow
+        when:
+          command_matches: ["echo *"]
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write test policy: %v", err)
+	}
+}
+
+func writeTestAuditEvents(t *testing.T, auditDir string, events []audit.Event) {
+	t.Helper()
+	if err := os.MkdirAll(auditDir, 0o755); err != nil {
+		t.Fatalf("mkdir audit dir: %v", err)
+	}
+
+	path := filepath.Join(auditDir, time.Now().UTC().Format("2006-01-02")+".jsonl")
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create audit file: %v", err)
+	}
+	defer file.Close()
+
+	for i, event := range events {
+		if event.ID == "" {
+			event.ID = fmt.Sprintf("evt-%d", i+1)
+		}
+		if event.Timestamp.IsZero() {
+			event.Timestamp = time.Now().UTC()
+		}
+		data, err := json.Marshal(event)
+		if err != nil {
+			t.Fatalf("marshal audit event: %v", err)
+		}
+		if _, err := file.Write(append(data, '\n')); err != nil {
+			t.Fatalf("write audit event: %v", err)
+		}
+	}
+}
+
+func findPolicyEntry(entries []inventoryPolicyFile, fileName string) (inventoryPolicyFile, bool) {
+	for _, entry := range entries {
+		if entry.FileName == fileName {
+			return entry, true
+		}
+	}
+	return inventoryPolicyFile{}, false
+}

--- a/cmd/rampart/cli/root.go
+++ b/cmd/rampart/cli/root.go
@@ -123,6 +123,7 @@ func NewRootCmd(ctx context.Context, outWriter, errWriter io.Writer) *cobra.Comm
 	setupCmd := newSetupCmd(opts)
 	doctorCmd := newDoctorCmd()
 	statusCmd := newStatusCmd()
+	inventoryCmd := newInventoryCmd(opts)
 	tokenCmd := newTokenShowCmd()
 	testCmd := newTestCmd(opts)
 	// benchCmd removed in v0.9 cleanup — use `go test -bench` instead
@@ -152,6 +153,7 @@ func NewRootCmd(ctx context.Context, outWriter, errWriter io.Writer) *cobra.Comm
 	serveCmd.GroupID = groupRuntime
 	tokenCmd.GroupID = groupRuntime
 	statusCmd.GroupID = groupRuntime
+	inventoryCmd.GroupID = groupRuntime
 	logCmd.GroupID = groupRuntime
 
 	approveCmd.GroupID = groupApprovals
@@ -190,6 +192,7 @@ func NewRootCmd(ctx context.Context, outWriter, errWriter io.Writer) *cobra.Comm
 	cmd.AddCommand(setupCmd)
 	cmd.AddCommand(doctorCmd)
 	cmd.AddCommand(statusCmd)
+	cmd.AddCommand(inventoryCmd)
 	cmd.AddCommand(tokenCmd)
 	cmd.AddCommand(testCmd)
 	// cmd.AddCommand(benchCmd)

--- a/cmd/rampart/cli/status.go
+++ b/cmd/rampart/cli/status.go
@@ -30,30 +30,144 @@ import (
 )
 
 func newStatusCmd() *cobra.Command {
-	return &cobra.Command{
+	var jsonOut bool
+
+	cmd := &cobra.Command{
 		Use:   "status",
 		Short: "Show Rampart protection status",
 		Long:  "Display a quick dashboard of Rampart protection status, mode, and today's events.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runStatus(cmd.OutOrStdout())
+			return runStatus(cmd.OutOrStdout(), jsonOut)
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output status as JSON")
+	return cmd
 }
 
-func runStatus(w io.Writer) error {
-	protected := detectProtectedAgents()
-	mode, defaultAction := detectMode()
-	allow, deny, pending, lastDeny := todayEvents()
-	serverRunning := isServeRunningLocal()
-	hookOnly := isHookBasedOnly(protected)
+const statusSchemaVersion = "rampart.status.v1"
+
+type statusSnapshot struct {
+	generatedAt   time.Time
+	buildVersion  string
+	protected     []string
+	mode          string
+	defaultAction string
+	serverRunning bool
+	hookOnly      bool
+	allow         int
+	deny          int
+	pending       int
+	lastDeny      *audit.Event
+}
+
+type statusJSONOutput struct {
+	SchemaVersion string              `json:"schema_version"`
+	GeneratedAt   time.Time           `json:"generated_at"`
+	BuildVersion  string              `json:"build_version"`
+	Protected     []string            `json:"protected_agents"`
+	Mode          string              `json:"mode"`
+	DefaultAction string              `json:"default_action"`
+	ServerRunning bool                `json:"server_running"`
+	HookOnly      bool                `json:"hook_only"`
+	Today         statusTodayJSON     `json:"today"`
+	LastDeny      *statusLastDenyJSON `json:"last_deny,omitempty"`
+}
+
+type statusTodayJSON struct {
+	Allow   int `json:"allow"`
+	Deny    int `json:"deny"`
+	Pending int `json:"pending"`
+}
+
+type statusLastDenyJSON struct {
+	Timestamp time.Time `json:"timestamp"`
+	Tool      string    `json:"tool"`
+	Command   string    `json:"command,omitempty"`
+}
+
+func runStatus(w io.Writer, jsonOut bool) error {
+	snapshot := collectStatusSnapshot(time.Now().UTC())
+	if jsonOut {
+		return writeStatusJSON(w, snapshot)
+	}
 
 	useColor := !noColor() && isTerminal(os.Stdout)
 
-	box := buildStatusBox(protected, mode, defaultAction, allow, deny, pending, serverRunning, hookOnly, lastDeny, useColor)
+	box := buildStatusBox(
+		snapshot.protected,
+		snapshot.mode,
+		snapshot.defaultAction,
+		snapshot.allow,
+		snapshot.deny,
+		snapshot.pending,
+		snapshot.serverRunning,
+		snapshot.hookOnly,
+		snapshot.lastDeny,
+		useColor,
+	)
 	fmt.Fprintln(w, box)
 
-	printStatusHints(w, serverRunning, protected, allow, deny, pending)
+	printStatusHints(w, snapshot.serverRunning, snapshot.protected, snapshot.allow, snapshot.deny, snapshot.pending)
 	return nil
+}
+
+func collectStatusSnapshot(generatedAt time.Time) statusSnapshot {
+	if generatedAt.IsZero() {
+		generatedAt = time.Now().UTC()
+	}
+	protected := detectProtectedAgents()
+	mode, defaultAction := detectMode()
+	allow, deny, pending, lastDeny := todayEventsAt(generatedAt)
+	return statusSnapshot{
+		generatedAt:   generatedAt,
+		buildVersion:  build.Version,
+		protected:     protected,
+		mode:          mode,
+		defaultAction: defaultAction,
+		serverRunning: isServeRunningLocal(),
+		hookOnly:      isHookBasedOnly(protected),
+		allow:         allow,
+		deny:          deny,
+		pending:       pending,
+		lastDeny:      lastDeny,
+	}
+}
+
+func writeStatusJSON(w io.Writer, snapshot statusSnapshot) error {
+	protected := snapshot.protected
+	if protected == nil {
+		protected = []string{}
+	}
+
+	out := statusJSONOutput{
+		SchemaVersion: statusSchemaVersion,
+		GeneratedAt:   snapshot.generatedAt,
+		BuildVersion:  snapshot.buildVersion,
+		Protected:     protected,
+		Mode:          snapshot.mode,
+		DefaultAction: snapshot.defaultAction,
+		ServerRunning: snapshot.serverRunning,
+		HookOnly:      snapshot.hookOnly,
+		Today: statusTodayJSON{
+			Allow:   snapshot.allow,
+			Deny:    snapshot.deny,
+			Pending: snapshot.pending,
+		},
+	}
+
+	if snapshot.lastDeny != nil {
+		last := &statusLastDenyJSON{
+			Timestamp: snapshot.lastDeny.Timestamp,
+			Tool:      snapshot.lastDeny.Tool,
+		}
+		if command := extractEventCommand(snapshot.lastDeny); !isUnknownOrEmpty(command) {
+			last.Command = command
+		}
+		out.LastDeny = last
+	}
+
+	enc := json.NewEncoder(w)
+	return enc.Encode(out)
 }
 
 // Box dimensions.
@@ -339,13 +453,20 @@ func detectMode() (string, string) {
 // todayEvents returns today's allow/deny/pending counts and the most recent deny event.
 // "pending" counts require_approval and webhook actions.
 func todayEvents() (allow, deny, pending int, lastDeny *audit.Event) {
+	return todayEventsAt(time.Now().UTC())
+}
+
+func todayEventsAt(now time.Time) (allow, deny, pending int, lastDeny *audit.Event) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return
 	}
 	auditDir := filepath.Join(home, ".rampart", "audit")
 
-	today := time.Now().UTC().Format("2006-01-02")
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	today := now.UTC().Format("2006-01-02")
 
 	seen := make(map[string]bool)
 	var candidates []string

--- a/cmd/rampart/cli/status_test.go
+++ b/cmd/rampart/cli/status_test.go
@@ -15,17 +15,19 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/peg/rampart/internal/audit"
 )
 
 func TestRunStatus(t *testing.T) {
 	var buf bytes.Buffer
-	err := runStatus(&buf)
+	err := runStatus(&buf, false)
 	if err != nil {
 		t.Fatalf("runStatus returned error: %v", err)
 	}
@@ -37,6 +39,111 @@ func TestRunStatus(t *testing.T) {
 	// Verify the status line is present.
 	if !strings.Contains(out, "Status") {
 		t.Error("missing Status row in status output")
+	}
+}
+
+func TestStatusCmdDefaultHumanOutput(t *testing.T) {
+	stdout, _, err := runCLI(t, "status")
+	if err != nil {
+		t.Fatalf("status returned error: %v", err)
+	}
+	if !strings.Contains(stdout, "RAMPART") {
+		t.Fatalf("expected human status box output, got: %s", stdout)
+	}
+	var payload map[string]any
+	if jsonErr := json.Unmarshal([]byte(stdout), &payload); jsonErr == nil {
+		t.Fatal("default status output should not be JSON")
+	}
+}
+
+func TestStatusCmdJSONOutput(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+
+	policyDir := filepath.Join(home, ".rampart", "policies")
+	if err := os.MkdirAll(policyDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(policyDir, "status.yaml"), []byte("version: \"1\"\ndefault_action: allow\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	auditDir := filepath.Join(home, ".rampart", "audit")
+	if err := os.MkdirAll(auditDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	allowEvent := audit.Event{
+		ID:        "01JTEST000000000000000001",
+		Timestamp: now.Add(-1 * time.Minute),
+		Agent:     "agent-1",
+		Session:   "session-1",
+		Tool:      "exec",
+		Request:   map[string]any{"command": "echo ok"},
+		Decision:  audit.EventDecision{Action: "allow", EvalTimeUS: 1},
+		Hash:      "sha256:allow",
+	}
+	denyEvent := audit.Event{
+		ID:        "01JTEST000000000000000002",
+		Timestamp: now,
+		Agent:     "agent-1",
+		Session:   "session-1",
+		Tool:      "exec",
+		Request:   map[string]any{"command": "rm -rf /tmp/demo"},
+		Decision:  audit.EventDecision{Action: "deny", EvalTimeUS: 1},
+		PrevHash:  allowEvent.Hash,
+		Hash:      "sha256:deny",
+	}
+	allowLine, err := json.Marshal(allowEvent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	denyLine, err := json.Marshal(denyEvent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	logPath := filepath.Join(auditDir, now.Format("2006-01-02")+".jsonl")
+	content := string(allowLine) + "\n" + string(denyLine) + "\n"
+	if err := os.WriteFile(logPath, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, _, err := runCLI(t, "status", "--json")
+	if err != nil {
+		t.Fatalf("status --json returned error: %v", err)
+	}
+
+	var got statusJSONOutput
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("status --json output is not valid JSON: %v\noutput: %s", err, stdout)
+	}
+
+	if got.SchemaVersion != statusSchemaVersion {
+		t.Fatalf("schema_version=%q, want %q", got.SchemaVersion, statusSchemaVersion)
+	}
+	if got.GeneratedAt.IsZero() {
+		t.Fatal("generated_at should be set")
+	}
+	if got.BuildVersion == "" {
+		t.Fatal("build_version should be set")
+	}
+	if got.Mode != "monitor" {
+		t.Fatalf("mode=%q, want monitor", got.Mode)
+	}
+	if got.DefaultAction != "allow" {
+		t.Fatalf("default_action=%q, want allow", got.DefaultAction)
+	}
+	if got.Today.Allow != 1 || got.Today.Deny != 1 || got.Today.Pending != 0 {
+		t.Fatalf("today counts mismatch: %+v", got.Today)
+	}
+	if got.LastDeny == nil {
+		t.Fatal("last_deny should be present")
+	}
+	if got.LastDeny.Tool != "exec" {
+		t.Fatalf("last_deny.tool=%q, want exec", got.LastDeny.Tool)
+	}
+	if !strings.Contains(got.LastDeny.Command, "rm -rf") {
+		t.Fatalf("last_deny.command=%q, want command summary", got.LastDeny.Command)
 	}
 }
 

--- a/docs-site/getting-started/installation.md
+++ b/docs-site/getting-started/installation.md
@@ -97,7 +97,7 @@ volumes:
   rampart-audit:
 ```
 
-Available tags include full versions such as `1.0.0`, minor versions such as `1.0`, and `latest` for the current stable release. Prereleases use their full tag, for example `1.0.0-rc.3`, and do not move `latest`. Pin to a specific version tag for reproducibility. Images are published on [GitHub Container Registry](https://github.com/peg/rampart/pkgs/container/rampart).
+Available tags include full versions such as `1.1.0`, minor versions such as `1.1`, and `latest` for the current stable release. Prereleases use their full tag, for example `1.1.0-rc.1`, and do not move `latest`. Pin to a specific version tag for reproducibility. Images are published on [GitHub Container Registry](https://github.com/peg/rampart/pkgs/container/rampart).
 
 ## Build from Source
 

--- a/docs-site/getting-started/troubleshooting.md
+++ b/docs-site/getting-started/troubleshooting.md
@@ -165,7 +165,7 @@ rampart test --tool read "/etc/shadow"
 
 ```bash
 openclaw plugins list
-# Should show: rampart  1.0.0  ✓ active
+# Should show: rampart  1.1.0  ✓ active
 
 rampart doctor
 # Should show: ✓ OpenClaw plugin: installed (before_tool_call hook active)

--- a/docs-site/index.html
+++ b/docs-site/index.html
@@ -27,7 +27,7 @@
       "url": "https://rampart.sh",
       "applicationCategory": "SecurityApplication",
       "operatingSystem": "Linux, macOS, Windows",
-      "softwareVersion": "1.0.0",
+      "softwareVersion": "1.1.0",
       "offers": {
         "@type": "Offer",
         "price": "0",
@@ -1112,7 +1112,7 @@
 <section class="hero">
     <div class="container hero-grid">
         <div>
-            <div class="eyebrow"><span class="eyebrow-dot"></span>v1.0.0 · launch-ready</div>
+            <div class="eyebrow"><span class="eyebrow-dot"></span>v1.1.0 · release-ready</div>
             <h1>Your agent has root.<br><span class="accent">That’s the problem.</span></h1>
             <p class="hero-sub">Rampart sits in the execution path. Install it, run <code>rampart quickstart</code>, and it wires the right protection path for Claude Code, Codex, Cline, or OpenClaw before risky tool calls run.</p>
             <div class="install-cluster">

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -205,7 +205,14 @@ verify -> outcomes.approval
 
 [:octicons-arrow-right-24: See all integration guides](integrations/index.md)
 
-## What's New in v1.0
+## What's New in v1.1
+
+- **Machine-readable diagnostics** — `rampart status --json`, `rampart doctor --json`, and `rampart inventory --json` expose structured runtime and integration state for automation.
+- **OpenClaw gateway v4 support** — the bundled plugin speaks the current gateway/status response contract while preserving native approval and audit ownership.
+- **Codex native shell audit coverage** — the release gate now proves Codex app-server native shell calls correlate with canonical Rampart `exec` audit events.
+- **Patched release toolchain** — CI, release, and Docker builds now use Go 1.25.10.
+
+### v1.0
 
 - **Update checks are sane** — `rampart doctor` understands the 1.0 release line and no longer suggests downgrading release candidates to the older stable `v0.9.22` release.
 - **OpenClaw 2026.5.6 verified for launch** — Rampart uses OpenClaw's first-class plugin approval path as the single human-approval owner, with Rampart handling policy, audit, and durable allow-always persistence. [Details →](integrations/openclaw.md)

--- a/docs-site/integrations/openclaw.md
+++ b/docs-site/integrations/openclaw.md
@@ -157,7 +157,7 @@ Or check plugin status directly:
 
 ```bash
 openclaw plugins list
-# rampart  v1.0.0  active
+# rampart  v1.1.0  active
 ```
 
 ## Troubleshooting

--- a/docs-site/reference/cli-commands.md
+++ b/docs-site/reference/cli-commands.md
@@ -270,6 +270,17 @@ rampart status --json      # Machine-readable snapshot
 
 `--json` emits a stable status payload (`schema_version: "rampart.status.v1"`) with mode, protection state, server flags, today's counts, and optional last deny details.
 
+### `rampart inventory`
+
+Local observability snapshot for automation and debugging.
+
+Use `--json` for a stable machine-readable contract (`rampart.inventory.v1`) that includes protected agents, policy file load status, audit footprint, and local `rampart serve` reachability.
+
+```bash
+rampart inventory
+rampart inventory --json
+```
+
 ### `rampart test`
 
 Dry-run commands against your policies or run a declarative test suite.

--- a/docs-site/reference/cli-commands.md
+++ b/docs-site/reference/cli-commands.md
@@ -245,6 +245,9 @@ Health check — verifies installation, policies, server, hooks, audit trail, an
 rampart doctor
 ```
 
+For automation, `rampart doctor --json` emits schema `rampart.doctor.v1` with top-level fields:
+`schema_version`, `generated_at`, `build_version`, `summary`, `checks`, numeric `warnings`/`issues`, and `warning_checks`/`issue_checks` arrays.
+
 When the OpenClaw native plugin is installed, doctor shows:
 ```
 ✓ OpenClaw plugin: installed (before_tool_call hook active)

--- a/docs-site/reference/cli-commands.md
+++ b/docs-site/reference/cli-commands.md
@@ -262,7 +262,10 @@ Quick dashboard showing protected agents, enforcement mode, and today's event co
 
 ```bash
 rampart status
+rampart status --json      # Machine-readable snapshot
 ```
+
+`--json` emits a stable status payload (`schema_version: "rampart.status.v1"`) with mode, protection state, server flags, today's counts, and optional last deny details.
 
 ### `rampart test`
 

--- a/docs-site/reference/threat-model.md
+++ b/docs-site/reference/threat-model.md
@@ -1,6 +1,6 @@
 # Threat Model
 
-> Last reviewed: 2026-04-30 | Applies to: v1.0.0
+> Last reviewed: 2026-05-24 | Applies to: v1.1.0
 
 Rampart is a policy engine for AI agents — not a sandbox, not a hypervisor, not a full isolation boundary. This document describes what Rampart protects against, what it doesn't, and why.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -45,12 +45,12 @@ What's coming next for Rampart. Priorities shift based on feedback — [open an 
 
 ## Current Focus
 
-### `v1.0.0`
-- Keep the integration support story boring and evidence-backed: hooks, plugins, preload/wrapper, MCP, and HTTP API should each say what is protected and what happens when policy evaluation is unavailable.
-- Treat OpenClaw `2026.5.2+` as the recommended 1.0 path for native plugin approvals, with launch dogfood verified on OpenClaw `2026.5.6`.
-- Keep `rampart doctor`, setup output, plugin metadata, and docs aligned so users can answer "am I protected, how, and what breaks if serve is down?" without reading source.
+### `v1.1.0`
+- Keep structured diagnostics boring and automation-friendly: `status --json`, `doctor --json`, and `inventory --json` should remain stable enough for scripts without replacing human-readable output.
+- Treat current OpenClaw gateway protocol support and Codex native shell audit correlation as release-gated integrations, with live regression proof before tagging.
+- Keep the release toolchain, plugin metadata, setup output, and docs aligned so users can answer "am I protected, how, and what version is active?" without reading source.
 
-### After 1.0
+### After 1.1
 - Collect feedback from real OpenClaw, Claude Code, Cline, Codex, and MCP users.
 - Fix integration bugs without widening the public API unless the tradeoff is explicit.
 - Keep the support matrix and threat model honest as agent runtimes evolve.

--- a/docs/design/openclaw-approval-acceptance-checklist.md
+++ b/docs/design/openclaw-approval-acceptance-checklist.md
@@ -41,9 +41,23 @@ go build ./cmd/rampart
 Pass criteria:
 - build completes successfully
 
+### 4. Live Codex app-server shell-audit regression
+
+```bash
+RAMPART_OPENCLAW_RUNTIME=1 node scripts/test-openclaw-codex-native-audit.mjs
+```
+
+Pass criteria:
+- test creates a real OpenClaw Codex app-server session metadata file (`*.jsonl.codex-app-server.json`)
+- trajectory contains a native Codex `bash` tool call for the test marker
+- Rampart audit contains a correlated canonical `exec` event for the same marker/session
+- OpenClaw config and Rampart token file are restored after the test
+
+Do not count a successful OpenClaw command or trajectory as sufficient by itself. The audit event is the proof that the native shell path crossed Rampart policy evaluation.
+
 ## Installed integration checks
 
-### 4. Reinstall plugin
+### 5. Reinstall plugin
 
 ```bash
 go build -o ~/.local/bin/rampart ./cmd/rampart
@@ -62,7 +76,7 @@ Pass criteria:
 
 ## Real product validation
 
-### 5. Native Discord approval card
+### 6. Native Discord approval card
 
 Validate with one real Discord DM case that becomes a real tool invocation.
 
@@ -74,7 +88,7 @@ Pass criteria:
 
 Do not count this as passed if only `exec.approval.list` or `plugin.approval.list` shows a pending record. Queue creation proves the backend path. It does not prove the user-facing approval path.
 
-### 6. Decision outcomes
+### 7. Decision outcomes
 
 Pass criteria:
 - allow once succeeds
@@ -82,7 +96,7 @@ Pass criteria:
 - allow always writes durable learned rule to `~/.rampart/policies/user-overrides.yaml`
 - no hidden second approval queue is created by Rampart
 
-### 7. Live three-state proof
+### 8. Live three-state proof
 
 Validate one case for each state:
 - allow: a previously learned command like `sudo true`

--- a/docs/index.html
+++ b/docs/index.html
@@ -27,7 +27,7 @@
       "url": "https://rampart.sh",
       "applicationCategory": "SecurityApplication",
       "operatingSystem": "Linux, macOS, Windows",
-      "softwareVersion": "1.0.0",
+      "softwareVersion": "1.1.0",
       "offers": {
         "@type": "Offer",
         "price": "0",
@@ -1112,7 +1112,7 @@
 <section class="hero">
     <div class="container hero-grid">
         <div>
-            <div class="eyebrow"><span class="eyebrow-dot"></span>v1.0.0 · launch-ready</div>
+            <div class="eyebrow"><span class="eyebrow-dot"></span>v1.1.0 · release-ready</div>
             <h1>Your agent has root.<br><span class="accent">That’s the problem.</span></h1>
             <p class="hero-sub">Rampart sits in the execution path. Install it, run <code>rampart quickstart</code>, and it wires the right protection path for Claude Code, Codex, Cline, or OpenClaw before risky tool calls run.</p>
             <div class="install-cluster">

--- a/docs/install
+++ b/docs/install
@@ -7,8 +7,8 @@
 # Usage: curl -fsSL https://rampart.sh/install | sh
 #        curl -fsSL https://rampart.sh/install | sh -s -- --version v0.1.0
 #        curl -fsSL https://rampart.sh/install | sh -s -- --auto-setup
-#        RAMPART_INSTALL_DRY_RUN=1 sh install.sh --version v1.0.0
-#        RAMPART_VERSION=v1.0.0 RAMPART_INSTALL_DIR=$HOME/.local/bin sh install.sh
+#        RAMPART_INSTALL_DRY_RUN=1 sh install.sh --version v1.1.0
+#        RAMPART_VERSION=v1.1.0 RAMPART_INSTALL_DIR=$HOME/.local/bin sh install.sh
 set -e
 
 REPO="peg/rampart"

--- a/docs/install.sh
+++ b/docs/install.sh
@@ -7,8 +7,8 @@
 # Usage: curl -fsSL https://rampart.sh/install | sh
 #        curl -fsSL https://rampart.sh/install | sh -s -- --version v0.1.0
 #        curl -fsSL https://rampart.sh/install | sh -s -- --auto-setup
-#        RAMPART_INSTALL_DRY_RUN=1 sh install.sh --version v1.0.0
-#        RAMPART_VERSION=v1.0.0 RAMPART_INSTALL_DIR=$HOME/.local/bin sh install.sh
+#        RAMPART_INSTALL_DRY_RUN=1 sh install.sh --version v1.1.0
+#        RAMPART_VERSION=v1.1.0 RAMPART_INSTALL_DIR=$HOME/.local/bin sh install.sh
 set -e
 
 REPO="peg/rampart"

--- a/install.sh
+++ b/install.sh
@@ -7,8 +7,8 @@
 # Usage: curl -fsSL https://rampart.sh/install | sh
 #        curl -fsSL https://rampart.sh/install | sh -s -- --version v0.1.0
 #        curl -fsSL https://rampart.sh/install | sh -s -- --auto-setup
-#        RAMPART_INSTALL_DRY_RUN=1 sh install.sh --version v1.0.0
-#        RAMPART_VERSION=v1.0.0 RAMPART_INSTALL_DIR=$HOME/.local/bin sh install.sh
+#        RAMPART_INSTALL_DRY_RUN=1 sh install.sh --version v1.1.0
+#        RAMPART_VERSION=v1.1.0 RAMPART_INSTALL_DIR=$HOME/.local/bin sh install.sh
 set -e
 
 REPO="peg/rampart"

--- a/internal/audit/cef.go
+++ b/internal/audit/cef.go
@@ -177,6 +177,7 @@ func (m *MultiSink) drain() {
 
 // Write writes to the primary sink and enqueues to secondary sinks (non-blocking).
 func (m *MultiSink) Write(event Event) error {
+	event = applyEventDefaults(event)
 	err := m.primary.Write(event)
 	// Non-blocking send to secondary sinks.
 	select {

--- a/internal/audit/defaults.go
+++ b/internal/audit/defaults.go
@@ -1,0 +1,74 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package audit
+
+import (
+	"os"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+)
+
+var (
+	hostContextOnce   sync.Once
+	cachedHostContext HostContext
+)
+
+func applyEventDefaults(event Event) Event {
+	if strings.TrimSpace(event.SchemaVersion) == "" {
+		event.SchemaVersion = EventSchemaVersion
+	}
+	if event.ID == "" {
+		event.ID = NewEventID()
+	}
+	if event.Timestamp.IsZero() {
+		event.Timestamp = time.Now().UTC()
+	}
+	if event.Host == nil {
+		event.Host = &HostContext{}
+	}
+	host := defaultHostContext(*event.Host)
+	event.Host = &host
+	return event
+}
+
+func defaultHostContext(host HostContext) HostContext {
+	defaults := localHostContext()
+	if strings.TrimSpace(host.Hostname) == "" {
+		host.Hostname = defaults.Hostname
+	}
+	if strings.TrimSpace(host.OS) == "" {
+		host.OS = defaults.OS
+	}
+	if strings.TrimSpace(host.Arch) == "" {
+		host.Arch = defaults.Arch
+	}
+	return host
+}
+
+func localHostContext() HostContext {
+	hostContextOnce.Do(func() {
+		hostname, err := os.Hostname()
+		if err != nil || strings.TrimSpace(hostname) == "" {
+			hostname = "unknown"
+		}
+		cachedHostContext = HostContext{
+			Hostname: hostname,
+			OS:       runtime.GOOS,
+			Arch:     runtime.GOARCH,
+		}
+	})
+	return cachedHostContext
+}

--- a/internal/audit/event.go
+++ b/internal/audit/event.go
@@ -31,12 +31,17 @@ import (
 	"time"
 )
 
+const EventSchemaVersion = "rampart.audit.v1"
+
 // Event represents a single audited tool call.
 //
 // Events are written to the audit trail in JSONL format, one per line.
 // The hash chain ensures integrity: modifying any event breaks the chain
 // for all subsequent events.
 type Event struct {
+	// SchemaVersion identifies the stable JSON event schema.
+	SchemaVersion string `json:"schema_version,omitempty"`
+
 	// ID is a ULID — time-ordered, lexicographically sortable, globally unique.
 	ID string `json:"id"`
 
@@ -48,6 +53,9 @@ type Event struct {
 
 	// Session identifies the agent's session (git repo/branch or RAMPART_SESSION).
 	Session string `json:"session"`
+
+	// Host records local, non-sensitive host context.
+	Host *HostContext `json:"host,omitempty"`
 
 	// RunID groups events from the same orchestration run.
 	// Sourced from Claude Code's session_id field, RAMPART_RUN env override,
@@ -74,6 +82,13 @@ type Event struct {
 	// Hash is the SHA-256 hash of this event (excluding the hash field itself).
 	// Computed by ComputeHash after all other fields are set.
 	Hash string `json:"hash"`
+}
+
+// HostContext contains non-sensitive local host identifiers.
+type HostContext struct {
+	Hostname string `json:"hostname"`
+	OS       string `json:"os"`
+	Arch     string `json:"arch"`
 }
 
 // EventDecision is the policy engine's verdict, recorded in the audit event.

--- a/internal/audit/event_compat_test.go
+++ b/internal/audit/event_compat_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package audit
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifyHash_LegacyEventWithoutSchemaAndHost(t *testing.T) {
+	type legacyEvent struct {
+		ID        string         `json:"id"`
+		Timestamp time.Time      `json:"timestamp"`
+		Agent     string         `json:"agent"`
+		Session   string         `json:"session"`
+		Tool      string         `json:"tool"`
+		Request   map[string]any `json:"request"`
+		Decision  EventDecision  `json:"decision"`
+		PrevHash  string         `json:"prev_hash"`
+		Hash      string         `json:"hash"`
+	}
+
+	legacy := legacyEvent{
+		ID:        "01JTEST000000000000000100",
+		Timestamp: time.Date(2026, 2, 12, 10, 0, 0, 0, time.UTC),
+		Agent:     "agent-1",
+		Session:   "session-1",
+		Tool:      "exec",
+		Request:   map[string]any{"command": "echo hello"},
+		Decision:  EventDecision{Action: "allow", EvalTimeUS: 7},
+		PrevHash:  "",
+	}
+
+	forHash := legacy
+	forHash.Hash = ""
+	data, err := json.Marshal(forHash)
+	require.NoError(t, err)
+
+	sum := sha256.Sum256(append([]byte(legacy.PrevHash), data...))
+	legacy.Hash = "sha256:" + hex.EncodeToString(sum[:])
+
+	line, err := json.Marshal(legacy)
+	require.NoError(t, err)
+
+	var parsed Event
+	require.NoError(t, json.Unmarshal(line, &parsed))
+	require.Empty(t, parsed.SchemaVersion)
+	require.Nil(t, parsed.Host)
+
+	ok, err := parsed.VerifyHash()
+	require.NoError(t, err)
+	require.True(t, ok)
+}

--- a/internal/audit/jsonl.go
+++ b/internal/audit/jsonl.go
@@ -190,12 +190,7 @@ func (s *JSONLSink) Write(event Event) error {
 	if s.closed {
 		return fmt.Errorf("audit: write on closed sink")
 	}
-	if event.ID == "" {
-		event.ID = NewEventID()
-	}
-	if event.Timestamp.IsZero() {
-		event.Timestamp = time.Now().UTC()
-	}
+	event = applyEventDefaults(event)
 
 	event.PrevHash = s.lastHash
 	if err := event.ComputeHash(); err != nil {

--- a/internal/audit/jsonl_test.go
+++ b/internal/audit/jsonl_test.go
@@ -18,9 +18,9 @@ import (
 	"encoding/json"
 	"io"
 	"log/slog"
-	"sort"
 	"os"
 	"path/filepath"
+	"sort"
 	"sync"
 	"testing"
 	"time"
@@ -61,6 +61,69 @@ func TestJSONLSinkWrite_ValidJSONLine(t *testing.T) {
 			assert.Equal(t, "exec", parsed.Tool)
 		})
 	}
+}
+
+func TestJSONLSinkWrite_AppliesDefaults(t *testing.T) {
+	dir := t.TempDir()
+	sink, err := NewJSONLSink(dir, WithFsync(false))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sink.Close() })
+
+	event := sampleEvent("exec")
+	event.ID = ""
+	event.Timestamp = time.Time{}
+	event.SchemaVersion = ""
+	event.Host = nil
+
+	require.NoError(t, sink.Write(event))
+
+	lines := readJSONLLines(t, sink.filePath())
+	require.Len(t, lines, 1)
+
+	var parsed Event
+	require.NoError(t, json.Unmarshal([]byte(lines[0]), &parsed))
+	assert.NotEmpty(t, parsed.ID)
+	assert.False(t, parsed.Timestamp.IsZero())
+	assert.Equal(t, EventSchemaVersion, parsed.SchemaVersion)
+	require.NotNil(t, parsed.Host)
+	assert.NotEmpty(t, parsed.Host.Hostname)
+	assert.NotEmpty(t, parsed.Host.OS)
+	assert.NotEmpty(t, parsed.Host.Arch)
+}
+
+func TestJSONLSinkWrite_HashCoversDefaultedFields(t *testing.T) {
+	dir := t.TempDir()
+	sink, err := NewJSONLSink(dir, WithFsync(false))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sink.Close() })
+
+	event := sampleEvent("exec")
+	event.ID = ""
+	event.Timestamp = time.Time{}
+	event.SchemaVersion = ""
+	event.Host = nil
+	require.NoError(t, sink.Write(event))
+
+	lines := readJSONLLines(t, sink.filePath())
+	require.Len(t, lines, 1)
+
+	var parsed Event
+	require.NoError(t, json.Unmarshal([]byte(lines[0]), &parsed))
+
+	mutated := parsed
+	mutated.SchemaVersion = "rampart.audit.v2"
+	ok, verifyErr := mutated.VerifyHash()
+	require.NoError(t, verifyErr)
+	assert.False(t, ok)
+
+	mutated = parsed
+	require.NotNil(t, mutated.Host)
+	mutatedHost := *mutated.Host
+	mutatedHost.Hostname = "tampered-host"
+	mutated.Host = &mutatedHost
+	ok, verifyErr = mutated.VerifyHash()
+	require.NoError(t, verifyErr)
+	assert.False(t, ok)
 }
 
 func TestJSONLSinkWrite_HashChainValid(t *testing.T) {

--- a/internal/audit/reader_test.go
+++ b/internal/audit/reader_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package audit
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadEventsFromOffset_BackwardCompatibleMissingFields(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "legacy.jsonl")
+	line := `{"id":"01JTEST000000000000000000","timestamp":"2026-02-12T00:00:00Z","agent":"agent-1","session":"session-1","tool":"exec","request":{"command":"echo hello"},"decision":{"action":"allow","evaluation_time_us":10},"prev_hash":"","hash":"sha256:abc"}` + "\n"
+	require.NoError(t, os.WriteFile(path, []byte(line), 0o600))
+
+	events, _, err := ReadEventsFromOffset(path, 0)
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+
+	require.Empty(t, events[0].SchemaVersion)
+	require.Nil(t, events[0].Host)
+}

--- a/internal/audit/rotate.go
+++ b/internal/audit/rotate.go
@@ -25,7 +25,7 @@ import (
 const anchorFilename = "audit-anchor.json"
 
 func (s *JSONLSink) shouldRotateLocked(incoming int) bool {
-	if s.rotateSize <= 0 {
+	if s.rotateSize <= 0 || s.currentSize == 0 {
 		return false
 	}
 	return s.currentSize+int64(incoming) > s.rotateSize

--- a/internal/audit/syslog_test.go
+++ b/internal/audit/syslog_test.go
@@ -144,6 +144,63 @@ func TestMultiSink_FanOut(t *testing.T) {
 	}
 }
 
+func TestMultiSink_FanOutUsesDefaultedEvent(t *testing.T) {
+	var primaryEvents []Event
+	primary := &mockSink{writeFn: func(e Event) error {
+		primaryEvents = append(primaryEvents, e)
+		return nil
+	}}
+	syslogSink := &mockSyslogSender{}
+
+	ms := NewMultiSink(primary, syslogSink, nil, nil)
+	e := Event{
+		Agent:   "test-agent",
+		Session: "sess-1",
+		Tool:    "exec",
+		Request: map[string]any{"command": "echo hello"},
+		Decision: EventDecision{
+			Action:     "allow",
+			EvalTimeUS: 42,
+		},
+	}
+
+	if err := ms.Write(e); err != nil {
+		t.Fatal(err)
+	}
+	if err := ms.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(primaryEvents) != 1 {
+		t.Fatalf("expected 1 primary write, got %d", len(primaryEvents))
+	}
+	if len(syslogSink.events) != 1 {
+		t.Fatalf("expected 1 secondary write, got %d", len(syslogSink.events))
+	}
+
+	primaryEvent := primaryEvents[0]
+	secondaryEvent := syslogSink.events[0]
+
+	if primaryEvent.SchemaVersion != EventSchemaVersion {
+		t.Fatalf("primary schema_version=%q, want %q", primaryEvent.SchemaVersion, EventSchemaVersion)
+	}
+	if secondaryEvent.SchemaVersion != EventSchemaVersion {
+		t.Fatalf("secondary schema_version=%q, want %q", secondaryEvent.SchemaVersion, EventSchemaVersion)
+	}
+	if primaryEvent.ID == "" || secondaryEvent.ID == "" {
+		t.Fatalf("expected defaulted id in both sinks")
+	}
+	if primaryEvent.Timestamp.IsZero() || secondaryEvent.Timestamp.IsZero() {
+		t.Fatalf("expected defaulted timestamp in both sinks")
+	}
+	if secondaryEvent.Host == nil {
+		t.Fatalf("expected defaulted host context in secondary sink")
+	}
+	if secondaryEvent.Host.Hostname == "" || secondaryEvent.Host.OS == "" || secondaryEvent.Host.Arch == "" {
+		t.Fatalf("expected defaulted host context in secondary sink: %+v", *secondaryEvent.Host)
+	}
+}
+
 func TestCEFFileSink_Write(t *testing.T) {
 	dir := t.TempDir()
 	path := dir + "/cef.log"
@@ -170,6 +227,16 @@ type mockSink struct {
 func (m *mockSink) Write(e Event) error { return m.writeFn(e) }
 func (m *mockSink) Flush() error        { return nil }
 func (m *mockSink) Close() error        { return nil }
+
+type mockSyslogSender struct {
+	events []Event
+}
+
+func (m *mockSyslogSender) Send(e Event) {
+	m.events = append(m.events, e)
+}
+
+func (m *mockSyslogSender) Close() error { return nil }
 
 func readFileBytes(path string) ([]byte, error) {
 	return os.ReadFile(path)

--- a/internal/bridge/openclaw.go
+++ b/internal/bridge/openclaw.go
@@ -50,6 +50,8 @@ import (
 	"github.com/peg/rampart/internal/engine"
 )
 
+const openClawGatewayProtocolVersion = 4
+
 // OpenClawBridge connects to the OpenClaw gateway and handles exec approval
 // routing through Rampart's policy engine.
 type OpenClawBridge struct {
@@ -264,8 +266,8 @@ func (b *OpenClawBridge) sendConnect(conn *websocket.Conn) error {
 		ID:     reqID,
 		Method: "connect",
 		Params: map[string]any{
-			"minProtocol": 3,
-			"maxProtocol": 3,
+			"minProtocol": openClawGatewayProtocolVersion,
+			"maxProtocol": openClawGatewayProtocolVersion,
 			"client": map[string]any{
 				"id":          "gateway-client",
 				"displayName": "Rampart Bridge",
@@ -309,6 +311,9 @@ func (b *OpenClawBridge) sendConnect(conn *websocket.Conn) error {
 	}
 	if resFrame.Type != "res" {
 		return fmt.Errorf("unexpected connect response type: %s", resFrame.Type)
+	}
+	if resFrame.OK != nil && !*resFrame.OK {
+		return fmt.Errorf("connect rejected: %s", string(resFrame.Error))
 	}
 
 	return nil
@@ -642,6 +647,7 @@ type gatewayFrame struct {
 	Event   string          `json:"event,omitempty"`
 	Payload json.RawMessage `json:"payload,omitempty"`
 	Result  json.RawMessage `json:"result,omitempty"`
+	OK      *bool           `json:"ok,omitempty"`
 	Error   json.RawMessage `json:"error,omitempty"`
 	Seq     int             `json:"seq,omitempty"`
 }

--- a/internal/bridge/openclaw_test.go
+++ b/internal/bridge/openclaw_test.go
@@ -86,6 +86,10 @@ func (mg *mockGateway) handleConnection(conn *websocket.Conn) {
 	}
 	var req gatewayRequest
 	json.Unmarshal(msg, &req)
+	params, ok := req.Params.(map[string]any)
+	assert.True(mg.t, ok)
+	assert.Equal(mg.t, float64(openClawGatewayProtocolVersion), params["minProtocol"])
+	assert.Equal(mg.t, float64(openClawGatewayProtocolVersion), params["maxProtocol"])
 
 	// Step 3: respond with hello-ok.
 	resp := map[string]any{

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -36,6 +36,8 @@ import (
 	"github.com/peg/rampart/internal/engine"
 )
 
+const openClawGatewayProtocolVersion = 4
+
 // Config holds the daemon configuration.
 type Config struct {
 	// GatewayURL is the OpenClaw Gateway WebSocket URL (e.g., ws://127.0.0.1:18789).
@@ -214,8 +216,8 @@ type wsMessage struct {
 
 // approvalRequest is the payload of an exec.approval.requested event.
 type approvalRequest struct {
-	ID      string                `json:"id"`
-	Request approvalRequestInner  `json:"request"`
+	ID      string               `json:"id"`
+	Request approvalRequestInner `json:"request"`
 }
 
 // approvalRequestInner contains the nested request fields from OpenClaw.
@@ -249,8 +251,8 @@ func (d *Daemon) handshake(ctx context.Context) error {
 		"id":     d.nextID(),
 		"method": "connect",
 		"params": map[string]any{
-			"minProtocol": 3,
-			"maxProtocol": 3,
+			"minProtocol": openClawGatewayProtocolVersion,
+			"maxProtocol": openClawGatewayProtocolVersion,
 			"client": map[string]any{
 				"id":       "gateway-client",
 				"version":  "0.1.0",

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -88,6 +88,10 @@ func (mg *mockGateway) handleConnection(conn *websocket.Conn) {
 
 	var connectReq map[string]any
 	json.Unmarshal(msg, &connectReq)
+	params, paramsOK := connectReq["params"].(map[string]any)
+	assert.True(mg.t, paramsOK)
+	assert.Equal(mg.t, float64(openClawGatewayProtocolVersion), params["minProtocol"])
+	assert.Equal(mg.t, float64(openClawGatewayProtocolVersion), params["maxProtocol"])
 	mg.received = append(mg.received, connectReq)
 
 	// Send hello-ok.
@@ -96,7 +100,7 @@ func (mg *mockGateway) handleConnection(conn *websocket.Conn) {
 		Type:    "res",
 		ID:      connectReq["id"].(string),
 		OK:      &ok,
-		Payload: json.RawMessage(`{"type":"hello-ok","protocol":3}`),
+		Payload: json.RawMessage(`{"type":"hello-ok","protocol":4}`),
 	}
 	data, _ := json.Marshal(hello)
 	conn.WriteMessage(websocket.TextMessage, data)

--- a/internal/plugin/openclaw/README.md
+++ b/internal/plugin/openclaw/README.md
@@ -14,6 +14,7 @@ From the repo root:
 node internal/plugin/openclaw/smoke-test.mjs
 node internal/plugin/openclaw/approval-regression.mjs
 node internal/plugin/openclaw/degraded-mode-test.mjs
+node internal/plugin/openclaw/tool-alias-test.mjs
 ```
 
 Default behavior simulates:
@@ -48,6 +49,7 @@ Arguments:
 - there is no legacy `params.ask = "always"` mutation path
 - degraded mode blocks sensitive tools (`exec`, `write`) when serve is unreachable or returns 5xx
 - configured fail-open tools (`read`, `web_fetch`, `web_search`, `image` by default) remain explicit and test-covered
+- command-execution aliases such as OpenClaw `bash` map to Rampart `exec` for policy checks, learning, and audit events
 
 This is a deterministic harness for the highest-leverage regression: approval-path behavior without depending on model tool selection.
 

--- a/internal/plugin/openclaw/README.md
+++ b/internal/plugin/openclaw/README.md
@@ -51,7 +51,26 @@ Arguments:
 - configured fail-open tools (`read`, `web_fetch`, `web_search`, `image` by default) remain explicit and test-covered
 - command-execution aliases such as OpenClaw `bash` map to Rampart `exec` for policy checks, learning, and audit events
 
-This is a deterministic harness for the highest-leverage regression: approval-path behavior without depending on model tool selection.
+This is a deterministic harness for the highest-leverage plugin regression: approval-path behavior without depending on model tool selection.
+
+It still does **not** prove that the currently installed OpenClaw + Codex app-server runtime is firing the hook for native shell calls. Use the live runtime regression below for that.
+
+## Live Codex app-server shell-audit regression
+
+Run this only when you intentionally want a real local OpenClaw runtime check:
+
+```bash
+RAMPART_OPENCLAW_RUNTIME=1 node scripts/test-openclaw-codex-native-audit.mjs
+```
+
+The live regression temporarily enables the Rampart OpenClaw plugin, points it at an ephemeral local `rampart serve`, restarts the OpenClaw user services, runs one real OpenClaw Codex app-server turn, and restores the prior OpenClaw config/token state before exit.
+
+Pass criteria:
+- a `*.jsonl.codex-app-server.json` metadata file exists for the test session
+- the OpenClaw trajectory contains a native Codex `bash` tool call for the marker command
+- the temporary Rampart audit log contains a correlated canonical `exec` event for that marker command
+
+A successful assistant response or OpenClaw trajectory alone is not enough; this test fails unless Rampart audit proves the native shell call crossed the policy path.
 
 ## Live validation notes
 

--- a/internal/plugin/openclaw/index.js
+++ b/internal/plugin/openclaw/index.js
@@ -98,6 +98,53 @@ function truncateForApprovalDescription(text, max = 220) {
   return `${normalized.slice(0, Math.max(0, max - 1)).trimEnd()}…`;
 }
 
+// OpenClaw has exposed command execution through more than one tool name over
+// time. Rampart policy is intentionally written against the stable "exec"
+// class, so command-style aliases must be normalized before policy evaluation.
+// Otherwise a host exposing a tool as "bash" can bypass exec policies and land
+// in allow-unmatched/default handling.
+const EXEC_TOOL_ALIASES = new Set(["bash", "shell", "terminal"]);
+
+function normalizeExecParams(params) {
+  if (!params || typeof params !== "object") return {};
+  const normalized = { ...params };
+  const command =
+    params.command ??
+    params.input?.command ??
+    params.script ??
+    params.cmd ??
+    params.args?.command;
+  if (typeof command === "string" && !normalized.command) {
+    normalized.command = command;
+  }
+  return normalized;
+}
+
+function normalizeToolCall(toolName, params) {
+  const originalToolName = typeof toolName === "string" && toolName ? toolName : "unknown";
+  const canonical = originalToolName.toLowerCase();
+  if (EXEC_TOOL_ALIASES.has(canonical)) {
+    return {
+      toolName: "exec",
+      params: normalizeExecParams(params),
+      originalToolName,
+      mapped: true,
+    };
+  }
+  return {
+    toolName: originalToolName,
+    params: params ?? {},
+    originalToolName,
+    mapped: false,
+  };
+}
+
+function toolDisplayName(toolName, originalToolName) {
+  return originalToolName && originalToolName !== toolName
+    ? `${originalToolName}→${toolName}`
+    : toolName;
+}
+
 // ─── Rampart API client ───────────────────────────────────────────────────────
 
 /**
@@ -237,7 +284,12 @@ export function register(api) {
 
   // ── before_tool_call ────────────────────────────────────────────────────────
   api.on("before_tool_call", async (event, ctx) => {
-    const { toolName, params } = event;
+    const normalized = normalizeToolCall(event?.toolName, event?.params);
+    const { toolName, params, originalToolName, mapped } = normalized;
+    const displayToolName = toolDisplayName(toolName, originalToolName);
+    if (mapped) {
+      api.logger.info(`[rampart] mapped OpenClaw tool ${originalToolName} to Rampart ${toolName}`);
+    }
 
     const result = await checkWithRampart(toolName, params, ctx, pluginConfig);
 
@@ -248,7 +300,7 @@ export function register(api) {
         : ["read", "web_fetch", "web_search", "image"];
     const failOpenTools = new Set(configuredFailOpenTools);
     const shouldFailOpen = failOpenTools.has(toolName);
-    const unreachableReason = `[rampart] serve unavailable for ${toolName} at ${serveUrl}`;
+    const unreachableReason = `[rampart] serve unavailable for ${displayToolName} at ${serveUrl}`;
 
     // Serve unreachable → explicit degraded-state handling
     if (result?._unreachable) {
@@ -256,42 +308,42 @@ export function register(api) {
       if (shouldFailOpen) return;
       return {
         block: true,
-        blockReason: `rampart: unavailable (${toolName}) — policy service down, refusing sensitive tool call`,
+        blockReason: `rampart: unavailable (${displayToolName}) — policy service down, refusing sensitive tool call`,
       };
     }
 
     // null (timeout/unknown error) → explicit degraded-state handling
     if (result === null) {
-      api.logger.warn(`[rampart] check timed out or failed for ${toolName} (${shouldFailOpen ? "configured fail-open" : "blocking tool call"})`);
+      api.logger.warn(`[rampart] check timed out or failed for ${displayToolName} (${shouldFailOpen ? "configured fail-open" : "blocking tool call"})`);
       if (shouldFailOpen) return;
       return {
         block: true,
-        blockReason: `rampart: unavailable (${toolName}) — policy check timed out, refusing sensitive tool call`,
+        blockReason: `rampart: unavailable (${displayToolName}) — policy check timed out, refusing sensitive tool call`,
       };
     }
 
     // Serve returned an error status → explicit degraded-state handling
     if (result?._serveError) {
-      api.logger.warn(`[rampart] serve returned HTTP ${result._status} for ${toolName} (${shouldFailOpen ? "configured fail-open" : "blocking tool call"})`);
+      api.logger.warn(`[rampart] serve returned HTTP ${result._status} for ${displayToolName} (${shouldFailOpen ? "configured fail-open" : "blocking tool call"})`);
       if (shouldFailOpen) return;
       return {
         block: true,
-        blockReason: `rampart: unavailable (${toolName}) — policy service error ${result._status}, refusing sensitive tool call`,
+        blockReason: `rampart: unavailable (${displayToolName}) — policy service error ${result._status}, refusing sensitive tool call`,
       };
     }
 
     const decision = result.decision ?? (result.allowed === false ? "deny" : "allow");
 
     // Debug log every decision (not just blocks/approvals)
-    api.logger.debug(`[rampart] ${toolName} → ${decision}${result.policy ? ` (policy: ${result.policy})` : ""}`);
+    api.logger.debug(`[rampart] ${displayToolName} → ${decision}${result.policy ? ` (policy: ${result.policy})` : ""}`);
     if (Object.prototype.hasOwnProperty.call(result, "approval_id")) {
-      api.logger.warn(`[rampart] unexpected approval_id from Rampart eval for OpenClaw-hosted ${toolName}; this would create dual-queue ownership`);
+      api.logger.warn(`[rampart] unexpected approval_id from Rampart eval for OpenClaw-hosted ${displayToolName}; this would create dual-queue ownership`);
     }
 
     switch (decision) {
       case "deny": {
         const reason = result.message ?? result.reason ?? "policy violation";
-        api.logger.warn(`[rampart] BLOCKED ${toolName}: ${reason}${result.policy ? ` [${result.policy}]` : ""}`);
+        api.logger.warn(`[rampart] BLOCKED ${displayToolName}: ${reason}${result.policy ? ` [${result.policy}]` : ""}`);
         return {
           block: true,
           blockReason: `rampart: ${reason}`,
@@ -304,10 +356,10 @@ export function register(api) {
         const severity = result.severity ?? "warning";
         const emoji = severityEmoji[severity] ?? "⚠️";
 
-        api.logger.info(`[rampart] returning requireApproval for ${toolName} (subject: ${subjectPreview})`);
+        api.logger.info(`[rampart] returning requireApproval for ${displayToolName} (subject: ${subjectPreview})`);
         return {
           requireApproval: {
-            title: `🛡️ Rampart — ${toolName} approval required`,
+            title: `🛡️ Rampart — ${displayToolName} approval required`,
             description: [
               `**Command:** \`${subjectPreview}\``,
               result.policy  ? `**Policy:** ${truncateForApprovalDescription(result.policy, 64)}` : null,
@@ -317,7 +369,7 @@ export function register(api) {
             timeoutMs: pluginConfig.approvalTimeoutMs ?? 120_000,
             timeoutBehavior: "deny",
             onResolution: async (resolution) => {
-              api.logger.info(`[rampart] plugin approval resolved: ${toolName} → ${resolution} (toolCallId: ${ctx.toolCallId ?? "none"}, session: ${ctx.sessionKey ?? "none"})`);
+              api.logger.info(`[rampart] plugin approval resolved: ${displayToolName} → ${resolution} (toolCallId: ${ctx.toolCallId ?? "none"}, session: ${ctx.sessionKey ?? "none"})`);
 
               if (resolution === "allow-always") {
                 const learnPayload = {
@@ -326,7 +378,7 @@ export function register(api) {
                   decision: "allow",
                   source: "openclaw-approval",
                 };
-                api.logger.info(`[rampart] attempting always-allow persistence via /v1/rules/learn: ${JSON.stringify({ ...learnPayload, session: ctx.sessionKey ?? null, toolCallId: ctx.toolCallId ?? null })}`);
+                api.logger.info(`[rampart] attempting always-allow persistence via /v1/rules/learn: ${JSON.stringify({ ...learnPayload, originalToolName: mapped ? originalToolName : undefined, session: ctx.sessionKey ?? null, toolCallId: ctx.toolCallId ?? null })}`);
 
                 // Write a persistent allow rule via /v1/rules/learn.
                 // This works regardless of whether an approval_id exists.
@@ -390,12 +442,14 @@ export function register(api) {
   });
 
   api.on("after_tool_call", async (event, ctx) => {
-    const { toolName, params, error, durationMs } = event;
+    const normalized = normalizeToolCall(event?.toolName, event?.params);
+    const { toolName, params, originalToolName } = normalized;
+    const { error, durationMs } = event;
 
     // Fire-and-forget — do not block the tool result
     Promise.resolve().then(async () => {
       try {
-        api.logger.debug(`[rampart] tool completed: ${toolName} (${durationMs ?? "?"}ms)`);
+        api.logger.debug(`[rampart] tool completed: ${toolDisplayName(toolName, originalToolName)} (${durationMs ?? "?"}ms)`);
 
         // Best-effort audit POST — Rampart serve already logs via before_tool_call path
         await auditLog(

--- a/internal/plugin/openclaw/index.js
+++ b/internal/plugin/openclaw/index.js
@@ -5,7 +5,7 @@
  * Replaces brittle dist-file patching with the official OpenClaw plugin API.
  *
  * @see https://github.com/peg/rampart
- * @version 1.0.0
+ * @version 1.1.0
  */
 
 import { readFile } from "fs/promises";
@@ -259,7 +259,7 @@ async function auditLog(toolName, params, ctx, outcome, config) {
 export const id = "rampart";
 export const name = "Rampart";
 export const description = "AI agent firewall — YAML policy-as-code for every tool call";
-export const version = "1.0.0";
+export const version = "1.1.0";
 
 // OpenClaw runs higher-priority before_tool_call hooks first. Rampart should
 // act as the final normal plugin gate so it evaluates the params that will

--- a/internal/plugin/openclaw/openclaw.plugin.json
+++ b/internal/plugin/openclaw/openclaw.plugin.json
@@ -8,7 +8,7 @@
       "hook"
     ]
   },
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": "peg",
   "homepage": "https://rampart.sh",
   "repository": "https://github.com/peg/rampart",

--- a/internal/plugin/openclaw/package.json
+++ b/internal/plugin/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rampart",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Rampart AI agent firewall — OpenClaw native plugin (before_tool_call hook)",
   "type": "module",
   "main": "index.js",

--- a/internal/plugin/openclaw/tool-alias-test.mjs
+++ b/internal/plugin/openclaw/tool-alias-test.mjs
@@ -1,0 +1,148 @@
+import plugin from './index.js';
+
+function createApi(pluginConfig = {}) {
+  const handlers = {};
+  const logs = [];
+  return {
+    handlers,
+    logs,
+    api: {
+      pluginConfig,
+      logger: {
+        info: (...a) => logs.push(['info', a.join(' ')]),
+        warn: (...a) => logs.push(['warn', a.join(' ')]),
+        debug: (...a) => logs.push(['debug', a.join(' ')]),
+      },
+      on: (name, fn) => { handlers[name] = fn; },
+      registerGatewayMethod: () => {},
+    },
+  };
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function parseBody(call) {
+  return JSON.parse(call.opts.body);
+}
+
+async function runWithFetch({ name, fetchImpl, pluginConfig = {}, invoke }) {
+  const { api, handlers, logs } = createApi(pluginConfig);
+  const originalFetch = global.fetch;
+  global.fetch = fetchImpl;
+  try {
+    plugin.register(api);
+    return await invoke({ handlers, logs });
+  } catch (err) {
+    err.message = `${name}: ${err.message}`;
+    throw err;
+  } finally {
+    global.fetch = originalFetch;
+  }
+}
+
+const calls = [];
+const allowResult = await runWithFetch({
+  name: 'bash-allow-maps-to-exec',
+  fetchImpl: async (url, opts = {}) => {
+    calls.push({ url: String(url), opts });
+    assert(String(url).includes('/v1/tool/exec'), `expected exec endpoint, got ${url}`);
+    return { ok: true, json: async () => ({ decision: 'allow' }) };
+  },
+  invoke: async ({ handlers, logs }) => {
+    const before = handlers.before_tool_call;
+    assert(typeof before === 'function', 'before_tool_call handler missing');
+    const result = await before({ toolName: 'bash', params: { cmd: 'echo hi' } }, {
+      agentId: 'main',
+      sessionKey: 'agent:main:test',
+      runId: 'bash-allow-run',
+    });
+    assert(logs.some((entry) => entry.join(' ').includes('mapped OpenClaw tool bash to Rampart exec')), 'mapping log missing');
+    return result;
+  },
+});
+assert(allowResult === undefined, 'allow decision should pass through');
+assert(calls.length === 1, `expected one policy call, got ${calls.length}`);
+const allowBody = parseBody(calls[0]);
+assert(allowBody.params.command === 'echo hi', `expected cmd promoted to command, got ${JSON.stringify(allowBody.params)}`);
+assert(allowBody.openclaw_hosted === true, 'expected openclaw_hosted=true');
+assert(allowBody.skip_pending_approval === true, 'expected skip_pending_approval=true');
+
+const learnCalls = [];
+const askResult = await runWithFetch({
+  name: 'bash-ask-learns-canonical-exec',
+  fetchImpl: async (url, opts = {}) => {
+    learnCalls.push({ url: String(url), opts });
+    if (String(url).includes('/v1/tool/exec')) {
+      return { ok: true, json: async () => ({ decision: 'ask', policy: 'test-policy', message: 'needs approval' }) };
+    }
+    if (String(url).includes('/v1/rules/learn')) {
+      return { ok: true, status: 200, text: async () => '{"ok":true}' };
+    }
+    throw new Error(`unexpected fetch ${url}`);
+  },
+  invoke: async ({ handlers }) => {
+    const before = handlers.before_tool_call;
+    const result = await before({ toolName: 'bash', params: { script: 'sudo true' } }, {
+      agentId: 'main',
+      sessionKey: 'agent:main:test',
+      runId: 'bash-ask-run',
+    });
+    assert(result?.requireApproval, 'expected requireApproval for ask');
+    assert(result.requireApproval.title.includes('bash→exec approval required'), `unexpected title: ${result.requireApproval.title}`);
+    await result.requireApproval.onResolution('allow-always');
+    return result;
+  },
+});
+assert(askResult.requireApproval.description.includes('sudo true'), 'approval description should include normalized command');
+const learnCall = learnCalls.find((call) => call.url.includes('/v1/rules/learn'));
+assert(learnCall, 'learn endpoint not called');
+const learnBody = parseBody(learnCall);
+assert(learnBody.tool === 'exec', `learn tool = ${learnBody.tool}, want exec`);
+assert(learnBody.args === 'sudo true', `learn args = ${learnBody.args}, want sudo true`);
+
+const unreachableResult = await runWithFetch({
+  name: 'bash-unreachable-blocks-as-exec',
+  fetchImpl: async () => { throw new TypeError('fetch failed', { cause: { code: 'ECONNREFUSED' } }); },
+  invoke: async ({ handlers }) => handlers.before_tool_call(
+    { toolName: 'bash', params: { command: 'echo hi' } },
+    { agentId: 'main', sessionKey: 'agent:main:test', runId: 'bash-unreachable-run' },
+  ),
+});
+assert(unreachableResult?.block === true, 'bash/exec alias should fail closed when Rampart is unreachable');
+assert(unreachableResult.blockReason.includes('bash→exec'), `block reason should show alias mapping: ${unreachableResult.blockReason}`);
+
+const auditCalls = [];
+await runWithFetch({
+  name: 'bash-after-audit-canonical-exec',
+  fetchImpl: async (url, opts = {}) => {
+    auditCalls.push({ url: String(url), opts });
+    return { ok: true, status: 200, json: async () => ({ ok: true }) };
+  },
+  invoke: async ({ handlers }) => {
+    const after = handlers.after_tool_call;
+    assert(typeof after === 'function', 'after_tool_call handler missing');
+    await after({ toolName: 'bash', params: { command: 'echo hi' }, durationMs: 7 }, {
+      agentId: 'main',
+      sessionKey: 'agent:main:test',
+      runId: 'bash-after-run',
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  },
+});
+const auditCall = auditCalls.find((call) => call.url.includes('/v1/audit'));
+assert(auditCall, 'audit endpoint not called');
+const auditBody = parseBody(auditCall);
+assert(auditBody.tool === 'exec', `audit tool = ${auditBody.tool}, want exec`);
+assert(auditBody.params.command === 'echo hi', `audit command missing: ${JSON.stringify(auditBody.params)}`);
+
+console.log(JSON.stringify({
+  ok: true,
+  scenarios: [
+    'bash-allow-maps-to-exec',
+    'bash-ask-learns-canonical-exec',
+    'bash-unreachable-blocks-as-exec',
+    'bash-after-audit-canonical-exec',
+  ],
+}, null, 2));

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,8 +7,8 @@
 # Usage: curl -fsSL https://rampart.sh/install | sh
 #        curl -fsSL https://rampart.sh/install | sh -s -- --version v0.1.0
 #        curl -fsSL https://rampart.sh/install | sh -s -- --auto-setup
-#        RAMPART_INSTALL_DRY_RUN=1 sh install.sh --version v1.0.0
-#        RAMPART_VERSION=v1.0.0 RAMPART_INSTALL_DIR=$HOME/.local/bin sh install.sh
+#        RAMPART_INSTALL_DRY_RUN=1 sh install.sh --version v1.1.0
+#        RAMPART_VERSION=v1.1.0 RAMPART_INSTALL_DIR=$HOME/.local/bin sh install.sh
 set -e
 
 REPO="peg/rampart"

--- a/scripts/test-openclaw-codex-native-audit.mjs
+++ b/scripts/test-openclaw-codex-native-audit.mjs
@@ -1,0 +1,418 @@
+#!/usr/bin/env node
+/**
+ * Live OpenClaw + Codex app-server regression for Rampart native shell coverage.
+ *
+ * This intentionally exercises the real OpenClaw runtime instead of the plugin
+ * unit harness. Passing means:
+ *   1. OpenClaw created a Codex app-server session for this run.
+ *   2. The session trajectory contains a native Codex `bash` tool call.
+ *   3. Rampart wrote a correlated audit event for that command as canonical
+ *      tool `exec`.
+ *
+ * The test temporarily enables the Rampart OpenClaw plugin and points it at an
+ * ephemeral Rampart server on localhost. It restores the OpenClaw config and
+ * Rampart token file before exit.
+ */
+
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import {
+  access,
+  copyFile,
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from 'node:fs/promises';
+import { tmpdir, homedir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+const yes = process.env.RAMPART_OPENCLAW_RUNTIME === '1' || process.argv.includes('--yes');
+
+if (!yes) {
+  console.error([
+    'Refusing to run live OpenClaw runtime regression without explicit opt-in.',
+    '',
+    'This test temporarily enables the Rampart OpenClaw plugin, restarts OpenClaw',
+    'user services, starts a local Rampart server, and runs one real OpenClaw',
+    'Codex app-server turn.',
+    '',
+    'Run intentionally from the repo root with:',
+    '  RAMPART_OPENCLAW_RUNTIME=1 node scripts/test-openclaw-codex-native-audit.mjs',
+  ].join('\n'));
+  process.exit(2);
+}
+
+const port = Number(process.env.RAMPART_OPENCLAW_TEST_PORT || '19090');
+const serveUrl = `http://127.0.0.1:${port}`;
+const agentId = process.env.RAMPART_OPENCLAW_AGENT || 'main';
+const openclawConfigPath = process.env.OPENCLAW_CONFIG_PATH || join(homedir(), '.openclaw', 'openclaw.json');
+const openclawStateDir = process.env.OPENCLAW_STATE_DIR || join(homedir(), '.openclaw');
+const sessionsDir = join(openclawStateDir, 'agents', agentId, 'sessions');
+const tokenPath = join(homedir(), '.rampart', 'token');
+const restartServices = (process.env.RAMPART_OPENCLAW_RESTART_SERVICES || 'openclaw-gateway.service,openclaw-node.service')
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+const marker = `rampart-runtime-codex-shell-${new Date().toISOString().replace(/[-:.TZ]/g, '').slice(0, 14)}`;
+const sessionId = marker;
+const command = `printf '%s\\n' '${marker}'`;
+const prompt = [
+  'This is a controlled Rampart/OpenClaw runtime regression test.',
+  'Use the native shell/terminal/bash command tool exactly once to run:',
+  command,
+  'Do not use any other tool. Reply with only the command stdout.',
+].join(' ');
+
+let tmpRoot;
+let auditDir;
+let server;
+let serverBinary;
+let serverLogs = '';
+let originalConfig = null;
+let configChanged = false;
+let tokenExisted = false;
+let tokenBackup = null;
+let cleanupErrors = [];
+
+function redact(text) {
+  return String(text ?? '')
+    .replace(/(token=)[A-Za-z0-9._~+/-]+/gi, '$1[REDACTED]')
+    .replace(/(Bearer\s+)[A-Za-z0-9._~+/-]+/gi, '$1[REDACTED]')
+    .replace(/("Authorization"\s*:\s*")[^"]+/gi, '$1[REDACTED]')
+    .replace(/("token"\s*:\s*")[^"]+/gi, '$1[REDACTED]');
+}
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function run(cmd, args = [], opts = {}) {
+  const timeoutMs = opts.timeoutMs ?? 60_000;
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(cmd, args, {
+      cwd: opts.cwd ?? repoRoot,
+      env: opts.env ?? process.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    const timer = setTimeout(() => {
+      child.kill('SIGTERM');
+      setTimeout(() => child.kill('SIGKILL'), 3_000).unref?.();
+      reject(new Error(`${cmd} ${args.join(' ')} timed out after ${timeoutMs}ms\nstdout:\n${redact(stdout)}\nstderr:\n${redact(stderr)}`));
+    }, timeoutMs);
+    child.stdout.on('data', (d) => { stdout += d.toString(); });
+    child.stderr.on('data', (d) => { stderr += d.toString(); });
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+    child.on('close', (code, signal) => {
+      clearTimeout(timer);
+      if (code === 0) {
+        resolvePromise({ stdout, stderr, code, signal });
+      } else {
+        reject(new Error(`${cmd} ${args.join(' ')} exited ${code ?? signal}\nstdout:\n${redact(stdout)}\nstderr:\n${redact(stderr)}`));
+      }
+    });
+  });
+}
+
+async function pathExists(path) {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForHealth(url, timeoutMs = 45_000) {
+  const deadline = Date.now() + timeoutMs;
+  let lastErr = null;
+  while (Date.now() < deadline) {
+    try {
+      const resp = await fetch(`${url}/healthz`, { signal: AbortSignal.timeout(1500) });
+      if (resp.ok) return;
+      lastErr = new Error(`healthz HTTP ${resp.status}`);
+    } catch (err) {
+      lastErr = err;
+    }
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  fail(`Rampart health check did not become ready at ${url}: ${lastErr?.message ?? 'unknown error'}\nserver logs:\n${redact(serverLogs).split('\n').slice(-40).join('\n')}`);
+}
+
+async function restartOpenClaw(reason) {
+  if (restartServices.length === 0) {
+    console.warn(`[runtime-regression] Skipping OpenClaw restart for ${reason} because RAMPART_OPENCLAW_RESTART_SERVICES is empty.`);
+    return;
+  }
+  for (const service of restartServices) {
+    await run('systemctl', ['--user', 'restart', service], { timeoutMs: 45_000, cwd: repoRoot });
+  }
+  for (const service of restartServices) {
+    await run('systemctl', ['--user', 'is-active', service], { timeoutMs: 15_000, cwd: repoRoot });
+  }
+}
+
+async function backupToken() {
+  tokenBackup = join(tmpRoot, 'rampart-token.backup');
+  tokenExisted = await pathExists(tokenPath);
+  if (tokenExisted) {
+    await copyFile(tokenPath, tokenBackup);
+  }
+}
+
+async function restoreToken() {
+  if (tokenExisted) {
+    await copyFile(tokenBackup, tokenPath);
+  } else if (await pathExists(tokenPath)) {
+    await rm(tokenPath, { force: true });
+  }
+}
+
+async function configureOpenClaw() {
+  originalConfig = await readFile(openclawConfigPath, 'utf8');
+  const cfg = JSON.parse(originalConfig);
+  cfg.plugins ??= {};
+  cfg.plugins.allow ??= [];
+  if (!cfg.plugins.allow.includes('rampart')) cfg.plugins.allow.push('rampart');
+  cfg.plugins.entries ??= {};
+  cfg.plugins.entries.rampart ??= {};
+  cfg.plugins.entries.rampart.enabled = true;
+  cfg.plugins.entries.rampart.config ??= {};
+  cfg.plugins.entries.rampart.config.serveUrl = serveUrl;
+  cfg.plugins.entries.rampart.config.failOpen = false;
+
+  const next = `${JSON.stringify(cfg, null, 2)}\n`;
+  if (next !== originalConfig) {
+    await writeFile(openclawConfigPath, next, 'utf8');
+    configChanged = true;
+  }
+
+  await run('openclaw', ['config', 'validate'], { timeoutMs: 30_000, cwd: repoRoot });
+  await restartOpenClaw('temporary Rampart plugin enablement');
+}
+
+async function restoreOpenClawConfig() {
+  if (originalConfig !== null && configChanged) {
+    await writeFile(openclawConfigPath, originalConfig, 'utf8');
+    await run('openclaw', ['config', 'validate'], { timeoutMs: 30_000, cwd: repoRoot });
+    await restartOpenClaw('Rampart plugin config restore');
+  }
+}
+
+async function startRampart() {
+  serverBinary = join(tmpRoot, 'rampart-runtime-regression-rampart');
+  await run('go', ['build', '-o', serverBinary, './cmd/rampart'], { timeoutMs: 120_000, cwd: repoRoot });
+
+  server = spawn(serverBinary, [
+    'serve',
+    '--no-openclaw-bridge',
+    '--addr', '127.0.0.1',
+    '--port', String(port),
+    '--audit-dir', auditDir,
+  ], {
+    cwd: repoRoot,
+    env: process.env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  server.stdout.on('data', (d) => { serverLogs += d.toString(); });
+  server.stderr.on('data', (d) => { serverLogs += d.toString(); });
+  server.on('exit', (code, signal) => {
+    if (code !== null && code !== 0) {
+      serverLogs += `\n[runtime-regression] rampart serve exited ${code}\n`;
+    } else if (signal) {
+      serverLogs += `\n[runtime-regression] rampart serve stopped by ${signal}\n`;
+    }
+  });
+  await waitForHealth(serveUrl);
+}
+
+async function stopRampart() {
+  if (!server || server.exitCode !== null || server.signalCode !== null) return;
+  await new Promise((resolvePromise) => {
+    const done = () => resolvePromise();
+    server.once('exit', done);
+    server.kill('SIGTERM');
+    setTimeout(() => {
+      if (server.exitCode === null && server.signalCode === null) server.kill('SIGKILL');
+    }, 5_000).unref?.();
+  });
+}
+
+function parseJSONLines(content, label) {
+  const events = [];
+  for (const [idx, line] of content.split(/\r?\n/).entries()) {
+    if (!line.trim()) continue;
+    try {
+      events.push(JSON.parse(line));
+    } catch (err) {
+      fail(`${label}:${idx + 1}: invalid JSONL: ${err.message}`);
+    }
+  }
+  return events;
+}
+
+async function newestAuditEvents() {
+  const entries = await readdir(auditDir).catch(() => []);
+  const jsonl = [];
+  for (const entry of entries) {
+    if (!entry.endsWith('.jsonl')) continue;
+    const path = join(auditDir, entry);
+    const info = await stat(path);
+    if (info.isFile()) jsonl.push(path);
+  }
+  const events = [];
+  for (const path of jsonl) {
+    events.push(...parseJSONLines(await readFile(path, 'utf8'), path));
+  }
+  return events;
+}
+
+async function runOpenClawTurn() {
+  const result = await run('openclaw', [
+    'agent',
+    '--agent', agentId,
+    '--session-id', sessionId,
+    '--message', prompt,
+    '--json',
+    '--timeout', process.env.RAMPART_OPENCLAW_AGENT_TIMEOUT || '180',
+  ], { timeoutMs: Number(process.env.RAMPART_OPENCLAW_AGENT_TIMEOUT_MS || '240000'), cwd: repoRoot });
+
+  const combined = `${result.stdout}\n${result.stderr}`;
+  if (!combined.includes(marker)) {
+    fail(`OpenClaw turn completed but output did not include marker ${marker}. Output:\n${redact(combined).slice(-4000)}`);
+  }
+}
+
+async function verifyCodexAppServerArtifact() {
+  const path = join(sessionsDir, `${sessionId}.jsonl.codex-app-server.json`);
+  if (!existsSync(path)) {
+    fail(`missing Codex app-server metadata file: ${path}`);
+  }
+  const meta = JSON.parse(await readFile(path, 'utf8'));
+  if (!String(meta.sessionFile || '').endsWith(`${sessionId}.jsonl`)) {
+    fail(`Codex app-server metadata did not point at this session file: ${path}`);
+  }
+  if (!meta.model) {
+    fail(`Codex app-server metadata missing model field: ${path}`);
+  }
+  return path;
+}
+
+async function verifyTrajectoryBashCall() {
+  const path = join(sessionsDir, `${sessionId}.trajectory.jsonl`);
+  if (!existsSync(path)) {
+    fail(`missing OpenClaw trajectory file: ${path}`);
+  }
+  const events = parseJSONLines(await readFile(path, 'utf8'), path);
+  const bashCall = events.find((evt) => (
+    evt?.type === 'tool.call' &&
+    evt?.data?.name === 'bash' &&
+    JSON.stringify(evt.data.arguments || {}).includes(marker)
+  ));
+  if (!bashCall) {
+    const toolNames = events
+      .filter((evt) => evt?.type === 'tool.call')
+      .map((evt) => evt?.data?.name)
+      .filter(Boolean);
+    fail(`trajectory did not contain a native bash tool.call for ${marker}; observed tools: ${JSON.stringify(toolNames)}`);
+  }
+  return path;
+}
+
+async function verifyRampartAudit() {
+  const deadline = Date.now() + 10_000;
+  let events = [];
+  while (Date.now() < deadline) {
+    events = await newestAuditEvents();
+    const match = events.find((evt) => {
+      const request = JSON.stringify(evt.request || evt.params || {});
+      const session = String(evt.session || '').toLowerCase();
+      return evt.tool === 'exec' &&
+        request.includes(marker) &&
+        session.includes(sessionId.toLowerCase());
+    });
+    if (match) return match;
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  const compact = events.map((evt) => ({
+    tool: evt.tool,
+    agent: evt.agent,
+    session: evt.session,
+    action: evt.decision?.action,
+    request: evt.request,
+  }));
+  fail(`Rampart audit did not contain canonical exec event for native bash marker ${marker}. Observed audit events: ${redact(JSON.stringify(compact, null, 2)).slice(-4000)}`);
+}
+
+async function cleanup() {
+  try { await stopRampart(); } catch (err) { cleanupErrors.push(`stop rampart: ${err.message}`); }
+  try { await restoreOpenClawConfig(); } catch (err) { cleanupErrors.push(`restore openclaw config: ${err.message}`); }
+  try { await restoreToken(); } catch (err) { cleanupErrors.push(`restore rampart token: ${err.message}`); }
+  if (tmpRoot && process.env.RAMPART_KEEP_RUNTIME_ARTIFACTS !== '1') {
+    try { await rm(tmpRoot, { recursive: true, force: true }); } catch (err) { cleanupErrors.push(`remove tmp: ${err.message}`); }
+  }
+}
+
+try {
+  tmpRoot = await mkdtemp(join(tmpdir(), 'rampart-openclaw-runtime-'));
+  auditDir = join(tmpRoot, 'audit');
+  await mkdir(auditDir, { recursive: true });
+  await writeFile(join(tmpRoot, 'README.txt'), 'Temporary files for Rampart/OpenClaw runtime regression.\n', 'utf8');
+  await backupToken();
+
+  console.log(`[runtime-regression] marker=${marker}`);
+  console.log(`[runtime-regression] auditDir=${auditDir}`);
+  await startRampart();
+  console.log(`[runtime-regression] Rampart serve ready at ${serveUrl}`);
+  await configureOpenClaw();
+  console.log('[runtime-regression] OpenClaw plugin temporarily enabled and services restarted');
+  await runOpenClawTurn();
+  const appServerPath = await verifyCodexAppServerArtifact();
+  const trajectoryPath = await verifyTrajectoryBashCall();
+  const auditEvent = await verifyRampartAudit();
+
+  console.log(JSON.stringify({
+    ok: true,
+    marker,
+    appServerMetadata: appServerPath,
+    trajectory: trajectoryPath,
+    rampartAudit: {
+      id: auditEvent.id,
+      tool: auditEvent.tool,
+      agent: auditEvent.agent,
+      session: auditEvent.session,
+      action: auditEvent.decision?.action,
+    },
+  }, null, 2));
+} catch (err) {
+  console.error(`[runtime-regression] FAIL: ${redact(err.stack || err.message)}`);
+  console.error(`[runtime-regression] Rampart server log tail:\n${redact(serverLogs).split('\n').slice(-40).join('\n')}`);
+  process.exitCode = 1;
+} finally {
+  await cleanup();
+  if (cleanupErrors.length > 0) {
+    console.error(`[runtime-regression] cleanup warnings:\n- ${cleanupErrors.map(redact).join('\n- ')}`);
+    if (process.exitCode === undefined || process.exitCode === 0) process.exitCode = 1;
+  }
+  if (tmpRoot && process.env.RAMPART_KEEP_RUNTIME_ARTIFACTS === '1') {
+    console.error(`[runtime-regression] kept temp artifacts at ${tmpRoot}`);
+  }
+}
+
+// OpenClaw/Codex runtime adapters can leave non-critical child-process or stream
+// handles alive after the proof has completed. Cleanup above is awaited first;
+// then exit explicitly so this regression reports the real pass/fail status
+// instead of hanging until an outer harness timeout marks it failed.
+process.exit(process.exitCode ?? 0);


### PR DESCRIPTION
## Summary
- Promote the validated staging branch for the v1.1.0 release candidate.
- Includes observability schema foundations, hardened doctor JSON output, inventory JSON support, and OpenClaw gateway protocol v4 compatibility.
- Includes OpenClaw native shell audit coverage and v1.1.0 release metadata alignment.

## Tests
- Latest staging CI passed on `c7ed8db`: https://github.com/peg/rampart/actions/runs/26373292474
- `GOFLAGS=-buildvcs=false node scripts/test-openclaw-codex-native-audit.mjs` refused without opt-in with exit code 2.
- `RAMPART_OPENCLAW_RUNTIME=1 GOFLAGS=-buildvcs=false node scripts/test-openclaw-codex-native-audit.mjs` passed against staging commit `c7ed8db` with marker `rampart-runtime-codex-shell-20260524221320`.
- Runtime proof included Codex app-server metadata, native `bash` trajectory evidence, and Rampart audit event `01KSE0TF2DNMFQP0MGTTG629JW` for canonical tool `exec`.
