### PR TITLE
feat: add experimental Hermes policy gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,9 @@ jobs:
           node internal/plugin/openclaw/approval-regression.mjs
           node internal/plugin/openclaw/degraded-mode-test.mjs
 
+      - name: Hermes plugin regression tests
+        run: python -m unittest internal/plugin/hermes/test_hermes_plugin.py
+
       - name: Policy check (standard)
         run: go run ./cmd/rampart policy check --config policies/standard.yaml
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@
 # Go build/test cache
 .cache/
 
+# Python cache
+__pycache__/
+*.py[cod]
+
 # IDE
 .idea/
 .vscode/

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ rampart setup claude-code
 # OpenClaw
 rampart setup openclaw
 
+# Hermes Agent (experimental)
+rampart setup hermes
+
 # Cline
 rampart setup cline
 
@@ -123,6 +126,7 @@ Pattern matching handles 95%+ of decisions in microseconds. The optional [rampar
 |-------|--------------|-------------|
 | **Claude Code** | `rampart setup claude-code` | Native `PreToolUse` hooks via `~/.claude/settings.json` |
 | **OpenClaw** | `rampart setup openclaw` | Native plugin + selective native approvals |
+| **Hermes Agent** | `rampart setup hermes` | Experimental `pre_tool_call` user plugin |
 | **Cline** | `rampart setup cline` | Native hooks via settings |
 | **Codex CLI** | `rampart setup codex` | Wrapper that runs Codex through `rampart preload` |
 | **Any agent** | `rampart wrap -- <agent>` | Shell wrapping via `$SHELL` |
@@ -136,7 +140,7 @@ Pattern matching handles 95%+ of decisions in microseconds. The optional [rampar
 <details>
 <summary><strong>Table of Contents</strong></summary>
 
-**Getting Started:** [Install](#install) · [Quick start](#quick-start) · [Claude Code](#claude-code) · [OpenClaw](#openclaw) · [Wrap any agent](#wrap-any-agent)
+**Getting Started:** [Install](#install) · [Quick start](#quick-start) · [Claude Code](#claude-code) · [OpenClaw](#openclaw) · [Hermes Agent](#hermes-agent-experimental) · [Wrap any agent](#wrap-any-agent)
 
 **Core Features:** [Policies](#writing-policies) · [Approval flow](#approval-flow) · [Audit trail](#audit-trail) · [Live dashboard](#live-dashboard) · [Webhook notifications](#webhook-notifications)
 
@@ -204,6 +208,19 @@ In practice, that means:
 `rampart setup openclaw --patch-tools` still exists as a compatibility option for older setups, but it is no longer the recommended path. It modifies OpenClaw dist files and must be re-applied after upgrades.
 
 Run `rampart doctor` at any time to verify the current OpenClaw integration state.
+
+---
+
+## Hermes Agent (experimental)
+
+Hermes Agent integration uses a user plugin installed into `~/.hermes/plugins/rampart`:
+
+```bash
+rampart setup hermes
+hermes plugins enable rampart
+```
+
+The plugin registers a Hermes `pre_tool_call` hook and sends sanitized tool metadata to Rampart before execution. It defaults to `/v1/preflight/{tool}` so early tests do not create hidden approvals that Hermes cannot resume. `ask` decisions block with an approval-required message until Hermes has a first-class plugin approval/resume flow.
 
 ---
 

--- a/cmd/rampart/cli/setup.go
+++ b/cmd/rampart/cli/setup.go
@@ -14,6 +14,7 @@ import (
 	"runtime"
 	"strings"
 
+	hermesplugin "github.com/peg/rampart/internal/plugin/hermes"
 	"github.com/peg/rampart/policies"
 	"github.com/spf13/cobra"
 )
@@ -32,8 +33,9 @@ Run without a subcommand to launch the interactive setup wizard.
 
 Supported AI Agents:
   • Claude Code (Anthropic)   - Native hook integration
+  • Hermes Agent              - Experimental user plugin integration
   • Cline (VS Code)           - Native hook integration
-  • OpenClaw                  - Shell wrapper integration`,
+  • OpenClaw                  - Native plugin integration`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runInteractiveSetup(cmd, opts)
 		},
@@ -42,10 +44,88 @@ Supported AI Agents:
 	cmd.Flags().BoolVar(&force, "force", false, "Skip confirmations during interactive setup")
 
 	cmd.AddCommand(newSetupClaudeCodeCmd(opts))
+	cmd.AddCommand(newSetupHermesCmd())
 	cmd.AddCommand(newSetupClineCmd(opts))
 	cmd.AddCommand(newSetupOpenClawCmd(opts))
 	cmd.AddCommand(newSetupCodexCmd(opts))
 
+	return cmd
+}
+
+func newSetupHermesCmd() *cobra.Command {
+	var enable bool
+	var remove bool
+	var pluginDir string
+
+	cmd := &cobra.Command{
+		Use:   "hermes",
+		Short: "Install the experimental Rampart plugin for Hermes Agent",
+		Long: `Installs Rampart's experimental Hermes Agent user plugin into
+~/.hermes/plugins/rampart without patching Hermes itself.
+
+The plugin uses Hermes' pre_tool_call hook, calls Rampart's policy API before
+sensitive tool calls execute, defaults to /v1/preflight/{tool}, blocks ask
+responses instead of creating hidden approvals, and fails closed for mutating
+or high-risk tools when Rampart serve is unavailable.
+
+By default this command installs the plugin files only. Use --enable to run
+"hermes plugins enable rampart" after installation. Restart long-running Hermes
+gateways after enabling so plugin discovery reloads cleanly.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return fmt.Errorf("setup hermes: resolve home: %w", err)
+			}
+			if strings.TrimSpace(pluginDir) == "" {
+				pluginDir = filepath.Join(home, ".hermes", "plugins", "rampart")
+			} else {
+				pluginDir = filepath.Clean(os.ExpandEnv(pluginDir))
+			}
+			if strings.HasPrefix(pluginDir, "~"+string(os.PathSeparator)) {
+				pluginDir = filepath.Join(home, strings.TrimPrefix(pluginDir, "~"+string(os.PathSeparator)))
+			}
+
+			if remove {
+				if err := os.Remove(filepath.Join(pluginDir, "__init__.py")); err != nil && !os.IsNotExist(err) {
+					return fmt.Errorf("setup hermes: remove plugin runtime: %w", err)
+				}
+				if err := os.Remove(filepath.Join(pluginDir, "plugin.yaml")); err != nil && !os.IsNotExist(err) {
+					return fmt.Errorf("setup hermes: remove plugin manifest: %w", err)
+				}
+				_ = os.Remove(pluginDir) // best-effort; succeeds only if the directory is empty
+				fmt.Fprintf(cmd.OutOrStdout(), "Removed Rampart Hermes plugin files from %s\n", pluginDir)
+				fmt.Fprintln(cmd.OutOrStdout(), "Run `hermes plugins disable rampart` if it is still enabled in Hermes config.")
+				return nil
+			}
+
+			if err := hermesplugin.Extract(pluginDir); err != nil {
+				return fmt.Errorf("setup hermes: install plugin: %w", err)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Installed experimental Rampart Hermes plugin v%s to %s\n", hermesplugin.Version(), pluginDir)
+
+			if enable {
+				hermesBin, err := execLookPath("hermes")
+				if err != nil {
+					return fmt.Errorf("setup hermes: plugin installed, but cannot enable automatically because hermes was not found in PATH: %w", err)
+				}
+				enableCmd := osexec.Command(hermesBin, "plugins", "enable", "rampart")
+				enableCmd.Stdout = cmd.OutOrStdout()
+				enableCmd.Stderr = cmd.ErrOrStderr()
+				if err := enableCmd.Run(); err != nil {
+					return fmt.Errorf("setup hermes: plugin installed, but `hermes plugins enable rampart` failed: %w", err)
+				}
+				fmt.Fprintln(cmd.OutOrStdout(), "Restart long-running Hermes gateways so the enabled plugin is loaded.")
+				return nil
+			}
+
+			fmt.Fprintln(cmd.OutOrStdout(), "Enable it with: hermes plugins enable rampart")
+			fmt.Fprintln(cmd.OutOrStdout(), "Then restart any long-running Hermes gateway before testing.")
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&enable, "enable", false, "Enable the plugin via `hermes plugins enable rampart` after installing")
+	cmd.Flags().BoolVar(&remove, "remove", false, "Remove the installed plugin files")
+	cmd.Flags().StringVar(&pluginDir, "plugin-dir", "", "Hermes plugin install directory (default ~/.hermes/plugins/rampart)")
 	return cmd
 }
 

--- a/docs-site/getting-started/support-matrix.md
+++ b/docs-site/getting-started/support-matrix.md
@@ -49,6 +49,13 @@ Use this page as the canonical support contract for Rampart's main integration s
       <td data-label="Support tier"><strong>Recommended</strong></td>
     </tr>
     <tr class="tier-supported">
+      <td data-label="Surface"><strong>Hermes Agent</strong></td>
+      <td data-label="Best path">Experimental user plugin<br><code>rampart setup hermes</code></td>
+      <td data-label="rampart serve">Required</td>
+      <td data-label="Approval UX"><code>ask</code> blocks until plugin approval/resume support exists</td>
+      <td data-label="Support tier">Experimental</td>
+    </tr>
+    <tr class="tier-supported">
       <td data-label="Surface"><strong>OpenClaw 2026.4.29 - 2026.5.1</strong></td>
       <td data-label="Best path">Native plugin<br><code>rampart setup openclaw</code></td>
       <td data-label="rampart serve">Required</td>
@@ -91,12 +98,14 @@ Use this page as the canonical support contract for Rampart's main integration s
 - **Claude Code** → best overall native path
 - **Codex CLI** → best CLI path when you want strong coverage
 - **OpenClaw >= 2026.5.2** → best OpenClaw path for 1.0; plugin + native approval UI
+- **Hermes Agent** → experimental plugin path for early testing; `ask` decisions block rather than resume
 - **Cline** → good supported path, but less polished approval UX than Claude Code
 
 ## Degraded behavior notes
 
 - **Claude Code / Cline native hooks**: local policy evaluation still works when `rampart serve` is down, but dashboard features, approval APIs, and external approval state do not.
 - **OpenClaw native plugin**: depends on `rampart serve`; sensitive tools block when the service is unavailable, while configured lower-risk fail-open tools may still proceed.
+- **Hermes Agent plugin**: depends on `rampart serve`; mutating/high-risk tools fail closed when unavailable, while explicitly configured read-only tools may fail open.
 - **Legacy OpenClaw patching**: compatibility-only path; requires re-patching after upgrades.
 - **Wrapper / preload / API paths**: behavior depends on integration settings and fail-open/fail-closed configuration.
 
@@ -104,6 +113,7 @@ Use this page as the canonical support contract for Rampart's main integration s
 
 - Use **native hooks** when the agent supports them.
 - Use the **OpenClaw native plugin** on current OpenClaw builds.
+- Use the **Hermes Agent plugin** for conservative early Hermes testing.
 - Use **wrapper / preload** when the CLI agent has no hook system.
 - Use **MCP proxy** or **HTTP API** for clients that integrate through MCP or custom service calls.
 
@@ -112,4 +122,5 @@ Use this page as the canonical support contract for Rampart's main integration s
 - [Quick Start](quickstart.md)
 - [How Rampart Works](how-it-works.md)
 - [OpenClaw integration](../integrations/openclaw.md)
+- [Hermes Agent integration](../integrations/hermes.md)
 - [Integration guides](../integrations/index.md)

--- a/docs-site/integrations/hermes.md
+++ b/docs-site/integrations/hermes.md
@@ -1,0 +1,118 @@
+---
+title: Securing Hermes Agent
+description: "Experimental Rampart integration for Hermes Agent using a user plugin and pre_tool_call policy checks."
+---
+
+# Hermes Agent
+
+Rampart can protect Hermes Agent through an **experimental user plugin**. The plugin registers a Hermes `pre_tool_call` hook, sends a sanitized policy check to Rampart before selected tools execute, and blocks the tool call when policy denies it.
+
+!!! warning "Experimental integration"
+    This integration is intentionally conservative. It does not patch Hermes, does not create a hidden approval queue, and does not resume `ask` decisions automatically. Policies that return `ask` are blocked with an approval-required message until Hermes has a first-class plugin approval/resume flow.
+
+## What it covers
+
+The plugin maps common Hermes tools to Rampart policy classes:
+
+| Hermes tool | Rampart class | Notes |
+| --- | --- | --- |
+| `terminal`, `execute_code` | `exec` | Sends command/script metadata; `execute_code` sends preview and size, not full code by default. |
+| `read_file`, `search_files` | `read` | Sends path/pattern metadata. |
+| `write_file` | `write` | Sends target path and content size/line counts, not file contents. |
+| `patch` | `edit` | Sends mode, patch size, and touched paths. |
+| Browser tools | `browser` / `web_fetch` / `web_search` | Sends URL/action metadata where available. |
+| `send_message`, `text_to_speech` | `message` | Sends target and message size/preview. |
+| `process`, `cronjob` | `process` | Sends action and job/session metadata. |
+
+Unknown tools are still sent to Rampart using their Hermes tool name with sensitive-looking values redacted.
+
+## Setup
+
+Install the bundled Hermes plugin files:
+
+```bash
+rampart setup hermes
+```
+
+Then enable the plugin in Hermes and restart any long-running Hermes gateway so plugin discovery reloads:
+
+```bash
+hermes plugins enable rampart
+# restart the Hermes gateway/service you use for Discord, Telegram, CLI daemon, etc.
+```
+
+You can install and enable in one step when `hermes` is available in `PATH`:
+
+```bash
+rampart setup hermes --enable
+```
+
+## Start Rampart serve
+
+The plugin defaults to `http://127.0.0.1:9090` and reads `RAMPART_TOKEN` or `~/.rampart/token` when present.
+
+```bash
+rampart serve --addr 127.0.0.1 --port 9090
+```
+
+If your Rampart API uses a different URL, set one of:
+
+```bash
+export RAMPART_HERMES_URL=http://127.0.0.1:9090
+# or
+export RAMPART_URL=http://127.0.0.1:9090
+```
+
+Hermes plugin config can also be stored under `plugins.entries.rampart.config`:
+
+```yaml
+plugins:
+  entries:
+    rampart:
+      config:
+        serve_url: http://127.0.0.1:9090
+        timeout_ms: 3000
+        endpoint_mode: preflight
+        fail_open_tools:
+          - read_file
+          - search_files
+```
+
+## Decision behavior
+
+| Rampart decision | Hermes behavior |
+| --- | --- |
+| `allow`, `watch`, `log` | Tool call continues. |
+| `deny` | Tool call is blocked with the policy reason. |
+| `ask`, `require_approval` | Tool call is blocked with an approval-required message. No hidden Rampart approval is created by default. |
+| Rampart unavailable | Mutating/high-risk tools fail closed; configured read-only tools may fail open. |
+
+The default endpoint mode is `preflight`, which calls `POST /v1/preflight/{tool}`. This is deliberate: it avoids creating pending Rampart approvals that Hermes cannot yet resume from a plugin hook.
+
+For experiments that need full `/v1/tool/{tool}` semantics, set:
+
+```bash
+export RAMPART_HERMES_ENDPOINT_MODE=tool
+```
+
+Use this only when you understand the approval ownership tradeoff.
+
+## Verification
+
+Use a deny rule for a harmless command and confirm Hermes blocks it before execution:
+
+```bash
+rampart serve --addr 127.0.0.1 --port 9090
+hermes plugins list
+```
+
+Then ask Hermes to run a command that policy denies, such as a destructive-command test pattern. The tool response should include a message beginning with `rampart:` and the command should not execute.
+
+## Uninstall
+
+```bash
+hermes plugins disable rampart
+rampart setup hermes --remove
+```
+
+Restart any long-running Hermes gateway after disabling or removing the plugin.

--- a/docs-site/integrations/index.md
+++ b/docs-site/integrations/index.md
@@ -1,6 +1,6 @@
 ---
 title: Integration Guides
-description: "Find the right Rampart integration for Claude Code, Cline, Cursor, OpenClaw, Codex, and custom agents. Compare hooks, MCP proxy, wrapping, and preload."
+description: "Find the right Rampart integration for Claude Code, Cline, Cursor, OpenClaw, Hermes Agent, Codex, and custom agents. Compare hooks, plugins, MCP proxy, wrapping, and preload."
 ---
 
 # Integration Guides
@@ -16,7 +16,7 @@ Rampart works with every major AI agent through multiple integration methods. Ch
 | **MCP Proxy** | Transparent proxy for MCP tool calls | Claude Desktop, Cursor |
 | **LD_PRELOAD** | Intercepts exec syscalls at the OS level | Codex CLI, any process |
 | **HTTP API** | RESTful endpoint for custom integrations | Python agents, custom code |
-| **Native Plugin** | Agent framework calls Rampart before each tool runs | OpenClaw |
+| **Native Plugin** | Agent framework calls Rampart before each tool runs | OpenClaw, Hermes Agent (experimental) |
 | **Shim + Service** | Legacy shell shim + dist patching compatibility path | Older OpenClaw |
 | **WebSocket Daemon** | WebSocket integration for real-time agents | OpenClaw (legacy / alternative) |
 
@@ -30,6 +30,7 @@ When a policy action is `ask`, behavior varies by integration:
 | **Cline** | Hook returns `{"cancel":true}` with approval message (no native ask) |
 | **MCP (Claude Desktop/Cursor)** | Proxy blocks, returns JSON-RPC error on deny |
 | **OpenClaw** | OpenClaw owns the visible approval UI; Rampart plugin supplies policy decisions |
+| **Hermes Agent** | Experimental plugin blocks `ask` with an approval-required message until Hermes owns a plugin approval/resume flow |
 | **Shell Wrapper** | Shim blocks, command appears "hung" until resolved |
 | **LD_PRELOAD** | Library blocks exec call, process appears "hung" |
 | **HTTP API** | Returns `"decision":"ask"` with approval metadata when interactive review is required |
@@ -44,6 +45,7 @@ When a policy action is `ask`, behavior varies by integration:
 | [Claude Desktop](claude-desktop.md) | MCP proxy | `rampart mcp --` | All |
 | [Codex CLI](codex-cli.md) | Wrapper + preload | `rampart setup codex` | Linux, macOS* |
 | [OpenClaw](openclaw.md) | Native plugin | `rampart setup openclaw` | Linux, macOS |
+| [Hermes Agent](hermes.md) | Experimental user plugin | `rampart setup hermes` | All |
 | [Python Agents](python-agents.md) | HTTP API | `rampart serve` | All |
 | [Any CLI Agent](any-cli-agent.md) | Shell wrapper | `rampart wrap --` | Linux, macOS |
 
@@ -61,7 +63,7 @@ q: "Integration method?" {shape: diamond}
 hooks: "rampart setup claude-code\\nrampart setup cline" {
   style.fill: "#1d3320"; style.stroke: "#2ea043"; style.font-color: "#3fb950"; style.border-radius: 6
 }
-shim: "rampart setup openclaw\\nnative plugin on current builds" {
+shim: "rampart setup openclaw\\nrampart setup hermes" {
   style.fill: "#1d3320"; style.stroke: "#2ea043"; style.font-color: "#3fb950"; style.border-radius: 6
 }
 mcp: "rampart mcp --" {
@@ -80,7 +82,7 @@ api: "HTTP API / SDK\\nlocalhost:9090" {
 start -> q
 
 q -> hooks: "Claude Code or Cline\\n(native hooks, lowest overhead)"
-q -> shim: "OpenClaw\\n(native plugin on supported builds)"
+q -> shim: "OpenClaw or Hermes Agent\\n(native plugin where supported)"
 q -> mcp: "Cursor, Claude Desktop\\nor any MCP-compatible client"
 q -> wrap: "Any CLI agent\\nwith \$SHELL support"
 q -> preload: "Any CLI agent\\nwithout \$SHELL or native hooks"

--- a/internal/plugin/hermes/__init__.py
+++ b/internal/plugin/hermes/__init__.py
@@ -1,0 +1,549 @@
+# Copyright 2026 The Rampart Authors
+# Licensed under the Apache License, Version 2.0
+"""Experimental Rampart policy gate for Hermes Agent.
+
+The plugin is intentionally conservative:
+
+* It uses Hermes' ``pre_tool_call`` hook and only returns a block directive.
+* It defaults to ``/v1/preflight/{tool}`` so Rampart does not create a hidden
+  approval queue while Hermes lacks a plugin-owned approval/resume primitive.
+* ``ask`` / ``require_approval`` decisions block with a clear message instead
+  of polling or creating a second approval surface.
+* If Rampart serve is unavailable, mutating/high-risk tools fail closed and only
+  explicitly configured read-only tools fail open.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import socket
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Mapping
+from urllib.parse import quote
+
+VERSION = "0.1.0"
+
+DEFAULT_SERVE_URL = "http://127.0.0.1:9090"
+DEFAULT_TIMEOUT_MS = 3000
+DEFAULT_ENDPOINT_MODE = "preflight"
+DEFAULT_AGENT_NAME = "hermes"
+
+# Read-only tools that may proceed when Rampart is unavailable. Operators can
+# narrow this with plugins.entries.rampart.config.fail_open_tools or
+# RAMPART_HERMES_FAIL_OPEN_TOOLS. Sensitive tools are intentionally absent.
+DEFAULT_FAIL_OPEN_TOOLS = frozenset(
+    {
+        "read_file",
+        "search_files",
+        "browser_snapshot",
+        "browser_get_images",
+        "browser_vision",
+        "vision_analyze",
+    }
+)
+
+TOOL_MAP = {
+    # Shell/code execution.
+    "terminal": "exec",
+    "execute_code": "exec",
+    # File access.
+    "read_file": "read",
+    "search_files": "read",
+    "write_file": "write",
+    "patch": "edit",
+    # Process/session control.
+    "process": "process",
+    "cronjob": "process",
+    # Browser and web surfaces.
+    "browser_back": "browser",
+    "browser_cdp": "browser",
+    "browser_click": "browser",
+    "browser_console": "browser",
+    "browser_dialog": "browser",
+    "browser_get_images": "browser",
+    "browser_navigate": "browser",
+    "browser_press": "browser",
+    "browser_scroll": "browser",
+    "browser_snapshot": "browser",
+    "browser_type": "browser",
+    "browser_vision": "browser",
+    "web_extract": "web_fetch",
+    "web_fetch": "web_fetch",
+    "web_search": "web_search",
+    # Outbound messaging/media and agent state.
+    "send_message": "message",
+    "text_to_speech": "message",
+    "memory": "write",
+    "todo": "write",
+    # Images/vision.
+    "vision_analyze": "image",
+}
+
+SENSITIVE_KEY_MARKERS = (
+    "token",
+    "secret",
+    "password",
+    "authorization",
+    "api_key",
+    "apikey",
+    "private_key",
+)
+
+logger = logging.getLogger(__name__)
+
+
+class RampartUnavailable(RuntimeError):
+    """Rampart serve could not be reached or returned an unusable response."""
+
+
+@dataclass(frozen=True)
+class PluginConfig:
+    serve_url: str = DEFAULT_SERVE_URL
+    timeout_ms: int = DEFAULT_TIMEOUT_MS
+    endpoint_mode: str = DEFAULT_ENDPOINT_MODE
+    fail_open_tools: frozenset[str] = DEFAULT_FAIL_OPEN_TOOLS
+    token_path: Path = Path.home() / ".rampart" / "token"
+    agent_name: str = DEFAULT_AGENT_NAME
+
+    @property
+    def timeout_seconds(self) -> float:
+        return max(0.1, self.timeout_ms / 1000.0)
+
+
+def _load_hermes_plugin_config() -> dict[str, Any]:
+    """Load plugins.entries.rampart.config from Hermes if available.
+
+    Tests and static inspection should not require Hermes to be installed, so all
+    imports are intentionally local and fail closed to an empty config.
+    """
+
+    try:
+        from hermes_cli.config import cfg_get, load_config  # type: ignore
+
+        raw = cfg_get(load_config(), "plugins", "entries", "rampart", "config", default={})
+        return raw if isinstance(raw, dict) else {}
+    except Exception:
+        return {}
+
+
+def _first_present(config: Mapping[str, Any], *keys: str, default: Any = None) -> Any:
+    for key in keys:
+        if key in config:
+            return config[key]
+    return default
+
+
+def _split_csv(value: str) -> list[str]:
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def load_config(overrides: Mapping[str, Any] | None = None) -> PluginConfig:
+    """Resolve plugin config from Hermes config, optional overrides, and env."""
+
+    raw: dict[str, Any] = dict(_load_hermes_plugin_config())
+    if overrides:
+        raw.update(dict(overrides))
+
+    serve_url = os.getenv("RAMPART_HERMES_URL") or os.getenv("RAMPART_URL") or os.getenv("RAMPART_SERVE_URL") or _first_present(
+        raw, "serve_url", "serveUrl", "url", default=DEFAULT_SERVE_URL
+    )
+    if not isinstance(serve_url, str) or not serve_url.strip():
+        serve_url = DEFAULT_SERVE_URL
+    serve_url = serve_url.rstrip("/")
+
+    timeout_raw = os.getenv("RAMPART_HERMES_TIMEOUT_MS") or _first_present(
+        raw, "timeout_ms", "timeoutMs", default=DEFAULT_TIMEOUT_MS
+    )
+    try:
+        timeout_ms = int(timeout_raw)
+    except (TypeError, ValueError):
+        timeout_ms = DEFAULT_TIMEOUT_MS
+    timeout_ms = min(max(timeout_ms, 100), 30_000)
+
+    endpoint_mode = os.getenv("RAMPART_HERMES_ENDPOINT_MODE") or _first_present(
+        raw, "endpoint_mode", "endpointMode", default=DEFAULT_ENDPOINT_MODE
+    )
+    if not isinstance(endpoint_mode, str):
+        endpoint_mode = DEFAULT_ENDPOINT_MODE
+    endpoint_mode = endpoint_mode.strip().lower()
+    if endpoint_mode not in {"preflight", "tool"}:
+        endpoint_mode = DEFAULT_ENDPOINT_MODE
+
+    fail_open_raw = os.getenv("RAMPART_HERMES_FAIL_OPEN_TOOLS")
+    if fail_open_raw is not None:
+        fail_open_tools = frozenset(_split_csv(fail_open_raw))
+    else:
+        configured = _first_present(raw, "fail_open_tools", "failOpenTools", default=None)
+        if isinstance(configured, str):
+            fail_open_tools = frozenset(_split_csv(configured))
+        elif isinstance(configured, (list, tuple, set)):
+            fail_open_tools = frozenset(str(item) for item in configured if str(item).strip())
+        else:
+            fail_open_tools = DEFAULT_FAIL_OPEN_TOOLS
+
+    token_path_raw = os.getenv("RAMPART_HERMES_TOKEN_PATH") or _first_present(
+        raw, "token_path", "tokenPath", default=str(Path.home() / ".rampart" / "token")
+    )
+    token_path = Path(str(token_path_raw)).expanduser()
+
+    agent_name = os.getenv("RAMPART_HERMES_AGENT") or _first_present(
+        raw, "agent", "agent_name", "agentName", default=DEFAULT_AGENT_NAME
+    )
+    if not isinstance(agent_name, str) or not agent_name.strip():
+        agent_name = DEFAULT_AGENT_NAME
+
+    return PluginConfig(
+        serve_url=serve_url,
+        timeout_ms=timeout_ms,
+        endpoint_mode=endpoint_mode,
+        fail_open_tools=fail_open_tools,
+        token_path=token_path,
+        agent_name=agent_name,
+    )
+
+
+def _load_token(config: PluginConfig) -> str | None:
+    env_token = os.getenv("RAMPART_TOKEN")
+    if env_token:
+        return env_token.strip()
+    try:
+        token = config.token_path.read_text(encoding="utf-8").strip()
+        return token or None
+    except OSError:
+        return None
+
+
+def _preview(value: Any, max_chars: int = 240) -> str | None:
+    if value is None:
+        return None
+    text = str(value).replace("\r", " ").replace("\n", " ").strip()
+    if not text:
+        return None
+    if len(text) <= max_chars:
+        return text
+    return text[: max_chars - 1].rstrip() + "…"
+
+
+def _byte_len(value: Any) -> int:
+    if value is None:
+        return 0
+    if isinstance(value, bytes):
+        return len(value)
+    return len(str(value).encode("utf-8"))
+
+
+def _line_count(value: Any) -> int:
+    if value is None:
+        return 0
+    return len(str(value).splitlines())
+
+
+def _safe_scalar(value: Any) -> Any:
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    return _preview(value)
+
+
+def _generic_metadata(args: Mapping[str, Any]) -> dict[str, Any]:
+    metadata: dict[str, Any] = {}
+    for key, value in args.items():
+        lower = str(key).lower()
+        if any(marker in lower for marker in SENSITIVE_KEY_MARKERS):
+            metadata[key] = "<redacted>"
+        elif lower in {"content", "data", "text", "message", "prompt", "old_string", "new_string", "patch"}:
+            metadata[f"{key}_bytes"] = _byte_len(value)
+            if lower in {"message", "prompt"}:
+                metadata[f"{key}_preview"] = _preview(value, 120)
+        else:
+            metadata[key] = _safe_scalar(value)
+    return metadata
+
+
+def _patch_touched_paths(patch_text: Any) -> list[str]:
+    if not isinstance(patch_text, str):
+        return []
+    paths: list[str] = []
+    for line in patch_text.splitlines():
+        if line.startswith("*** Update File: ") or line.startswith("*** Add File: ") or line.startswith("*** Delete File: "):
+            path = line.split(": ", 1)[1].strip()
+            if path and path not in paths:
+                paths.append(path)
+    return paths[:20]
+
+
+def normalize_tool_call(tool_name: str, args: Mapping[str, Any] | None) -> tuple[str, dict[str, Any]]:
+    """Map a Hermes tool call to a Rampart tool class with sanitized params."""
+
+    original_tool = tool_name if isinstance(tool_name, str) and tool_name else "unknown"
+    raw_args: Mapping[str, Any] = args if isinstance(args, Mapping) else {}
+    rampart_tool = TOOL_MAP.get(original_tool, original_tool)
+
+    params: dict[str, Any]
+    if original_tool == "terminal":
+        params = {
+            "command": raw_args.get("command", ""),
+            "workdir": raw_args.get("workdir"),
+            "timeout": raw_args.get("timeout"),
+            "background": bool(raw_args.get("background", False)),
+            "pty": bool(raw_args.get("pty", False)),
+            "notify_on_complete": bool(raw_args.get("notify_on_complete", False)),
+        }
+        if raw_args.get("watch_patterns"):
+            params["watch_patterns_count"] = len(raw_args.get("watch_patterns") or [])
+    elif original_tool == "execute_code":
+        code = raw_args.get("code", "")
+        params = {
+            "command": "python execute_code",
+            "script_preview": _preview(code, 240),
+            "script_bytes": _byte_len(code),
+            "script_lines": _line_count(code),
+        }
+    elif original_tool == "read_file":
+        params = {
+            "path": raw_args.get("path", ""),
+            "offset": raw_args.get("offset"),
+            "limit": raw_args.get("limit"),
+        }
+    elif original_tool == "search_files":
+        params = {
+            "path": raw_args.get("path", "."),
+            "pattern": raw_args.get("pattern", ""),
+            "target": raw_args.get("target", "content"),
+            "file_glob": raw_args.get("file_glob"),
+            "output_mode": raw_args.get("output_mode"),
+            "limit": raw_args.get("limit"),
+            "offset": raw_args.get("offset"),
+        }
+    elif original_tool == "write_file":
+        content = raw_args.get("content", "")
+        params = {
+            "path": raw_args.get("path", ""),
+            "content_bytes": _byte_len(content),
+            "content_lines": _line_count(content),
+        }
+    elif original_tool == "patch":
+        mode = raw_args.get("mode", "replace")
+        patch_text = raw_args.get("patch", "")
+        params = {
+            "mode": mode,
+            "path": raw_args.get("path"),
+            "replace_all": bool(raw_args.get("replace_all", False)),
+            "old_string_bytes": _byte_len(raw_args.get("old_string")),
+            "new_string_bytes": _byte_len(raw_args.get("new_string")),
+            "patch_bytes": _byte_len(patch_text),
+            "touched_paths": _patch_touched_paths(patch_text),
+        }
+    elif original_tool.startswith("browser_"):
+        action = original_tool.removeprefix("browser_")
+        params = {
+            "action": action,
+            "url": raw_args.get("url"),
+            "ref": raw_args.get("ref"),
+            "key": raw_args.get("key"),
+            "direction": raw_args.get("direction"),
+            "expression_preview": _preview(raw_args.get("expression"), 200),
+            "text_bytes": _byte_len(raw_args.get("text")) if "text" in raw_args else None,
+        }
+    elif original_tool == "process":
+        params = {
+            "action": raw_args.get("action"),
+            "session_id": raw_args.get("session_id"),
+            "timeout": raw_args.get("timeout"),
+            "data_bytes": _byte_len(raw_args.get("data")) if "data" in raw_args else None,
+        }
+    elif original_tool == "cronjob":
+        prompt = raw_args.get("prompt", "")
+        params = {
+            "action": raw_args.get("action"),
+            "job_id": raw_args.get("job_id"),
+            "schedule": raw_args.get("schedule"),
+            "name": raw_args.get("name"),
+            "prompt_bytes": _byte_len(prompt),
+            "prompt_preview": _preview(prompt, 120),
+            "no_agent": bool(raw_args.get("no_agent", False)),
+        }
+    elif original_tool == "send_message":
+        message = raw_args.get("message", "")
+        params = {
+            "action": raw_args.get("action", "send"),
+            "target": raw_args.get("target"),
+            "message_bytes": _byte_len(message),
+            "message_preview": _preview(message, 120),
+            "has_media": "MEDIA:" in message if isinstance(message, str) else False,
+        }
+    elif original_tool == "memory":
+        params = {
+            "action": raw_args.get("action"),
+            "target": raw_args.get("target"),
+            "content_bytes": _byte_len(raw_args.get("content")) if "content" in raw_args else None,
+        }
+    else:
+        params = _generic_metadata(raw_args)
+
+    params = {key: value for key, value in params.items() if value is not None}
+    params["hermes_tool"] = original_tool
+    params["rampart_tool"] = rampart_tool
+    return rampart_tool, params
+
+
+def _build_payload(
+    config: PluginConfig,
+    params: Mapping[str, Any],
+    *,
+    session_id: str = "",
+    task_id: str = "",
+    tool_call_id: str = "",
+) -> dict[str, Any]:
+    payload_params = dict(params)
+    if tool_call_id:
+        payload_params["hermes_tool_call_id"] = tool_call_id
+    return {
+        "agent": config.agent_name,
+        "session": session_id or "",
+        "run_id": task_id or "",
+        "params": payload_params,
+    }
+
+
+def _endpoint_url(config: PluginConfig, rampart_tool: str) -> str:
+    endpoint = "tool" if config.endpoint_mode == "tool" else "preflight"
+    return f"{config.serve_url}/v1/{endpoint}/{quote(rampart_tool, safe='')}"
+
+
+def _decode_http_error(exc: urllib.error.HTTPError) -> dict[str, Any]:
+    body = exc.read().decode("utf-8", errors="replace")
+    try:
+        parsed = json.loads(body) if body else {}
+    except json.JSONDecodeError:
+        parsed = {}
+    if isinstance(parsed, dict):
+        parsed.setdefault("message", body or f"Rampart returned HTTP {exc.code}")
+        return parsed
+    return {"decision": "deny", "allowed": False, "message": body or f"Rampart returned HTTP {exc.code}"}
+
+
+def post_to_rampart(config: PluginConfig, rampart_tool: str, payload: Mapping[str, Any]) -> dict[str, Any]:
+    token = _load_token(config)
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    request = urllib.request.Request(
+        _endpoint_url(config, rampart_tool),
+        data=json.dumps(payload, separators=(",", ":")).encode("utf-8"),
+        headers=headers,
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=config.timeout_seconds) as response:
+            data = response.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as exc:
+        if exc.code in {401, 403}:
+            return _decode_http_error(exc)
+        raise RampartUnavailable(f"Rampart returned HTTP {exc.code}") from exc
+    except (urllib.error.URLError, TimeoutError, socket.timeout, OSError) as exc:
+        raise RampartUnavailable(str(exc)) from exc
+
+    try:
+        parsed = json.loads(data) if data else {}
+    except json.JSONDecodeError as exc:
+        raise RampartUnavailable("Rampart returned invalid JSON") from exc
+    if not isinstance(parsed, dict):
+        raise RampartUnavailable("Rampart returned non-object JSON")
+    return parsed
+
+
+def _block(message: str) -> dict[str, str]:
+    return {"action": "block", "message": message}
+
+
+def _decision_from_result(result: Mapping[str, Any]) -> str:
+    decision = result.get("decision")
+    if isinstance(decision, str) and decision:
+        return decision.lower()
+    if result.get("allowed") is False:
+        return "deny"
+    return "allow"
+
+
+def evaluate_pre_tool_call(
+    tool_name: str,
+    args: Mapping[str, Any] | None,
+    *,
+    task_id: str = "",
+    session_id: str = "",
+    tool_call_id: str = "",
+    config_overrides: Mapping[str, Any] | None = None,
+    requester: Callable[[PluginConfig, str, Mapping[str, Any]], Mapping[str, Any]] | None = None,
+) -> dict[str, str] | None:
+    """Evaluate a Hermes tool call and return a Hermes block directive or None."""
+
+    config = load_config(config_overrides)
+    rampart_tool, params = normalize_tool_call(tool_name, args)
+    payload = _build_payload(
+        config,
+        params,
+        session_id=session_id,
+        task_id=task_id,
+        tool_call_id=tool_call_id,
+    )
+    caller = requester or post_to_rampart
+
+    try:
+        result = caller(config, rampart_tool, payload)
+    except RampartUnavailable as exc:
+        if tool_name in config.fail_open_tools or rampart_tool in config.fail_open_tools:
+            logger.warning("Rampart unavailable for %s/%s; configured fail-open", tool_name, rampart_tool)
+            return None
+        return _block(
+            f"rampart: unavailable ({tool_name}→{rampart_tool}) — policy service could not be reached; refusing sensitive tool call"
+        )
+
+    decision = _decision_from_result(result)
+    if decision in {"allow", "watch", "log"}:
+        return None
+
+    reason = str(result.get("message") or result.get("reason") or "policy violation")
+    policy = result.get("policy") or result.get("matched_policies")
+    policy_suffix = ""
+    if isinstance(policy, str) and policy:
+        policy_suffix = f" [policy: {policy}]"
+    elif isinstance(policy, list) and policy:
+        policy_suffix = f" [policy: {policy[0]}]"
+
+    if decision in {"ask", "require_approval"}:
+        return _block(
+            "rampart: approval required"
+            f" for {tool_name}→{rampart_tool}{policy_suffix} — {reason}. "
+            "Hermes Rampart integration is experimental and does not yet resume plugin-driven approvals; "
+            "adjust policy or use a first-class Hermes approval flow before retrying."
+        )
+
+    return _block(f"rampart: {reason}{policy_suffix}")
+
+
+def register(ctx: Any) -> None:
+    """Hermes plugin entrypoint."""
+
+    def _pre_tool_call(
+        tool_name: str,
+        args: Mapping[str, Any] | None = None,
+        task_id: str = "",
+        session_id: str = "",
+        tool_call_id: str = "",
+        **_: Any,
+    ) -> dict[str, str] | None:
+        return evaluate_pre_tool_call(
+            tool_name,
+            args,
+            task_id=task_id,
+            session_id=session_id,
+            tool_call_id=tool_call_id,
+        )
+
+    ctx.register_hook("pre_tool_call", _pre_tool_call)

--- a/internal/plugin/hermes/embed.go
+++ b/internal/plugin/hermes/embed.go
@@ -1,0 +1,55 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+// Package hermes provides the bundled experimental Rampart Hermes Agent plugin.
+package hermes
+
+import (
+	"embed"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+//go:embed __init__.py plugin.yaml
+var PluginFS embed.FS
+
+// Version returns the bundled plugin version from plugin.yaml.
+func Version() string {
+	data, err := PluginFS.ReadFile("plugin.yaml")
+	if err != nil {
+		return "unknown"
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		key, value, ok := strings.Cut(line, ":")
+		if !ok || strings.TrimSpace(key) != "version" {
+			continue
+		}
+		version := strings.Trim(strings.TrimSpace(value), `"'`)
+		if version != "" {
+			return version
+		}
+	}
+	return "unknown"
+}
+
+// Extract writes the embedded plugin files to dir.
+func Extract(dir string) error {
+	files := []string{"__init__.py", "plugin.yaml"}
+	for _, name := range files {
+		data, err := PluginFS.ReadFile(name)
+		if err != nil {
+			return fmt.Errorf("read embedded Hermes plugin file %q: %w", name, err)
+		}
+		dest := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+			return fmt.Errorf("create Hermes plugin dir for %q: %w", dest, err)
+		}
+		if err := os.WriteFile(dest, data, 0o644); err != nil {
+			return fmt.Errorf("write Hermes plugin file %q: %w", dest, err)
+		}
+	}
+	return nil
+}

--- a/internal/plugin/hermes/embed_test.go
+++ b/internal/plugin/hermes/embed_test.go
@@ -1,0 +1,41 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0
+
+package hermes
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestVersionReadsManifest(t *testing.T) {
+	if got, want := Version(), "0.1.0"; got != want {
+		t.Fatalf("Version() = %q, want %q", got, want)
+	}
+}
+
+func TestExtractWritesPluginFiles(t *testing.T) {
+	dir := t.TempDir()
+	if err := Extract(dir); err != nil {
+		t.Fatalf("Extract() error = %v", err)
+	}
+	for _, name := range []string{"__init__.py", "plugin.yaml"} {
+		path := filepath.Join(dir, name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("expected %s to be written: %v", name, err)
+		}
+		if len(data) == 0 {
+			t.Fatalf("expected %s to be non-empty", name)
+		}
+	}
+	manifest, err := os.ReadFile(filepath.Join(dir, "plugin.yaml"))
+	if err != nil {
+		t.Fatalf("read extracted manifest: %v", err)
+	}
+	if !strings.Contains(string(manifest), "provides_hooks:") || !strings.Contains(string(manifest), "pre_tool_call") {
+		t.Fatalf("manifest must declare pre_tool_call hook: %s", string(manifest))
+	}
+}

--- a/internal/plugin/hermes/plugin.yaml
+++ b/internal/plugin/hermes/plugin.yaml
@@ -1,0 +1,6 @@
+name: rampart
+version: 0.1.0
+description: Experimental Rampart policy gate for Hermes Agent pre_tool_call hooks
+author: peg
+provides_hooks:
+  - pre_tool_call

--- a/internal/plugin/hermes/test_hermes_plugin.py
+++ b/internal/plugin/hermes/test_hermes_plugin.py
@@ -1,0 +1,170 @@
+# Copyright 2026 The Rampart Authors
+# Licensed under the Apache License, Version 2.0
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+PLUGIN_PATH = Path(__file__).with_name("__init__.py")
+spec = importlib.util.spec_from_file_location("rampart_hermes_plugin_under_test", PLUGIN_PATH)
+assert spec is not None
+assert spec.loader is not None
+plugin = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = plugin
+spec.loader.exec_module(plugin)
+
+
+class HermesPluginTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.env_patch = mock.patch.dict(
+            os.environ,
+            {
+                key: value
+                for key, value in os.environ.items()
+                if not key.startswith("RAMPART_")
+            },
+            clear=True,
+        )
+        self.env_patch.start()
+
+    def tearDown(self) -> None:
+        self.env_patch.stop()
+
+    def test_terminal_maps_to_exec_with_command_metadata(self) -> None:
+        rampart_tool, params = plugin.normalize_tool_call(
+            "terminal",
+            {"command": "sudo true", "workdir": "/tmp", "background": True},
+        )
+
+        self.assertEqual(rampart_tool, "exec")
+        self.assertEqual(params["command"], "sudo true")
+        self.assertEqual(params["workdir"], "/tmp")
+        self.assertTrue(params["background"])
+        self.assertEqual(params["hermes_tool"], "terminal")
+        self.assertEqual(params["rampart_tool"], "exec")
+
+    def test_write_file_does_not_send_content(self) -> None:
+        rampart_tool, params = plugin.normalize_tool_call(
+            "write_file",
+            {"path": "/tmp/secret.txt", "content": "API_TOKEN=super-secret\n"},
+        )
+
+        self.assertEqual(rampart_tool, "write")
+        self.assertEqual(params["path"], "/tmp/secret.txt")
+        self.assertEqual(params["content_lines"], 1)
+        self.assertNotIn("content", params)
+        self.assertNotIn("super-secret", json.dumps(params))
+
+    def test_patch_mode_reports_size_and_touched_paths_only(self) -> None:
+        rampart_tool, params = plugin.normalize_tool_call(
+            "patch",
+            {
+                "mode": "patch",
+                "patch": "*** Begin Patch\n*** Update File: a.txt\n-secret\n+replacement\n*** End Patch",
+            },
+        )
+
+        self.assertEqual(rampart_tool, "edit")
+        self.assertEqual(params["mode"], "patch")
+        self.assertGreater(params["patch_bytes"], 0)
+        self.assertEqual(params["touched_paths"], ["a.txt"])
+        self.assertNotIn("replacement", json.dumps(params))
+
+    def test_preflight_endpoint_is_default(self) -> None:
+        config = plugin.load_config({"serve_url": "http://example.invalid/base/", "timeout_ms": 250})
+        self.assertEqual(config.endpoint_mode, "preflight")
+        self.assertEqual(plugin._endpoint_url(config, "exec"), "http://example.invalid/base/v1/preflight/exec")
+
+    def test_deny_decision_blocks(self) -> None:
+        captured = {}
+
+        def requester(config, rampart_tool, payload):
+            captured["config"] = config
+            captured["tool"] = rampart_tool
+            captured["payload"] = payload
+            return {"decision": "deny", "message": "blocked", "policy": "danger"}
+
+        result = plugin.evaluate_pre_tool_call(
+            "terminal",
+            {"command": "rm -rf /tmp/example"},
+            task_id="task-1",
+            session_id="sess-1",
+            tool_call_id="call-1",
+            config_overrides={"serve_url": "http://127.0.0.1:9090"},
+            requester=requester,
+        )
+
+        self.assertEqual(captured["tool"], "exec")
+        self.assertEqual(captured["payload"]["agent"], "hermes")
+        self.assertEqual(captured["payload"]["session"], "sess-1")
+        self.assertEqual(captured["payload"]["run_id"], "task-1")
+        self.assertEqual(captured["payload"]["params"]["hermes_tool_call_id"], "call-1")
+        self.assertEqual(result["action"], "block")
+        self.assertIn("blocked", result["message"])
+        self.assertIn("danger", result["message"])
+
+    def test_ask_decision_blocks_without_hidden_approval(self) -> None:
+        def requester(config, rampart_tool, payload):
+            self.assertEqual(config.endpoint_mode, "preflight")
+            self.assertNotIn("openclaw_hosted", payload)
+            self.assertNotIn("skip_pending_approval", payload)
+            return {"decision": "ask", "message": "needs human review", "matched_policies": ["prod-change"]}
+
+        result = plugin.evaluate_pre_tool_call(
+            "terminal",
+            {"command": "kubectl apply -f prod.yaml"},
+            requester=requester,
+        )
+
+        self.assertEqual(result["action"], "block")
+        self.assertIn("approval required", result["message"])
+        self.assertIn("does not yet resume", result["message"])
+        self.assertIn("prod-change", result["message"])
+
+    def test_unavailable_blocks_mutating_tool(self) -> None:
+        def requester(config, rampart_tool, payload):
+            raise plugin.RampartUnavailable("connection refused")
+
+        result = plugin.evaluate_pre_tool_call(
+            "write_file",
+            {"path": "/tmp/a", "content": "x"},
+            requester=requester,
+        )
+
+        self.assertEqual(result["action"], "block")
+        self.assertIn("unavailable", result["message"])
+
+    def test_unavailable_allows_configured_read_only_tool(self) -> None:
+        def requester(config, rampart_tool, payload):
+            raise plugin.RampartUnavailable("connection refused")
+
+        result = plugin.evaluate_pre_tool_call(
+            "read_file",
+            {"path": "/tmp/a"},
+            requester=requester,
+        )
+
+        self.assertIsNone(result)
+
+    def test_register_installs_pre_tool_call_hook(self) -> None:
+        class Ctx:
+            def __init__(self):
+                self.hooks = {}
+
+            def register_hook(self, name, callback):
+                self.hooks[name] = callback
+
+        ctx = Ctx()
+        plugin.register(ctx)
+
+        self.assertIn("pre_tool_call", ctx.hooks)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -152,6 +152,7 @@ nav:
     - Cursor: integrations/cursor.md
     - Codex CLI: integrations/codex-cli.md
     - OpenClaw: integrations/openclaw.md
+    - Hermes Agent: integrations/hermes.md
     - Python Agents: integrations/python-agents.md
     - Any CLI Agent: integrations/any-cli-agent.md
   - Features:


### PR DESCRIPTION
## Summary
- Add an experimental Hermes Agent user plugin that registers a `pre_tool_call` policy gate and sends sanitized tool metadata to Rampart.
- Add `rampart setup hermes` to install, remove, and optionally enable the bundled plugin without patching Hermes itself.
- Document the Hermes integration, support matrix placement, and add CI regression coverage for the plugin.

## Tests
- `python3 -m unittest internal/plugin/hermes/test_hermes_plugin.py`
- `go test ./internal/plugin/hermes ./cmd/rampart/cli`
- `go test ./...`
- `go build ./cmd/rampart`
- `./rampart setup hermes --help`
- `mkdocs build --strict`
- `git diff --check`
