### PR TITLE
fix: redact serve token from non-interactive logs

### DIFF
--- a/cmd/rampart/cli/cli_test.go
+++ b/cmd/rampart/cli/cli_test.go
@@ -286,9 +286,14 @@ func TestServeReadsAndPersistsToken(t *testing.T) {
 
 	logs := stderr.String()
 
-	// Serve must log the persisted token, not a fresh random one.
-	if !strings.Contains(logs, knownToken) {
-		t.Fatalf("serve did not use persisted token from ~/.rampart/token.\nlogs:\n%s", logs)
+	// Serve must use the persisted token without leaking the full secret into
+	// non-interactive logs. The ready line includes a short display prefix, which
+	// is enough to distinguish the persisted token from a fresh random one.
+	if strings.Contains(logs, knownToken) {
+		t.Fatalf("serve leaked full persisted token in logs.\nlogs:\n%s", logs)
+	}
+	if !strings.Contains(logs, "token=deadbeef...") {
+		t.Fatalf("serve did not appear to use persisted token prefix from ~/.rampart/token.\nlogs:\n%s", logs)
 	}
 
 	// Token file must still contain the same value after serve writes it back.

--- a/cmd/rampart/cli/serve.go
+++ b/cmd/rampart/cli/serve.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net"
 	"net/http"
@@ -46,6 +47,23 @@ import (
 type serveDeps struct {
 	newWatcher    func() (*fsnotify.Watcher, error)
 	notifyContext func(context.Context, ...os.Signal) (context.Context, context.CancelFunc)
+}
+
+func printServeToken(w io.Writer, token string, interactive bool) {
+	if interactive {
+		fmt.Fprintf(w, "  🔑 Full token : %s\n", token)
+		return
+	}
+	fmt.Fprintln(w, "  🔑 Token      : saved to ~/.rampart/token")
+}
+
+func printPersistTokenWarning(w io.Writer, err error, token string, interactive bool) {
+	fmt.Fprintf(w, "⚠ Warning: could not save token to ~/.rampart/token: %v\n", err)
+	if interactive {
+		fmt.Fprintf(w, "  Run: echo '%s' > ~/.rampart/token\n", token)
+		return
+	}
+	fmt.Fprintln(w, "  Token not printed because stderr is not an interactive terminal.")
 }
 
 func defaultServeDeps() serveDeps {
@@ -408,10 +426,9 @@ func newServeCmd(opts *rootOptions, deps *serveDeps) *cobra.Command {
 				}
 
 				// Only print the full token to an interactive terminal, never to
-				// a log file (background mode redirects stderr to serve.log).
-				if !background {
-					fmt.Fprintf(cmd.ErrOrStderr(), "  🔑 Full token : %s\n", token)
-				}
+				// a log file or redirected stderr (background mode redirects stderr to serve.log).
+				interactiveStderr := isTerminal(os.Stderr)
+				printServeToken(cmd.ErrOrStderr(), token, interactiveStderr)
 				scheme := "http"
 				if tlsCfg != nil {
 					scheme = "https"
@@ -423,8 +440,7 @@ func newServeCmd(opts *rootOptions, deps *serveDeps) *cobra.Command {
 
 				// Persist the token so it survives restarts.
 				if err := persistToken(token); err != nil {
-					fmt.Fprintf(cmd.ErrOrStderr(), "⚠ Warning: could not save token to ~/.rampart/token: %v\n", err)
-					fmt.Fprintf(cmd.ErrOrStderr(), "  Run: echo '%s' > ~/.rampart/token\n", token)
+					printPersistTokenWarning(cmd.ErrOrStderr(), err, token, interactiveStderr)
 				}
 
 				if metrics {

--- a/cmd/rampart/cli/serve_test.go
+++ b/cmd/rampart/cli/serve_test.go
@@ -7,12 +7,49 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/peg/rampart/policies"
 )
+
+func TestServeTokenOutputRedactsWhenNonInteractive(t *testing.T) {
+	const token = "secret-token-value"
+	var buf bytes.Buffer
+	printServeToken(&buf, token, false)
+	got := buf.String()
+	if strings.Contains(got, token) {
+		t.Fatalf("non-interactive output leaked full token: %q", got)
+	}
+	if !strings.Contains(got, "saved to ~/.rampart/token") {
+		t.Fatalf("non-interactive output should point to token file, got: %q", got)
+	}
+}
+
+func TestServeTokenOutputPrintsForInteractiveTerminal(t *testing.T) {
+	const token = "secret-token-value"
+	var buf bytes.Buffer
+	printServeToken(&buf, token, true)
+	got := buf.String()
+	if !strings.Contains(got, token) {
+		t.Fatalf("interactive output should include full token, got: %q", got)
+	}
+}
+
+func TestPersistTokenWarningRedactsFallbackWhenNonInteractive(t *testing.T) {
+	const token = "secret-token-value"
+	var buf bytes.Buffer
+	printPersistTokenWarning(&buf, os.ErrPermission, token, false)
+	got := buf.String()
+	if strings.Contains(got, token) {
+		t.Fatalf("non-interactive persist warning leaked full token: %q", got)
+	}
+	if !strings.Contains(got, "not printed") {
+		t.Fatalf("non-interactive persist warning should explain redaction, got: %q", got)
+	}
+}
 
 func TestIsWriteEvent(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary
- Redact the full Rampart auth token when `rampart serve` writes to non-interactive stderr/logs.
- Preserve full-token display for interactive terminals.
- Keep persisted-token regression coverage by checking the displayed prefix and token file content.

## Testing
- `go test ./cmd/rampart/cli -run 'TestServeReadsAndPersistsToken|TestServeTokenOutput|TestPersistTokenWarning|TestActivePolicyMDWrite' -count=1`\n- `go test ./cmd/rampart/cli -count=1`\n- `go test ./...`\n- `python -m unittest internal/plugin/hermes/test_hermes_plugin.py`