### PR TITLE
Align 1.1.1 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1] - 2026-05-26
+
+### Added
+
+- **Experimental Hermes Agent policy gate** — `rampart setup hermes` installs a user plugin that evaluates Hermes `pre_tool_call` events through Rampart without patching Hermes itself.
+
+### Changed
+
+- **Bundled OpenClaw plugin metadata is aligned for v1.1.1** — The package manifest, OpenClaw manifest, runtime export, and user-facing examples now report `1.1.1`.
+
+### Fixed
+
+- **Serve tokens stay out of non-interactive logs** — `rampart serve` redacts full tokens when output may be captured by service logs while preserving local token persistence.
+- **Policy polish for agent integration maintenance** — Standard policy now allows safe setup help and hook inspection forms while continuing to deny setup execution, hook mutation, compound inspection-plus-mutation commands, and high-risk environment assignments.
+- **Filtered audit views include sidecar files** — `rampart log --deny` searches all audit JSONL files before filtering so deny events are not hidden by later-sorting sidecar logs.
+
 ## [1.1.0] - 2026-05-24
 
 ### Added

--- a/docs-site/getting-started/installation.md
+++ b/docs-site/getting-started/installation.md
@@ -97,7 +97,7 @@ volumes:
   rampart-audit:
 ```
 
-Available tags include full versions such as `1.1.0`, minor versions such as `1.1`, and `latest` for the current stable release. Prereleases use their full tag, for example `1.1.0-rc.1`, and do not move `latest`. Pin to a specific version tag for reproducibility. Images are published on [GitHub Container Registry](https://github.com/peg/rampart/pkgs/container/rampart).
+Available tags include full versions such as `1.1.1`, minor versions such as `1.1`, and `latest` for the current stable release. Prereleases use their full tag, for example `1.1.0-rc.1`, and do not move `latest`. Pin to a specific version tag for reproducibility. Images are published on [GitHub Container Registry](https://github.com/peg/rampart/pkgs/container/rampart).
 
 ## Build from Source
 

--- a/docs-site/getting-started/troubleshooting.md
+++ b/docs-site/getting-started/troubleshooting.md
@@ -165,7 +165,7 @@ rampart test --tool read "/etc/shadow"
 
 ```bash
 openclaw plugins list
-# Should show: rampart  1.1.0  ✓ active
+# Should show: rampart  1.1.1  ✓ active
 
 rampart doctor
 # Should show: ✓ OpenClaw plugin: installed (before_tool_call hook active)

--- a/docs-site/index.html
+++ b/docs-site/index.html
@@ -27,7 +27,7 @@
       "url": "https://rampart.sh",
       "applicationCategory": "SecurityApplication",
       "operatingSystem": "Linux, macOS, Windows",
-      "softwareVersion": "1.1.0",
+      "softwareVersion": "1.1.1",
       "offers": {
         "@type": "Offer",
         "price": "0",
@@ -1112,7 +1112,7 @@
 <section class="hero">
     <div class="container hero-grid">
         <div>
-            <div class="eyebrow"><span class="eyebrow-dot"></span>v1.1.0 · release-ready</div>
+            <div class="eyebrow"><span class="eyebrow-dot"></span>v1.1.1 · release-ready</div>
             <h1>Your agent has root.<br><span class="accent">That’s the problem.</span></h1>
             <p class="hero-sub">Rampart sits in the execution path. Install it, run <code>rampart quickstart</code>, and it wires the right protection path for Claude Code, Codex, Cline, or OpenClaw before risky tool calls run.</p>
             <div class="install-cluster">

--- a/docs-site/integrations/openclaw.md
+++ b/docs-site/integrations/openclaw.md
@@ -157,7 +157,7 @@ Or check plugin status directly:
 
 ```bash
 openclaw plugins list
-# rampart  v1.1.0  active
+# rampart  v1.1.1  active
 ```
 
 ## Troubleshooting

--- a/docs-site/reference/threat-model.md
+++ b/docs-site/reference/threat-model.md
@@ -1,6 +1,6 @@
 # Threat Model
 
-> Last reviewed: 2026-05-24 | Applies to: v1.1.0
+> Last reviewed: 2026-05-26 | Applies to: v1.1.1
 
 Rampart is a policy engine for AI agents — not a sandbox, not a hypervisor, not a full isolation boundary. This document describes what Rampart protects against, what it doesn't, and why.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -27,7 +27,7 @@
       "url": "https://rampart.sh",
       "applicationCategory": "SecurityApplication",
       "operatingSystem": "Linux, macOS, Windows",
-      "softwareVersion": "1.1.0",
+      "softwareVersion": "1.1.1",
       "offers": {
         "@type": "Offer",
         "price": "0",
@@ -1112,7 +1112,7 @@
 <section class="hero">
     <div class="container hero-grid">
         <div>
-            <div class="eyebrow"><span class="eyebrow-dot"></span>v1.1.0 · release-ready</div>
+            <div class="eyebrow"><span class="eyebrow-dot"></span>v1.1.1 · release-ready</div>
             <h1>Your agent has root.<br><span class="accent">That’s the problem.</span></h1>
             <p class="hero-sub">Rampart sits in the execution path. Install it, run <code>rampart quickstart</code>, and it wires the right protection path for Claude Code, Codex, Cline, or OpenClaw before risky tool calls run.</p>
             <div class="install-cluster">

--- a/docs/install
+++ b/docs/install
@@ -7,8 +7,8 @@
 # Usage: curl -fsSL https://rampart.sh/install | sh
 #        curl -fsSL https://rampart.sh/install | sh -s -- --version v0.1.0
 #        curl -fsSL https://rampart.sh/install | sh -s -- --auto-setup
-#        RAMPART_INSTALL_DRY_RUN=1 sh install.sh --version v1.1.0
-#        RAMPART_VERSION=v1.1.0 RAMPART_INSTALL_DIR=$HOME/.local/bin sh install.sh
+#        RAMPART_INSTALL_DRY_RUN=1 sh install.sh --version v1.1.1
+#        RAMPART_VERSION=v1.1.1 RAMPART_INSTALL_DIR=$HOME/.local/bin sh install.sh
 set -e
 
 REPO="peg/rampart"

--- a/docs/install.sh
+++ b/docs/install.sh
@@ -7,8 +7,8 @@
 # Usage: curl -fsSL https://rampart.sh/install | sh
 #        curl -fsSL https://rampart.sh/install | sh -s -- --version v0.1.0
 #        curl -fsSL https://rampart.sh/install | sh -s -- --auto-setup
-#        RAMPART_INSTALL_DRY_RUN=1 sh install.sh --version v1.1.0
-#        RAMPART_VERSION=v1.1.0 RAMPART_INSTALL_DIR=$HOME/.local/bin sh install.sh
+#        RAMPART_INSTALL_DRY_RUN=1 sh install.sh --version v1.1.1
+#        RAMPART_VERSION=v1.1.1 RAMPART_INSTALL_DIR=$HOME/.local/bin sh install.sh
 set -e
 
 REPO="peg/rampart"

--- a/install.sh
+++ b/install.sh
@@ -7,8 +7,8 @@
 # Usage: curl -fsSL https://rampart.sh/install | sh
 #        curl -fsSL https://rampart.sh/install | sh -s -- --version v0.1.0
 #        curl -fsSL https://rampart.sh/install | sh -s -- --auto-setup
-#        RAMPART_INSTALL_DRY_RUN=1 sh install.sh --version v1.1.0
-#        RAMPART_VERSION=v1.1.0 RAMPART_INSTALL_DIR=$HOME/.local/bin sh install.sh
+#        RAMPART_INSTALL_DRY_RUN=1 sh install.sh --version v1.1.1
+#        RAMPART_VERSION=v1.1.1 RAMPART_INSTALL_DIR=$HOME/.local/bin sh install.sh
 set -e
 
 REPO="peg/rampart"

--- a/internal/plugin/openclaw/index.js
+++ b/internal/plugin/openclaw/index.js
@@ -5,7 +5,7 @@
  * Replaces brittle dist-file patching with the official OpenClaw plugin API.
  *
  * @see https://github.com/peg/rampart
- * @version 1.1.0
+ * @version 1.1.1
  */
 
 import { readFile } from "fs/promises";
@@ -259,7 +259,7 @@ async function auditLog(toolName, params, ctx, outcome, config) {
 export const id = "rampart";
 export const name = "Rampart";
 export const description = "AI agent firewall — YAML policy-as-code for every tool call";
-export const version = "1.1.0";
+export const version = "1.1.1";
 
 // OpenClaw runs higher-priority before_tool_call hooks first. Rampart should
 // act as the final normal plugin gate so it evaluates the params that will

--- a/internal/plugin/openclaw/openclaw.plugin.json
+++ b/internal/plugin/openclaw/openclaw.plugin.json
@@ -8,7 +8,7 @@
       "hook"
     ]
   },
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": "peg",
   "homepage": "https://rampart.sh",
   "repository": "https://github.com/peg/rampart",

--- a/internal/plugin/openclaw/package.json
+++ b/internal/plugin/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rampart",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Rampart AI agent firewall — OpenClaw native plugin (before_tool_call hook)",
   "type": "module",
   "main": "index.js",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,8 +7,8 @@
 # Usage: curl -fsSL https://rampart.sh/install | sh
 #        curl -fsSL https://rampart.sh/install | sh -s -- --version v0.1.0
 #        curl -fsSL https://rampart.sh/install | sh -s -- --auto-setup
-#        RAMPART_INSTALL_DRY_RUN=1 sh install.sh --version v1.1.0
-#        RAMPART_VERSION=v1.1.0 RAMPART_INSTALL_DIR=$HOME/.local/bin sh install.sh
+#        RAMPART_INSTALL_DRY_RUN=1 sh install.sh --version v1.1.1
+#        RAMPART_VERSION=v1.1.1 RAMPART_INSTALL_DIR=$HOME/.local/bin sh install.sh
 set -e
 
 REPO="peg/rampart"


### PR DESCRIPTION
## Summary
- Add a 1.1.1 changelog entry covering the Hermes policy gate, serve-token redaction, and policy/audit polish in staging.
- Align bundled OpenClaw plugin metadata/runtime version and user-facing examples with the intended 1.1.1 release.
- Update current install/troubleshooting/threat-model release examples so the promotion does not ship stale 1.1.0 markers.

## Validation
- `go test -count=1 ./...`
- `go vet ./...`
- `go run ./cmd/rampart policy lint policies/standard.yaml`
- `python -m unittest internal/plugin/hermes/test_hermes_plugin.py`
- OpenClaw plugin JS regression tests: `smoke-test.mjs`, `degraded-mode-test.mjs`, `tool-alias-test.mjs`, `approval-regression.mjs`
- setup/help surface smoke for Claude Code, Codex, Cline, OpenClaw, Hermes, MCP, wrap, and preload
- targeted `go test -race` for bridge/plugin/MCP/proxy/intercept/OpenClaw packages
- `mkdocs build --strict`
- `git diff --check`
