### PR TITLE
feat: add hosted approval API foundation

### DIFF
--- a/internal/audit/event.go
+++ b/internal/audit/event.go
@@ -62,6 +62,16 @@ type Event struct {
 	// or CLAUDE_CONVERSATION_ID fallback. Empty if no grouping applies.
 	RunID string `json:"run_id,omitempty"`
 
+	// ToolCallID is an optional host-provided identifier for the exact tool call.
+	// Agent hosts that own approval/resume flows can use this to correlate the
+	// Rampart policy decision with their native approval object and resumed call.
+	ToolCallID string `json:"tool_call_id,omitempty"`
+
+	// ApprovalOwner records which system owns the user-facing approval object.
+	// In hosted-approval flows this is intentionally not a Rampart pending
+	// approval; it is correlation metadata for audit and callbacks.
+	ApprovalOwner map[string]any `json:"approval_owner,omitempty"`
+
 	// Tool is the tool that was invoked (e.g., "exec", "read").
 	Tool string `json:"tool"`
 

--- a/internal/proxy/approval_handlers.go
+++ b/internal/proxy/approval_handlers.go
@@ -442,6 +442,128 @@ func (s *Server) handleBulkResolve(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+func (s *Server) handleResolveHostedApproval(w http.ResponseWriter, r *http.Request) {
+	if !s.checkAdminAuth(w, r) {
+		return
+	}
+
+	auditID := strings.TrimSpace(r.PathValue("auditID"))
+	if auditID == "" {
+		writeError(w, http.StatusBadRequest, "audit_id is required")
+		return
+	}
+
+	var req hostedApprovalResolveRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid request body: %v", err))
+		return
+	}
+
+	outcome := strings.ToLower(strings.TrimSpace(req.Outcome))
+	switch outcome {
+	case "approved", "denied", "timeout", "cancelled":
+		// valid
+	default:
+		writeError(w, http.StatusBadRequest, "outcome must be one of: approved, denied, timeout, cancelled")
+		return
+	}
+
+	scope := strings.ToLower(strings.TrimSpace(req.Scope))
+	if scope != "" {
+		switch scope {
+		case "once", "session", "always":
+			// valid
+		default:
+			writeError(w, http.StatusBadRequest, "scope must be one of: once, session, always")
+			return
+		}
+	}
+
+	resolvedBy := strings.TrimSpace(req.ResolvedBy)
+	if resolvedBy == "" {
+		resolvedBy = "api"
+	}
+
+	resolvedAt := time.Now().UTC()
+	if strings.TrimSpace(req.ResolvedAt) != "" {
+		parsed, err := time.Parse(time.RFC3339, strings.TrimSpace(req.ResolvedAt))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "resolved_at must be RFC3339")
+			return
+		}
+		resolvedAt = parsed.UTC()
+	}
+
+	if s.sink == nil {
+		writeError(w, http.StatusServiceUnavailable, "audit sink is not initialized")
+		return
+	}
+
+	tool := strings.TrimSpace(req.Tool)
+	if tool == "" {
+		tool = "hosted_approval"
+	}
+
+	request := map[string]any{
+		"action":      "hosted_approval_resolved",
+		"audit_id":    auditID,
+		"outcome":     outcome,
+		"resolved_by": resolvedBy,
+		"resolved_at": resolvedAt.Format(time.RFC3339),
+	}
+	if req.ToolCallID != "" {
+		request["tool_call_id"] = req.ToolCallID
+	}
+	if req.HostApprovalID != "" {
+		request["host_approval_id"] = req.HostApprovalID
+	}
+	if scope != "" {
+		request["scope"] = scope
+	}
+	if req.Message != "" {
+		request["message"] = req.Message
+	}
+	if owner := req.ApprovalOwner.toMap(); len(owner) > 0 {
+		request["approval_owner"] = owner
+	}
+
+	message := req.Message
+	if message == "" {
+		message = fmt.Sprintf("hosted approval %s by %s", outcome, resolvedBy)
+	}
+
+	eventID := audit.NewEventID()
+	event := audit.Event{
+		ID:            eventID,
+		Timestamp:     resolvedAt,
+		Agent:         req.Agent,
+		Session:       req.Session,
+		RunID:         req.RunID,
+		ToolCallID:    req.ToolCallID,
+		ApprovalOwner: req.ApprovalOwner.toMap(),
+		Tool:          tool,
+		Request:       request,
+		Decision: audit.EventDecision{
+			Action:  outcome,
+			Message: message,
+		},
+	}
+	if err := s.sink.Write(event); err != nil {
+		s.logger.Error("proxy: audit write for hosted approval resolution failed", "error", err)
+		writeError(w, http.StatusServiceUnavailable, "failed to write hosted approval audit event")
+		return
+	}
+	s.broadcastSSE(map[string]any{"type": "audit", "event": event})
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"audit_id":    auditID,
+		"event_id":    eventID,
+		"status":      "recorded",
+		"outcome":     outcome,
+		"resolved_at": resolvedAt.Format(time.RFC3339),
+	})
+}
+
 func (s *Server) approvalResolveURL(id string, expiresAt time.Time) string {
 	base := s.resolveURLBase()
 	if base == "" {

--- a/internal/proxy/eval_handlers.go
+++ b/internal/proxy/eval_handlers.go
@@ -122,7 +122,7 @@ func (s *Server) handleToolCall(w http.ResponseWriter, r *http.Request) {
 		SetUptime(time.Since(s.startedAt))
 	}
 
-	s.writeAudit(req, toolName, decision)
+	auditID := s.writeAudit(req, toolName, decision)
 
 	allowed := decision.Action == engine.ActionAllow || decision.Action == engine.ActionWatch
 	resp := map[string]any{
@@ -130,6 +130,9 @@ func (s *Server) handleToolCall(w http.ResponseWriter, r *http.Request) {
 		"decision":         decision.Action.String(),
 		"message":          decision.Message,
 		"eval_duration_us": decision.EvalDuration.Microseconds(),
+	}
+	if auditID != "" {
+		resp["audit_id"] = auditID
 	}
 
 	if len(decision.MatchedPolicies) > 0 {
@@ -169,23 +172,37 @@ func (s *Server) handleToolCall(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if s.mode == "enforce" && (decision.Action == engine.ActionRequireApproval || decision.Action == engine.ActionAsk) {
-		if req.OpenClawHosted || req.SkipPendingApproval {
-			if identity.IsAdmin && req.OpenClawHosted && req.SkipPendingApproval {
-				s.logger.Info("proxy: trusted OpenClaw-hosted approval evaluation requested, skipping Rampart pending approval creation",
+		if req.requestsHostedApproval() {
+			if identity.IsAdmin {
+				if err := req.validateTrustedHostedApproval(); err != nil {
+					writeError(w, http.StatusBadRequest, err.Error())
+					return
+				}
+				s.logger.Info("proxy: trusted hosted approval evaluation requested, skipping Rampart pending approval creation",
 					"tool", toolName,
 					"decision", decision.Action.String(),
 					"session", call.Session,
+					"approval_owner", req.hostedApprovalOwnerMap(),
 				)
+				resp["approval_mode"] = "hosted"
+				if owner := req.hostedApprovalOwnerMap(); len(owner) > 0 {
+					resp["approval_owner"] = owner
+				}
+				if req.ToolCallID != "" {
+					resp["tool_call_id"] = req.ToolCallID
+				}
+				resp["approval"] = s.hostedApprovalDescriptor(req, decision)
 				writeJSON(w, http.StatusOK, resp)
 				return
 			}
-			s.logger.Warn("proxy: ignoring caller-supplied hosted approval bypass flags for untrusted or incomplete request",
+			s.logger.Warn("proxy: ignoring caller-supplied hosted approval bypass flags for untrusted request",
 				"tool", toolName,
 				"decision", decision.Action.String(),
 				"session", call.Session,
 				"is_admin", identity.IsAdmin,
 				"openclaw_hosted", req.OpenClawHosted,
 				"skip_pending_approval", req.SkipPendingApproval,
+				"approval_owner", req.hostedApprovalOwnerMap(),
 			)
 		}
 
@@ -263,18 +280,22 @@ func (s *Server) applyResponseEvaluation(
 	return true
 }
 
-func (s *Server) writeAudit(req toolRequest, toolName string, decision engine.Decision) {
+func (s *Server) writeAudit(req toolRequest, toolName string, decision engine.Decision) string {
 	if s.sink == nil {
-		return
+		return ""
 	}
 
+	eventID := audit.NewEventID()
 	event := audit.Event{
-		ID:        audit.NewEventID(),
-		Timestamp: time.Now().UTC(),
-		Agent:     req.Agent,
-		Session:   req.Session,
-		Tool:      toolName,
-		Request:   req.Params,
+		ID:            eventID,
+		Timestamp:     time.Now().UTC(),
+		Agent:         req.Agent,
+		Session:       req.Session,
+		RunID:         req.RunID,
+		ToolCallID:    req.ToolCallID,
+		ApprovalOwner: req.hostedApprovalOwnerMap(),
+		Tool:          toolName,
+		Request:       req.Params,
 		Decision: audit.EventDecision{
 			Action:          decision.Action.String(),
 			MatchedPolicies: decision.MatchedPolicies,
@@ -286,6 +307,7 @@ func (s *Server) writeAudit(req toolRequest, toolName string, decision engine.De
 
 	if err := s.sink.Write(event); err != nil {
 		s.logger.Error("proxy: audit write failed", "error", err)
+		return ""
 	}
 	s.broadcastSSE(map[string]any{"type": "audit", "event": event})
 
@@ -305,6 +327,26 @@ func (s *Server) writeAudit(req toolRequest, toolName string, decision engine.De
 			}
 			go s.sendWebhook(call, decision)
 		}
+	}
+	return eventID
+}
+
+func (s *Server) hostedApprovalDescriptor(req toolRequest, decision engine.Decision) map[string]any {
+	timeout := s.approvalTimeout
+	if timeout <= 0 {
+		timeout = 2 * time.Minute
+	}
+	scopeOptions := []string{"once", "session"}
+	allowAlways := req.ApprovalOwner != nil && req.ApprovalOwner.SupportsAllowAlways
+	if allowAlways {
+		scopeOptions = append(scopeOptions, "always")
+	}
+	return map[string]any{
+		"reason":                 decision.Message,
+		"scope_options":          scopeOptions,
+		"allow_always_supported": allowAlways,
+		"timeout_ms":             timeout.Milliseconds(),
+		"expires_at":             time.Now().UTC().Add(timeout).Format(time.RFC3339),
 	}
 }
 
@@ -372,7 +414,7 @@ func (s *Server) handlePreflight(w http.ResponseWriter, r *http.Request) {
 	}
 	decision := s.engine.EvaluateWith(call, evalOpts)
 	allowed := decision.Action == engine.ActionAllow || decision.Action == engine.ActionWatch
-	s.writeAudit(req, toolName, decision)
+	auditID := s.writeAudit(req, toolName, decision)
 
 	preflightResp := map[string]any{
 		"allowed":          allowed,
@@ -380,6 +422,9 @@ func (s *Server) handlePreflight(w http.ResponseWriter, r *http.Request) {
 		"message":          decision.Message,
 		"matched_policies": decision.MatchedPolicies,
 		"eval_duration_us": decision.EvalDuration.Microseconds(),
+	}
+	if auditID != "" {
+		preflightResp["audit_id"] = auditID
 	}
 	if len(decision.Suggestions) > 0 {
 		preflightResp["suggestions"] = decision.Suggestions

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -355,6 +355,7 @@ func (s *Server) handler() http.Handler {
 	mux.HandleFunc("GET /v1/approvals/{id}", s.handleGetApproval)
 	mux.HandleFunc("POST /v1/approvals/{id}/resolve", s.handleResolveApproval)
 	mux.HandleFunc("POST /v1/approvals/bulk-resolve", s.handleBulkResolve)
+	mux.HandleFunc("POST /v1/hosted-approvals/{auditID}/resolve", s.handleResolveHostedApproval)
 	mux.HandleFunc("GET /v1/rules/auto-allowed", s.handleGetAutoAllowed)
 	mux.HandleFunc("DELETE /v1/rules/auto-allowed/{name}", s.handleDeleteAutoAllowed)
 	mux.HandleFunc("POST /v1/rules/learn", s.handleLearnRule)
@@ -390,8 +391,10 @@ type toolRequest struct {
 	Agent               string         `json:"agent"`
 	Session             string         `json:"session"`
 	RunID               string         `json:"run_id,omitempty"`
+	ToolCallID          string         `json:"tool_call_id,omitempty"`
 	Params              map[string]any `json:"params"`
 	Input               map[string]any `json:"input,omitempty"`
+	ApprovalOwner       *approvalOwner `json:"approval_owner,omitempty"`
 	OpenClawHosted      bool           `json:"openclaw_hosted,omitempty"`
 	SkipPendingApproval bool           `json:"skip_pending_approval,omitempty"`
 
@@ -408,6 +411,82 @@ type toolRequest struct {
 	Response string `json:"response,omitempty"`
 }
 
+// approvalOwner describes host-owned approval/resume capabilities for a tool
+// evaluation. approval_owner.mode=hosted means the caller owns the user-facing
+// approval object; Rampart records policy/audit data but must not create a
+// second Rampart-native pending approval for the same tool call.
+type approvalOwner struct {
+	Host                   string `json:"host,omitempty"`
+	Mode                   string `json:"mode,omitempty"`
+	Surface                string `json:"surface,omitempty"`
+	SupportsExactResume    bool   `json:"supports_exact_resume,omitempty"`
+	SupportsAllowAlways    bool   `json:"supports_allow_always,omitempty"`
+	SupportsResultCallback bool   `json:"supports_result_callback,omitempty"`
+}
+
+func (o *approvalOwner) isHosted() bool {
+	return o != nil && strings.EqualFold(strings.TrimSpace(o.Mode), "hosted")
+}
+
+func (o *approvalOwner) toMap() map[string]any {
+	if o == nil {
+		return nil
+	}
+	out := map[string]any{}
+	if host := strings.TrimSpace(o.Host); host != "" {
+		out["host"] = host
+	}
+	if mode := strings.TrimSpace(o.Mode); mode != "" {
+		out["mode"] = mode
+	}
+	if surface := strings.TrimSpace(o.Surface); surface != "" {
+		out["surface"] = surface
+	}
+	if o.SupportsExactResume {
+		out["supports_exact_resume"] = true
+	}
+	if o.SupportsAllowAlways {
+		out["supports_allow_always"] = true
+	}
+	if o.SupportsResultCallback {
+		out["supports_result_callback"] = true
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func (req toolRequest) requestsHostedApproval() bool {
+	return req.ApprovalOwner.isHosted() || req.OpenClawHosted || req.SkipPendingApproval
+}
+
+func (req toolRequest) hostedApprovalOwnerMap() map[string]any {
+	if owner := req.ApprovalOwner.toMap(); len(owner) > 0 {
+		return owner
+	}
+	if req.OpenClawHosted {
+		return map[string]any{"host": "openclaw", "mode": "hosted"}
+	}
+	return nil
+}
+
+func (req toolRequest) validateTrustedHostedApproval() error {
+	if req.ApprovalOwner.isHosted() {
+		if strings.TrimSpace(req.ApprovalOwner.Host) == "" {
+			return fmt.Errorf("approval_owner.host is required when approval_owner.mode=hosted")
+		}
+		if !req.ApprovalOwner.SupportsExactResume {
+			return fmt.Errorf("approval_owner.supports_exact_resume=true is required for hosted approvals")
+		}
+		return nil
+	}
+	if req.OpenClawHosted && req.SkipPendingApproval {
+		return nil
+	}
+	return fmt.Errorf("hosted approval requests require approval_owner.mode=hosted or both openclaw_hosted and skip_pending_approval")
+}
+
 // createApprovalRequest is the JSON body for POST /v1/approvals.
 type createApprovalRequest struct {
 	Tool    string `json:"tool"`
@@ -422,6 +501,21 @@ type resolveRequest struct {
 	Approved   bool   `json:"approved"`
 	ResolvedBy string `json:"resolved_by"`
 	Persist    bool   `json:"persist"`
+}
+
+type hostedApprovalResolveRequest struct {
+	Agent          string         `json:"agent,omitempty"`
+	Session        string         `json:"session,omitempty"`
+	RunID          string         `json:"run_id,omitempty"`
+	Tool           string         `json:"tool,omitempty"`
+	ToolCallID     string         `json:"tool_call_id,omitempty"`
+	HostApprovalID string         `json:"host_approval_id,omitempty"`
+	ApprovalOwner  *approvalOwner `json:"approval_owner,omitempty"`
+	Outcome        string         `json:"outcome"`
+	Scope          string         `json:"scope,omitempty"`
+	ResolvedBy     string         `json:"resolved_by,omitempty"`
+	ResolvedAt     string         `json:"resolved_at,omitempty"`
+	Message        string         `json:"message,omitempty"`
 }
 
 // bulkResolveRequest is the JSON body for POST /v1/approvals/bulk-resolve.

--- a/internal/proxy/server_test.go
+++ b/internal/proxy/server_test.go
@@ -731,6 +731,131 @@ policies:
 	assert.Len(t, srv.approvals.List(), 1, "agent token must still enqueue Rampart approvals")
 }
 
+func TestGenericHostedAskSkipsPendingApprovalCreationForAdmin(t *testing.T) {
+	configYAML := `version: "1"
+default_action: deny
+policies:
+  - name: require-human
+    match:
+      tool: exec
+    rules:
+      - action: ask
+        when:
+          command_matches:
+            - "sudo *"
+        message: "needs approval"
+`
+
+	srv, token, sink := setupTestServer(t, configYAML, "enforce")
+	ts := httptest.NewServer(srv.handler())
+	defer ts.Close()
+
+	body := `{"agent":"hermes","session":"discord/thread/test","run_id":"run-1","tool_call_id":"tool-call-1","approval_owner":{"host":"hermes","mode":"hosted","surface":"discord","supports_exact_resume":true,"supports_allow_always":true,"supports_result_callback":true},"params":{"command":"sudo true"}}`
+	req, err := http.NewRequest(http.MethodPost, ts.URL+"/v1/tool/exec", bytes.NewBufferString(body))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var got map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&got))
+	assert.Equal(t, "ask", got["decision"])
+	assert.Equal(t, "hosted", got["approval_mode"])
+	assert.Equal(t, "tool-call-1", got["tool_call_id"])
+	require.NotEmpty(t, got["audit_id"])
+	_, hasApprovalID := got["approval_id"]
+	assert.False(t, hasApprovalID, "hosted evaluation must not create Rampart approval_id")
+	assert.Len(t, srv.approvals.List(), 0, "hosted evaluation must not enqueue Rampart approvals")
+
+	owner, ok := got["approval_owner"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "hermes", owner["host"])
+	assert.Equal(t, "hosted", owner["mode"])
+	approval, ok := got["approval"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "needs approval", approval["reason"])
+
+	require.Equal(t, 1, sink.count(), "hosted evaluation should write exactly one policy audit event")
+	ev := sink.lastEvent()
+	assert.Equal(t, got["audit_id"], ev.ID)
+	assert.Equal(t, "tool-call-1", ev.ToolCallID)
+	assert.Equal(t, "run-1", ev.RunID)
+	assert.Equal(t, "ask", ev.Decision.Action)
+	require.NotNil(t, ev.ApprovalOwner)
+	assert.Equal(t, "hermes", ev.ApprovalOwner["host"])
+}
+
+func TestHostedAskRequiresExactResumeForAdmin(t *testing.T) {
+	configYAML := `version: "1"
+default_action: deny
+policies:
+  - name: require-human
+    match:
+      tool: exec
+    rules:
+      - action: ask
+        when:
+          command_matches:
+            - "sudo *"
+        message: "needs approval"
+`
+
+	srv, token, _ := setupTestServer(t, configYAML, "enforce")
+	ts := httptest.NewServer(srv.handler())
+	defer ts.Close()
+
+	body := `{"agent":"hermes","session":"discord/thread/test","approval_owner":{"host":"hermes","mode":"hosted"},"params":{"command":"sudo true"}}`
+	req, err := http.NewRequest(http.MethodPost, ts.URL+"/v1/tool/exec", bytes.NewBufferString(body))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Len(t, srv.approvals.List(), 0, "invalid hosted request must not fall back to hidden Rampart approval queue")
+}
+
+func TestHostedApprovalResolveRecordsAuditWithoutPendingApproval(t *testing.T) {
+	srv, token, sink := setupTestServer(t, testPolicyYAML, "enforce")
+	ts := httptest.NewServer(srv.handler())
+	defer ts.Close()
+
+	body := `{"agent":"hermes","session":"discord/thread/test","run_id":"run-1","tool":"exec","tool_call_id":"tool-call-1","host_approval_id":"hermes-approval-1","approval_owner":{"host":"hermes","mode":"hosted","surface":"discord","supports_exact_resume":true},"outcome":"approved","scope":"once","resolved_by":"trevor","message":"approved in Hermes"}`
+	req, err := http.NewRequest(http.MethodPost, ts.URL+"/v1/hosted-approvals/audit-1/resolve", bytes.NewBufferString(body))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var got map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&got))
+	assert.Equal(t, "audit-1", got["audit_id"])
+	assert.Equal(t, "recorded", got["status"])
+	assert.Equal(t, "approved", got["outcome"])
+	assert.Len(t, srv.approvals.List(), 0, "hosted resolution callback must not create Rampart pending approvals")
+
+	require.Equal(t, 1, sink.count())
+	ev := sink.lastEvent()
+	assert.Equal(t, "exec", ev.Tool)
+	assert.Equal(t, "tool-call-1", ev.ToolCallID)
+	assert.Equal(t, "run-1", ev.RunID)
+	assert.Equal(t, "approved", ev.Decision.Action)
+	assert.Equal(t, "approved in Hermes", ev.Decision.Message)
+	assert.Equal(t, "hosted_approval_resolved", ev.Request["action"])
+	assert.Equal(t, "audit-1", ev.Request["audit_id"])
+	assert.Equal(t, "hermes-approval-1", ev.Request["host_approval_id"])
+}
+
 func TestUserOverridesBypassApprovalQueue(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)


### PR DESCRIPTION
## Summary
- Add generic hosted approval ownership metadata for tool evaluations, including `approval_owner`, `tool_call_id`, and response `audit_id` correlation.
- Return hosted approval requirements for trusted host-owned requests without creating Rampart-native pending approvals.
- Add a hosted approval resolution callback endpoint that records operator outcomes in audit without touching the pending approval queue.

## Tests
- `go test ./internal/proxy -run 'Test(GenericHostedAskSkipsPendingApprovalCreationForAdmin|HostedAskRequiresExactResumeForAdmin|HostedApprovalResolveRecordsAuditWithoutPendingApproval|OpenClawHostedAskSkipsPendingApprovalCreationForAdmin|OpenClawHostedAskDoesNotSkipPendingApprovalCreationForAgentToken)'`
- `go test ./internal/proxy ./internal/audit`
- `go test ./...`
