### PR TITLE
feat: correlate Hermes plugin audit IDs

### DIFF
--- a/docs-site/integrations/hermes.md
+++ b/docs-site/integrations/hermes.md
@@ -5,7 +5,7 @@ description: "Experimental Rampart integration for Hermes Agent using a user plu
 
 # Hermes Agent
 
-Rampart can protect Hermes Agent through an **experimental user plugin**. The plugin registers a Hermes `pre_tool_call` hook, sends a sanitized policy check to Rampart before selected tools execute, and blocks the tool call when policy denies it.
+Rampart can protect Hermes Agent through an **experimental user plugin**. The plugin registers a Hermes `pre_tool_call` hook, sends a sanitized policy check to Rampart before selected tools execute, passes Hermes' top-level `tool_call_id` for audit correlation, and blocks the tool call when policy denies it.
 
 !!! warning "Experimental integration"
     This integration is intentionally conservative. It does not patch Hermes, does not create a hidden approval queue, and does not resume `ask` decisions automatically. Policies that return `ask` are blocked with an approval-required message until Hermes has a first-class plugin approval/resume flow.
@@ -84,18 +84,20 @@ plugins:
 | --- | --- |
 | `allow`, `watch`, `log` | Tool call continues. |
 | `deny` | Tool call is blocked with the policy reason. |
-| `ask`, `require_approval` | Tool call is blocked with an approval-required message. No hidden Rampart approval is created by default. |
+| `ask`, `require_approval` | Tool call is blocked with an approval-required message. No hidden Rampart approval is created by default. When Rampart returns an `audit_id`, the block message includes it for correlation. |
 | Rampart unavailable | Mutating/high-risk tools fail closed; configured read-only tools may fail open. |
 
-The default endpoint mode is `preflight`, which calls `POST /v1/preflight/{tool}`. This is deliberate: it avoids creating pending Rampart approvals that Hermes cannot yet resume from a plugin hook.
+The default endpoint mode is `preflight`, which calls `POST /v1/preflight/{tool}`. This is deliberate: it avoids creating pending Rampart approvals that Hermes cannot yet resume from a plugin hook. Rampart records the evaluation audit ID, and the plugin sends Hermes' top-level `tool_call_id` when Hermes provides one.
 
-For experiments that need full `/v1/tool/{tool}` semantics, set:
+Rampart's hosted approval API is ready for hosts that can create a single user-facing approval and resume the exact tool call. This plugin does not request hosted approvals yet because current Hermes plugin hooks do not expose that exact approval/resume contract as a stable plugin primitive.
+
+For experiments that need raw `/v1/tool/{tool}` semantics, set:
 
 ```bash
 export RAMPART_HERMES_ENDPOINT_MODE=tool
 ```
 
-Use this only when you understand the approval ownership tradeoff.
+Use this only when you understand the approval ownership tradeoff. If a policy returns `ask` in raw tool mode, Rampart may create a Rampart-native pending approval that Hermes cannot resume; keep the default `preflight` mode for normal Hermes testing.
 
 ## Verification
 

--- a/internal/plugin/hermes/__init__.py
+++ b/internal/plugin/hermes/__init__.py
@@ -7,8 +7,11 @@ The plugin is intentionally conservative:
 * It uses Hermes' ``pre_tool_call`` hook and only returns a block directive.
 * It defaults to ``/v1/preflight/{tool}`` so Rampart does not create a hidden
   approval queue while Hermes lacks a plugin-owned approval/resume primitive.
+* It passes Hermes' native ``tool_call_id`` as top-level Rampart metadata so
+  Rampart audit IDs can be correlated with the exact Hermes tool call.
 * ``ask`` / ``require_approval`` decisions block with a clear message instead
-  of polling or creating a second approval surface.
+  of polling or creating a second approval surface, and include Rampart's
+  ``audit_id`` when available.
 * If Rampart serve is unavailable, mutating/high-risk tools fail closed and only
   explicitly configured read-only tools fail open.
 """
@@ -26,7 +29,7 @@ from pathlib import Path
 from typing import Any, Callable, Mapping
 from urllib.parse import quote
 
-VERSION = "0.1.0"
+VERSION = "0.1.1"
 
 DEFAULT_SERVE_URL = "http://127.0.0.1:9090"
 DEFAULT_TIMEOUT_MS = 3000
@@ -399,15 +402,15 @@ def _build_payload(
     task_id: str = "",
     tool_call_id: str = "",
 ) -> dict[str, Any]:
-    payload_params = dict(params)
-    if tool_call_id:
-        payload_params["hermes_tool_call_id"] = tool_call_id
-    return {
+    payload: dict[str, Any] = {
         "agent": config.agent_name,
         "session": session_id or "",
         "run_id": task_id or "",
-        "params": payload_params,
+        "params": dict(params),
     }
+    if tool_call_id:
+        payload["tool_call_id"] = tool_call_id
+    return payload
 
 
 def _endpoint_url(config: PluginConfig, rampart_tool: str) -> str:
@@ -471,6 +474,13 @@ def _decision_from_result(result: Mapping[str, Any]) -> str:
     return "allow"
 
 
+def _audit_suffix(result: Mapping[str, Any]) -> str:
+    audit_id = result.get("audit_id")
+    if isinstance(audit_id, str) and audit_id.strip():
+        return f" [audit_id: {audit_id.strip()}]"
+    return ""
+
+
 def evaluate_pre_tool_call(
     tool_name: str,
     args: Mapping[str, Any] | None,
@@ -510,6 +520,7 @@ def evaluate_pre_tool_call(
 
     reason = str(result.get("message") or result.get("reason") or "policy violation")
     policy = result.get("policy") or result.get("matched_policies")
+    audit_suffix = _audit_suffix(result)
     policy_suffix = ""
     if isinstance(policy, str) and policy:
         policy_suffix = f" [policy: {policy}]"
@@ -519,12 +530,12 @@ def evaluate_pre_tool_call(
     if decision in {"ask", "require_approval"}:
         return _block(
             "rampart: approval required"
-            f" for {tool_name}→{rampart_tool}{policy_suffix} — {reason}. "
+            f" for {tool_name}→{rampart_tool}{policy_suffix}{audit_suffix} — {reason}. "
             "Hermes Rampart integration is experimental and does not yet resume plugin-driven approvals; "
             "adjust policy or use a first-class Hermes approval flow before retrying."
         )
 
-    return _block(f"rampart: {reason}{policy_suffix}")
+    return _block(f"rampart: {reason}{policy_suffix}{audit_suffix}")
 
 
 def register(ctx: Any) -> None:

--- a/internal/plugin/hermes/embed_test.go
+++ b/internal/plugin/hermes/embed_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestVersionReadsManifest(t *testing.T) {
-	if got, want := Version(), "0.1.0"; got != want {
+	if got, want := Version(), "0.1.1"; got != want {
 		t.Fatalf("Version() = %q, want %q", got, want)
 	}
 }

--- a/internal/plugin/hermes/plugin.yaml
+++ b/internal/plugin/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: rampart
-version: 0.1.0
+version: 0.1.1
 description: Experimental Rampart policy gate for Hermes Agent pre_tool_call hooks
 author: peg
 provides_hooks:

--- a/internal/plugin/hermes/test_hermes_plugin.py
+++ b/internal/plugin/hermes/test_hermes_plugin.py
@@ -88,7 +88,7 @@ class HermesPluginTests(unittest.TestCase):
             captured["config"] = config
             captured["tool"] = rampart_tool
             captured["payload"] = payload
-            return {"decision": "deny", "message": "blocked", "policy": "danger"}
+            return {"decision": "deny", "message": "blocked", "policy": "danger", "audit_id": "audit-deny-1"}
 
         result = plugin.evaluate_pre_tool_call(
             "terminal",
@@ -104,21 +104,30 @@ class HermesPluginTests(unittest.TestCase):
         self.assertEqual(captured["payload"]["agent"], "hermes")
         self.assertEqual(captured["payload"]["session"], "sess-1")
         self.assertEqual(captured["payload"]["run_id"], "task-1")
-        self.assertEqual(captured["payload"]["params"]["hermes_tool_call_id"], "call-1")
+        self.assertEqual(captured["payload"]["tool_call_id"], "call-1")
+        self.assertNotIn("hermes_tool_call_id", captured["payload"]["params"])
         self.assertEqual(result["action"], "block")
         self.assertIn("blocked", result["message"])
         self.assertIn("danger", result["message"])
+        self.assertIn("audit-deny-1", result["message"])
 
     def test_ask_decision_blocks_without_hidden_approval(self) -> None:
         def requester(config, rampart_tool, payload):
             self.assertEqual(config.endpoint_mode, "preflight")
             self.assertNotIn("openclaw_hosted", payload)
             self.assertNotIn("skip_pending_approval", payload)
-            return {"decision": "ask", "message": "needs human review", "matched_policies": ["prod-change"]}
+            self.assertEqual(payload["tool_call_id"], "call-ask-1")
+            return {
+                "decision": "ask",
+                "message": "needs human review",
+                "matched_policies": ["prod-change"],
+                "audit_id": "audit-ask-1",
+            }
 
         result = plugin.evaluate_pre_tool_call(
             "terminal",
             {"command": "kubectl apply -f prod.yaml"},
+            tool_call_id="call-ask-1",
             requester=requester,
         )
 
@@ -126,6 +135,7 @@ class HermesPluginTests(unittest.TestCase):
         self.assertIn("approval required", result["message"])
         self.assertIn("does not yet resume", result["message"])
         self.assertIn("prod-change", result["message"])
+        self.assertIn("audit-ask-1", result["message"])
 
     def test_unavailable_blocks_mutating_tool(self) -> None:
         def requester(config, rampart_tool, payload):


### PR DESCRIPTION
## Summary
- Send Hermes `tool_call_id` as top-level Rampart evaluation metadata so audits correlate with the exact Hermes tool call.
- Include Rampart `audit_id` in Hermes plugin deny/approval-required block messages when available.
- Update the experimental Hermes integration docs and plugin manifest version to reflect audit-correlation behavior and current hosted-approval boundaries.

## Tests
- `python3 -m unittest internal/plugin/hermes/test_hermes_plugin.py`
- `go test ./internal/plugin/hermes ./cmd/rampart/cli`
- `git diff --check`
- `go test ./...`
