### PR TITLE
fix: preserve OpenClaw plugin discovery defaults

### DIFF
--- a/cmd/rampart/cli/doctor.go
+++ b/cmd/rampart/cli/doctor.go
@@ -294,6 +294,9 @@ func runDoctor(w io.Writer, jsonOut bool) error {
 	if n := doctorOpenClawPlugin(emit); n > 0 {
 		warnings += n
 	}
+	if n := doctorOpenClawProviderDiscovery(emit); n > 0 {
+		warnings += n
+	}
 	if n := doctorOpenClawReadiness(emit, pluginActive, serveURL, token); n > 0 {
 		warnings += n
 	}
@@ -1653,6 +1656,43 @@ func doctorOpenClawPlugin(emit emitFn) (warnings int) {
 	}
 	emit("OpenClaw plugin", "ok", detail)
 	return 0
+}
+
+func doctorOpenClawProviderDiscovery(emit emitFn) (warnings int) {
+	if !isOpenClawInstalled() {
+		return 0
+	}
+	bin, err := findOpenClawBinary()
+	if err != nil {
+		return 0
+	}
+	_, configPath, err := resolveOpenClawStateDir(bin)
+	if err != nil {
+		return 0
+	}
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return 0
+	}
+	var cfg struct {
+		Plugins struct {
+			Allow            *[]string `json:"allow"`
+			BundledDiscovery string    `json:"bundledDiscovery"`
+		} `json:"plugins"`
+	}
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return 0
+	}
+	if cfg.Plugins.Allow == nil {
+		return 0
+	}
+	if strings.EqualFold(strings.TrimSpace(cfg.Plugins.BundledDiscovery), "allowlist") {
+		return 0
+	}
+	emit("OpenClaw provider discovery", "warn",
+		"plugins.allow is restrictive, but bundled provider discovery is still in compatibility mode"+hintSep+
+			"After confirming plugins.allow includes every bundled provider you intend to keep, run: openclaw config set plugins.bundledDiscovery allowlist")
+	return 1
 }
 
 func isReleaseVersion(version string) bool {

--- a/cmd/rampart/cli/doctor_test.go
+++ b/cmd/rampart/cli/doctor_test.go
@@ -651,6 +651,9 @@ func TestDoctorOpenClawPlugin(t *testing.T) {
 		requireNoErr(t, os.WriteFile(filepath.Join(binDir, "openclaw"), []byte("#!/bin/sh\nexit 0\n"), 0o755))
 		t.Setenv("PATH", binDir)
 		requireNoErr(t, os.MkdirAll(filepath.Join(home, ".openclaw", "extensions", "rampart"), 0o755))
+		pluginDir := filepath.Join(home, ".openclaw", "extensions", "rampart")
+		requireNoErr(t, os.WriteFile(filepath.Join(pluginDir, "openclaw.plugin.json"), []byte(`{"version":"1.0.0","activation":{"onStartup":true}}`), 0o600))
+		requireNoErr(t, os.WriteFile(filepath.Join(pluginDir, "index.js"), []byte(`export const version = "1.0.0";`), 0o600))
 		return home
 	}
 
@@ -663,6 +666,17 @@ func TestDoctorOpenClawPlugin(t *testing.T) {
 		warnings := doctorOpenClawPlugin(emit)
 		return warnings, results
 	}
+
+	t.Run("allows plugin when plugins.allow is absent", func(t *testing.T) {
+		home := setup(t)
+		requireNoErr(t, os.MkdirAll(filepath.Join(home, ".openclaw"), 0o755))
+		requireNoErr(t, os.WriteFile(filepath.Join(home, ".openclaw", "openclaw.json"), []byte(`{"plugins":{"entries":{"rampart":{"enabled":true}}}}`), 0o600))
+
+		warnings, results := run(t)
+		if warnings != 0 || len(results) != 1 || results[0].Status != "ok" {
+			t.Fatalf("expected ok, got warnings=%d results=%+v", warnings, results)
+		}
+	})
 
 	t.Run("warns when plugin missing from allow list", func(t *testing.T) {
 		home := setup(t)
@@ -703,6 +717,48 @@ func TestDoctorOpenClawPlugin(t *testing.T) {
 		}
 		if !strings.Contains(results[0].Message, "could not verify plugins.allow / enabled state") {
 			t.Fatalf("expected unreadable-config warning, got %s", results[0].Message)
+		}
+	})
+}
+
+func TestDoctorOpenClawProviderDiscovery(t *testing.T) {
+	skipOnWindows(t, "PATH shim binaries in this test are Unix-only")
+
+	setup := func(t *testing.T, config string) []checkResult {
+		t.Helper()
+		home := t.TempDir()
+		testSetHome(t, home)
+		binDir := t.TempDir()
+		requireNoErr(t, os.WriteFile(filepath.Join(binDir, "openclaw"), []byte("#!/bin/sh\nexit 0\n"), 0o755))
+		t.Setenv("PATH", binDir)
+		requireNoErr(t, os.MkdirAll(filepath.Join(home, ".openclaw", "extensions", "rampart"), 0o755))
+		requireNoErr(t, os.WriteFile(filepath.Join(home, ".openclaw", "openclaw.json"), []byte(config), 0o600))
+		var results []checkResult
+		doctorOpenClawProviderDiscovery(func(name, status, msg string) {
+			results = append(results, checkResult{Name: name, Status: status, Message: msg})
+		})
+		return results
+	}
+
+	t.Run("warns for restrictive allowlist with compatibility discovery", func(t *testing.T) {
+		results := setup(t, `{"plugins":{"allow":["rampart","codex"],"bundledDiscovery":"compat"}}`)
+		if len(results) != 1 || results[0].Status != "warn" {
+			t.Fatalf("expected one warning, got %+v", results)
+		}
+		if !strings.Contains(results[0].Message, "bundled provider discovery") {
+			t.Fatalf("expected provider discovery warning, got %s", results[0].Message)
+		}
+	})
+
+	t.Run("skips when allowlist absent", func(t *testing.T) {
+		if results := setup(t, `{"plugins":{"entries":{"rampart":{"enabled":true}}}}`); len(results) != 0 {
+			t.Fatalf("expected no warning, got %+v", results)
+		}
+	})
+
+	t.Run("skips when allowlist mode configured", func(t *testing.T) {
+		if results := setup(t, `{"plugins":{"allow":["rampart"],"bundledDiscovery":"allowlist"}}`); len(results) != 0 {
+			t.Fatalf("expected no warning, got %+v", results)
 		}
 	})
 }

--- a/cmd/rampart/cli/setup.go
+++ b/cmd/rampart/cli/setup.go
@@ -435,7 +435,8 @@ func newSetupOpenClawCmd(opts *rootOptions) *cobra.Command {
 Default behavior on current OpenClaw builds (>= 2026.3.28):
   - Installs the native Rampart plugin via "openclaw plugins install"
   - Ensures rampart serve is available for policy evaluation and approvals
-  - Adds rampart to plugins.allow and installs the OpenClaw policy profile
+  - Preserves OpenClaw's plugin discovery defaults; if plugins.allow already exists, adds rampart to it
+  - Installs the OpenClaw policy profile
   - Preserves OpenClaw's native approval UI while Rampart evaluates policy
 
 Legacy compatibility options still exist for older OpenClaw setups:

--- a/cmd/rampart/cli/setup_openclaw_plugin.go
+++ b/cmd/rampart/cli/setup_openclaw_plugin.go
@@ -123,11 +123,15 @@ func runSetupOpenClawPlugin(w io.Writer, errW io.Writer) error {
 		fmt.Fprintln(w, "✓ Set tools.exec.ask = \"off\" (OpenClaw keeps native approval ownership; Rampart evaluates policy behind it)")
 	}
 
-	// 4b. Add rampart to plugins.allow. Existing plugins are preserved — we only append.
+	// 4b. Preserve OpenClaw's default plugin discovery unless the user already
+	// configured a restrictive plugins.allow list. When the allowlist exists,
+	// append only — never remove or overwrite existing plugin IDs.
 	if added, existing, err := addToOpenClawPluginsAllow("rampart"); err != nil {
 		fmt.Fprintf(errW, "⚠ Could not update plugins.allow in openclaw.json: %v\n", err)
 	} else if added {
-		fmt.Fprintf(w, "✓ Added rampart to plugins.allow (existing: %v)\n", existing)
+		fmt.Fprintf(w, "✓ Added rampart to existing plugins.allow (existing: %v)\n", existing)
+	} else if existing == nil {
+		fmt.Fprintln(w, "✓ plugins.allow is not configured; left OpenClaw's default plugin discovery unchanged")
 	} else {
 		fmt.Fprintln(w, "✓ rampart already in plugins.allow (no changes to other plugins)")
 	}
@@ -575,10 +579,11 @@ func parseCalVer(v string) []int {
 	return result
 }
 
-// setOpenClawExecAsk sets tools.exec.ask in the active OpenClaw config.
-// addToOpenClawPluginsAllow adds pluginID to the plugins.allow list in openclaw.json
-// if it is not already present. Returns (added, existingIDs, error).
-// NEVER removes or overwrites existing entries — only appends.
+// addToOpenClawPluginsAllow adds pluginID to an existing plugins.allow list in
+// openclaw.json if it is not already present. If plugins.allow is absent,
+// OpenClaw's default discovery remains unrestricted, so this function leaves the
+// config unchanged and returns added=false, existing=nil. Existing entries are
+// never removed or overwritten.
 func addToOpenClawPluginsAllow(pluginID string) (added bool, existing []string, err error) {
 	bin, berr := findOpenClawBinary()
 	if berr != nil {
@@ -598,10 +603,16 @@ func addToOpenClawPluginsAllow(pluginID string) (added bool, existing []string, 
 	}
 	plugins, _ := cfg["plugins"].(map[string]any)
 	if plugins == nil {
-		plugins = map[string]any{}
-		cfg["plugins"] = plugins
+		return false, nil, nil
 	}
-	allowRaw, _ := plugins["allow"].([]any)
+	allowValue, allowExists := plugins["allow"]
+	if !allowExists {
+		return false, nil, nil
+	}
+	allowRaw, ok := allowValue.([]any)
+	if !ok {
+		return false, nil, fmt.Errorf("plugins.allow must be a JSON array when present")
+	}
 	// Collect existing string entries and check for duplicates.
 	for _, v := range allowRaw {
 		if s, ok := v.(string); ok {
@@ -820,7 +831,7 @@ func getOpenClawPluginState() openClawPluginState {
 
 	var cfg struct {
 		Plugins struct {
-			Allow   []string `json:"allow"`
+			Allow   *[]string `json:"allow"`
 			Entries map[string]struct {
 				Enabled *bool `json:"enabled"`
 			} `json:"entries"`
@@ -830,11 +841,14 @@ func getOpenClawPluginState() openClawPluginState {
 		return state
 	}
 
-	state.Allowed = false
-	for _, id := range cfg.Plugins.Allow {
-		if id == "rampart" {
-			state.Allowed = true
-			break
+	state.Allowed = true
+	if cfg.Plugins.Allow != nil {
+		state.Allowed = false
+		for _, id := range *cfg.Plugins.Allow {
+			if id == "rampart" {
+				state.Allowed = true
+				break
+			}
 		}
 	}
 	if entry, ok := cfg.Plugins.Entries["rampart"]; ok && entry.Enabled != nil {

--- a/cmd/rampart/cli/setup_openclaw_plugin_test.go
+++ b/cmd/rampart/cli/setup_openclaw_plugin_test.go
@@ -78,3 +78,66 @@ func TestResolveOpenClawStateDirHonorsConfigEnv(t *testing.T) {
 		t.Fatalf("stateDir/configPath = %q/%q, want %q/%q", stateDir, configPath, tmp, cfg)
 	}
 }
+
+func TestAddToOpenClawPluginsAllowPreservesAbsentAllowlist(t *testing.T) {
+	skipOnWindows(t, "PATH shim binaries in this test are Unix-only")
+	configPath := setupOpenClawConfigTest(t, `{"plugins":{"entries":{"rampart":{"enabled":true}}}}`)
+	before, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	added, existing, err := addToOpenClawPluginsAllow("rampart")
+	if err != nil {
+		t.Fatalf("addToOpenClawPluginsAllow returned error: %v", err)
+	}
+	if added || existing != nil {
+		t.Fatalf("expected no change with nil existing allowlist, got added=%v existing=%v", added, existing)
+	}
+	after, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(before) {
+		t.Fatalf("config changed when plugins.allow was absent:\nbefore=%s\nafter=%s", before, after)
+	}
+}
+
+func TestAddToOpenClawPluginsAllowAppendsExistingAllowlist(t *testing.T) {
+	skipOnWindows(t, "PATH shim binaries in this test are Unix-only")
+	configPath := setupOpenClawConfigTest(t, `{"plugins":{"allow":["codex"]}}`)
+
+	added, existing, err := addToOpenClawPluginsAllow("rampart")
+	if err != nil {
+		t.Fatalf("addToOpenClawPluginsAllow returned error: %v", err)
+	}
+	if !added || len(existing) != 1 || existing[0] != "codex" {
+		t.Fatalf("expected append after existing codex allowlist, got added=%v existing=%v", added, existing)
+	}
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{`"codex"`, `"rampart"`} {
+		if !strings.Contains(string(data), want) {
+			t.Fatalf("updated config missing %s: %s", want, data)
+		}
+	}
+}
+
+func setupOpenClawConfigTest(t *testing.T, config string) string {
+	t.Helper()
+	stateDir := t.TempDir()
+	binDir := t.TempDir()
+	bin := filepath.Join(binDir, "openclaw")
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("RAMPART_OPENCLAW_BIN", bin)
+	t.Setenv("OPENCLAW_STATE_DIR", stateDir)
+	configPath := filepath.Join(stateDir, "openclaw.json")
+	if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return configPath
+}

--- a/cmd/rampart/cli/status_test.go
+++ b/cmd/rampart/cli/status_test.go
@@ -228,6 +228,11 @@ func TestDetectProtectedAgents_OpenClawPluginRequiresAllowedAndEnabled(t *testin
 		t.Fatal("OpenClaw should not be reported when plugins.allow is missing rampart")
 	}
 
+	mustWrite(`{"plugins":{"entries":{"rampart":{"enabled":true}}}}`)
+	if !contains("OpenClaw (plugin)") {
+		t.Fatal("expected plugin to be reported when plugins.allow is absent")
+	}
+
 	mustWrite(`{"plugins":{"allow":["rampart"],"entries":{"rampart":{"enabled":false}}}}`)
 	if containsOpenClaw() {
 		t.Fatal("OpenClaw should not be reported when plugins.entries.rampart.enabled=false")


### PR DESCRIPTION
## Summary
- Preserve OpenClaw's default plugin discovery when `plugins.allow` is absent during `rampart setup openclaw`.
- Treat an absent OpenClaw plugin allowlist as unrestricted for Rampart status/doctor detection.
- Add a doctor warning for restrictive `plugins.allow` configs that have not switched bundled provider discovery to allowlist mode.
- Update setup help and regression coverage for absent and existing allowlist behavior.

## Tests
- `git diff --check`
- `go test ./cmd/rampart/cli ./internal/openclaw/hardening ./internal/plugin/openclaw`
- `go test ./...`
- Isolated `rampart serve` on port `19090` with temporary HOME/config/audit directories; verified `/v1/status`, `/v1/tool/exec` allow and hosted-approval responses, audit JSONL correlation, and `rampart audit verify --audit-dir <temp-audit-dir>`.
