### PR TITLE
fix: harden audit recovery for v1.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-05-28
+
+### Added
+
+- **Hosted approval API foundation for host-owned approval flows** — Rampart can return hosted approval metadata without creating a hidden Rampart pending queue item, preserving the single approval-owner boundary for hosts such as Hermes.
+- **Hermes audit/tool-call correlation** — The experimental Hermes policy gate passes Hermes tool-call metadata through Rampart so audit entries can be correlated with the originating Hermes tool call.
+
+### Changed
+
+- **Bundled plugin metadata is aligned for v1.2.0** — The OpenClaw and experimental Hermes plugin manifests, runtime exports, and public examples now report `1.2.0` with the Rampart release.
+- **Release-facing docs and install examples now point at v1.2.0** — Current-version markers, troubleshooting examples, and container tag examples are refreshed for the release.
+
+### Fixed
+
+- **Audit chain recovery now resumes from the latest valid JSONL event** — Startup reconstruction recovers both the event count and chain head from existing audit logs instead of trusting absent, stale, or tampered anchors as the next `prev_hash` source.
+- **Partial audit verification is safer** — `rampart audit verify --since` accepts intentionally truncated history while continuing to verify the included hash chain and anchor data that is present in the selected window.
+
 ## [1.1.1] - 2026-05-26
 
 ### Added

--- a/cmd/rampart/cli/audit.go
+++ b/cmd/rampart/cli/audit.go
@@ -152,7 +152,8 @@ Example:
 				return fmt.Errorf("audit: no .jsonl files found in %s", auditDir)
 			}
 
-			// Filter files by --since date if provided
+			// Filter files by --since date if provided. Size-rotated files use
+			// YYYY-MM-DD.pN.jsonl names, so compare only the leading date.
 			if since != "" {
 				sinceDate, parseErr := time.Parse("2006-01-02", since)
 				if parseErr != nil {
@@ -161,11 +162,13 @@ Example:
 				filtered := files[:0]
 				for _, f := range files {
 					base := filepath.Base(f)
-					// Filename format: YYYY-MM-DD.jsonl
 					datePart := strings.TrimSuffix(base, ".jsonl")
+					if len(datePart) >= len("2006-01-02") {
+						datePart = datePart[:len("2006-01-02")]
+					}
 					fileDate, dateErr := time.Parse("2006-01-02", datePart)
 					if dateErr != nil {
-						// Can't parse date from filename — include it to be safe
+						// Can't parse date from filename — include it to be safe.
 						filtered = append(filtered, f)
 						continue
 					}
@@ -179,12 +182,12 @@ Example:
 				}
 			}
 
-			count, hashesByID, err := verifyAuditChain(files)
+			count, hashesByID, err := verifyAuditChain(files, since != "")
 			if err != nil {
 				return err
 			}
 
-			if err := verifyAnchors(auditDir, hashesByID); err != nil {
+			if err := verifyAnchors(auditDir, hashesByID, since == ""); err != nil {
 				return err
 			}
 
@@ -200,7 +203,8 @@ Example:
 	return cmd
 }
 
-func verifyAuditChain(files []string) (int, map[string]string, error) {
+func verifyAuditChain(files []string, allowInitialPrev ...bool) (int, map[string]string, error) {
+	partialChain := len(allowInitialPrev) > 0 && allowInitialPrev[0]
 	prevHash := ""
 	eventCount := 0
 	hashesByID := map[string]string{}
@@ -208,7 +212,7 @@ func verifyAuditChain(files []string) (int, map[string]string, error) {
 	for _, file := range files {
 		scanErr := scanAuditEvents(file, func(event audit.Event) error {
 			eventCount++
-			if eventCount == 1 && event.PrevHash != "" {
+			if eventCount == 1 && event.PrevHash != "" && !partialChain {
 				return fmt.Errorf("audit: CHAIN BROKEN at event %s in file %s: first event has non-empty prev_hash", event.ID, filepath.Base(file))
 			}
 			if eventCount > 1 && event.PrevHash != prevHash {

--- a/cmd/rampart/cli/audit_helpers.go
+++ b/cmd/rampart/cli/audit_helpers.go
@@ -320,7 +320,11 @@ func eventMatchesQuery(event audit.Event, query string) bool {
 	return false
 }
 
-func verifyAnchors(auditDir string, hashesByID map[string]string) error {
+func verifyAnchors(auditDir string, hashesByID map[string]string, strictOpt ...bool) error {
+	strict := true
+	if len(strictOpt) > 0 {
+		strict = strictOpt[0]
+	}
 	anchors, err := listAnchorFiles(auditDir)
 	if err != nil {
 		return err
@@ -342,6 +346,9 @@ func verifyAnchors(auditDir string, hashesByID map[string]string) error {
 
 		hash, ok := hashesByID[anchor.EventID]
 		if !ok {
+			if !strict {
+				continue
+			}
 			return fmt.Errorf("audit: CHAIN BROKEN at event %s in file %s: anchor event not found", anchor.EventID, filepath.Base(anchorFile))
 		}
 		if hash != anchor.Hash {

--- a/cmd/rampart/cli/audit_test.go
+++ b/cmd/rampart/cli/audit_test.go
@@ -110,6 +110,46 @@ func TestAuditVerify_ValidChain(t *testing.T) {
 	assert.Contains(t, stdout, "10 events")
 }
 
+func TestAuditVerifySince_AllowsPartialChainAndSkippedAnchor(t *testing.T) {
+	dir := t.TempDir()
+
+	first := makeEvent("exec", "old", "main", "allow", "ok")
+	first.ID = audit.NewEventID()
+	first.Timestamp = time.Date(2026, 2, 8, 12, 0, 0, 0, time.UTC)
+	require.NoError(t, first.ComputeHash())
+
+	second := makeEvent("exec", "new", "main", "allow", "ok")
+	second.ID = audit.NewEventID()
+	second.Timestamp = time.Date(2026, 2, 9, 12, 0, 0, 0, time.UTC)
+	second.PrevHash = first.Hash
+	require.NoError(t, second.ComputeHash())
+
+	writeSingleAuditEvent := func(name string, event audit.Event) {
+		t.Helper()
+		data, err := json.Marshal(event)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), append(data, '\n'), 0o644))
+	}
+	writeSingleAuditEvent("2026-02-08.jsonl", first)
+	writeSingleAuditEvent("2026-02-09.jsonl", second)
+
+	anchor := audit.ChainAnchor{
+		EventID:    first.ID,
+		Hash:       first.Hash,
+		EventCount: 1,
+		Timestamp:  first.Timestamp,
+		File:       "2026-02-08.jsonl",
+	}
+	anchorData, err := json.Marshal(anchor)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "audit-anchor.json"), anchorData, 0o644))
+
+	stdout, _, err := runCLI(t, "audit", "verify", "--audit-dir", dir, "--since", "2026-02-09")
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "1 events")
+	assert.Contains(t, stdout, "no tampering detected")
+}
+
 func TestAuditVerify_BrokenChain(t *testing.T) {
 	dir := t.TempDir()
 	events := make([]audit.Event, 5)

--- a/docs-site/getting-started/installation.md
+++ b/docs-site/getting-started/installation.md
@@ -97,7 +97,7 @@ volumes:
   rampart-audit:
 ```
 
-Available tags include full versions such as `1.1.1`, minor versions such as `1.1`, and `latest` for the current stable release. Prereleases use their full tag, for example `1.1.0-rc.1`, and do not move `latest`. Pin to a specific version tag for reproducibility. Images are published on [GitHub Container Registry](https://github.com/peg/rampart/pkgs/container/rampart).
+Available tags include full versions such as `1.2.0`, minor versions such as `1.2`, and `latest` for the current stable release. Prereleases use their full tag, for example `1.2.0-rc.1`, and do not move `latest`. Pin to a specific version tag for reproducibility. Images are published on [GitHub Container Registry](https://github.com/peg/rampart/pkgs/container/rampart).
 
 ## Build from Source
 

--- a/docs-site/getting-started/troubleshooting.md
+++ b/docs-site/getting-started/troubleshooting.md
@@ -165,7 +165,7 @@ rampart test --tool read "/etc/shadow"
 
 ```bash
 openclaw plugins list
-# Should show: rampart  1.1.1  ✓ active
+# Should show: rampart  1.2.0  ✓ active
 
 rampart doctor
 # Should show: ✓ OpenClaw plugin: installed (before_tool_call hook active)

--- a/docs-site/index.html
+++ b/docs-site/index.html
@@ -27,7 +27,7 @@
       "url": "https://rampart.sh",
       "applicationCategory": "SecurityApplication",
       "operatingSystem": "Linux, macOS, Windows",
-      "softwareVersion": "1.1.1",
+      "softwareVersion": "1.2.0",
       "offers": {
         "@type": "Offer",
         "price": "0",
@@ -1112,7 +1112,7 @@
 <section class="hero">
     <div class="container hero-grid">
         <div>
-            <div class="eyebrow"><span class="eyebrow-dot"></span>v1.1.1 · release-ready</div>
+            <div class="eyebrow"><span class="eyebrow-dot"></span>v1.2.0 · release-ready</div>
             <h1>Your agent has root.<br><span class="accent">That’s the problem.</span></h1>
             <p class="hero-sub">Rampart sits in the execution path. Install it, run <code>rampart quickstart</code>, and it wires the right protection path for Claude Code, Codex, Cline, or OpenClaw before risky tool calls run.</p>
             <div class="install-cluster">

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -205,7 +205,14 @@ verify -> outcomes.approval
 
 [:octicons-arrow-right-24: See all integration guides](integrations/index.md)
 
-## What's New in v1.1
+## What's New in v1.2
+
+- **Audit recovery is release-hardened** — `rampart serve` reconstructs the audit chain head from the latest valid JSONL event across log files, so absent, stale, or tampered anchors cannot reset the next `prev_hash`.
+- **Hosted approval foundation** — Rampart can support host-owned approval flows without creating a second hidden Rampart approval queue, preserving a single user-facing approval owner.
+- **Experimental Hermes policy gate correlation** — Hermes tool-call metadata now reaches Rampart audit records so policy-gate decisions can be traced back to the originating Hermes tool call.
+- **Bundled plugin versions are coherent** — OpenClaw and experimental Hermes plugin manifests/runtime exports now report `1.2.0` alongside the Rampart release.
+
+### v1.1
 
 - **Machine-readable diagnostics** — `rampart status --json`, `rampart doctor --json`, and `rampart inventory --json` expose structured runtime and integration state for automation.
 - **OpenClaw gateway v4 support** — the bundled plugin speaks the current gateway/status response contract while preserving native approval and audit ownership.

--- a/docs-site/integrations/openclaw.md
+++ b/docs-site/integrations/openclaw.md
@@ -157,7 +157,7 @@ Or check plugin status directly:
 
 ```bash
 openclaw plugins list
-# rampart  v1.1.1  active
+# rampart  v1.2.0  active
 ```
 
 ## Troubleshooting

--- a/docs-site/reference/threat-model.md
+++ b/docs-site/reference/threat-model.md
@@ -1,6 +1,6 @@
 # Threat Model
 
-> Last reviewed: 2026-05-26 | Applies to: v1.1.1
+> Last reviewed: 2026-05-28 | Applies to: v1.2.0
 
 Rampart is a policy engine for AI agents — not a sandbox, not a hypervisor, not a full isolation boundary. This document describes what Rampart protects against, what it doesn't, and why.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -45,12 +45,12 @@ What's coming next for Rampart. Priorities shift based on feedback — [open an 
 
 ## Current Focus
 
-### `v1.1.0`
-- Keep structured diagnostics boring and automation-friendly: `status --json`, `doctor --json`, and `inventory --json` should remain stable enough for scripts without replacing human-readable output.
-- Treat current OpenClaw gateway protocol support and Codex native shell audit correlation as release-gated integrations, with live regression proof before tagging.
-- Keep the release toolchain, plugin metadata, setup output, and docs aligned so users can answer "am I protected, how, and what version is active?" without reading source.
+### `v1.2.0`
+- Keep release-integrity claims backed by verifiable audit-chain behavior: startup recovery must continue from the latest valid JSONL event even when anchors are absent, stale, or tampered.
+- Keep hosted approval work scoped to the correct ownership boundary: host agents own the visible approval and exact resume, while Rampart owns policy, deny enforcement, audit, and diagnostics.
+- Keep bundled OpenClaw and experimental Hermes plugin metadata, setup output, and docs aligned so users can answer "am I protected, how, and what version is active?" without reading source.
 
-### After 1.1
+### After 1.2
 - Collect feedback from real OpenClaw, Claude Code, Cline, Codex, and MCP users.
 - Fix integration bugs without widening the public API unless the tradeoff is explicit.
 - Keep the support matrix and threat model honest as agent runtimes evolve.

--- a/docs/index.html
+++ b/docs/index.html
@@ -27,7 +27,7 @@
       "url": "https://rampart.sh",
       "applicationCategory": "SecurityApplication",
       "operatingSystem": "Linux, macOS, Windows",
-      "softwareVersion": "1.1.1",
+      "softwareVersion": "1.2.0",
       "offers": {
         "@type": "Offer",
         "price": "0",
@@ -1112,7 +1112,7 @@
 <section class="hero">
     <div class="container hero-grid">
         <div>
-            <div class="eyebrow"><span class="eyebrow-dot"></span>v1.1.1 · release-ready</div>
+            <div class="eyebrow"><span class="eyebrow-dot"></span>v1.2.0 · release-ready</div>
             <h1>Your agent has root.<br><span class="accent">That’s the problem.</span></h1>
             <p class="hero-sub">Rampart sits in the execution path. Install it, run <code>rampart quickstart</code>, and it wires the right protection path for Claude Code, Codex, Cline, or OpenClaw before risky tool calls run.</p>
             <div class="install-cluster">

--- a/docs/install
+++ b/docs/install
@@ -7,8 +7,8 @@
 # Usage: curl -fsSL https://rampart.sh/install | sh
 #        curl -fsSL https://rampart.sh/install | sh -s -- --version v0.1.0
 #        curl -fsSL https://rampart.sh/install | sh -s -- --auto-setup
-#        RAMPART_INSTALL_DRY_RUN=1 sh install.sh --version v1.1.1
-#        RAMPART_VERSION=v1.1.1 RAMPART_INSTALL_DIR=$HOME/.local/bin sh install.sh
+#        RAMPART_INSTALL_DRY_RUN=1 sh install.sh --version v1.2.0
+#        RAMPART_VERSION=v1.2.0 RAMPART_INSTALL_DIR=$HOME/.local/bin sh install.sh
 set -e
 
 REPO="peg/rampart"

--- a/docs/install.sh
+++ b/docs/install.sh
@@ -7,8 +7,8 @@
 # Usage: curl -fsSL https://rampart.sh/install | sh
 #        curl -fsSL https://rampart.sh/install | sh -s -- --version v0.1.0
 #        curl -fsSL https://rampart.sh/install | sh -s -- --auto-setup
-#        RAMPART_INSTALL_DRY_RUN=1 sh install.sh --version v1.1.1
-#        RAMPART_VERSION=v1.1.1 RAMPART_INSTALL_DIR=$HOME/.local/bin sh install.sh
+#        RAMPART_INSTALL_DRY_RUN=1 sh install.sh --version v1.2.0
+#        RAMPART_VERSION=v1.2.0 RAMPART_INSTALL_DIR=$HOME/.local/bin sh install.sh
 set -e
 
 REPO="peg/rampart"

--- a/install.sh
+++ b/install.sh
@@ -7,8 +7,8 @@
 # Usage: curl -fsSL https://rampart.sh/install | sh
 #        curl -fsSL https://rampart.sh/install | sh -s -- --version v0.1.0
 #        curl -fsSL https://rampart.sh/install | sh -s -- --auto-setup
-#        RAMPART_INSTALL_DRY_RUN=1 sh install.sh --version v1.1.1
-#        RAMPART_VERSION=v1.1.1 RAMPART_INSTALL_DIR=$HOME/.local/bin sh install.sh
+#        RAMPART_INSTALL_DRY_RUN=1 sh install.sh --version v1.2.0
+#        RAMPART_VERSION=v1.2.0 RAMPART_INSTALL_DIR=$HOME/.local/bin sh install.sh
 set -e
 
 REPO="peg/rampart"

--- a/internal/audit/jsonl.go
+++ b/internal/audit/jsonl.go
@@ -21,6 +21,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -28,56 +29,82 @@ import (
 	"github.com/oklog/ulid/v2"
 )
 
-// readLastLineHash reads the last non-empty line of a JSONL file and extracts
-// its "hash" field. Returns the hash and true if successful.
-func readLastLineHash(path string) (string, bool) {
-	f, err := os.Open(path)
-	if err != nil {
-		return "", false
-	}
-	defer f.Close()
-
-	var lastLine string
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		if line := scanner.Text(); line != "" {
-			lastLine = line
-		}
-	}
-	if lastLine == "" {
-		return "", false
-	}
-	var partial struct {
-		Hash string `json:"hash"`
-	}
-	if err := json.Unmarshal([]byte(lastLine), &partial); err != nil {
-		return "", false
-	}
-	return partial.Hash, partial.Hash != ""
+type recoveredChainState struct {
+	eventCount int64
+	lastHash   string
+	lastFile   string
 }
 
-// countLinesInDir counts non-empty lines across all .jsonl files in dir
-// using streaming IO to avoid loading entire files into memory.
-func countLinesInDir(dir string) int64 {
-	var count int64
-	entries, _ := os.ReadDir(dir)
-	for _, e := range entries {
-		if !strings.HasSuffix(e.Name(), ".jsonl") {
-			continue
+// recoverChainStateFromDir reconstructs the append position from the latest
+// valid event in existing JSONL audit files. Chain-continuation headers are
+// skipped. Anchors are checkpoints for verification, not the authority for the
+// next event's prev_hash.
+func recoverChainStateFromDir(dir string, logger *slog.Logger) recoveredChainState {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if logger != nil {
+			logger.Debug("audit: read audit dir during recovery", "error", err)
 		}
-		f, err := os.Open(filepath.Join(dir, e.Name()))
-		if err != nil {
-			continue
-		}
-		scanner := bufio.NewScanner(f)
-		for scanner.Scan() {
-			if len(scanner.Bytes()) > 0 {
-				count++
-			}
-		}
-		_ = f.Close()
+		return recoveredChainState{}
 	}
-	return count
+
+	files := make([]string, 0)
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".jsonl") {
+			continue
+		}
+		files = append(files, entry.Name())
+	}
+	sort.Strings(files)
+
+	var state recoveredChainState
+	for _, name := range files {
+		path := filepath.Join(dir, name)
+		file, err := os.Open(path)
+		if err != nil {
+			if logger != nil {
+				logger.Debug("audit: open audit file during recovery", "file", name, "error", err)
+			}
+			continue
+		}
+
+		scanner := bufio.NewScanner(file)
+		lineNum := 0
+		for scanner.Scan() {
+			lineNum++
+			line := strings.TrimSpace(scanner.Text())
+			if line == "" {
+				continue
+			}
+
+			var event Event
+			if err := json.Unmarshal([]byte(line), &event); err != nil {
+				if logger != nil {
+					logger.Debug("audit: skip unparsable audit line during recovery", "file", name, "line", lineNum, "error", err)
+				}
+				continue
+			}
+			if event.ID == "" {
+				continue
+			}
+			ok, err := event.VerifyHash()
+			if err != nil || !ok {
+				if logger != nil {
+					logger.Debug("audit: skip invalid audit event during recovery", "file", name, "line", lineNum, "event_id", event.ID, "error", err)
+				}
+				continue
+			}
+
+			state.eventCount++
+			state.lastHash = event.Hash
+			state.lastFile = name
+		}
+		if err := scanner.Err(); err != nil && logger != nil {
+			logger.Debug("audit: scan audit file during recovery", "file", name, "error", err)
+		}
+		_ = file.Close()
+	}
+	return state
 }
 
 // JSONLSink is an append-only JSONL audit sink with hash chaining.
@@ -126,42 +153,40 @@ func NewJSONLSink(dir string, opts ...SinkOption) (*JSONLSink, error) {
 		logger:         logger,
 	}
 
-	// Recover state from anchor file if it exists.
+	// Recover append state from existing JSONL events. Anchors are not trusted as
+	// the sole chain head because they can be absent, stale, or tampered with.
+	recovered := recoverChainStateFromDir(dir, logger)
+	sink.eventCount = recovered.eventCount
+	sink.lastHash = recovered.lastHash
+	if sink.eventCount > 0 {
+		logger.Info("audit: recovered chain state from log files",
+			"event_count", sink.eventCount,
+			"hash", sink.lastHash,
+			"file", recovered.lastFile,
+		)
+	}
+
+	// Inspect the current anchor for diagnostics only. The next event always
+	// continues from the latest valid JSONL event recovered above.
 	anchorPath := filepath.Join(dir, anchorFilename)
-	anchorTrusted := false
 	if data, err := os.ReadFile(anchorPath); err == nil {
 		var anchor ChainAnchor
-		if err := json.Unmarshal(data, &anchor); err == nil {
-			// Validate anchor: verify the hash matches the last line of the referenced log file.
-			if anchor.File != "" {
-				if lastHash, ok := readLastLineHash(filepath.Join(dir, anchor.File)); ok {
-					if lastHash == anchor.Hash {
-						anchorTrusted = true
-					} else {
-						logger.Debug("audit: anchor hash mismatch, falling back to line count",
-							"tamper_suspected", false,
-							"anchor_hash", anchor.Hash,
-							"file_hash", lastHash,
-							"file", anchor.File,
-						)
-					}
-				}
-			}
-			if anchorTrusted {
-				sink.lastHash = anchor.Hash
-				sink.eventCount = anchor.EventCount
-				logger.Info("audit: recovered state from anchor",
+		if err := json.Unmarshal(data, &anchor); err == nil && anchor.EventID != "" {
+			if anchor.Hash == sink.lastHash && anchor.EventCount == sink.eventCount {
+				logger.Debug("audit: anchor matches recovered chain head",
 					"event_count", anchor.EventCount,
 					"hash", anchor.Hash,
+					"file", anchor.File,
+				)
+			} else {
+				logger.Debug("audit: anchor is not current chain head; continuing from latest log event",
+					"anchor_event_count", anchor.EventCount,
+					"recovered_event_count", sink.eventCount,
+					"anchor_hash", anchor.Hash,
+					"recovered_hash", sink.lastHash,
+					"file", anchor.File,
 				)
 			}
-		}
-	}
-	if !anchorTrusted {
-		// No anchor — count non-empty lines in existing log files to recover eventCount.
-		sink.eventCount = countLinesInDir(dir)
-		if sink.eventCount > 0 {
-			logger.Info("audit: recovered event count from log files", "event_count", sink.eventCount)
 		}
 	}
 

--- a/internal/audit/jsonl_test.go
+++ b/internal/audit/jsonl_test.go
@@ -378,6 +378,76 @@ func TestJSONLSink_RecoverByLineCounting(t *testing.T) {
 	defer sink2.Close()
 
 	assert.EqualValues(t, 5, sink2.eventCount)
+	assert.NotEmpty(t, sink2.lastHash)
+}
+
+func TestJSONLSink_RecoverWithoutAnchorContinuesHashChain(t *testing.T) {
+	dir := t.TempDir()
+
+	sink, err := NewJSONLSink(dir, WithFsync(false), WithAnchorInterval(0))
+	require.NoError(t, err)
+	for i := 0; i < 5; i++ {
+		require.NoError(t, sink.Write(sampleEvent("exec")))
+	}
+	savedHash := sink.lastHash
+	require.NoError(t, sink.Close())
+
+	sink2, err := NewJSONLSink(dir, WithFsync(false), WithAnchorInterval(0),
+		WithLogger(slog.New(slog.NewTextHandler(io.Discard, nil))))
+	require.NoError(t, err)
+	defer sink2.Close()
+
+	assert.EqualValues(t, 5, sink2.eventCount)
+	assert.Equal(t, savedHash, sink2.lastHash)
+	require.NoError(t, sink2.Write(sampleEvent("exec")))
+	assertLastEventPrevHash(t, sink2.filePath(), savedHash)
+}
+
+func TestJSONLSink_StaleAnchorDoesNotOverrideLatestEvent(t *testing.T) {
+	dir := t.TempDir()
+
+	// Anchor interval 2 leaves a valid anchor on event 2 after event 3 is written.
+	sink, err := NewJSONLSink(dir, WithFsync(false), WithAnchorInterval(2))
+	require.NoError(t, err)
+	for i := 0; i < 3; i++ {
+		require.NoError(t, sink.Write(sampleEvent("exec")))
+	}
+	savedHash := sink.lastHash
+	require.NoError(t, sink.Close())
+
+	sink2, err := NewJSONLSink(dir, WithFsync(false), WithAnchorInterval(2),
+		WithLogger(slog.New(slog.NewTextHandler(io.Discard, nil))))
+	require.NoError(t, err)
+	defer sink2.Close()
+
+	assert.EqualValues(t, 3, sink2.eventCount)
+	assert.Equal(t, savedHash, sink2.lastHash)
+	require.NoError(t, sink2.Write(sampleEvent("exec")))
+	assertLastEventPrevHash(t, sink2.filePath(), savedHash)
+}
+
+func TestJSONLSink_RecoverAcrossDayFileContinuesHashChain(t *testing.T) {
+	dir := t.TempDir()
+
+	sink, err := NewJSONLSink(dir, WithFsync(false), WithAnchorInterval(0))
+	require.NoError(t, err)
+	require.NoError(t, sink.Write(sampleEvent("exec")))
+	savedHash := sink.lastHash
+	oldPath := sink.filePath()
+	require.NoError(t, sink.Close())
+
+	yesterdayName := time.Now().UTC().Add(-24*time.Hour).Format("2006-01-02") + ".jsonl"
+	require.NoError(t, os.Rename(oldPath, filepath.Join(dir, yesterdayName)))
+
+	sink2, err := NewJSONLSink(dir, WithFsync(false), WithAnchorInterval(0),
+		WithLogger(slog.New(slog.NewTextHandler(io.Discard, nil))))
+	require.NoError(t, err)
+	defer sink2.Close()
+
+	assert.EqualValues(t, 1, sink2.eventCount)
+	assert.Equal(t, savedHash, sink2.lastHash)
+	require.NoError(t, sink2.Write(sampleEvent("exec")))
+	assertLastEventPrevHash(t, sink2.filePath(), savedHash)
 }
 
 func TestJSONLSink_TamperedAnchorFallsBack(t *testing.T) {
@@ -389,6 +459,7 @@ func TestJSONLSink_TamperedAnchorFallsBack(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		require.NoError(t, sink.Write(sampleEvent("exec")))
 	}
+	savedHash := sink.lastHash
 	require.NoError(t, sink.Close())
 
 	// Tamper with the anchor — change the hash.
@@ -407,10 +478,11 @@ func TestJSONLSink_TamperedAnchorFallsBack(t *testing.T) {
 	require.NoError(t, err)
 	defer sink2.Close()
 
-	// Should have recovered 3 events by line counting (not 2 from anchor).
+	// Should have recovered 3 events by scanning log events, not from the anchor.
 	assert.EqualValues(t, 3, sink2.eventCount)
-	// lastHash should be empty since we didn't trust the anchor.
-	assert.Empty(t, sink2.lastHash)
+	assert.Equal(t, savedHash, sink2.lastHash)
+	require.NoError(t, sink2.Write(sampleEvent("exec")))
+	assertLastEventPrevHash(t, sink2.filePath(), savedHash)
 }
 
 func TestJSONLSink_WriteErrorDoesNotUpdateHash(t *testing.T) {
@@ -450,6 +522,26 @@ func sampleEvent(tool string) Event {
 		},
 		Response: &ToolResponse{DurationMS: 5},
 	}
+}
+
+func assertLastEventPrevHash(t *testing.T, path, wantPrevHash string) {
+	t.Helper()
+	lines := readJSONLLines(t, path)
+	require.NotEmpty(t, lines)
+
+	for i := len(lines) - 1; i >= 0; i-- {
+		var event Event
+		require.NoError(t, json.Unmarshal([]byte(lines[i]), &event))
+		if event.ID == "" {
+			continue
+		}
+		assert.Equal(t, wantPrevHash, event.PrevHash)
+		ok, err := event.VerifyHash()
+		require.NoError(t, err)
+		assert.True(t, ok)
+		return
+	}
+	t.Fatal("no audit event found")
 }
 
 func readJSONLLines(t *testing.T, path string) []string {

--- a/internal/plugin/hermes/__init__.py
+++ b/internal/plugin/hermes/__init__.py
@@ -29,7 +29,7 @@ from pathlib import Path
 from typing import Any, Callable, Mapping
 from urllib.parse import quote
 
-VERSION = "0.1.1"
+VERSION = "1.2.0"
 
 DEFAULT_SERVE_URL = "http://127.0.0.1:9090"
 DEFAULT_TIMEOUT_MS = 3000

--- a/internal/plugin/hermes/embed_test.go
+++ b/internal/plugin/hermes/embed_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestVersionReadsManifest(t *testing.T) {
-	if got, want := Version(), "0.1.1"; got != want {
+	if got, want := Version(), "1.2.0"; got != want {
 		t.Fatalf("Version() = %q, want %q", got, want)
 	}
 }

--- a/internal/plugin/hermes/plugin.yaml
+++ b/internal/plugin/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: rampart
-version: 0.1.1
+version: 1.2.0
 description: Experimental Rampart policy gate for Hermes Agent pre_tool_call hooks
 author: peg
 provides_hooks:

--- a/internal/plugin/openclaw/index.js
+++ b/internal/plugin/openclaw/index.js
@@ -5,7 +5,7 @@
  * Replaces brittle dist-file patching with the official OpenClaw plugin API.
  *
  * @see https://github.com/peg/rampart
- * @version 1.1.1
+ * @version 1.2.0
  */
 
 import { readFile } from "fs/promises";
@@ -259,7 +259,7 @@ async function auditLog(toolName, params, ctx, outcome, config) {
 export const id = "rampart";
 export const name = "Rampart";
 export const description = "AI agent firewall — YAML policy-as-code for every tool call";
-export const version = "1.1.1";
+export const version = "1.2.0";
 
 // OpenClaw runs higher-priority before_tool_call hooks first. Rampart should
 // act as the final normal plugin gate so it evaluates the params that will

--- a/internal/plugin/openclaw/openclaw.plugin.json
+++ b/internal/plugin/openclaw/openclaw.plugin.json
@@ -8,7 +8,7 @@
       "hook"
     ]
   },
-  "version": "1.1.1",
+  "version": "1.2.0",
   "author": "peg",
   "homepage": "https://rampart.sh",
   "repository": "https://github.com/peg/rampart",

--- a/internal/plugin/openclaw/package.json
+++ b/internal/plugin/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rampart",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Rampart AI agent firewall — OpenClaw native plugin (before_tool_call hook)",
   "type": "module",
   "main": "index.js",

--- a/policies/openclaw.yaml
+++ b/policies/openclaw.yaml
@@ -1,4 +1,4 @@
-# rampart-policy-version: 1.0.0
+# rampart-policy-version: 1.2.0
 # Rampart built-in profile: openclaw
 # Use with: rampart init --profile openclaw
 #

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,8 +7,8 @@
 # Usage: curl -fsSL https://rampart.sh/install | sh
 #        curl -fsSL https://rampart.sh/install | sh -s -- --version v0.1.0
 #        curl -fsSL https://rampart.sh/install | sh -s -- --auto-setup
-#        RAMPART_INSTALL_DRY_RUN=1 sh install.sh --version v1.1.1
-#        RAMPART_VERSION=v1.1.1 RAMPART_INSTALL_DIR=$HOME/.local/bin sh install.sh
+#        RAMPART_INSTALL_DRY_RUN=1 sh install.sh --version v1.2.0
+#        RAMPART_VERSION=v1.2.0 RAMPART_INSTALL_DIR=$HOME/.local/bin sh install.sh
 set -e
 
 REPO="peg/rampart"


### PR DESCRIPTION
## Summary
- Recover audit append state from the latest valid JSONL event instead of trusting absent, stale, or tampered anchors as the chain head.
- Make `audit verify --since` support intentionally partial history while preserving strict full-chain and anchor verification by default.
- Align bundled OpenClaw and experimental Hermes plugin metadata/runtime versions to `1.2.0`.
- Refresh v1.2.0 changelog, release-facing docs, install examples, and current-version markers.

## Tests
- `go test ./...`
- `go vet ./...`
- `python -m unittest internal/plugin/hermes/test_hermes_plugin.py`
- `node internal/plugin/openclaw/smoke-test.mjs && node internal/plugin/openclaw/degraded-mode-test.mjs && node internal/plugin/openclaw/tool-alias-test.mjs && node internal/plugin/openclaw/approval-regression.mjs`
- `go run ./cmd/rampart policy lint policies/standard.yaml`
- `mkdocs build --strict`
- `git diff --check`
- `cmp -s install.sh docs/install && cmp -s install.sh docs/install.sh && cmp -s install.sh scripts/install.sh`
