### PR TITLE
chore: add integration compatibility gates

### DIFF
--- a/.github/workflows/upstream-compat.yml
+++ b/.github/workflows/upstream-compat.yml
@@ -1,0 +1,46 @@
+name: Upstream Compatibility
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '17 9 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  hermes-latest:
+    name: Hermes latest isolated plugin gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.25.10'
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Validate against latest Hermes Agent
+        run: python scripts/compat-hermes-latest.py
+
+  openclaw-latest:
+    name: OpenClaw latest isolated plugin gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Install latest OpenClaw
+        run: npm install -g openclaw@latest
+
+      - name: Validate against latest OpenClaw
+        run: node scripts/compat-openclaw-latest.mjs

--- a/cmd/rampart/cli/doctor.go
+++ b/cmd/rampart/cli/doctor.go
@@ -34,6 +34,7 @@ import (
 	"github.com/peg/rampart/internal/engine"
 	ochardening "github.com/peg/rampart/internal/openclaw/hardening"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 // defaultServePort is the default port for rampart serve.
@@ -320,6 +321,12 @@ func runDoctor(w io.Writer, jsonOut bool) error {
 	// binary is present with no native hooks (OpenClaw only covers sessions
 	// run through it; direct `claude` invocations would be unprotected).
 	if n := doctorCoverage(emit, protected); n > 0 {
+		warnings += n
+	}
+
+	// 17b. Hermes experimental plugin health. This is scoped separately from
+	// OpenClaw so optional Hermes gaps do not obscure OpenClaw readiness.
+	if n := doctorHermesIntegration(emit, serveURL, token); n > 0 {
 		warnings += n
 	}
 
@@ -2021,6 +2028,298 @@ func doctorOpenClawAskMode(emit emitFn) (warnings int) {
 				"Set tools.exec.ask to \"off\" for native plugin mode or \"on-miss\" for bridge-first exec mode, then restart OpenClaw")
 		return 1
 	}
+}
+
+type hermesDoctorConfig struct {
+	Plugins struct {
+		Enabled  []string `yaml:"enabled"`
+		Disabled []string `yaml:"disabled"`
+		Entries  map[string]struct {
+			Config map[string]any `yaml:"config"`
+		} `yaml:"entries"`
+	} `yaml:"plugins"`
+}
+
+type hermesPluginManifest struct {
+	Name          string   `yaml:"name"`
+	Version       string   `yaml:"version"`
+	ProvidesHooks []string `yaml:"provides_hooks"`
+}
+
+func doctorHermesIntegration(emit emitFn, serveURL, token string) (warnings int) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return 0
+	}
+	hermesHome := hermesHomeDir(home)
+	pluginDir := filepath.Join(hermesHome, "plugins", "rampart")
+	pluginInstalled := hermesPluginFilesInstalled(pluginDir)
+
+	hermesBin, hermesErr := exec.LookPath("hermes")
+	hermesInstalled := hermesErr == nil
+	if !hermesInstalled && !pluginInstalled {
+		return 0
+	}
+
+	if hermesInstalled {
+		emit("Hermes Agent", "ok", hermesVersionSummary(hermesBin))
+	} else {
+		emit("Hermes Agent", "warn", "Rampart Hermes plugin files are present, but the hermes binary was not found in PATH"+hintSep+
+			"Install Hermes Agent or remove the plugin with: rampart setup hermes --remove")
+		warnings++
+	}
+
+	if !pluginInstalled {
+		emit("Hermes plugin", "warn", "Hermes is installed, but Rampart's experimental plugin is not installed"+hintSep+
+			"rampart setup hermes --enable")
+		return warnings + 1
+	}
+
+	manifest, manifestErr := readHermesPluginManifest(pluginDir)
+	if manifestErr != nil {
+		emit("Hermes plugin", "warn", fmt.Sprintf("installed, but failed to parse plugin.yaml: %v", manifestErr)+hintSep+
+			"Reinstall the plugin: rampart setup hermes")
+		warnings++
+	} else {
+		if manifest.Name != "" && manifest.Name != "rampart" {
+			emit("Hermes plugin", "warn", fmt.Sprintf("installed manifest name is %q, expected rampart", manifest.Name)+hintSep+
+				"Reinstall the plugin: rampart setup hermes")
+			warnings++
+		}
+		if !containsString(manifest.ProvidesHooks, "pre_tool_call") {
+			emit("Hermes plugin", "warn", "installed manifest does not declare pre_tool_call hook support"+hintSep+
+				"Reinstall the plugin from a current Rampart build: rampart setup hermes")
+			warnings++
+		}
+		if manifest.Version != "" && !pluginVersionMatchesBuildVersion(manifest.Version, build.Version) {
+			emit("Hermes plugin", "warn", fmt.Sprintf("installed manifest version %s does not match rampart binary %s", manifest.Version, build.Version)+hintSep+
+				"Rerun `rampart setup hermes` from the same Rampart build, then restart long-running Hermes gateways")
+			warnings++
+		} else {
+			detail := "installed (experimental pre_tool_call policy gate)"
+			if manifest.Version != "" {
+				detail = fmt.Sprintf("installed (v%s, experimental pre_tool_call policy gate)", manifest.Version)
+			}
+			emit("Hermes plugin", "ok", detail)
+		}
+	}
+
+	cfg, configPath, configErr := readHermesDoctorConfig(hermesHome)
+	pluginEnabled := false
+	pluginConfig := map[string]any(nil)
+	if configErr != nil {
+		emit("Hermes plugin enabled", "warn", fmt.Sprintf("could not verify plugins.enabled in %s: %v", configPath, configErr)+hintSep+
+			"hermes plugins enable rampart")
+		warnings++
+	} else {
+		if containsString(cfg.Plugins.Disabled, "rampart") {
+			emit("Hermes plugin enabled", "warn", "plugins.disabled includes rampart, so Hermes will not load the policy hook"+hintSep+
+				"hermes plugins enable rampart")
+			warnings++
+		} else if !containsString(cfg.Plugins.Enabled, "rampart") {
+			emit("Hermes plugin enabled", "warn", "plugin files are installed, but rampart is not listed in plugins.enabled"+hintSep+
+				"hermes plugins enable rampart")
+			warnings++
+		} else {
+			pluginEnabled = true
+			emit("Hermes plugin enabled", "ok", "rampart listed in plugins.enabled; restart long-running gateways after changes")
+		}
+		if cfg.Plugins.Entries != nil {
+			if entry, ok := cfg.Plugins.Entries["rampart"]; ok {
+				pluginConfig = entry.Config
+			}
+		}
+	}
+
+	endpointMode := strings.ToLower(strings.TrimSpace(hermesConfigString(pluginConfig, "preflight", "endpoint_mode", "endpointMode")))
+	if endpointMode == "" {
+		endpointMode = "preflight"
+	}
+	if endpointMode == "tool" {
+		emit("Hermes policy mode", "warn", "endpoint_mode=tool can create Rampart-native pending approvals that Hermes cannot resume"+hintSep+
+			"Use endpoint_mode: preflight unless you are explicitly testing raw /v1/tool semantics")
+		warnings++
+	} else if endpointMode != "preflight" {
+		emit("Hermes policy mode", "warn", fmt.Sprintf("unknown endpoint_mode %q; plugin will fall back to preflight", endpointMode)+hintSep+
+			"Set endpoint_mode: preflight")
+		warnings++
+	} else {
+		emit("Hermes policy mode", "ok", "preflight mode; ask decisions block until Hermes exposes plugin approval/resume")
+	}
+
+	failOpenTools := hermesFailOpenTools(pluginConfig)
+	if risky := riskyHermesFailOpenTools(failOpenTools); len(risky) > 0 {
+		emit("Hermes degraded mode", "warn", fmt.Sprintf("fail_open_tools includes mutating/high-risk tools: %s", strings.Join(risky, ", "))+hintSep+
+			"Limit fail_open_tools to explicit read-only tools or set it to [] for fail-closed behavior")
+		warnings++
+	} else {
+		detail := "mutating/high-risk tools fail closed when Rampart is unavailable"
+		if len(failOpenTools) > 0 {
+			detail += fmt.Sprintf("; configured fail-open tools: %s", strings.Join(failOpenTools, ", "))
+		}
+		emit("Hermes degraded mode", "ok", detail)
+	}
+
+	if pluginEnabled {
+		if serveURL == "" {
+			emit("Hermes readiness", "warn", "plugin enabled, but rampart serve is unreachable; mutating/high-risk Hermes tools will fail closed"+hintSep+
+				"rampart serve --background")
+			warnings++
+		} else if strings.TrimSpace(token) == "" {
+			emit("Hermes readiness", "warn", "plugin enabled and serve reachable, but no Rampart token was found for authenticated policy checks"+hintSep+
+				"rampart serve --background")
+			warnings++
+		} else {
+			emit("Hermes readiness", "ok", fmt.Sprintf("experimental policy gate configured; serve reachable at %s; token present (redacted)", serveURL))
+		}
+	}
+
+	emit("Hermes support tier", "info", "experimental policy gate; full approval/resume support requires Hermes-owned approval APIs and E2E validation")
+	return warnings
+}
+
+func hermesHomeDir(home string) string {
+	if envHome := strings.TrimSpace(os.Getenv("HERMES_HOME")); envHome != "" {
+		expanded := os.ExpandEnv(envHome)
+		if strings.HasPrefix(expanded, "~"+string(os.PathSeparator)) {
+			expanded = filepath.Join(home, strings.TrimPrefix(expanded, "~"+string(os.PathSeparator)))
+		}
+		return filepath.Clean(expanded)
+	}
+	return filepath.Join(home, ".hermes")
+}
+
+func hermesPluginFilesInstalled(pluginDir string) bool {
+	if _, err := os.Stat(filepath.Join(pluginDir, "plugin.yaml")); err != nil {
+		return false
+	}
+	if _, err := os.Stat(filepath.Join(pluginDir, "__init__.py")); err != nil {
+		return false
+	}
+	return true
+}
+
+func readHermesPluginManifest(pluginDir string) (hermesPluginManifest, error) {
+	var manifest hermesPluginManifest
+	data, err := os.ReadFile(filepath.Join(pluginDir, "plugin.yaml"))
+	if err != nil {
+		return manifest, err
+	}
+	if err := yaml.Unmarshal(data, &manifest); err != nil {
+		return manifest, err
+	}
+	return manifest, nil
+}
+
+func readHermesDoctorConfig(hermesHome string) (hermesDoctorConfig, string, error) {
+	var cfg hermesDoctorConfig
+	path := filepath.Join(hermesHome, "config.yaml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return cfg, path, err
+	}
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return cfg, path, err
+	}
+	return cfg, path, nil
+}
+
+func hermesVersionSummary(bin string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, bin, "--version").CombinedOutput()
+	if err != nil || strings.TrimSpace(string(out)) == "" {
+		return "installed (version unavailable)"
+	}
+	line := strings.TrimSpace(strings.Split(strings.ReplaceAll(string(out), "\r\n", "\n"), "\n")[0])
+	if len(line) > 160 {
+		line = line[:160]
+	}
+	return fmt.Sprintf("installed (%s)", line)
+}
+
+func hermesConfigString(config map[string]any, defaultValue string, keys ...string) string {
+	if config == nil {
+		return defaultValue
+	}
+	for _, key := range keys {
+		if value, ok := config[key]; ok {
+			if s, ok := value.(string); ok {
+				return s
+			}
+		}
+	}
+	return defaultValue
+}
+
+func hermesFailOpenTools(config map[string]any) []string {
+	defaultTools := []string{"read_file", "search_files", "browser_snapshot", "browser_get_images", "browser_vision", "vision_analyze"}
+	if config == nil {
+		return defaultTools
+	}
+	var raw any
+	for _, key := range []string{"fail_open_tools", "failOpenTools"} {
+		if value, ok := config[key]; ok {
+			raw = value
+			break
+		}
+	}
+	if raw == nil {
+		return defaultTools
+	}
+	var tools []string
+	switch v := raw.(type) {
+	case []string:
+		tools = append(tools, v...)
+	case []any:
+		for _, item := range v {
+			tools = append(tools, fmt.Sprint(item))
+		}
+	case string:
+		tools = strings.Split(v, ",")
+	default:
+		return defaultTools
+	}
+	return normalizedStringList(tools)
+}
+
+func riskyHermesFailOpenTools(tools []string) []string {
+	var risky []string
+	for _, tool := range tools {
+		switch strings.ToLower(strings.TrimSpace(tool)) {
+		case "terminal", "execute_code", "write_file", "patch", "process", "cronjob", "send_message", "text_to_speech", "memory", "todo",
+			"browser_back", "browser_cdp", "browser_click", "browser_console", "browser_dialog", "browser_navigate", "browser_press", "browser_scroll", "browser_type":
+			risky = append(risky, tool)
+		}
+	}
+	return normalizedStringList(risky)
+}
+
+func normalizedStringList(values []string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if seen[value] {
+			continue
+		}
+		seen[value] = true
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }
 
 func relHome(path, home string) string {

--- a/cmd/rampart/cli/doctor_test.go
+++ b/cmd/rampart/cli/doctor_test.go
@@ -855,6 +855,134 @@ if (!params.decision) {
 	}
 }
 
+func TestDoctorHermesIntegrationSkipsWhenHermesAbsent(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+	t.Setenv("HERMES_HOME", filepath.Join(home, "hermes"))
+	t.Setenv("PATH", filepath.Join(home, "empty-bin"))
+
+	var results []checkResult
+	warnings := doctorHermesIntegration(func(name, status, msg string) {
+		results = append(results, checkResult{Name: name, Status: status, Message: msg})
+	}, "", "")
+	if warnings != 0 || len(results) != 0 {
+		t.Fatalf("expected no Hermes checks, got warnings=%d results=%+v", warnings, results)
+	}
+}
+
+func TestDoctorHermesIntegrationWarnsWhenPluginNotEnabled(t *testing.T) {
+	home, _ := setupHermesDoctorFixture(t, `plugins:
+  enabled: []
+`)
+	t.Setenv("PATH", filepath.Join(home, "empty-bin"))
+
+	var results []checkResult
+	warnings := doctorHermesIntegration(func(name, status, msg string) {
+		results = append(results, checkResult{Name: name, Status: status, Message: msg})
+	}, "http://127.0.0.1:9090", "test-token")
+	if warnings == 0 {
+		t.Fatalf("expected warnings, got results=%+v", results)
+	}
+	out := doctorResultText(results)
+	if !strings.Contains(out, "hermes binary was not found") {
+		t.Fatalf("expected missing-binary warning, got: %s", out)
+	}
+	if !strings.Contains(out, "not listed in plugins.enabled") {
+		t.Fatalf("expected plugin-enabled warning, got: %s", out)
+	}
+}
+
+func TestDoctorHermesIntegrationReportsReadyExperimentalGate(t *testing.T) {
+	home, _ := setupHermesDoctorFixture(t, `plugins:
+  enabled:
+    - rampart
+  entries:
+    rampart:
+      config:
+        endpoint_mode: preflight
+        fail_open_tools:
+          - read_file
+          - search_files
+`)
+	t.Setenv("PATH", filepath.Join(home, "empty-bin"))
+
+	var results []checkResult
+	warnings := doctorHermesIntegration(func(name, status, msg string) {
+		results = append(results, checkResult{Name: name, Status: status, Message: msg})
+	}, "http://127.0.0.1:9090", "test-token")
+	if warnings != 1 {
+		t.Fatalf("expected only missing-binary warning, got warnings=%d results=%+v", warnings, results)
+	}
+	out := doctorResultText(results)
+	if !strings.Contains(out, "experimental policy gate configured") {
+		t.Fatalf("expected Hermes readiness message, got: %s", out)
+	}
+	if !strings.Contains(out, "full approval/resume support requires") {
+		t.Fatalf("expected support-tier boundary, got: %s", out)
+	}
+}
+
+func TestDoctorHermesIntegrationWarnsOnToolModeAndRiskyFailOpen(t *testing.T) {
+	home, _ := setupHermesDoctorFixture(t, `plugins:
+  enabled:
+    - rampart
+  entries:
+    rampart:
+      config:
+        endpoint_mode: tool
+        fail_open_tools:
+          - read_file
+          - terminal
+`)
+	t.Setenv("PATH", filepath.Join(home, "empty-bin"))
+
+	var results []checkResult
+	warnings := doctorHermesIntegration(func(name, status, msg string) {
+		results = append(results, checkResult{Name: name, Status: status, Message: msg})
+	}, "http://127.0.0.1:9090", "test-token")
+	if warnings < 3 {
+		t.Fatalf("expected missing-binary, endpoint-mode, and fail-open warnings, got warnings=%d results=%+v", warnings, results)
+	}
+	out := doctorResultText(results)
+	if !strings.Contains(out, "endpoint_mode=tool") {
+		t.Fatalf("expected tool-mode warning, got: %s", out)
+	}
+	if !strings.Contains(out, "terminal") || !strings.Contains(out, "mutating/high-risk") {
+		t.Fatalf("expected risky fail-open warning, got: %s", out)
+	}
+}
+
+func setupHermesDoctorFixture(t *testing.T, config string) (home string, hermesHome string) {
+	t.Helper()
+	home = t.TempDir()
+	testSetHome(t, home)
+	hermesHome = filepath.Join(home, "hermes")
+	t.Setenv("HERMES_HOME", hermesHome)
+	pluginDir := filepath.Join(hermesHome, "plugins", "rampart")
+	requireNoErr(t, os.MkdirAll(pluginDir, 0o755))
+	requireNoErr(t, os.WriteFile(filepath.Join(pluginDir, "plugin.yaml"), []byte(`name: rampart
+version: 1.2.0
+provides_hooks:
+  - pre_tool_call
+`), 0o644))
+	requireNoErr(t, os.WriteFile(filepath.Join(pluginDir, "__init__.py"), []byte("def register(ctx):\n    pass\n"), 0o644))
+	requireNoErr(t, os.WriteFile(filepath.Join(hermesHome, "config.yaml"), []byte(config), 0o644))
+	return home, hermesHome
+}
+
+func doctorResultText(results []checkResult) string {
+	var b strings.Builder
+	for _, result := range results {
+		b.WriteString(result.Name)
+		b.WriteString(": ")
+		b.WriteString(result.Status)
+		b.WriteString(": ")
+		b.WriteString(result.Message)
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
 func TestIsReleaseVersion(t *testing.T) {
 	tests := []struct {
 		version string

--- a/docs-site/getting-started/release-compatibility-gate.md
+++ b/docs-site/getting-started/release-compatibility-gate.md
@@ -1,0 +1,73 @@
+---
+title: Release Compatibility Gate
+description: "How Rampart validates advertised agent integrations before release, including latest OpenClaw and experimental Hermes Agent checks."
+---
+
+# Release Compatibility Gate
+
+Use this checklist before publishing a Rampart release that advertises agent integration support. It keeps support claims tied to evidence from the exact candidate build, not a prior local install or stale plugin copy.
+
+## Support tiers
+
+Rampart uses these tiers in the support matrix:
+
+- **Recommended**: actively tested against the current stable runtime, polished approval UX, and clear `rampart doctor` checks.
+- **Supported**: documented and regression-covered, with narrower UX or less frequent runtime smoke coverage.
+- **Experimental**: installable and useful, but with known limits that are still part of the public contract.
+- **Legacy compatibility**: maintained where practical for older clients, but not the preferred path.
+
+Hermes Agent remains **experimental** until Hermes exposes a stable plugin approval/resume primitive and a full end-to-end test proves a single user-facing approval, exact tool-call resume, deny non-bypass, and audit/result correlation.
+
+## Required gate for release candidates
+
+1. **Start from a clean candidate**
+   - Fetch the target release branch and validate a clean worktree.
+   - Build the exact candidate commit.
+   - Reinstall bundled agent plugins from that exact build.
+   - Compare binary version, plugin manifest version, and runtime-reported plugin version.
+
+2. **Check upstream version currency**
+   - Record latest stable OpenClaw from npm.
+   - Record latest stable Hermes Agent from PyPI.
+   - Treat upstream release notes touching plugin discovery, hook dispatch, approval behavior, native tool relay, model/tool execution, or security boundaries as compatibility-relevant.
+
+3. **Validate latest stable OpenClaw**
+   - Use a controlled OpenClaw state, not a dirty local gateway config.
+   - Install the candidate Rampart OpenClaw plugin.
+   - Run `openclaw config validate` when available.
+   - Confirm plugin metadata reports the candidate version and startup activation.
+   - Exercise allow, ask, and deny with a unique marker.
+   - For command execution paths, require OpenClaw runtime evidence plus a correlated Rampart audit event for canonical `exec`.
+   - Check for stale shim, dist patch, or duplicate enforcement paths before calling the result clean.
+
+4. **Validate latest stable Hermes Agent in isolation**
+   - Use a temporary `HERMES_HOME` or temporary home directory.
+   - Install latest Hermes Agent in a temporary Python environment.
+   - Install the candidate Rampart plugin into only that temporary Hermes plugin directory.
+   - Enable only the temporary Hermes config.
+   - Exercise the real Hermes plugin dispatcher, including plugin discovery and `pre_tool_call` hook registration.
+   - Prove deny blocks before execution, allow continues, `ask` blocks with an approval-required/no-resume message, and mutating tools fail closed when Rampart is unavailable.
+   - Do not restart or mutate a live Discord, Telegram, or other long-running Hermes gateway for this gate.
+
+5. **Run `rampart doctor` as a support-contract check**
+   - Group findings by integration surface.
+   - Classify each finding as blocker, expected optional local gap, or follow-up diagnostic improvement.
+   - Do not collapse OpenClaw, Hermes, Claude Code, Codex, and Cline findings into one global yes/no.
+
+6. **Publish claims that match the evidence**
+   - OpenClaw can be called recommended only when the latest stable path has fresh runtime/audit proof.
+   - Hermes can be called an experimental policy gate when isolated latest-Hermes plugin dispatch has deny, allow, ask-block, and fail-closed proof.
+   - Full Hermes support requires Hermes-owned approval/resume APIs plus live or staging end-to-end validation.
+
+## CI and local compatibility scripts
+
+The repository includes compatibility harnesses for latest upstream agent checks:
+
+```bash
+python scripts/compat-hermes-latest.py
+node scripts/compat-openclaw-latest.mjs
+```
+
+The Hermes harness installs or uses an isolated Hermes runtime and never touches the active gateway. The OpenClaw harness expects `openclaw` to be on `PATH`, uses a temporary home/state directory, and validates plugin installation plus the bundled plugin behavior checks.
+
+A scheduled/manual GitHub Actions workflow runs these upstream checks outside the core unit-test matrix so external upstream breakage is visible without destabilizing ordinary pull-request CI.

--- a/docs-site/getting-started/release-compatibility-gate.md
+++ b/docs-site/getting-started/release-compatibility-gate.md
@@ -70,4 +70,12 @@ node scripts/compat-openclaw-latest.mjs
 
 The Hermes harness installs or uses an isolated Hermes runtime and never touches the active gateway. The OpenClaw harness expects `openclaw` to be on `PATH`, uses a temporary home/state directory, and validates plugin installation plus the bundled plugin behavior checks.
 
+For OpenClaw's recommended support tier, also run the opt-in runtime audit regression before a release promotion:
+
+```bash
+RAMPART_OPENCLAW_RUNTIME=1 node scripts/test-openclaw-codex-native-audit.mjs
+```
+
+That live regression is intentionally separate from scheduled CI because it temporarily enables the OpenClaw Rampart plugin, restarts local OpenClaw user services, runs one real OpenClaw Codex app-server turn, and requires correlated OpenClaw trajectory plus Rampart canonical `exec` audit proof.
+
 A scheduled/manual GitHub Actions workflow runs these upstream checks outside the core unit-test matrix so external upstream breakage is visible without destabilizing ordinary pull-request CI.

--- a/docs-site/getting-started/support-matrix.md
+++ b/docs-site/getting-started/support-matrix.md
@@ -7,6 +7,8 @@ description: "Supported Rampart integration modes, coverage, approval UX, serve 
 
 Use this page as the canonical support contract for Rampart's main integration surfaces.
 
+For release-candidate validation and latest-agent checks, use the [Release Compatibility Gate](release-compatibility-gate.md). The support tier below should match the most recent evidence from the exact Rampart candidate build and bundled plugin metadata.
+
 ## At a glance
 
 <table class="support-matrix-table">
@@ -97,7 +99,7 @@ Use this page as the canonical support contract for Rampart's main integration s
 
 - **Claude Code** → best overall native path
 - **Codex CLI** → best CLI path when you want strong coverage
-- **OpenClaw >= 2026.5.2** → best OpenClaw path for 1.0; plugin + native approval UI
+- **OpenClaw >= 2026.5.2** → best OpenClaw path; plugin + native approval UI
 - **Hermes Agent** → experimental plugin path for early testing; `ask` decisions block rather than resume
 - **Cline** → good supported path, but less polished approval UX than Claude Code
 
@@ -120,6 +122,7 @@ Use this page as the canonical support contract for Rampart's main integration s
 ## Related guides
 
 - [Quick Start](quickstart.md)
+- [Release Compatibility Gate](release-compatibility-gate.md)
 - [How Rampart Works](how-it-works.md)
 - [OpenClaw integration](../integrations/openclaw.md)
 - [Hermes Agent integration](../integrations/hermes.md)

--- a/docs-site/integrations/hermes.md
+++ b/docs-site/integrations/hermes.md
@@ -101,14 +101,22 @@ Use this only when you understand the approval ownership tradeoff. If a policy r
 
 ## Verification
 
-Use a deny rule for a harmless command and confirm Hermes blocks it before execution:
+Use the isolated latest-Hermes compatibility harness before enabling the plugin on a live gateway:
+
+```bash
+python scripts/compat-hermes-latest.py
+```
+
+The harness creates a temporary Hermes state, installs the Rampart plugin there, exercises Hermes plugin discovery plus `pre_tool_call` dispatch, and verifies deny, allow, `ask` blocking, and fail-closed behavior without restarting any long-running Hermes gateway.
+
+For manual verification, use a deny rule for a harmless command and confirm Hermes blocks it before execution:
 
 ```bash
 rampart serve --addr 127.0.0.1 --port 9090
 hermes plugins list
 ```
 
-Then ask Hermes to run a command that policy denies, such as a destructive-command test pattern. The tool response should include a message beginning with `rampart:` and the command should not execute.
+Then ask Hermes to run a command that policy denies, such as a harmless unique-marker test pattern. The tool response should include a message beginning with `rampart:` and the command should not execute.
 
 ## Uninstall
 

--- a/docs-site/integrations/openclaw.md
+++ b/docs-site/integrations/openclaw.md
@@ -16,7 +16,7 @@ For sensitive tools, the recommended operating assumption is simple: if Rampart 
     - **OpenClaw 2026.4.29 - 2026.5.1**: Supported for native plugin startup/interception; plugin approval delivery was not the launch baseline.
     - **OpenClaw 2026.3.28 - 2026.4.28**: Native plugin works for tool enforcement, but Rampart's polished approval path is supported on newer OpenClaw builds.
     - **OpenClaw < 2026.3.28**: Legacy shim + bridge — exec-only coverage, requires re-patching after upgrades.
-    - **Verified 1.0 launch dogfood on**: OpenClaw 2026.5.6
+    - Refresh release claims against the latest stable OpenClaw before publishing a new Rampart release. See the [Release Compatibility Gate](../getting-started/release-compatibility-gate.md).
 
     `rampart setup openclaw` auto-detects your version and uses the right method.
 
@@ -152,6 +152,12 @@ For end-to-end confidence, validate one case in each state:
 - learned allow, for example `sudo true`
 - fresh ask, for example `sudo id`
 - hard deny, for example `rm -rf /tmp`
+
+For release-candidate validation, run the latest-OpenClaw compatibility harness in a temporary state directory:
+
+```bash
+node scripts/compat-openclaw-latest.mjs
+```
 
 Or check plugin status directly:
 

--- a/docs-site/integrations/openclaw.md
+++ b/docs-site/integrations/openclaw.md
@@ -159,6 +159,14 @@ For release-candidate validation, run the latest-OpenClaw compatibility harness 
 node scripts/compat-openclaw-latest.mjs
 ```
 
+That isolated harness validates plugin install/config and bundled plugin behavior. Before promoting a release that claims OpenClaw as recommended, also run the opt-in live runtime audit regression:
+
+```bash
+RAMPART_OPENCLAW_RUNTIME=1 node scripts/test-openclaw-codex-native-audit.mjs
+```
+
+The live regression temporarily enables the Rampart OpenClaw plugin and restarts local OpenClaw user services, then requires a real OpenClaw Codex app-server turn with correlated trajectory and Rampart canonical `exec` audit evidence.
+
 Or check plugin status directly:
 
 ```bash

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -121,6 +121,7 @@ nav:
     - Installation: getting-started/installation.md
     - Quick Start: getting-started/quickstart.md
     - Support Matrix: getting-started/support-matrix.md
+    - Release Compatibility Gate: getting-started/release-compatibility-gate.md
     - How It Works: getting-started/how-it-works.md
     - "Tutorial: 5 Minutes to Protected": getting-started/tutorial.md
     - Configuration: getting-started/configuration.md

--- a/scripts/compat-hermes-latest.py
+++ b/scripts/compat-hermes-latest.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""Validate Rampart's Hermes plugin against an isolated Hermes runtime.
+
+This harness is intentionally isolated. It creates a temporary home/HERMES_HOME,
+installs the candidate Rampart plugin there, and exercises Hermes' real plugin
+discovery plus pre_tool_call dispatcher without touching a live Hermes gateway.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import textwrap
+import threading
+import venv
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class RampartStub(BaseHTTPRequestHandler):
+    requests_seen: list[dict[str, Any]] = []
+
+    def do_POST(self) -> None:  # noqa: N802, inherited name
+        length = int(self.headers.get("Content-Length", "0") or "0")
+        raw = self.rfile.read(length).decode("utf-8") if length else "{}"
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError:
+            payload = {}
+
+        params = payload.get("params") if isinstance(payload, dict) else {}
+        if not isinstance(params, dict):
+            params = {}
+        command = str(params.get("command") or "")
+        record = {
+            "path": self.path,
+            "agent": payload.get("agent") if isinstance(payload, dict) else None,
+            "session": payload.get("session") if isinstance(payload, dict) else None,
+            "tool_call_id_present": bool(payload.get("tool_call_id")) if isinstance(payload, dict) else False,
+            "command_marker": _marker_from_command(command),
+        }
+        self.requests_seen.append(record)
+
+        if "rampart-deny-marker" in command:
+            body = {
+                "decision": "deny",
+                "message": "blocked by compatibility harness",
+                "policy": "compat-deny",
+                "audit_id": "compat-audit-deny",
+            }
+        elif "rampart-ask-marker" in command:
+            body = {
+                "decision": "ask",
+                "message": "requires compatibility harness approval",
+                "matched_policies": ["compat-ask"],
+                "audit_id": "compat-audit-ask",
+            }
+        else:
+            body = {
+                "decision": "allow",
+                "message": "allowed by compatibility harness",
+                "audit_id": "compat-audit-allow",
+            }
+
+        encoded = json.dumps(body).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+    def log_message(self, format: str, *args: Any) -> None:
+        _ = (format, args)
+        return
+
+
+def _marker_from_command(command: str) -> str:
+    for marker in ("rampart-deny-marker", "rampart-ask-marker", "rampart-allow-marker"):
+        if marker in command:
+            return marker
+    return ""
+
+
+def run(cmd: list[str], *, env: dict[str, str] | None = None, cwd: Path = REPO_ROOT) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        cmd,
+        cwd=str(cwd),
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+
+
+def make_venv(root: Path, package: str) -> tuple[Path, Path]:
+    venv_dir = root / "venv"
+    venv.EnvBuilder(with_pip=True, clear=True).create(venv_dir)
+    python = venv_dir / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+    hermes = venv_dir / ("Scripts/hermes.exe" if os.name == "nt" else "bin/hermes")
+    run([str(python), "-m", "pip", "install", "--upgrade", "pip"], cwd=root)
+    run([str(python), "-m", "pip", "install", package], cwd=root)
+    return python, hermes
+
+
+def free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def write_hermes_config(hermes_home: Path, serve_url: str) -> None:
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / "config.yaml").write_text(
+        textwrap.dedent(
+            f"""
+            plugins:
+              enabled:
+                - rampart
+              entries:
+                rampart:
+                  config:
+                    serve_url: {serve_url}
+                    endpoint_mode: preflight
+                    timeout_ms: 1000
+                    fail_open_tools:
+                      - read_file
+                      - search_files
+            """
+        ).lstrip(),
+        encoding="utf-8",
+    )
+
+
+def child_probe_code(unused_port: int) -> str:
+    return textwrap.dedent(
+        f"""
+        import json
+        import os
+        from hermes_cli.plugins import discover_plugins, get_plugin_manager, get_pre_tool_call_block_message
+
+        discover_plugins(force=True)
+        manager = get_plugin_manager()
+        loaded = manager._plugins.get('rampart')
+        if loaded is None:
+            raise SystemExit('rampart plugin was not discovered')
+        if not loaded.enabled:
+            raise SystemExit(f'rampart plugin discovered but not enabled: {{loaded.error}}')
+        hooks = manager._hooks.get('pre_tool_call') or []
+        if not hooks:
+            raise SystemExit('rampart plugin did not register a pre_tool_call hook')
+
+        def block(tool, args, call_id):
+            return get_pre_tool_call_block_message(
+                tool,
+                args,
+                task_id='compat-task',
+                session_id='compat-session',
+                tool_call_id=call_id,
+            )
+
+        deny = block('terminal', {{'command': 'printf rampart-deny-marker'}}, 'compat-deny-call')
+        if not deny or 'blocked by compatibility harness' not in deny or 'compat-audit-deny' not in deny:
+            raise SystemExit(f'deny did not block as expected: {{deny!r}}')
+
+        ask = block('terminal', {{'command': 'printf rampart-ask-marker'}}, 'compat-ask-call')
+        if not ask or 'approval required' not in ask or 'does not yet resume' not in ask or 'compat-audit-ask' not in ask:
+            raise SystemExit(f'ask did not block with no-resume message: {{ask!r}}')
+
+        allow = block('terminal', {{'command': 'printf rampart-allow-marker'}}, 'compat-allow-call')
+        if allow is not None:
+            raise SystemExit(f'allow should continue without a block message: {{allow!r}}')
+
+        os.environ['RAMPART_HERMES_URL'] = 'http://127.0.0.1:{unused_port}'
+        os.environ['RAMPART_HERMES_TIMEOUT_MS'] = '250'
+        fail_closed = block('terminal', {{'command': 'printf rampart-fail-closed-marker'}}, 'compat-fail-closed-call')
+        if not fail_closed or 'unavailable' not in fail_closed:
+            raise SystemExit(f'mutating terminal did not fail closed: {{fail_closed!r}}')
+
+        fail_open = block('read_file', {{'path': '/tmp/rampart-compat-read.txt'}}, 'compat-fail-open-call')
+        if fail_open is not None:
+            raise SystemExit(f'configured read_file fail-open should continue: {{fail_open!r}}')
+
+        print(json.dumps({{
+            'ok': True,
+            'plugin_version': loaded.manifest.version,
+            'hooks_registered': loaded.hooks_registered,
+            'pre_tool_call_hooks': len(hooks),
+            'deny_blocked': True,
+            'ask_blocked_without_resume': True,
+            'allow_continued': True,
+            'mutating_fail_closed': True,
+            'configured_read_fail_open': True,
+        }}, sort_keys=True))
+        """
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate Rampart's Hermes plugin against an isolated latest Hermes runtime.")
+    parser.add_argument("--package", default="hermes-agent", help="pip package spec to install, default: hermes-agent")
+    parser.add_argument("--hermes-python", help="Use an existing Python interpreter with Hermes installed instead of creating a venv")
+    parser.add_argument("--hermes-bin", help="Hermes executable to report version from when --hermes-python is used")
+    parser.add_argument("--keep-temp", action="store_true", help="Keep the temporary directory for debugging")
+    args = parser.parse_args()
+
+    temp = Path(tempfile.mkdtemp(prefix="rampart-hermes-compat-"))
+    try:
+        if args.hermes_python:
+            hermes_python = Path(args.hermes_python).resolve()
+            hermes_bin = Path(args.hermes_bin).resolve() if args.hermes_bin else shutil.which("hermes")
+            hermes_bin_path = Path(hermes_bin) if hermes_bin else None
+        else:
+            hermes_python, hermes_bin_path = make_venv(temp, args.package)
+
+        hermes_home = temp / "hermes-home"
+        plugin_dir = hermes_home / "plugins" / "rampart"
+
+        server = ThreadingHTTPServer(("127.0.0.1", 0), RampartStub)
+        serve_url = f"http://127.0.0.1:{server.server_address[1]}"
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+
+        try:
+            write_hermes_config(hermes_home, serve_url)
+            env = os.environ.copy()
+            env.update(
+                {
+                    "HOME": str(temp / "home"),
+                    "HERMES_HOME": str(hermes_home),
+                    "RAMPART_TOKEN": "compat-test-token",
+                    "RAMPART_HERMES_URL": serve_url,
+                    "RAMPART_HERMES_TIMEOUT_MS": "1000",
+                    "PYTHONWARNINGS": "ignore::DeprecationWarning",
+                }
+            )
+            Path(env["HOME"]).mkdir(parents=True, exist_ok=True)
+
+            run(
+                [
+                    "go",
+                    "run",
+                    "./cmd/rampart",
+                    "setup",
+                    "hermes",
+                    "--plugin-dir",
+                    str(plugin_dir),
+                ],
+                env=env,
+            )
+
+            hermes_version = "unavailable"
+            if hermes_bin_path:
+                try:
+                    version_result = run([str(hermes_bin_path), "--version"], env=env, cwd=temp)
+                    hermes_version = (version_result.stdout or version_result.stderr).strip().splitlines()[0]
+                except Exception:
+                    hermes_version = "version command failed"
+
+            probe = run([str(hermes_python), "-c", child_probe_code(free_port())], env=env, cwd=temp)
+            child_summary = json.loads(probe.stdout.strip().splitlines()[-1])
+
+            paths = {entry["path"] for entry in RampartStub.requests_seen}
+            if "/v1/preflight/exec" not in paths:
+                raise RuntimeError(f"expected /v1/preflight/exec request, saw {sorted(paths)}")
+            markers = {entry["command_marker"] for entry in RampartStub.requests_seen}
+            expected = {"rampart-deny-marker", "rampart-ask-marker", "rampart-allow-marker"}
+            if not expected.issubset(markers):
+                raise RuntimeError(f"expected request markers {sorted(expected)}, saw {sorted(markers)}")
+
+            print(
+                json.dumps(
+                    {
+                        "ok": True,
+                        "hermes_version": hermes_version,
+                        "hermes_home_isolated": str(hermes_home),
+                        "plugin_dir": str(plugin_dir),
+                        "requests_seen": RampartStub.requests_seen,
+                        "dispatcher": child_summary,
+                    },
+                    indent=2,
+                    sort_keys=True,
+                )
+            )
+            return 0
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=5)
+    finally:
+        if args.keep_temp:
+            print(f"kept temporary directory: {temp}", file=sys.stderr)
+        else:
+            shutil.rmtree(temp, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/compat-openclaw-latest.mjs
+++ b/scripts/compat-openclaw-latest.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+/**
+ * Validate Rampart's OpenClaw plugin against an isolated OpenClaw state.
+ *
+ * The script expects an `openclaw` executable on PATH. It sets HOME and
+ * OPENCLAW_CONFIG_PATH to a temporary directory so plugin install/config checks
+ * do not touch a live OpenClaw gateway or user config.
+ */
+
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const repoRoot = resolve(new URL('..', import.meta.url).pathname);
+const tempRoot = mkdtempSync(join(tmpdir(), 'rampart-openclaw-compat-'));
+const tempHome = join(tempRoot, 'home');
+const openclawDir = join(tempHome, '.openclaw');
+const configPath = join(openclawDir, 'openclaw.json');
+const keepTemp = process.argv.includes('--keep-temp');
+
+function run(command, args, { required = true, env = compatEnv() } = {}) {
+  const result = spawnSync(command, args, {
+    cwd: repoRoot,
+    env,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const record = {
+    command: [command, ...args].join(' '),
+    status: result.status,
+    stdout: (result.stdout || '').trim(),
+    stderr: (result.stderr || '').trim(),
+  };
+  if (required && result.status !== 0) {
+    const detail = JSON.stringify(record, null, 2);
+    throw new Error(`command failed: ${detail}`);
+  }
+  return record;
+}
+
+function compatEnv() {
+  return {
+    ...process.env,
+    HOME: tempHome,
+    USERPROFILE: tempHome,
+    XDG_CONFIG_HOME: join(tempHome, '.config'),
+    OPENCLAW_CONFIG_PATH: configPath,
+    RAMPART_TOKEN: 'compat-test-token',
+    RAMPART_URL: 'http://127.0.0.1:19090',
+  };
+}
+
+function setupTempState() {
+  mkdirSync(openclawDir, { recursive: true });
+  writeFileSync(
+    configPath,
+    JSON.stringify(
+      {
+        plugins: {
+          entries: {},
+        },
+        tools: {
+          exec: {
+            ask: 'off',
+          },
+        },
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+function commandOutput(record) {
+  return record.stdout || record.stderr || '';
+}
+
+function main() {
+  setupTempState();
+  const env = compatEnv();
+  const pluginDir = join(repoRoot, 'internal', 'plugin', 'openclaw');
+
+  const version = run('openclaw', ['--version'], { env });
+  const install = run('openclaw', ['plugins', 'install', pluginDir], { env });
+  const validate = run('openclaw', ['config', 'validate'], { env });
+  const inspect = run('openclaw', ['plugins', 'inspect', 'rampart'], { required: false, env });
+  const list = inspect.status === 0
+    ? { command: 'openclaw plugins list', status: 0, stdout: '', stderr: '' }
+    : run('openclaw', ['plugins', 'list'], { env });
+
+  const installedOutput = `${commandOutput(inspect)}\n${commandOutput(list)}\n${commandOutput(install)}`;
+  if (!installedOutput.includes('rampart')) {
+    throw new Error(`OpenClaw plugin output did not mention rampart: ${installedOutput}`);
+  }
+
+  const smoke = run(process.execPath, ['internal/plugin/openclaw/smoke-test.mjs'], { env });
+  const approvals = run(process.execPath, ['internal/plugin/openclaw/approval-regression.mjs'], { env });
+  const degraded = run(process.execPath, ['internal/plugin/openclaw/degraded-mode-test.mjs'], { env });
+
+  const summary = {
+    ok: true,
+    temp_home: tempHome,
+    openclaw_version: commandOutput(version).split('\n')[0],
+    plugin_install_checked: true,
+    config_validate_checked: validate.status === 0,
+    plugin_inspect_checked: inspect.status === 0,
+    plugin_list_checked: inspect.status !== 0 && list.status === 0,
+    bundled_plugin_harnesses: {
+      smoke: JSON.parse(smoke.stdout),
+      approvals: JSON.parse(approvals.stdout),
+      degraded: JSON.parse(degraded.stdout),
+    },
+  };
+  console.log(JSON.stringify(summary, null, 2));
+}
+
+try {
+  main();
+} finally {
+  if (keepTemp) {
+    console.error(`kept temporary directory: ${tempRoot}`);
+  } else {
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+}


### PR DESCRIPTION
## Summary
- Add a release compatibility gate document that defines support tiers and latest-agent validation requirements.
- Add isolated Hermes and OpenClaw upstream compatibility harnesses plus a scheduled/manual workflow.
- Extend `rampart doctor` with Hermes plugin readiness checks, including enabled state, endpoint mode, fail-open risk, and experimental support-tier boundaries.
- Clarify that OpenClaw recommended release promotion still requires the opt-in live runtime audit regression with correlated trajectory and Rampart canonical `exec` audit proof.

## Tests
- `python3 -m py_compile scripts/compat-hermes-latest.py`
- `node --check scripts/compat-openclaw-latest.mjs`
- `python3 -m unittest internal/plugin/hermes/test_hermes_plugin.py`
- `node internal/plugin/openclaw/smoke-test.mjs`
- `node internal/plugin/openclaw/approval-regression.mjs`
- `node internal/plugin/openclaw/degraded-mode-test.mjs`
- `go test ./cmd/rampart/cli`
- `git diff --check`
- `python3 scripts/compat-hermes-latest.py` (validated isolated Hermes Agent v0.15.2)
- `node scripts/compat-openclaw-latest.mjs` (validated isolated OpenClaw 2026.5.27 plugin install/config/harness behavior)
- `go test ./...`

Not run:
- `python3 -m mkdocs build --strict`, because `mkdocs` is not installed in the local environment.
- `RAMPART_OPENCLAW_RUNTIME=1 node scripts/test-openclaw-codex-native-audit.mjs`, because it temporarily enables the local OpenClaw Rampart plugin, restarts OpenClaw user services, and runs a live OpenClaw Codex app-server turn.
