### PR TITLE
fix: report Hermes plugin readiness in doctor

### DIFF
--- a/cmd/rampart/cli/doctor.go
+++ b/cmd/rampart/cli/doctor.go
@@ -306,6 +306,9 @@ func runDoctor(w io.Writer, jsonOut bool) error {
 	if n := doctorOpenClawDiscordApprovalRuntime(emit); n > 0 {
 		warnings += n
 	}
+	if n := doctorHermesPlugin(emit, serveURL); n > 0 {
+		warnings += n
+	}
 
 	// 17. OpenClaw ask mode — only needed for legacy bridge users.
 	// With the native plugin active, before_tool_call covers all tool calls
@@ -676,6 +679,52 @@ func hasPermissiveAllowUnmatched(cfg *engine.Config) bool {
 		}
 	}
 	return false
+}
+
+func doctorHermesPlugin(emit emitFn, serveURL string) (warnings int) {
+	state := detectHermesPluginState()
+	_, hermesBinErr := exec.LookPath("hermes")
+	hermesDetected := hermesBinErr == nil || state.ConfigPresent || state.Installed
+	if !hermesDetected {
+		return 0
+	}
+	if !state.Installed {
+		emit("Hermes Agent plugin", "warn",
+			"Hermes detected but Rampart plugin is not installed"+
+				hintSep+"rampart setup hermes --enable")
+		return 1
+	}
+	if !state.ManifestValid {
+		emit("Hermes Agent plugin", "warn",
+			fmt.Sprintf("Rampart Hermes plugin manifest is invalid at %s", filepath.Join(state.PluginDir, "plugin.yaml"))+
+				hintSep+"rampart setup hermes")
+		return 1
+	}
+	if !state.HookDeclared {
+		emit("Hermes Agent plugin", "warn",
+			"Rampart Hermes plugin manifest does not declare pre_tool_call"+
+				hintSep+"rampart setup hermes")
+		return 1
+	}
+	if !state.Enabled {
+		emit("Hermes Agent plugin", "warn",
+			"Rampart Hermes plugin is installed but not enabled"+
+				hintSep+"hermes plugins enable rampart && restart long-running Hermes gateways")
+		return 1
+	}
+
+	version := state.Version
+	if version == "" {
+		version = "unknown version"
+	} else {
+		version = "v" + strings.TrimPrefix(version, "v")
+	}
+	msg := fmt.Sprintf("installed and enabled (%s, pre_tool_call hook declared)", version)
+	if serveURL != "" {
+		msg += fmt.Sprintf("; serve reachable at %s", serveURL)
+	}
+	emit("Hermes Agent plugin", "ok", msg)
+	return 0
 }
 
 // doctorServer checks if rampart serve is running on defaultServePort.

--- a/cmd/rampart/cli/doctor_test.go
+++ b/cmd/rampart/cli/doctor_test.go
@@ -640,6 +640,51 @@ func TestDoctorCoverage_OpenClawOnlyNoClaude(t *testing.T) {
 	}
 }
 
+func TestDoctorHermesPluginEnabled(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+	t.Setenv("PATH", t.TempDir())
+	writeHermesRampartPluginFixture(t, home, "plugins:\n  enabled:\n    - rampart\n")
+
+	var results []checkResult
+	emit := func(name, status, msg string) {
+		results = append(results, checkResult{Name: name, Status: status, Message: msg})
+	}
+	warnings := doctorHermesPlugin(emit, "http://localhost:9090")
+	if warnings != 0 {
+		t.Fatalf("expected no warnings for enabled Hermes plugin, got %d (%+v)", warnings, results)
+	}
+	if len(results) != 1 || results[0].Name != "Hermes Agent plugin" || results[0].Status != "ok" {
+		t.Fatalf("expected ok Hermes Agent plugin check, got %+v", results)
+	}
+	if !strings.Contains(results[0].Message, "v1.2.0") || !strings.Contains(results[0].Message, "pre_tool_call") {
+		t.Fatalf("expected version and hook in message, got %q", results[0].Message)
+	}
+}
+
+func TestDoctorHermesPluginMissingWhenHermesDetected(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PATH shim binaries in this test are Unix-only")
+	}
+	home := t.TempDir()
+	testSetHome(t, home)
+	binDir := t.TempDir()
+	writeTestExecutable(t, filepath.Join(binDir, "hermes"))
+	t.Setenv("PATH", binDir)
+
+	var results []checkResult
+	emit := func(name, status, msg string) {
+		results = append(results, checkResult{Name: name, Status: status, Message: msg})
+	}
+	warnings := doctorHermesPlugin(emit, "http://localhost:9090")
+	if warnings != 1 {
+		t.Fatalf("expected one warning for missing Hermes plugin, got %d (%+v)", warnings, results)
+	}
+	if len(results) != 1 || results[0].Status != "warn" || !strings.Contains(results[0].Message, "not installed") {
+		t.Fatalf("expected missing-plugin warning, got %+v", results)
+	}
+}
+
 func TestDoctorOpenClawPlugin(t *testing.T) {
 	skipOnWindows(t, "PATH shim binaries in this test are Unix-only")
 

--- a/cmd/rampart/cli/status.go
+++ b/cmd/rampart/cli/status.go
@@ -27,6 +27,7 @@ import (
 	"github.com/peg/rampart/internal/build"
 	"github.com/peg/rampart/internal/engine"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 func newStatusCmd() *cobra.Command {
@@ -400,7 +401,102 @@ func detectProtectedAgents() []string {
 		agents = append(agents, "Codex (wrapper)")
 	}
 
+	// Hermes Agent user plugin installed by `rampart setup hermes`.
+	if state := detectHermesPluginStateForHome(home); state.Installed && state.Enabled && state.ManifestValid && state.HookDeclared {
+		agents = append(agents, "Hermes Agent (plugin)")
+	}
+
 	return agents
+}
+
+type hermesPluginState struct {
+	Installed     bool
+	Enabled       bool
+	ConfigPresent bool
+	ManifestValid bool
+	HookDeclared  bool
+	Version       string
+	PluginDir     string
+}
+
+type hermesPluginManifest struct {
+	Name          string   `yaml:"name"`
+	Version       string   `yaml:"version"`
+	ProvidesHooks []string `yaml:"provides_hooks"`
+}
+
+type hermesConfigFile struct {
+	Plugins hermesConfigPlugins `yaml:"plugins"`
+}
+
+type hermesConfigPlugins struct {
+	Enabled  []string                      `yaml:"enabled"`
+	Disabled []string                      `yaml:"disabled"`
+	Entries  map[string]hermesPluginConfig `yaml:"entries"`
+}
+
+type hermesPluginConfig struct {
+	Enabled *bool `yaml:"enabled"`
+}
+
+func detectHermesPluginState() hermesPluginState {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return hermesPluginState{}
+	}
+	return detectHermesPluginStateForHome(home)
+}
+
+func detectHermesPluginStateForHome(home string) hermesPluginState {
+	state := hermesPluginState{PluginDir: filepath.Join(home, ".hermes", "plugins", "rampart")}
+	manifestPath := filepath.Join(state.PluginDir, "plugin.yaml")
+	data, err := os.ReadFile(manifestPath)
+	if err == nil {
+		state.Installed = true
+		var manifest hermesPluginManifest
+		if yaml.Unmarshal(data, &manifest) == nil {
+			state.ManifestValid = strings.TrimSpace(manifest.Name) == "rampart"
+			state.Version = strings.TrimSpace(manifest.Version)
+			for _, hook := range manifest.ProvidesHooks {
+				if strings.TrimSpace(hook) == "pre_tool_call" {
+					state.HookDeclared = true
+					break
+				}
+			}
+		}
+	}
+
+	configPath := filepath.Join(home, ".hermes", "config.yaml")
+	configData, err := os.ReadFile(configPath)
+	if err != nil {
+		return state
+	}
+	state.ConfigPresent = true
+
+	var cfg hermesConfigFile
+	if yaml.Unmarshal(configData, &cfg) != nil {
+		return state
+	}
+	if stringListContains(cfg.Plugins.Disabled, "rampart") {
+		state.Enabled = false
+		return state
+	}
+	if stringListContains(cfg.Plugins.Enabled, "rampart") {
+		state.Enabled = true
+	}
+	if entry, ok := cfg.Plugins.Entries["rampart"]; ok && entry.Enabled != nil {
+		state.Enabled = *entry.Enabled
+	}
+	return state
+}
+
+func stringListContains(values []string, want string) bool {
+	for _, value := range values {
+		if strings.TrimSpace(value) == want {
+			return true
+		}
+	}
+	return false
 }
 
 func hasLegacyOpenClawBridgeConfig(data []byte) bool {

--- a/cmd/rampart/cli/status_test.go
+++ b/cmd/rampart/cli/status_test.go
@@ -189,6 +189,54 @@ func TestDetectProtectedAgents_IgnoresPlainCodexBinary(t *testing.T) {
 	}
 }
 
+func TestDetectProtectedAgents_HermesPluginEnabled(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+	writeHermesRampartPluginFixture(t, home, "plugins:\n  enabled:\n    - rampart\n")
+
+	found := false
+	for _, agent := range detectProtectedAgents() {
+		if agent == "Hermes Agent (plugin)" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected Hermes Agent plugin detection, got %v", detectProtectedAgents())
+	}
+}
+
+func TestDetectProtectedAgents_HermesPluginDisabled(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+	writeHermesRampartPluginFixture(t, home, "plugins:\n  enabled:\n    - rampart\n  disabled:\n    - rampart\n")
+
+	for _, agent := range detectProtectedAgents() {
+		if agent == "Hermes Agent (plugin)" {
+			t.Fatalf("disabled Hermes plugin should not be reported as protected: %v", agent)
+		}
+	}
+}
+
+func writeHermesRampartPluginFixture(t *testing.T, home, config string) {
+	t.Helper()
+	pluginDir := filepath.Join(home, ".hermes", "plugins", "rampart")
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manifest := "name: rampart\nversion: 1.2.0\nprovides_hooks:\n  - pre_tool_call\n"
+	if err := os.WriteFile(filepath.Join(pluginDir, "plugin.yaml"), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	configPath := filepath.Join(home, ".hermes", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestDetectProtectedAgents_OpenClawPluginRequiresAllowedAndEnabled(t *testing.T) {
 	home := t.TempDir()
 	testSetHome(t, home)


### PR DESCRIPTION
## Summary
- Detect an installed and enabled Rampart Hermes plugin in `rampart status`.
- Add a Hermes Agent plugin readiness check to `rampart doctor`.
- Cover enabled, disabled, and missing-plugin states with CLI tests.

## Tests
- `git diff --check`
- `go test ./...`
- `python3 -m unittest internal/plugin/hermes/test_hermes_plugin.py`
- `node --check scripts/test-openclaw-codex-native-audit.mjs`
- `node internal/plugin/openclaw/smoke-test.mjs`
- `node internal/plugin/openclaw/approval-regression.mjs`
- `node internal/plugin/openclaw/degraded-mode-test.mjs`
- `go test ./cmd/rampart/cli ./internal/plugin/hermes ./internal/plugin/openclaw ./internal/proxy`