### PR TITLE
fix: reuse Hermes plugin manifest type

### DIFF
--- a/cmd/rampart/cli/status.go
+++ b/cmd/rampart/cli/status.go
@@ -419,12 +419,6 @@ type hermesPluginState struct {
 	PluginDir     string
 }
 
-type hermesPluginManifest struct {
-	Name          string   `yaml:"name"`
-	Version       string   `yaml:"version"`
-	ProvidesHooks []string `yaml:"provides_hooks"`
-}
-
 type hermesConfigFile struct {
 	Plugins hermesConfigPlugins `yaml:"plugins"`
 }


### PR DESCRIPTION
## Summary
- Removes the duplicate Hermes plugin manifest type from status reporting.
- Reuses the package-level manifest type already added for Hermes doctor readiness checks.
- Restores staging CI after the compatibility-gate and Hermes doctor changes landed together.

## Tests
- `go test ./cmd/rampart/cli`
- `git diff --check`
- `go vet ./...`
- `go test ./...`