### PR TITLE
Fix release-blocking audit and Hermes checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,12 @@ permissions:
 
 jobs:
   test:
+    name: test (${{ matrix.os }})
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-2022]
-        go-version: ['1.25.10']
+        go-version: ['1.25.11']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -52,6 +53,7 @@ jobs:
         if: runner.os != 'Windows'
         run: |
           node internal/plugin/openclaw/smoke-test.mjs
+          node internal/plugin/openclaw/tool-alias-test.mjs
           node internal/plugin/openclaw/approval-regression.mjs
           node internal/plugin/openclaw/degraded-mode-test.mjs
 
@@ -148,7 +150,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.10'
+          go-version: '1.25.11'
 
       - name: GoReleaser snapshot (all platforms, no publish)
         uses: goreleaser/goreleaser-action@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.10"
+          go-version: "1.25.11"
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7

--- a/.github/workflows/upstream-compat.yml
+++ b/.github/workflows/upstream-compat.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.10'
+          go-version: '1.25.11'
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -39,8 +39,5 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Install latest OpenClaw
-        run: npm install -g openclaw@latest
-
       - name: Validate against latest OpenClaw
-        run: node scripts/compat-openclaw-latest.mjs
+        run: node scripts/compat-openclaw-latest.mjs --npm-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Audit chain recovery now resumes from the latest valid JSONL event** — Startup reconstruction recovers both the event count and chain head from existing audit logs instead of trusting absent, stale, or tampered anchors as the next `prev_hash` source.
 - **Partial audit verification is safer** — `rampart audit verify --since` accepts intentionally truncated history while continuing to verify the included hash chain and anchor data that is present in the selected window.
+- **Release builds use Go 1.25.11**: CI, release, Docker, and upstream compatibility gates now use the Go patch release that resolves the called standard-library vulnerabilities reported against Go 1.25.10.
 
 ## [1.1.1] - 2026-05-26
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # requested image platform so linux/arm64 releases don't depend on slow QEMU
 # emulation for the Go build itself.
 ARG BUILDPLATFORM
-FROM --platform=$BUILDPLATFORM golang:1.25.10-bookworm AS build
+FROM --platform=$BUILDPLATFORM golang:1.25.11-bookworm AS build
 WORKDIR /src
 
 ARG TARGETOS

--- a/cmd/rampart/cli/audit.go
+++ b/cmd/rampart/cli/audit.go
@@ -18,7 +18,6 @@ import (
 	"math"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 	"time"
 
@@ -144,6 +143,7 @@ a known break in the chain from a previous dev session).
 Example:
   rampart audit verify --since 2026-03-20`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			var sinceDate *time.Time
 			files, err := listAuditFiles(auditDir)
 			if err != nil {
 				return err
@@ -155,10 +155,11 @@ Example:
 			// Filter files by --since date if provided. Size-rotated files use
 			// YYYY-MM-DD.pN.jsonl names, so compare only the leading date.
 			if since != "" {
-				sinceDate, parseErr := time.Parse("2006-01-02", since)
+				parsedSinceDate, parseErr := time.Parse("2006-01-02", since)
 				if parseErr != nil {
 					return fmt.Errorf("audit: invalid --since date %q: expected YYYY-MM-DD format", since)
 				}
+				sinceDate = &parsedSinceDate
 				filtered := files[:0]
 				for _, f := range files {
 					base := filepath.Base(f)
@@ -172,7 +173,7 @@ Example:
 						filtered = append(filtered, f)
 						continue
 					}
-					if !fileDate.Before(sinceDate) {
+					if !fileDate.Before(*sinceDate) {
 						filtered = append(filtered, f)
 					}
 				}
@@ -187,7 +188,7 @@ Example:
 				return err
 			}
 
-			if err := verifyAnchors(auditDir, hashesByID, since == ""); err != nil {
+			if err := verifyAnchorsWithSince(auditDir, hashesByID, since == "", sinceDate); err != nil {
 				return err
 			}
 
@@ -386,7 +387,7 @@ func listAuditFiles(auditDir string) ([]string, error) {
 		}
 		files = append(files, filepath.Join(auditDir, entry.Name()))
 	}
-	sort.Strings(files)
+	audit.SortAuditFiles(files)
 	return files, nil
 }
 

--- a/cmd/rampart/cli/audit_helpers.go
+++ b/cmd/rampart/cli/audit_helpers.go
@@ -325,6 +325,10 @@ func verifyAnchors(auditDir string, hashesByID map[string]string, strictOpt ...b
 	if len(strictOpt) > 0 {
 		strict = strictOpt[0]
 	}
+	return verifyAnchorsWithSince(auditDir, hashesByID, strict, nil)
+}
+
+func verifyAnchorsWithSince(auditDir string, hashesByID map[string]string, strict bool, sinceDate *time.Time) error {
 	anchors, err := listAnchorFiles(auditDir)
 	if err != nil {
 		return err
@@ -346,7 +350,7 @@ func verifyAnchors(auditDir string, hashesByID map[string]string, strictOpt ...b
 
 		hash, ok := hashesByID[anchor.EventID]
 		if !ok {
-			if !strict {
+			if !strict && sinceDate != nil && anchorBeforeSince(anchor, *sinceDate) {
 				continue
 			}
 			return fmt.Errorf("audit: CHAIN BROKEN at event %s in file %s: anchor event not found", anchor.EventID, filepath.Base(anchorFile))
@@ -356,6 +360,25 @@ func verifyAnchors(auditDir string, hashesByID map[string]string, strictOpt ...b
 		}
 	}
 	return nil
+}
+
+func anchorBeforeSince(anchor audit.ChainAnchor, sinceDate time.Time) bool {
+	if !anchor.Timestamp.IsZero() {
+		return anchor.Timestamp.Before(sinceDate)
+	}
+	if anchor.File == "" {
+		return false
+	}
+	base := filepath.Base(anchor.File)
+	datePart := strings.TrimSuffix(base, ".jsonl")
+	if len(datePart) >= len("2006-01-02") {
+		datePart = datePart[:len("2006-01-02")]
+	}
+	fileDate, err := time.Parse("2006-01-02", datePart)
+	if err != nil {
+		return false
+	}
+	return fileDate.Before(sinceDate)
 }
 
 func listAnchorFiles(auditDir string) ([]string, error) {

--- a/cmd/rampart/cli/audit_test.go
+++ b/cmd/rampart/cli/audit_test.go
@@ -150,6 +150,50 @@ func TestAuditVerifySince_AllowsPartialChainAndSkippedAnchor(t *testing.T) {
 	assert.Contains(t, stdout, "no tampering detected")
 }
 
+func TestAuditVerifySince_FailsMissingAnchorInsideWindow(t *testing.T) {
+	dir := t.TempDir()
+
+	event := makeEvent("exec", "new", "main", "allow", "ok")
+	event.ID = audit.NewEventID()
+	event.Timestamp = time.Date(2026, 2, 9, 12, 0, 0, 0, time.UTC)
+	require.NoError(t, event.ComputeHash())
+
+	data, err := json.Marshal(event)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "2026-02-09.jsonl"), append(data, '\n'), 0o644))
+
+	anchor := audit.ChainAnchor{
+		EventID:    audit.NewEventID(),
+		Hash:       event.Hash,
+		EventCount: 1,
+		Timestamp:  event.Timestamp,
+		File:       "2026-02-09.jsonl",
+	}
+	anchorData, err := json.Marshal(anchor)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "audit-anchor.json"), anchorData, 0o644))
+
+	_, _, err = runCLI(t, "audit", "verify", "--audit-dir", dir, "--since", "2026-02-09")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "anchor event not found")
+}
+
+func TestListAuditFiles_SortsRotatedFilesNaturally(t *testing.T) {
+	dir := t.TempDir()
+	names := []string{"2026-02-13.jsonl", "2026-02-13.p1.jsonl", "2026-02-13.p2.jsonl", "2026-02-13.p10.jsonl"}
+	for _, name := range names {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), nil, 0o644))
+	}
+
+	files, err := listAuditFiles(dir)
+	require.NoError(t, err)
+	require.Len(t, files, len(names))
+
+	for i, file := range files {
+		assert.Equal(t, names[i], filepath.Base(file))
+	}
+}
+
 func TestAuditVerify_BrokenChain(t *testing.T) {
 	dir := t.TempDir()
 	events := make([]audit.Event, 5)

--- a/docs-site/getting-started/release-compatibility-gate.md
+++ b/docs-site/getting-started/release-compatibility-gate.md
@@ -46,7 +46,7 @@ Hermes Agent remains **experimental** until Hermes exposes a stable plugin appro
    - Install the candidate Rampart plugin into only that temporary Hermes plugin directory.
    - Enable only the temporary Hermes config.
    - Exercise the real Hermes plugin dispatcher, including plugin discovery and `pre_tool_call` hook registration.
-   - Prove deny blocks before execution, allow continues, `ask` blocks with an approval-required/no-resume message, and mutating tools fail closed when Rampart is unavailable.
+   - Prove deny blocks before execution, allow continues, `ask` blocks with an approval-required/no-resume message, Rampart auth failures fail closed for mutating tools, and mutating tools fail closed when Rampart is unavailable.
    - Do not restart or mutate a live Discord, Telegram, or other long-running Hermes gateway for this gate.
 
 5. **Run `rampart doctor` as a support-contract check**
@@ -65,10 +65,10 @@ The repository includes compatibility harnesses for latest upstream agent checks
 
 ```bash
 python scripts/compat-hermes-latest.py
-node scripts/compat-openclaw-latest.mjs
+node scripts/compat-openclaw-latest.mjs --npm-latest
 ```
 
-The Hermes harness installs or uses an isolated Hermes runtime and never touches the active gateway. The OpenClaw harness expects `openclaw` to be on `PATH`, uses a temporary home/state directory, and validates plugin installation plus the bundled plugin behavior checks.
+The Hermes harness installs or uses an isolated Hermes runtime and never touches the active gateway. The OpenClaw harness can run either the `openclaw` on `PATH` or `--npm-latest` for the latest npm package, uses a temporary home/state directory, and validates plugin installation plus the bundled plugin behavior checks.
 
 For OpenClaw's recommended support tier, also run the opt-in runtime audit regression before a release promotion:
 

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -211,6 +211,7 @@ verify -> outcomes.approval
 - **Hosted approval foundation** — Rampart can support host-owned approval flows without creating a second hidden Rampart approval queue, preserving a single user-facing approval owner.
 - **Experimental Hermes policy gate correlation** — Hermes tool-call metadata now reaches Rampart audit records so policy-gate decisions can be traced back to the originating Hermes tool call.
 - **Bundled plugin versions are coherent** — OpenClaw and experimental Hermes plugin manifests/runtime exports now report `1.2.0` alongside the Rampart release.
+- **Patched release toolchain**: CI, release, Docker, and upstream compatibility gates now use Go 1.25.11.
 
 ### v1.1
 

--- a/docs-site/integrations/openclaw.md
+++ b/docs-site/integrations/openclaw.md
@@ -12,7 +12,7 @@ When `rampart serve` is healthy, every supported tool call — exec, read, write
 For sensitive tools, the recommended operating assumption is simple: if Rampart policy service is unavailable, treat that as a broken state and fix it before trusting approval-path tests. By default the plugin blocks sensitive tools such as `exec` and `write` when `rampart serve` is unavailable; lower-risk tools (`read`, `web_fetch`, `web_search`, `image`) are explicitly configured fail-open and can be tightened with `plugins.entries.rampart.config.failOpenTools`.
 
 !!! info "Version requirements"
-    - **OpenClaw >= 2026.5.2**: Recommended 1.0 path. Supports explicit plugin startup activation plus first-class plugin approvals on the shared `/approve` / native approval path.
+    - **OpenClaw >= 2026.5.2**: Recommended current path. Supports explicit plugin startup activation plus first-class plugin approvals on the shared `/approve` / native approval path.
     - **OpenClaw 2026.4.29 - 2026.5.1**: Supported for native plugin startup/interception; plugin approval delivery was not the launch baseline.
     - **OpenClaw 2026.3.28 - 2026.4.28**: Native plugin works for tool enforcement, but Rampart's polished approval path is supported on newer OpenClaw builds.
     - **OpenClaw < 2026.3.28**: Legacy shim + bridge — exec-only coverage, requires re-patching after upgrades.
@@ -156,7 +156,7 @@ For end-to-end confidence, validate one case in each state:
 For release-candidate validation, run the latest-OpenClaw compatibility harness in a temporary state directory:
 
 ```bash
-node scripts/compat-openclaw-latest.mjs
+node scripts/compat-openclaw-latest.mjs --npm-latest
 ```
 
 That isolated harness validates plugin install/config and bundled plugin behavior. Before promoting a release that claims OpenClaw as recommended, also run the opt-in live runtime audit regression:

--- a/internal/audit/filename_sort.go
+++ b/internal/audit/filename_sort.go
@@ -1,0 +1,93 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package audit
+
+import (
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// SortAuditFiles sorts audit JSONL files in chronological rotation order.
+//
+// Size-rotated files are named YYYY-MM-DD.pN.jsonl. A plain lexicographic sort
+// places .p10 before .p2, which can replay and recover hash-chain state in the
+// wrong order. Unknown legacy filenames retain lexicographic fallback ordering.
+func SortAuditFiles(files []string) {
+	sort.SliceStable(files, func(i, j int) bool {
+		return compareAuditFile(files[i], files[j]) < 0
+	})
+}
+
+func compareAuditFile(a, b string) int {
+	ak, aok := auditFileSortKey(a)
+	bk, bok := auditFileSortKey(b)
+	if aok && bok {
+		if ak.date != bk.date {
+			return strings.Compare(ak.date, bk.date)
+		}
+		if ak.seq != bk.seq {
+			if ak.seq < bk.seq {
+				return -1
+			}
+			return 1
+		}
+	}
+
+	abase := filepath.Base(a)
+	bbase := filepath.Base(b)
+	if abase < bbase {
+		return -1
+	}
+	if abase > bbase {
+		return 1
+	}
+	return 0
+}
+
+type auditFileKey struct {
+	date string
+	seq  int
+}
+
+func auditFileSortKey(path string) (auditFileKey, bool) {
+	name := filepath.Base(path)
+	if !strings.HasSuffix(name, ".jsonl") {
+		return auditFileKey{}, false
+	}
+	stem := strings.TrimSuffix(name, ".jsonl")
+	if len(stem) < len("2006-01-02") {
+		return auditFileKey{}, false
+	}
+
+	date := stem[:len("2006-01-02")]
+	if _, err := time.Parse("2006-01-02", date); err != nil {
+		return auditFileKey{}, false
+	}
+
+	rest := stem[len("2006-01-02"):]
+	if rest == "" {
+		return auditFileKey{date: date, seq: 0}, true
+	}
+	if !strings.HasPrefix(rest, ".p") {
+		return auditFileKey{}, false
+	}
+	seq, err := strconv.Atoi(strings.TrimPrefix(rest, ".p"))
+	if err != nil || seq < 1 {
+		return auditFileKey{}, false
+	}
+	return auditFileKey{date: date, seq: seq}, true
+}

--- a/internal/audit/jsonl.go
+++ b/internal/audit/jsonl.go
@@ -21,7 +21,6 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -55,7 +54,7 @@ func recoverChainStateFromDir(dir string, logger *slog.Logger) recoveredChainSta
 		}
 		files = append(files, entry.Name())
 	}
-	sort.Strings(files)
+	SortAuditFiles(files)
 
 	var state recoveredChainState
 	for _, name := range files {

--- a/internal/audit/jsonl_test.go
+++ b/internal/audit/jsonl_test.go
@@ -450,6 +450,32 @@ func TestJSONLSink_RecoverAcrossDayFileContinuesHashChain(t *testing.T) {
 	assertLastEventPrevHash(t, sink2.filePath(), savedHash)
 }
 
+func TestJSONLSink_RecoverSortsRotatedFilesNaturally(t *testing.T) {
+	dir := t.TempDir()
+	names := []string{"2026-02-13.jsonl", "2026-02-13.p1.jsonl", "2026-02-13.p2.jsonl", "2026-02-13.p10.jsonl"}
+
+	prevHash := ""
+	var lastHash string
+	for i, name := range names {
+		event := sampleEvent("exec")
+		event.ID = NewEventID()
+		event.Timestamp = time.Date(2026, 2, 13, 12, i, 0, 0, time.UTC)
+		event.PrevHash = prevHash
+		require.NoError(t, event.ComputeHash())
+		prevHash = event.Hash
+		lastHash = event.Hash
+
+		data, err := json.Marshal(event)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), append(data, '\n'), 0o644))
+	}
+
+	state := recoverChainStateFromDir(dir, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	assert.EqualValues(t, len(names), state.eventCount)
+	assert.Equal(t, lastHash, state.lastHash)
+	assert.Equal(t, "2026-02-13.p10.jsonl", state.lastFile)
+}
+
 func TestJSONLSink_TamperedAnchorFallsBack(t *testing.T) {
 	dir := t.TempDir()
 

--- a/internal/plugin/hermes/__init__.py
+++ b/internal/plugin/hermes/__init__.py
@@ -425,7 +425,10 @@ def _decode_http_error(exc: urllib.error.HTTPError) -> dict[str, Any]:
     except json.JSONDecodeError:
         parsed = {}
     if isinstance(parsed, dict):
-        parsed.setdefault("message", body or f"Rampart returned HTTP {exc.code}")
+        message = parsed.get("message") or parsed.get("error") or body or f"Rampart returned HTTP {exc.code}"
+        parsed["decision"] = "deny"
+        parsed["allowed"] = False
+        parsed["message"] = str(message)
         return parsed
     return {"decision": "deny", "allowed": False, "message": body or f"Rampart returned HTTP {exc.code}"}
 
@@ -469,6 +472,8 @@ def _decision_from_result(result: Mapping[str, Any]) -> str:
     decision = result.get("decision")
     if isinstance(decision, str) and decision:
         return decision.lower()
+    if result.get("error"):
+        return "deny"
     if result.get("allowed") is False:
         return "deny"
     return "allow"

--- a/internal/plugin/hermes/test_hermes_plugin.py
+++ b/internal/plugin/hermes/test_hermes_plugin.py
@@ -150,6 +150,19 @@ class HermesPluginTests(unittest.TestCase):
         self.assertEqual(result["action"], "block")
         self.assertIn("unavailable", result["message"])
 
+    def test_auth_error_response_blocks_mutating_tool(self) -> None:
+        def requester(config, rampart_tool, payload):
+            return {"error": "invalid authorization token", "message": "invalid authorization token"}
+
+        result = plugin.evaluate_pre_tool_call(
+            "terminal",
+            {"command": "printf safe"},
+            requester=requester,
+        )
+
+        self.assertEqual(result["action"], "block")
+        self.assertIn("invalid authorization token", result["message"])
+
     def test_unavailable_allows_configured_read_only_tool(self) -> None:
         def requester(config, rampart_tool, payload):
             raise plugin.RampartUnavailable("connection refused")

--- a/scripts/compat-hermes-latest.py
+++ b/scripts/compat-hermes-latest.py
@@ -51,6 +51,7 @@ class RampartStub(BaseHTTPRequestHandler):
         }
         self.requests_seen.append(record)
 
+        status = 200
         if "rampart-deny-marker" in command:
             body = {
                 "decision": "deny",
@@ -65,6 +66,12 @@ class RampartStub(BaseHTTPRequestHandler):
                 "matched_policies": ["compat-ask"],
                 "audit_id": "compat-audit-ask",
             }
+        elif "rampart-auth-error-marker" in command:
+            status = 401
+            body = {
+                "error": "invalid authorization token",
+                "message": "invalid authorization token",
+            }
         else:
             body = {
                 "decision": "allow",
@@ -73,7 +80,7 @@ class RampartStub(BaseHTTPRequestHandler):
             }
 
         encoded = json.dumps(body).encode("utf-8")
-        self.send_response(200)
+        self.send_response(status)
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(encoded)))
         self.end_headers()
@@ -85,7 +92,7 @@ class RampartStub(BaseHTTPRequestHandler):
 
 
 def _marker_from_command(command: str) -> str:
-    for marker in ("rampart-deny-marker", "rampart-ask-marker", "rampart-allow-marker"):
+    for marker in ("rampart-deny-marker", "rampart-ask-marker", "rampart-allow-marker", "rampart-auth-error-marker"):
         if marker in command:
             return marker
     return ""
@@ -101,6 +108,19 @@ def run(cmd: list[str], *, env: dict[str, str] | None = None, cwd: Path = REPO_R
         stderr=subprocess.PIPE,
         check=True,
     )
+
+
+def resolve_executable(value: str) -> Path:
+    if not value:
+        raise ValueError("empty executable path")
+    if os.sep not in value and (os.altsep is None or os.altsep not in value):
+        found = shutil.which(value)
+        if found:
+            return Path(found)
+    path = Path(value).expanduser().resolve()
+    if not path.exists():
+        raise FileNotFoundError(f"executable not found: {value}")
+    return path
 
 
 def make_venv(root: Path, package: str) -> tuple[Path, Path]:
@@ -181,6 +201,10 @@ def child_probe_code(unused_port: int) -> str:
         if allow is not None:
             raise SystemExit(f'allow should continue without a block message: {{allow!r}}')
 
+        auth_error = block('terminal', {{'command': 'printf rampart-auth-error-marker'}}, 'compat-auth-error-call')
+        if not auth_error or 'invalid authorization token' not in auth_error:
+            raise SystemExit(f'auth error did not fail closed: {{auth_error!r}}')
+
         os.environ['RAMPART_HERMES_URL'] = 'http://127.0.0.1:{unused_port}'
         os.environ['RAMPART_HERMES_TIMEOUT_MS'] = '250'
         fail_closed = block('terminal', {{'command': 'printf rampart-fail-closed-marker'}}, 'compat-fail-closed-call')
@@ -199,6 +223,7 @@ def child_probe_code(unused_port: int) -> str:
             'deny_blocked': True,
             'ask_blocked_without_resume': True,
             'allow_continued': True,
+            'auth_error_fail_closed': True,
             'mutating_fail_closed': True,
             'configured_read_fail_open': True,
         }}, sort_keys=True))
@@ -217,9 +242,11 @@ def main() -> int:
     temp = Path(tempfile.mkdtemp(prefix="rampart-hermes-compat-"))
     try:
         if args.hermes_python:
-            hermes_python = Path(args.hermes_python).resolve()
-            hermes_bin = Path(args.hermes_bin).resolve() if args.hermes_bin else shutil.which("hermes")
-            hermes_bin_path = Path(hermes_bin) if hermes_bin else None
+            hermes_python = resolve_executable(args.hermes_python)
+            hermes_bin_path = resolve_executable(args.hermes_bin) if args.hermes_bin else None
+            if hermes_bin_path is None:
+                hermes_bin = shutil.which("hermes")
+                hermes_bin_path = Path(hermes_bin) if hermes_bin else None
         else:
             hermes_python, hermes_bin_path = make_venv(temp, args.package)
 
@@ -274,7 +301,7 @@ def main() -> int:
             if "/v1/preflight/exec" not in paths:
                 raise RuntimeError(f"expected /v1/preflight/exec request, saw {sorted(paths)}")
             markers = {entry["command_marker"] for entry in RampartStub.requests_seen}
-            expected = {"rampart-deny-marker", "rampart-ask-marker", "rampart-allow-marker"}
+            expected = {"rampart-deny-marker", "rampart-ask-marker", "rampart-allow-marker", "rampart-auth-error-marker"}
             if not expected.issubset(markers):
                 raise RuntimeError(f"expected request markers {sorted(expected)}, saw {sorted(markers)}")
 

--- a/scripts/compat-openclaw-latest.mjs
+++ b/scripts/compat-openclaw-latest.mjs
@@ -2,9 +2,10 @@
 /**
  * Validate Rampart's OpenClaw plugin against an isolated OpenClaw state.
  *
- * The script expects an `openclaw` executable on PATH. It sets HOME and
- * OPENCLAW_CONFIG_PATH to a temporary directory so plugin install/config checks
- * do not touch a live OpenClaw gateway or user config.
+ * By default the script expects an `openclaw` executable on PATH. Pass
+ * `--npm-latest` to run through `npm exec --package openclaw@latest` instead.
+ * It sets HOME and OPENCLAW_CONFIG_PATH to a temporary directory so plugin
+ * install/config checks do not touch a live OpenClaw gateway or user config.
  */
 
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
@@ -17,7 +18,11 @@ const tempRoot = mkdtempSync(join(tmpdir(), 'rampart-openclaw-compat-'));
 const tempHome = join(tempRoot, 'home');
 const openclawDir = join(tempHome, '.openclaw');
 const configPath = join(openclawDir, 'openclaw.json');
-const keepTemp = process.argv.includes('--keep-temp');
+const args = process.argv.slice(2);
+const keepTemp = args.includes('--keep-temp');
+const useNpmLatest = args.includes('--npm-latest');
+const openclawPackageArg = args.find((arg) => arg.startsWith('--openclaw-package='));
+const openclawPackage = openclawPackageArg ? openclawPackageArg.split('=', 2)[1] : 'openclaw@latest';
 
 function run(command, args, { required = true, env = compatEnv() } = {}) {
   const result = spawnSync(command, args, {
@@ -37,6 +42,13 @@ function run(command, args, { required = true, env = compatEnv() } = {}) {
     throw new Error(`command failed: ${detail}`);
   }
   return record;
+}
+
+function runOpenClaw(openclawArgs, options = {}) {
+  if (useNpmLatest) {
+    return run('npm', ['exec', '--yes', '--package', openclawPackage, '--', 'openclaw', ...openclawArgs], options);
+  }
+  return run('openclaw', openclawArgs, options);
 }
 
 function compatEnv() {
@@ -81,13 +93,13 @@ function main() {
   const env = compatEnv();
   const pluginDir = join(repoRoot, 'internal', 'plugin', 'openclaw');
 
-  const version = run('openclaw', ['--version'], { env });
-  const install = run('openclaw', ['plugins', 'install', pluginDir], { env });
-  const validate = run('openclaw', ['config', 'validate'], { env });
-  const inspect = run('openclaw', ['plugins', 'inspect', 'rampart'], { required: false, env });
+  const version = runOpenClaw(['--version'], { env });
+  const install = runOpenClaw(['plugins', 'install', pluginDir], { env });
+  const validate = runOpenClaw(['config', 'validate'], { env });
+  const inspect = runOpenClaw(['plugins', 'inspect', 'rampart'], { required: false, env });
   const list = inspect.status === 0
     ? { command: 'openclaw plugins list', status: 0, stdout: '', stderr: '' }
-    : run('openclaw', ['plugins', 'list'], { env });
+    : runOpenClaw(['plugins', 'list'], { env });
 
   const installedOutput = `${commandOutput(inspect)}\n${commandOutput(list)}\n${commandOutput(install)}`;
   if (!installedOutput.includes('rampart')) {
@@ -102,6 +114,7 @@ function main() {
     ok: true,
     temp_home: tempHome,
     openclaw_version: commandOutput(version).split('\n')[0],
+    openclaw_source: useNpmLatest ? openclawPackage : 'PATH',
     plugin_install_checked: true,
     config_validate_checked: validate.status === 0,
     plugin_inspect_checked: inspect.status === 0,

--- a/scripts/compat-openclaw-latest.mjs
+++ b/scripts/compat-openclaw-latest.mjs
@@ -107,6 +107,7 @@ function main() {
   }
 
   const smoke = run(process.execPath, ['internal/plugin/openclaw/smoke-test.mjs'], { env });
+  const toolAlias = run(process.execPath, ['internal/plugin/openclaw/tool-alias-test.mjs'], { env });
   const approvals = run(process.execPath, ['internal/plugin/openclaw/approval-regression.mjs'], { env });
   const degraded = run(process.execPath, ['internal/plugin/openclaw/degraded-mode-test.mjs'], { env });
 
@@ -121,6 +122,7 @@ function main() {
     plugin_list_checked: inspect.status !== 0 && list.status === 0,
     bundled_plugin_harnesses: {
       smoke: JSON.parse(smoke.stdout),
+      tool_alias: JSON.parse(toolAlias.stdout),
       approvals: JSON.parse(approvals.stdout),
       degraded: JSON.parse(degraded.stdout),
     },


### PR DESCRIPTION
## Summary
- fail closed for Hermes auth-error responses instead of treating error-only bodies as allow decisions
- tighten `audit verify --since` anchor verification so only anchors proven outside the selected window are skipped
- sort rotated audit files by date and numeric `.pN` suffix for recovery and CLI verification
- refresh release compatibility harnesses/docs for latest Hermes/OpenClaw checks, including Hermes auth-error fail-closed coverage, OpenClaw tool-alias coverage, and latest OpenClaw via npm
- update CI, release, Docker, and upstream compatibility gates to Go 1.25.11 and stabilize CI test job names

## Validation
- GitHub CI run `26989880335`: all jobs passed
- `git diff --check`
- `go vet ./...`
- `go test -count=1 ./...`
- `go test -race -count=1 ./internal/proxy`
- `go build -v ./cmd/rampart`
- `go1.25.11 vet ./...`
- `go1.25.11 test -count=1 ./...`
- `go1.25.11 run golang.org/x/vuln/cmd/govulncheck@v1.3.0 ./...` (0 called vulnerabilities)
- `python -m unittest internal/plugin/hermes/test_hermes_plugin.py`
- `python scripts/compat-hermes-latest.py` (Hermes Agent v0.15.2, plugin v1.2.0, deny/ask/allow/auth-error/fail-closed/fail-open checks passed)
- `node scripts/compat-openclaw-latest.mjs --npm-latest` (OpenClaw 2026.6.1, plugin install/config/tool-alias harness checks passed)
- `npm exec --yes --package openclaw@latest -- node scripts/test-openclaw-codex-native-audit.mjs --yes` (OpenClaw 2026.6.1 CLI path, Codex native `bash` trajectory and Rampart canonical `exec` audit correlation passed)
- `node internal/plugin/openclaw/smoke-test.mjs`
- `node internal/plugin/openclaw/tool-alias-test.mjs`
- `node internal/plugin/openclaw/approval-regression.mjs`
- `node internal/plugin/openclaw/degraded-mode-test.mjs`
- `mkdocs build --strict`
