### PR TITLE
test: add OpenClaw provider surface replay

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
         run: |
           node internal/plugin/openclaw/smoke-test.mjs
           node internal/plugin/openclaw/tool-alias-test.mjs
+          node internal/plugin/openclaw/provider-surface-replay.mjs
           node internal/plugin/openclaw/approval-regression.mjs
           node internal/plugin/openclaw/degraded-mode-test.mjs
 

--- a/internal/plugin/openclaw/README.md
+++ b/internal/plugin/openclaw/README.md
@@ -15,6 +15,7 @@ node internal/plugin/openclaw/smoke-test.mjs
 node internal/plugin/openclaw/approval-regression.mjs
 node internal/plugin/openclaw/degraded-mode-test.mjs
 node internal/plugin/openclaw/tool-alias-test.mjs
+node internal/plugin/openclaw/provider-surface-replay.mjs
 ```
 
 Default behavior simulates:
@@ -50,6 +51,7 @@ Arguments:
 - degraded mode blocks sensitive tools (`exec`, `write`) when serve is unreachable or returns 5xx
 - configured fail-open tools (`read`, `web_fetch`, `web_search`, `image` by default) remain explicit and test-covered
 - command-execution aliases such as OpenClaw `bash` map to Rampart `exec` for policy checks, learning, and audit events
+- provider-surface replay covers canonical `exec`, nested `input.command`, command aliases, file tools, hosted approval, auth-error fail-closed behavior, audit normalization, and degraded sensitive-tool blocking
 
 This is a deterministic harness for the highest-leverage plugin regression: approval-path behavior without depending on model tool selection.
 

--- a/internal/plugin/openclaw/index.js
+++ b/internal/plugin/openclaw/index.js
@@ -123,6 +123,14 @@ function normalizeExecParams(params) {
 function normalizeToolCall(toolName, params) {
   const originalToolName = typeof toolName === "string" && toolName ? toolName : "unknown";
   const canonical = originalToolName.toLowerCase();
+  if (canonical === "exec") {
+    return {
+      toolName: "exec",
+      params: normalizeExecParams(params),
+      originalToolName,
+      mapped: originalToolName !== "exec",
+    };
+  }
   if (EXEC_TOOL_ALIASES.has(canonical)) {
     return {
       toolName: "exec",

--- a/internal/plugin/openclaw/provider-surface-replay.mjs
+++ b/internal/plugin/openclaw/provider-surface-replay.mjs
@@ -33,6 +33,15 @@ function parseBody(call) {
   return JSON.parse(call.opts.body);
 }
 
+async function waitFor(predicate, message, { timeoutMs = 250, intervalMs = 5 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() <= deadline) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  throw new Error(message);
+}
+
 function fetchJson(result) {
   return { ok: true, status: 200, json: async () => result, text: async () => JSON.stringify(result) };
 }
@@ -156,7 +165,10 @@ await withPlugin({
     const after = handlers.after_tool_call;
     assert(typeof after === 'function', 'after_tool_call handler missing');
     await after({ toolName: 'terminal', params: { args: { command: 'echo audited-provider' } }, durationMs: 5 }, ctx);
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await waitFor(
+      () => auditCalls.some((call) => call.url.includes('/v1/audit')),
+      'audit endpoint not called',
+    );
   },
 });
 const auditCall = auditCalls.find((call) => call.url.includes('/v1/audit'));

--- a/internal/plugin/openclaw/provider-surface-replay.mjs
+++ b/internal/plugin/openclaw/provider-surface-replay.mjs
@@ -1,0 +1,181 @@
+import plugin from './index.js';
+
+const ctx = {
+  agentId: 'main',
+  sessionKey: 'agent:main:provider-surface',
+  runId: 'provider-surface-run',
+};
+
+function createApi(pluginConfig = {}) {
+  const handlers = {};
+  const logs = [];
+  return {
+    handlers,
+    logs,
+    api: {
+      pluginConfig,
+      logger: {
+        info: (...a) => logs.push(['info', a.join(' ')]),
+        warn: (...a) => logs.push(['warn', a.join(' ')]),
+        debug: (...a) => logs.push(['debug', a.join(' ')]),
+      },
+      on: (name, fn) => { handlers[name] = fn; },
+      registerGatewayMethod: () => {},
+    },
+  };
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function parseBody(call) {
+  return JSON.parse(call.opts.body);
+}
+
+function fetchJson(result) {
+  return { ok: true, status: 200, json: async () => result, text: async () => JSON.stringify(result) };
+}
+
+async function withPlugin({ name, fetchImpl, pluginConfig = {}, invoke }) {
+  const { api, handlers, logs } = createApi(pluginConfig);
+  const originalFetch = global.fetch;
+  global.fetch = fetchImpl;
+  try {
+    plugin.register(api);
+    return await invoke({ handlers, logs });
+  } catch (err) {
+    err.message = `${name}: ${err.message}`;
+    throw err;
+  } finally {
+    global.fetch = originalFetch;
+  }
+}
+
+async function runPolicyScenario({ name, event, expectedTool, expectedCommand, response = { decision: 'allow' }, assertResult }) {
+  const calls = [];
+  const result = await withPlugin({
+    name,
+    fetchImpl: async (url, opts = {}) => {
+      calls.push({ url: String(url), opts });
+      assert(String(url).includes(`/v1/tool/${encodeURIComponent(expectedTool)}`), `expected /v1/tool/${expectedTool}, got ${url}`);
+      return fetchJson(response);
+    },
+    invoke: async ({ handlers }) => {
+      const before = handlers.before_tool_call;
+      assert(typeof before === 'function', 'before_tool_call handler missing');
+      return await before(event, ctx);
+    },
+  });
+
+  assert(calls.length === 1, `expected one policy call, got ${calls.length}`);
+  const body = parseBody(calls[0]);
+  assert(body.openclaw_hosted === true, 'expected openclaw_hosted=true');
+  assert(body.skip_pending_approval === true, 'expected skip_pending_approval=true');
+  if (expectedCommand !== undefined) {
+    assert(body.params.command === expectedCommand, `expected command ${expectedCommand}, got ${JSON.stringify(body.params)}`);
+  }
+  if (assertResult) assertResult(result, body);
+  return { result, body };
+}
+
+const scenarios = [];
+
+await runPolicyScenario({
+  name: 'canonical-exec-flat-command',
+  event: { toolName: 'exec', params: { command: 'echo flat-provider' } },
+  expectedTool: 'exec',
+  expectedCommand: 'echo flat-provider',
+});
+scenarios.push('canonical-exec-flat-command');
+
+await runPolicyScenario({
+  name: 'canonical-exec-nested-input-command',
+  event: { toolName: 'exec', params: { input: { command: 'echo nested-provider' } } },
+  expectedTool: 'exec',
+  expectedCommand: 'echo nested-provider',
+});
+scenarios.push('canonical-exec-nested-input-command');
+
+for (const [name, toolName, params, expectedCommand] of [
+  ['bash-cmd-alias', 'bash', { cmd: 'echo bash-provider' }, 'echo bash-provider'],
+  ['shell-script-alias', 'shell', { script: 'echo shell-provider' }, 'echo shell-provider'],
+  ['terminal-args-command-alias', 'terminal', { args: { command: 'echo terminal-provider' } }, 'echo terminal-provider'],
+]) {
+  await runPolicyScenario({
+    name,
+    event: { toolName, params },
+    expectedTool: 'exec',
+    expectedCommand,
+  });
+  scenarios.push(name);
+}
+
+await runPolicyScenario({
+  name: 'read-tool-policy-surface',
+  event: { toolName: 'read', params: { path: '/tmp/provider-fixture.txt' } },
+  expectedTool: 'read',
+});
+scenarios.push('read-tool-policy-surface');
+
+const ask = await runPolicyScenario({
+  name: 'write-tool-hosted-approval',
+  event: { toolName: 'write', params: { path: '/tmp/provider-fixture.txt', content: 'fixture' } },
+  expectedTool: 'write',
+  response: { decision: 'ask', policy: 'provider-fixture', message: 'write requires approval', severity: 'warning' },
+  assertResult: (result) => {
+    assert(result?.requireApproval, 'expected requireApproval for ask decision');
+    assert(result.requireApproval.title.includes('write approval required'), `unexpected approval title: ${result.requireApproval.title}`);
+    assert(result.requireApproval.description.includes('/tmp/provider-fixture.txt'), 'approval description should include path');
+  },
+});
+assert(ask.result.requireApproval.timeoutBehavior === 'deny', 'approval should deny on timeout');
+scenarios.push('write-tool-hosted-approval');
+
+const authError = await withPlugin({
+  name: 'auth-error-fail-closed',
+  fetchImpl: async () => ({ ok: false, status: 401, text: async () => '{"error":"invalid token"}' }),
+  invoke: async ({ handlers }) => {
+    const before = handlers.before_tool_call;
+    assert(typeof before === 'function', 'before_tool_call handler missing');
+    return await before({ toolName: 'exec', params: { command: 'sudo id' } }, ctx);
+  },
+});
+assert(authError?.block === true, '401 auth error should block sensitive tool calls');
+assert(authError.blockReason.includes('HTTP 401'), `auth block reason should mention HTTP 401: ${authError.blockReason}`);
+scenarios.push('auth-error-fail-closed');
+
+const auditCalls = [];
+await withPlugin({
+  name: 'after-tool-audit-canonical-exec',
+  fetchImpl: async (url, opts = {}) => {
+    auditCalls.push({ url: String(url), opts });
+    return fetchJson({ ok: true });
+  },
+  invoke: async ({ handlers }) => {
+    const after = handlers.after_tool_call;
+    assert(typeof after === 'function', 'after_tool_call handler missing');
+    await after({ toolName: 'terminal', params: { args: { command: 'echo audited-provider' } }, durationMs: 5 }, ctx);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  },
+});
+const auditCall = auditCalls.find((call) => call.url.includes('/v1/audit'));
+assert(auditCall, 'audit endpoint not called');
+const auditBody = parseBody(auditCall);
+assert(auditBody.tool === 'exec', `expected canonical audit tool exec, got ${auditBody.tool}`);
+assert(auditBody.params.command === 'echo audited-provider', `expected normalized audit command, got ${JSON.stringify(auditBody.params)}`);
+scenarios.push('after-tool-audit-canonical-exec');
+
+const degraded = await withPlugin({
+  name: 'degraded-sensitive-exec-blocks',
+  fetchImpl: async () => { throw new TypeError('fetch failed', { cause: { code: 'ECONNREFUSED' } }); },
+  invoke: async ({ handlers }) => handlers.before_tool_call(
+    { toolName: 'exec', params: { command: 'sudo true' } },
+    ctx,
+  ),
+});
+assert(degraded?.block === true, 'degraded exec should fail closed');
+assert(degraded.blockReason.includes('policy service down'), `unexpected degraded block reason: ${degraded.blockReason}`);
+scenarios.push('degraded-sensitive-exec-blocks');
+
+console.log(JSON.stringify({ ok: true, scenarios }, null, 2));

--- a/internal/plugin/openclaw/tool-alias-test.mjs
+++ b/internal/plugin/openclaw/tool-alias-test.mjs
@@ -27,6 +27,15 @@ function parseBody(call) {
   return JSON.parse(call.opts.body);
 }
 
+async function waitFor(predicate, message, { timeoutMs = 250, intervalMs = 5 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() <= deadline) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  throw new Error(message);
+}
+
 async function runWithFetch({ name, fetchImpl, pluginConfig = {}, invoke }) {
   const { api, handlers, logs } = createApi(pluginConfig);
   const originalFetch = global.fetch;
@@ -128,7 +137,10 @@ await runWithFetch({
       sessionKey: 'agent:main:test',
       runId: 'bash-after-run',
     });
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await waitFor(
+      () => auditCalls.some((call) => call.url.includes('/v1/audit')),
+      'audit endpoint not called',
+    );
   },
 });
 const auditCall = auditCalls.find((call) => call.url.includes('/v1/audit'));

--- a/scripts/compat-openclaw-latest.mjs
+++ b/scripts/compat-openclaw-latest.mjs
@@ -108,6 +108,7 @@ function main() {
 
   const smoke = run(process.execPath, ['internal/plugin/openclaw/smoke-test.mjs'], { env });
   const toolAlias = run(process.execPath, ['internal/plugin/openclaw/tool-alias-test.mjs'], { env });
+  const providerSurface = run(process.execPath, ['internal/plugin/openclaw/provider-surface-replay.mjs'], { env });
   const approvals = run(process.execPath, ['internal/plugin/openclaw/approval-regression.mjs'], { env });
   const degraded = run(process.execPath, ['internal/plugin/openclaw/degraded-mode-test.mjs'], { env });
 
@@ -123,6 +124,7 @@ function main() {
     bundled_plugin_harnesses: {
       smoke: JSON.parse(smoke.stdout),
       tool_alias: JSON.parse(toolAlias.stdout),
+      provider_surface: JSON.parse(providerSurface.stdout),
       approvals: JSON.parse(approvals.stdout),
       degraded: JSON.parse(degraded.stdout),
     },


### PR DESCRIPTION
## Summary
- Adds an OpenClaw provider surface replay harness for canonical exec, alias tools, read/write hooks, audit normalization, auth failures, and degraded-mode blocking.
- Promotes nested `params.input.command` into canonical exec parameters before Rampart policy and audit calls.
- Runs the replay harness in OpenClaw CI and the latest-OpenClaw compatibility script.
- Stabilizes async audit replay assertions so CI waits for best-effort audit calls before restoring mocked fetch state.

## Tests
- `node internal/plugin/openclaw/smoke-test.mjs`
- `node internal/plugin/openclaw/tool-alias-test.mjs`
- `node internal/plugin/openclaw/provider-surface-replay.mjs`
- `node internal/plugin/openclaw/approval-regression.mjs`
- `node internal/plugin/openclaw/degraded-mode-test.mjs`
- `30/30 tool-alias + provider-surface passed with temp HOME`
- `git diff --check origin/staging...HEAD`
- `node scripts/compat-openclaw-latest.mjs --npm-latest`
