### PR TITLE
chore: update Go toolchain to 1.25.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-2022]
-        go-version: ['1.25.11']
+        go-version: ['1.25.12']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -151,7 +151,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.11'
+          go-version: '1.25.12'
 
       - name: GoReleaser snapshot (all platforms, no publish)
         uses: goreleaser/goreleaser-action@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.11"
+          go-version: "1.25.12"
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7

--- a/.github/workflows/upstream-compat.yml
+++ b/.github/workflows/upstream-compat.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.11'
+          go-version: '1.25.12'
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Release and source-build toolchains use Go 1.25.12** — The module baseline, CI, GoReleaser, Docker, and upstream compatibility workflows now use the patched Go release required for a clean reachable-vulnerability scan.
+
 ## [1.2.0] - 2026-05-28
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # requested image platform so linux/arm64 releases don't depend on slow QEMU
 # emulation for the Go build itself.
 ARG BUILDPLATFORM
-FROM --platform=$BUILDPLATFORM golang:1.25.11-bookworm AS build
+FROM --platform=$BUILDPLATFORM golang:1.25.12-bookworm AS build
 WORKDIR /src
 
 ARG TARGETOS

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **A firewall for AI coding agents.**
 
-[![Go](https://img.shields.io/badge/Go-1.24+-00ADD8?style=flat&logo=go)](https://go.dev)
+[![Go](https://img.shields.io/badge/Go-1.25.12+-00ADD8?style=flat&logo=go)](https://go.dev)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![CI](https://github.com/peg/rampart/actions/workflows/ci.yml/badge.svg)](https://github.com/peg/rampart/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/peg/rampart?style=flat)](https://github.com/peg/rampart/releases)
@@ -29,7 +29,7 @@ brew install peg/tap/rampart
 # One-line install (no sudo required)
 curl -fsSL https://rampart.sh/install | bash
 
-# Go install (requires Go 1.24+)
+# Go install (requires Go 1.25.12+)
 go install github.com/peg/rampart/cmd/rampart@latest
 ```
 
@@ -638,7 +638,7 @@ go build -o rampart ./cmd/rampart
 go test ./...
 ```
 
-Requires Go 1.24+.
+Requires Go 1.25.12+.
 
 ---
 

--- a/docs-site/contributing.md
+++ b/docs-site/contributing.md
@@ -15,7 +15,7 @@ cd rampart
 go test ./...
 ```
 
-Requires Go 1.24+.
+Requires Go 1.25.12+.
 
 ## Workflow
 

--- a/docs-site/getting-started/installation.md
+++ b/docs-site/getting-started/installation.md
@@ -43,7 +43,7 @@ This installs the `rampart` binary.
 
 ## Go Install
 
-Requires Go 1.24+:
+Requires Go 1.25.12+:
 
 ```bash
 go install github.com/peg/rampart/cmd/rampart@latest

--- a/docs-site/getting-started/tutorial.md
+++ b/docs-site/getting-started/tutorial.md
@@ -16,7 +16,7 @@ Let's set it up.
 ## Prerequisites
 
 - **macOS or Linux** (Windows WSL works too)
-- **Go 1.24+** (recommended) or the install script for a no-Go option
+- **Go 1.25.12+** (recommended) or the install script for a no-Go option
 - **Claude Code, Codex, or Cline** — this guide uses Claude Code, but Rampart works with [many agents](../integrations/index.md)
 
 ---

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/peg/rampart
 
-go 1.24.2
+go 1.25.12
 
 require (
 	github.com/charmbracelet/bubbletea v1.3.10


### PR DESCRIPTION
## Summary
- update the module, CI, release, upstream compatibility, and Docker build toolchains to Go 1.25.12
- align current source-build documentation with the minimum toolchain
- record the toolchain security baseline in the Unreleased changelog

## Validation
- full Go tests and race tests
- vet and build
- govulncheck: 0 reachable vulnerabilities
- strict documentation build
- Docker build and container version smoke
- OpenClaw 2026.6.11 isolated compatibility harnesses
- Hermes regression suite
- targeted Claude Code, Codex, hook, and preload tests