### PR TITLE
fix: prevent Windows token ACL lockouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,24 @@ jobs:
       - name: Build
         run: go build -v ./cmd/rampart
 
+      - name: PowerShell installers parse
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          foreach ($file in @("install.ps1", "docs/install.ps1")) {
+            $tokens = $null
+            $errors = $null
+            [System.Management.Automation.Language.Parser]::ParseFile(
+              (Resolve-Path $file),
+              [ref]$tokens,
+              [ref]$errors
+            ) | Out-Null
+            if ($errors.Count -gt 0) {
+              $errors | ForEach-Object { Write-Error "$file`: $_" }
+              exit 1
+            }
+          }
+
       - name: Installer scripts are synced
         if: runner.os == 'Linux'
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.3.0] - 2026-07-24
 
+> **Windows upgrade guidance:** If you installed Rampart 1.2.x on Windows, rerun the official PowerShell installer:
+> `irm https://rampart.sh/install.ps1 | iex`. The installer repairs the affected legacy `~\.rampart` ACL before replacing the binary. Do not rely on `rampart upgrade` if Windows cannot execute `rampart.exe` from the locked directory.
+
 ### Added
 
 - **Zero-configuration OpenClaw protection** — `rampart protect openclaw` installs managed Guard and OpenClaw policies, enables the bundled native plugin, starts the local policy service, configures fail-closed degraded behavior, restarts the gateway, and verifies the boundary with safe behavioral canaries.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.3.0] - 2026-07-22
+## [1.3.0] - 2026-07-24
 
 ### Added
 
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Windows token hardening cannot lock domain or AzureAD users out of Rampart** — Token ACLs now use the current process SID through native Windows security APIs, protect only the token file, and fail setup safely if hardening cannot be applied.
 - **OpenClaw policy responses fail closed** — Malformed, empty, array, or unknown policy responses block the tool call instead of silently becoming an allow decision.
 - **Rampart tokens stay on the loopback trust boundary** — Managed OpenClaw configuration forces the local policy URL, and the plugin refuses to send its admin token to non-loopback endpoints.
 - **Managed policies are loaded before enforcement and hot-reload correctly** — Fresh protection no longer starts with only one managed layer, and `rampart serve` now reloads YAML files created, replaced, renamed, or removed in the policy directory.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ go install github.com/peg/rampart/cmd/rampart@latest
 irm https://rampart.sh/install.ps1 | iex
 ```
 
+> **Upgrading from Rampart 1.2.x on Windows?** Rerun the PowerShell installer above. It repairs the affected legacy `~\.rampart` ACL before replacing the binary. If that directory is locked, `rampart upgrade` may be unable to start and cannot perform the repair itself.
+
 For an unattended OpenClaw agent, the zero-configuration path is:
 
 ```bash

--- a/cmd/rampart/cli/hook.go
+++ b/cmd/rampart/cli/hook.go
@@ -230,6 +230,13 @@ Claude Code setup (add to ~/.claude/settings.json):
 
 Cline setup: Use "rampart setup cline" to install hooks automatically.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := ensureDefaultRampartDirAccessible(); err != nil {
+				if mode == "enforce" {
+					return outputHookResult(cmd, format, hookDeny, false, "Rampart data directory is inaccessible; refusing tool call until permissions are repaired", "")
+				}
+				return fmt.Errorf("hook: prepare Rampart data directory: %w", err)
+			}
+
 			// Derive session identity once at the top (git repo/branch or RAMPART_SESSION env).
 			gitCtx := deriveGitContext()
 			hookSession := gitCtx.session

--- a/cmd/rampart/cli/paths.go
+++ b/cmd/rampart/cli/paths.go
@@ -22,3 +22,11 @@ func rampartDir() (string, error) {
 	}
 	return filepath.Join(home, ".rampart"), nil
 }
+
+func ensureDefaultRampartDirAccessible() error {
+	dir, err := rampartDir()
+	if err != nil {
+		return err
+	}
+	return ensureRampartDirAccessible(dir)
+}

--- a/cmd/rampart/cli/protect.go
+++ b/cmd/rampart/cli/protect.go
@@ -36,6 +36,9 @@ behavior, and verifies the live boundary with non-destructive canaries.
 OpenClaw is the first fully supported zero-configuration target.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := ensureDefaultRampartDirAccessible(); err != nil {
+				return fmt.Errorf("protect: prepare Rampart data directory: %w", err)
+			}
 			target := ""
 			if len(args) == 1 {
 				target = strings.ToLower(strings.TrimSpace(args[0]))

--- a/cmd/rampart/cli/serve.go
+++ b/cmd/rampart/cli/serve.go
@@ -57,15 +57,6 @@ func printServeToken(w io.Writer, token string, interactive bool) {
 	fmt.Fprintln(w, "  🔑 Token      : saved to ~/.rampart/token")
 }
 
-func printPersistTokenWarning(w io.Writer, err error, token string, interactive bool) {
-	fmt.Fprintf(w, "⚠ Warning: could not save token to ~/.rampart/token: %v\n", err)
-	if interactive {
-		fmt.Fprintf(w, "  Run: echo '%s' > ~/.rampart/token\n", token)
-		return
-	}
-	fmt.Fprintln(w, "  Token not printed because stderr is not an interactive terminal.")
-}
-
 func defaultServeDeps() serveDeps {
 	return serveDeps{
 		newWatcher:    fsnotify.NewWatcher,
@@ -105,6 +96,12 @@ func newServeCmd(opts *rootOptions, deps *serveDeps) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "serve",
 		Short: "Start Rampart policy runtime and file watcher",
+		PreRunE: func(_ *cobra.Command, _ []string) error {
+			if err := ensureDefaultRampartDirAccessible(); err != nil {
+				return fmt.Errorf("serve: prepare Rampart data directory: %w", err)
+			}
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if background {
 				home, err := os.UserHomeDir()
@@ -429,6 +426,13 @@ func newServeCmd(opts *rootOptions, deps *serveDeps) *cobra.Command {
 				}
 				listenPort := listener.Addr().(*net.TCPAddr).Port
 
+				// Persist before reporting readiness or starting the server.
+				// Hooks cannot authenticate safely without the shared token.
+				if err := persistToken(token); err != nil {
+					_ = listener.Close()
+					return fmt.Errorf("serve: persist token: %w", err)
+				}
+
 				// Stop the startup spinner and print a clean ready message.
 				if startSpin != nil {
 					startSpin.Stop(fmt.Sprintf("Rampart ready  —  :%d (token=%s)", listenPort, display))
@@ -446,11 +450,6 @@ func newServeCmd(opts *rootOptions, deps *serveDeps) *cobra.Command {
 				fmt.Fprintf(cmd.ErrOrStderr(), "  🌐 Dashboard  : %s://localhost:%d/dashboard/\n", scheme, listenPort)
 				if tlsCfg != nil && tlsFingerprint != "" {
 					fmt.Fprintf(cmd.ErrOrStderr(), "  🔒 TLS        : sha256:%s\n", tlsFingerprint[:23]+"...")
-				}
-
-				// Persist the token so it survives restarts.
-				if err := persistToken(token); err != nil {
-					printPersistTokenWarning(cmd.ErrOrStderr(), err, token, interactiveStderr)
 				}
 
 				if metrics {

--- a/cmd/rampart/cli/serve_install.go
+++ b/cmd/rampart/cli/serve_install.go
@@ -18,7 +18,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"html/template"
-	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -137,7 +136,8 @@ func tokenFilePath() (string, error) {
 }
 
 // persistToken writes the token to ~/.rampart/token with owner-only permissions.
-// On Unix: 0600. On Windows: ACL granting GENERIC_ALL to owner only.
+// It secures a temporary file before writing the token, then atomically replaces
+// the destination so a hardening failure cannot expose or destroy a valid token.
 func persistToken(token string) error {
 	p, err := tokenFilePath()
 	if err != nil {
@@ -148,14 +148,31 @@ func persistToken(token string) error {
 		return err
 	}
 	if err := secureDirPermissions(dir); err != nil {
-		slog.Debug("could not secure directory permissions", "path", dir, "error", err)
+		return fmt.Errorf("secure token directory: %w", err)
 	}
-	if err := os.WriteFile(p, []byte(token), 0o600); err != nil {
-		return err
+
+	f, err := os.CreateTemp(dir, ".token-*")
+	if err != nil {
+		return fmt.Errorf("create temporary token file: %w", err)
 	}
-	if err := secureFilePermissions(p); err != nil {
-		slog.Debug("could not secure file permissions", "path", p, "error", err)
+	tmpPath := f.Name()
+	defer os.Remove(tmpPath)
+
+	if err := secureFilePermissions(tmpPath); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("secure temporary token file: %w", err)
 	}
+	if _, err := f.WriteString(token); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("write temporary token file: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close temporary token file: %w", err)
+	}
+	if err := os.Rename(tmpPath, p); err != nil {
+		return fmt.Errorf("replace token file: %w", err)
+	}
+
 	return nil
 }
 

--- a/cmd/rampart/cli/serve_install.go
+++ b/cmd/rampart/cli/serve_install.go
@@ -16,6 +16,7 @@ package cli
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"html/template"
 	"os"
@@ -144,8 +145,11 @@ func persistToken(token string) error {
 		return err
 	}
 	dir := filepath.Dir(p)
+	if err := ensureRampartDirAccessible(dir); err != nil {
+		return fmt.Errorf("prepare token directory: %w", err)
+	}
 	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return err
+		return fmt.Errorf("create token directory: %w", err)
 	}
 	if err := secureDirPermissions(dir); err != nil {
 		return fmt.Errorf("secure token directory: %w", err)
@@ -329,11 +333,8 @@ func installDarwin(cmd *cobra.Command, cfg serviceConfig, force, generated bool,
 		return nil
 	}
 
-	// Unload any existing service before writing new plist.
-	// Best-effort: ignore errors if the service wasn't loaded.
-	if _, err := os.Stat(path); err == nil {
-		_, _ = runner("launchctl", "unload", path).CombinedOutput()
-	}
+	_, existingErr := os.Stat(path)
+	serviceExists := existingErr == nil
 
 	content, err := generatePlist(cfg)
 	if err != nil {
@@ -354,13 +355,26 @@ func installDarwin(cmd *cobra.Command, cfg serviceConfig, force, generated bool,
 	}
 	_ = os.Chmod(path, 0o600)
 
+	// Stop before rotating the shared token. Otherwise an old process can keep
+	// authenticating with the previous token while hooks read the new one.
+	if serviceExists {
+		// A plist can exist while the job is already unloaded. Only unload a
+		// job launchctl reports as loaded; a real unload failure is fatal.
+		loaded, err := launchctlServiceLoaded(runner)
+		if err != nil {
+			return err
+		}
+		if loaded {
+			if out, err := runner("launchctl", "unload", path).CombinedOutput(); err != nil {
+				return fmt.Errorf("launchctl unload: %w\n%s", err, out)
+			}
+		}
+	}
+	if err := persistToken(cfg.Token); err != nil {
+		return fmt.Errorf("persist service token: %w", err)
+	}
 	if out, err := runner("launchctl", "load", path).CombinedOutput(); err != nil {
 		return fmt.Errorf("launchctl load: %w\n%s", err, out)
-	}
-
-	if err := persistToken(cfg.Token); err != nil {
-		fmt.Fprintf(cmd.ErrOrStderr(), "⚠ Warning: could not save token to ~/.rampart/token: %v\n", err)
-		fmt.Fprintf(cmd.ErrOrStderr(), "  Run: echo '%s' > ~/.rampart/token\n", cfg.Token)
 	}
 	printSuccess(cmd, cfg.Token, generated, port, path)
 	return nil
@@ -376,6 +390,9 @@ func installLinux(cmd *cobra.Command, cfg serviceConfig, force, generated bool, 
 		fmt.Fprintf(cmd.ErrOrStderr(), "Service already installed at %s\nUse --force to overwrite.\n", path)
 		return nil
 	}
+
+	_, existingErr := os.Stat(path)
+	serviceExists := existingErr == nil
 
 	content, err := generateSystemdUnit(cfg)
 	if err != nil {
@@ -395,22 +412,44 @@ func installLinux(cmd *cobra.Command, cfg serviceConfig, force, generated bool, 
 	}
 	_ = os.Chmod(path, 0o600)
 
-	// Stop the old service before reload so the new binary/token take effect.
-	_, _ = runner("systemctl", "--user", "stop", "rampart-serve.service").CombinedOutput()
-
+	// Fail closed during token rotation: stop the old process before changing
+	// either the loaded unit or the token hooks will read.
+	if serviceExists {
+		if out, err := runner("systemctl", "--user", "stop", "rampart-serve.service").CombinedOutput(); err != nil {
+			return fmt.Errorf("systemctl stop: %w\n%s", err, out)
+		}
+	}
 	if out, err := runner("systemctl", "--user", "daemon-reload").CombinedOutput(); err != nil {
 		return fmt.Errorf("systemctl daemon-reload: %w\n%s", err, out)
 	}
-	if out, err := runner("systemctl", "--user", "enable", "--now", "rampart-serve.service").CombinedOutput(); err != nil {
+	if err := persistToken(cfg.Token); err != nil {
+		return fmt.Errorf("persist service token: %w", err)
+	}
+	if out, err := runner("systemctl", "--user", "enable", "rampart-serve.service").CombinedOutput(); err != nil {
 		return fmt.Errorf("systemctl enable: %w\n%s", err, out)
 	}
-
-	if err := persistToken(cfg.Token); err != nil {
-		fmt.Fprintf(cmd.ErrOrStderr(), "⚠ Warning: could not save token to ~/.rampart/token: %v\n", err)
-		fmt.Fprintf(cmd.ErrOrStderr(), "  Run: echo '%s' > ~/.rampart/token\n", cfg.Token)
+	if out, err := runner("systemctl", "--user", "start", "rampart-serve.service").CombinedOutput(); err != nil {
+		return fmt.Errorf("systemctl start: %w\n%s", err, out)
 	}
 	printSuccess(cmd, cfg.Token, generated, port, path)
 	return nil
+}
+
+func launchctlServiceLoaded(runner commandRunner) (bool, error) {
+	out, err := runner("launchctl", "list", plistLabel).CombinedOutput()
+	if err == nil {
+		return true, nil
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ExitCode() == 113 {
+		return false, nil
+	}
+	message := strings.ToLower(string(out))
+	if strings.Contains(message, "could not find service") ||
+		strings.Contains(message, "could not find specified service") {
+		return false, nil
+	}
+	return false, fmt.Errorf("launchctl list %s: %w\n%s", plistLabel, err, out)
 }
 
 func printSuccess(cmd *cobra.Command, token string, generated bool, port int, path string) {

--- a/cmd/rampart/cli/serve_install_test.go
+++ b/cmd/rampart/cli/serve_install_test.go
@@ -19,6 +19,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 func TestGeneratePlist(t *testing.T) {
@@ -209,6 +211,193 @@ func TestBuildServiceArgs_Defaults(t *testing.T) {
 func mockRunner(calls *[]string) commandRunner {
 	return func(name string, args ...string) *exec.Cmd {
 		*calls = append(*calls, name+" "+strings.Join(args, " "))
+		return exec.Command("true")
+	}
+}
+
+func TestInstallLinuxRotatesTokenBetweenStopAndStart(t *testing.T) {
+	skipOnWindows(t, "Unix service runner")
+	home := t.TempDir()
+	testSetHome(t, home)
+	if err := persistToken("old-token"); err != nil {
+		t.Fatal(err)
+	}
+	unitPath, err := systemdUnitPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(unitPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(unitPath, []byte("old unit"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var calls []string
+	runner := tokenObservingRunner(t, &calls)
+	cfg := serviceConfig{
+		Binary:  "/usr/local/bin/rampart",
+		Token:   "new-token",
+		LogPath: filepath.Join(home, ".rampart", "serve.log"),
+	}
+	cmd := &cobra.Command{}
+	if err := installLinux(cmd, cfg, true, false, defaultServePort, runner); err != nil {
+		t.Fatalf("installLinux: %v", err)
+	}
+
+	want := []string{
+		"systemctl --user stop rampart-serve.service|old-token",
+		"systemctl --user daemon-reload|old-token",
+		"systemctl --user enable rampart-serve.service|new-token",
+		"systemctl --user start rampart-serve.service|new-token",
+	}
+	if strings.Join(calls, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("service/token ordering:\n got: %q\nwant: %q", calls, want)
+	}
+}
+
+func TestInstallDarwinRotatesTokenBetweenUnloadAndLoad(t *testing.T) {
+	skipOnWindows(t, "Unix service runner")
+	home := t.TempDir()
+	testSetHome(t, home)
+	if err := persistToken("old-token"); err != nil {
+		t.Fatal(err)
+	}
+	path, err := plistPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("old plist"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var calls []string
+	runner := tokenObservingRunner(t, &calls)
+	cfg := serviceConfig{
+		Binary:  "/usr/local/bin/rampart",
+		Token:   "new-token",
+		LogPath: filepath.Join(home, ".rampart", "serve.log"),
+	}
+	cmd := &cobra.Command{}
+	if err := installDarwin(cmd, cfg, true, false, defaultServePort, runner); err != nil {
+		t.Fatalf("installDarwin: %v", err)
+	}
+
+	want := []string{
+		"launchctl list " + plistLabel + "|old-token",
+		"launchctl unload " + path + "|old-token",
+		"launchctl load " + path + "|new-token",
+	}
+	if strings.Join(calls, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("service/token ordering:\n got: %q\nwant: %q", calls, want)
+	}
+}
+
+func TestInstallDarwinAllowsExistingUnloadedService(t *testing.T) {
+	skipOnWindows(t, "Unix service runner")
+	home := t.TempDir()
+	testSetHome(t, home)
+	if err := persistToken("old-token"); err != nil {
+		t.Fatal(err)
+	}
+	path, err := plistPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("old plist"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var calls []string
+	runner := func(name string, args ...string) *exec.Cmd {
+		calls = append(calls, name+" "+strings.Join(args, " "))
+		if len(args) > 0 && args[0] == "list" {
+			return exec.Command("sh", "-c", "exit 113")
+		}
+		return exec.Command("true")
+	}
+	cfg := serviceConfig{
+		Binary:  "/usr/local/bin/rampart",
+		Token:   "new-token",
+		LogPath: filepath.Join(home, ".rampart", "serve.log"),
+	}
+	if err := installDarwin(&cobra.Command{}, cfg, true, false, defaultServePort, runner); err != nil {
+		t.Fatalf("installDarwin: %v", err)
+	}
+	want := []string{
+		"launchctl list " + plistLabel,
+		"launchctl load " + path,
+	}
+	if strings.Join(calls, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("calls:\n got: %q\nwant: %q", calls, want)
+	}
+	token, err := readPersistedToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token != "new-token" {
+		t.Fatalf("persisted token = %q, want new-token", token)
+	}
+}
+
+func TestInstallDarwinRefusesTokenRotationOnUnknownListFailure(t *testing.T) {
+	skipOnWindows(t, "Unix service runner")
+	home := t.TempDir()
+	testSetHome(t, home)
+	if err := persistToken("old-token"); err != nil {
+		t.Fatal(err)
+	}
+	path, err := plistPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("old plist"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var calls []string
+	runner := func(name string, args ...string) *exec.Cmd {
+		calls = append(calls, name+" "+strings.Join(args, " "))
+		return exec.Command("false")
+	}
+	cfg := serviceConfig{
+		Binary:  "/usr/local/bin/rampart",
+		Token:   "new-token",
+		LogPath: filepath.Join(home, ".rampart", "serve.log"),
+	}
+	err = installDarwin(&cobra.Command{}, cfg, true, false, defaultServePort, runner)
+	if err == nil || !strings.Contains(err.Error(), "launchctl list") {
+		t.Fatalf("installDarwin error = %v, want launchctl list failure", err)
+	}
+	if len(calls) != 1 || calls[0] != "launchctl list "+plistLabel {
+		t.Fatalf("calls after ambiguous list failure = %q", calls)
+	}
+	token, err := readPersistedToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token != "old-token" {
+		t.Fatalf("persisted token = %q, want old-token", token)
+	}
+}
+
+func tokenObservingRunner(t *testing.T, calls *[]string) commandRunner {
+	t.Helper()
+	return func(name string, args ...string) *exec.Cmd {
+		token, err := readPersistedToken()
+		if err != nil {
+			t.Fatalf("read token while invoking %s: %v", name, err)
+		}
+		*calls = append(*calls, name+" "+strings.Join(args, " ")+"|"+token)
 		return exec.Command("true")
 	}
 }

--- a/cmd/rampart/cli/serve_test.go
+++ b/cmd/rampart/cli/serve_test.go
@@ -38,19 +38,6 @@ func TestServeTokenOutputPrintsForInteractiveTerminal(t *testing.T) {
 	}
 }
 
-func TestPersistTokenWarningRedactsFallbackWhenNonInteractive(t *testing.T) {
-	const token = "secret-token-value"
-	var buf bytes.Buffer
-	printPersistTokenWarning(&buf, os.ErrPermission, token, false)
-	got := buf.String()
-	if strings.Contains(got, token) {
-		t.Fatalf("non-interactive persist warning leaked full token: %q", got)
-	}
-	if !strings.Contains(got, "not printed") {
-		t.Fatalf("non-interactive persist warning should explain redaction, got: %q", got)
-	}
-}
-
 func TestIsWriteEvent(t *testing.T) {
 	tests := []struct {
 		name string

--- a/cmd/rampart/cli/setup.go
+++ b/cmd/rampart/cli/setup.go
@@ -36,6 +36,18 @@ Supported AI Agents:
   • Hermes Agent              - Experimental user plugin integration
   • Cline (VS Code)           - Native hook integration
   • OpenClaw                  - Native plugin integration`,
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			if flag := cmd.Flags().Lookup("remove"); flag != nil {
+				remove, err := cmd.Flags().GetBool("remove")
+				if err == nil && remove {
+					return nil
+				}
+			}
+			if err := ensureDefaultRampartDirAccessible(); err != nil {
+				return fmt.Errorf("setup: prepare Rampart data directory: %w", err)
+			}
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runInteractiveSetup(cmd, opts)
 		},

--- a/cmd/rampart/cli/setup_openclaw_plugin.go
+++ b/cmd/rampart/cli/setup_openclaw_plugin.go
@@ -57,9 +57,7 @@ const openclawMinVersion = "2026.3.28"
 func runSetupOpenClawPlugin(w io.Writer, errW io.Writer) error {
 	// 0. Ensure rampart serve is running (start as systemd service if needed).
 	if err := ensureServeRunning(w, errW); err != nil {
-		fmt.Fprintf(errW, "⚠ Could not start rampart serve: %v\n", err)
-		fmt.Fprintln(errW, "  Start manually: rampart serve --background")
-		// Non-fatal — continue setup, serve can be started later.
+		return fmt.Errorf("start Rampart policy service: %w", err)
 	}
 
 	// 1. Locate openclaw.

--- a/cmd/rampart/cli/token_unix.go
+++ b/cmd/rampart/cli/token_unix.go
@@ -15,3 +15,8 @@ func secureFilePermissions(path string) error {
 func secureDirPermissions(path string) error {
 	return os.Chmod(path, 0o700)
 }
+
+// Unix directory permissions never used the affected Windows ACL path.
+func ensureRampartDirAccessible(string) error {
+	return nil
+}

--- a/cmd/rampart/cli/token_windows.go
+++ b/cmd/rampart/cli/token_windows.go
@@ -4,51 +4,65 @@ package cli
 
 import (
 	"fmt"
-	"log/slog"
-	"os"
-	"os/exec"
-	"os/user"
+
+	"golang.org/x/sys/windows"
 )
 
-// secureFilePermissions sets owner-only access on Windows using icacls.
-// This removes inherited permissions and grants full control only to the current user.
+var (
+	currentProcessUserSID = func() (*windows.SID, error) {
+		tokenUser, err := windows.GetCurrentProcessToken().GetTokenUser()
+		if err != nil {
+			return nil, err
+		}
+		return tokenUser.User.Sid, nil
+	}
+	aclFromEntries       = windows.ACLFromEntries
+	setNamedSecurityInfo = windows.SetNamedSecurityInfo
+)
+
+// secureFilePermissions replaces the file DACL atomically with a protected
+// owner-only DACL. Reading the SID from the process token avoids account-name
+// resolution, which may be unavailable on domain and AzureAD machines.
 func secureFilePermissions(path string) error {
-	return setOwnerOnlyAccess(path)
-}
-
-// secureDirPermissions sets owner-only access on Windows using icacls.
-func secureDirPermissions(path string) error {
-	return setOwnerOnlyAccess(path)
-}
-
-func setOwnerOnlyAccess(path string) error {
-	// Get current username
-	currentUser, err := user.Current()
+	sid, err := currentProcessUserSID()
 	if err != nil {
-		// Fall back to no-op on error
-		return nil
+		return fmt.Errorf("get current process user SID: %w", err)
 	}
 
-	// icacls commands:
-	// /inheritance:r - Remove inherited permissions
-	// /grant:r USER:F - Replace with full control for current user only
-	//
-	// This is equivalent to: only the current user can read/write the file.
-	cmd := exec.Command("icacls", path,
-		"/inheritance:r",
-		"/grant:r", fmt.Sprintf("%s:F", currentUser.Username),
-	)
-	
-	// Suppress output - we only care about the exit code
-	cmd.Stdout = nil
-	cmd.Stderr = nil
-
-	if err := cmd.Run(); err != nil {
-		// If icacls fails, fall back to os.Chmod (no-op on Windows, but doesn't error).
-		// Warn because the file may have overly permissive inherited permissions.
-		slog.Warn("token: icacls failed, file permissions may be too permissive", "path", path, "err", err)
-		return os.Chmod(path, 0o600)
+	acl, err := aclFromEntries([]windows.EXPLICIT_ACCESS{
+		{
+			AccessPermissions: windows.GENERIC_ALL,
+			AccessMode:        windows.SET_ACCESS,
+			Inheritance:       windows.NO_INHERITANCE,
+			Trustee: windows.TRUSTEE{
+				TrusteeForm:  windows.TRUSTEE_IS_SID,
+				TrusteeType:  windows.TRUSTEE_IS_USER,
+				TrusteeValue: windows.TrusteeValueFromSID(sid),
+			},
+		},
+	}, nil)
+	if err != nil {
+		return fmt.Errorf("build owner-only DACL: %w", err)
 	}
 
+	if err := setNamedSecurityInfo(
+		path,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION,
+		nil,
+		nil,
+		acl,
+		nil,
+	); err != nil {
+		return fmt.Errorf("set owner-only DACL: %w", err)
+	}
+
+	return nil
+}
+
+// secureDirPermissions deliberately leaves the shared Rampart data directory
+// ACL unchanged. Only the token file contains a secret that needs a protected
+// owner-only DACL.
+func secureDirPermissions(string) error {
 	return nil
 }

--- a/cmd/rampart/cli/token_windows.go
+++ b/cmd/rampart/cli/token_windows.go
@@ -87,10 +87,14 @@ func ensureRampartDirAccessible(path string) error {
 		if !info.IsDir() {
 			return fmt.Errorf("Rampart data path is not a directory: %s", path)
 		}
-		// The affected legacy ACL denies even directory metadata access. Avoid
-		// creating a probe file on every short-lived hook invocation when Stat
-		// proves this is not that lockout shape.
-		return nil
+		// Stat can succeed on Windows even when the directory denies traversal.
+		// Opening the directory is a read-only access probe and avoids creating
+		// an antivirus-visible temp file on every short-lived hook invocation.
+		if err := probeDirectoryAccess(path); err == nil {
+			return nil
+		} else if !errors.Is(err, windows.ERROR_ACCESS_DENIED) {
+			return fmt.Errorf("check Rampart directory access: %w", err)
+		}
 	}
 
 	sid, err := currentProcessUserSID()
@@ -164,6 +168,14 @@ func ensureRampartDirAccessible(path string) error {
 		return fmt.Errorf("verify repaired Rampart directory access: %w", err)
 	}
 	return nil
+}
+
+func probeDirectoryAccess(path string) error {
+	dir, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	return dir.Close()
 }
 
 func aclContainsExplicitSID(acl *windows.ACL, sid *windows.SID) (bool, error) {

--- a/cmd/rampart/cli/token_windows.go
+++ b/cmd/rampart/cli/token_windows.go
@@ -3,7 +3,10 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
+	"os"
+	"unsafe"
 
 	"golang.org/x/sys/windows"
 )
@@ -17,6 +20,7 @@ var (
 		return tokenUser.User.Sid, nil
 	}
 	aclFromEntries       = windows.ACLFromEntries
+	getNamedSecurityInfo = windows.GetNamedSecurityInfo
 	setNamedSecurityInfo = windows.SetNamedSecurityInfo
 )
 
@@ -61,8 +65,140 @@ func secureFilePermissions(path string) error {
 }
 
 // secureDirPermissions deliberately leaves the shared Rampart data directory
-// ACL unchanged. Only the token file contains a secret that needs a protected
-// owner-only DACL.
+// ACL unchanged. Sensitive files apply their own protected DACLs.
 func secureDirPermissions(string) error {
 	return nil
+}
+
+// ensureRampartDirAccessible repairs only the legacy Rampart lockout shape:
+// an existing directory owned by this process user, protected from inherited
+// ACLs, and currently unwritable. Accessible or deliberately customized ACLs
+// are never modified.
+func ensureRampartDirAccessible(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		if !errors.Is(err, windows.ERROR_ACCESS_DENIED) {
+			return fmt.Errorf("inspect Rampart directory: %w", err)
+		}
+	} else {
+		if !info.IsDir() {
+			return fmt.Errorf("Rampart data path is not a directory: %s", path)
+		}
+		// The affected legacy ACL denies even directory metadata access. Avoid
+		// creating a probe file on every short-lived hook invocation when Stat
+		// proves this is not that lockout shape.
+		return nil
+	}
+
+	sid, err := currentProcessUserSID()
+	if err != nil {
+		return fmt.Errorf("get current process user SID: %w", err)
+	}
+
+	descriptor, err := getNamedSecurityInfo(
+		path,
+		windows.SE_FILE_OBJECT,
+		windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION,
+	)
+	if err != nil {
+		return fmt.Errorf("read directory DACL: %w", err)
+	}
+	owner, _, err := descriptor.Owner()
+	if err != nil {
+		return fmt.Errorf("read directory owner: %w", err)
+	}
+	if owner == nil || !owner.Equals(sid) {
+		return fmt.Errorf("refusing to repair Rampart directory not owned by the current process user")
+	}
+	control, _, err := descriptor.Control()
+	if err != nil {
+		return fmt.Errorf("read directory DACL control: %w", err)
+	}
+	if control&windows.SE_DACL_PROTECTED == 0 {
+		return fmt.Errorf("refusing to repair an inaccessible Rampart directory without the legacy protected DACL")
+	}
+	existingACL, _, err := descriptor.DACL()
+	if err != nil {
+		return fmt.Errorf("extract directory DACL: %w", err)
+	}
+	hasCurrentSIDEntry, err := aclContainsExplicitSID(existingACL, sid)
+	if err != nil {
+		return fmt.Errorf("inspect directory DACL entries: %w", err)
+	}
+	if hasCurrentSIDEntry {
+		return fmt.Errorf("refusing to repair a Rampart directory with an existing current-user ACL entry")
+	}
+
+	acl, err := aclFromEntries([]windows.EXPLICIT_ACCESS{
+		{
+			AccessPermissions: windows.GENERIC_ALL,
+			AccessMode:        windows.GRANT_ACCESS,
+			Inheritance:       windows.NO_INHERITANCE,
+			Trustee: windows.TRUSTEE{
+				TrusteeForm:  windows.TRUSTEE_IS_SID,
+				TrusteeType:  windows.TRUSTEE_IS_USER,
+				TrusteeValue: windows.TrusteeValueFromSID(sid),
+			},
+		},
+	}, existingACL)
+	if err != nil {
+		return fmt.Errorf("build recoverable directory DACL: %w", err)
+	}
+
+	if err := setNamedSecurityInfo(
+		path,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION|windows.UNPROTECTED_DACL_SECURITY_INFORMATION,
+		nil,
+		nil,
+		acl,
+		nil,
+	); err != nil {
+		return fmt.Errorf("set recoverable directory DACL: %w", err)
+	}
+
+	if err := probeDirectoryWrite(path); err != nil {
+		return fmt.Errorf("verify repaired Rampart directory access: %w", err)
+	}
+	return nil
+}
+
+func aclContainsExplicitSID(acl *windows.ACL, sid *windows.SID) (bool, error) {
+	if acl == nil {
+		return false, nil
+	}
+	for i := uint32(0); i < uint32(acl.AceCount); i++ {
+		var ace *windows.ACCESS_ALLOWED_ACE
+		if err := windows.GetAce(acl, i, &ace); err != nil {
+			return false, err
+		}
+		if ace.Header.AceFlags&windows.INHERITED_ACE != 0 {
+			continue
+		}
+		if ace.Header.AceType != windows.ACCESS_ALLOWED_ACE_TYPE &&
+			ace.Header.AceType != windows.ACCESS_DENIED_ACE_TYPE {
+			continue
+		}
+		aceSID := (*windows.SID)(unsafe.Pointer(&ace.SidStart))
+		if aceSID.Equals(sid) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func probeDirectoryWrite(path string) error {
+	f, err := os.CreateTemp(path, ".rampart-access-*")
+	if err != nil {
+		return err
+	}
+	name := f.Name()
+	if err := f.Close(); err != nil {
+		_ = os.Remove(name)
+		return err
+	}
+	return os.Remove(name)
 }

--- a/cmd/rampart/cli/token_windows_test.go
+++ b/cmd/rampart/cli/token_windows_test.go
@@ -414,8 +414,8 @@ func lockLegacyRampartDir(t *testing.T, dir string) {
 	if err := windows.SetNamedSecurityInfo(
 		dir,
 		windows.SE_FILE_OBJECT,
-		windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION,
-		nil,
+		windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION,
+		processSID,
 		nil,
 		lockedACL,
 		nil,

--- a/cmd/rampart/cli/token_windows_test.go
+++ b/cmd/rampart/cli/token_windows_test.go
@@ -1,0 +1,229 @@
+//go:build windows
+
+package cli
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+func withWindowsACLStubs(t *testing.T) {
+	t.Helper()
+	originalCurrentProcessUserSID := currentProcessUserSID
+	originalACLFromEntries := aclFromEntries
+	originalSetNamedSecurityInfo := setNamedSecurityInfo
+	t.Cleanup(func() {
+		currentProcessUserSID = originalCurrentProcessUserSID
+		aclFromEntries = originalACLFromEntries
+		setNamedSecurityInfo = originalSetNamedSecurityInfo
+	})
+}
+
+func TestSecureFilePermissionsUsesProcessSIDAndProtectedDACL(t *testing.T) {
+	withWindowsACLStubs(t)
+
+	sid, err := windows.StringToSid("S-1-5-21-1-2-3-1001")
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantACL := &windows.ACL{}
+
+	currentProcessUserSID = func() (*windows.SID, error) {
+		return sid, nil
+	}
+	aclFromEntries = func(entries []windows.EXPLICIT_ACCESS, merged *windows.ACL) (*windows.ACL, error) {
+		if merged != nil {
+			t.Fatal("owner-only ACL must not merge inherited or existing entries")
+		}
+		if len(entries) != 1 {
+			t.Fatalf("got %d ACL entries, want 1", len(entries))
+		}
+		entry := entries[0]
+		if entry.AccessPermissions != windows.GENERIC_ALL {
+			t.Errorf("permissions = %#x, want GENERIC_ALL", entry.AccessPermissions)
+		}
+		if entry.AccessMode != windows.SET_ACCESS {
+			t.Errorf("access mode = %d, want SET_ACCESS", entry.AccessMode)
+		}
+		if entry.Inheritance != windows.NO_INHERITANCE {
+			t.Errorf("inheritance = %#x, want NO_INHERITANCE", entry.Inheritance)
+		}
+		if entry.Trustee.TrusteeForm != windows.TRUSTEE_IS_SID {
+			t.Errorf("trustee form = %d, want TRUSTEE_IS_SID", entry.Trustee.TrusteeForm)
+		}
+		if entry.Trustee.TrusteeType != windows.TRUSTEE_IS_USER {
+			t.Errorf("trustee type = %d, want TRUSTEE_IS_USER", entry.Trustee.TrusteeType)
+		}
+		if entry.Trustee.TrusteeValue != windows.TrusteeValueFromSID(sid) {
+			t.Error("ACL trustee does not use the current process SID")
+		}
+		return wantACL, nil
+	}
+
+	var setCalled bool
+	setNamedSecurityInfo = func(
+		path string,
+		objectType windows.SE_OBJECT_TYPE,
+		securityInformation windows.SECURITY_INFORMATION,
+		owner *windows.SID,
+		group *windows.SID,
+		dacl *windows.ACL,
+		sacl *windows.ACL,
+	) error {
+		setCalled = true
+		if path != `C:\Users\alice\.rampart\.token-123` {
+			t.Errorf("path = %q", path)
+		}
+		if objectType != windows.SE_FILE_OBJECT {
+			t.Errorf("object type = %d, want SE_FILE_OBJECT", objectType)
+		}
+		wantInformation := windows.SECURITY_INFORMATION(
+			windows.DACL_SECURITY_INFORMATION | windows.PROTECTED_DACL_SECURITY_INFORMATION,
+		)
+		if securityInformation != wantInformation {
+			t.Errorf("security information = %#x, want %#x", securityInformation, wantInformation)
+		}
+		if owner != nil || group != nil || sacl != nil {
+			t.Error("unexpected owner, group, or SACL change")
+		}
+		if dacl != wantACL {
+			t.Error("SetNamedSecurityInfo did not receive the owner-only DACL")
+		}
+		return nil
+	}
+
+	if err := secureFilePermissions(`C:\Users\alice\.rampart\.token-123`); err != nil {
+		t.Fatalf("secureFilePermissions: %v", err)
+	}
+	if !setCalled {
+		t.Fatal("SetNamedSecurityInfo was not called")
+	}
+}
+
+func TestSecureFilePermissionsFailsClosed(t *testing.T) {
+	tests := []struct {
+		name    string
+		sidErr  error
+		aclErr  error
+		setErr  error
+		wantErr string
+	}{
+		{name: "SID lookup", sidErr: errors.New("token unavailable"), wantErr: "get current process user SID"},
+		{name: "ACL construction", aclErr: errors.New("invalid ACL"), wantErr: "build owner-only DACL"},
+		{name: "ACL application", setErr: errors.New("access denied"), wantErr: "set owner-only DACL"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			withWindowsACLStubs(t)
+
+			sid, err := windows.StringToSid("S-1-5-21-1-2-3-1001")
+			if err != nil {
+				t.Fatal(err)
+			}
+			currentProcessUserSID = func() (*windows.SID, error) {
+				return sid, tc.sidErr
+			}
+			aclFromEntries = func([]windows.EXPLICIT_ACCESS, *windows.ACL) (*windows.ACL, error) {
+				return &windows.ACL{}, tc.aclErr
+			}
+			setNamedSecurityInfo = func(
+				string,
+				windows.SE_OBJECT_TYPE,
+				windows.SECURITY_INFORMATION,
+				*windows.SID,
+				*windows.SID,
+				*windows.ACL,
+				*windows.ACL,
+			) error {
+				return tc.setErr
+			}
+
+			err = secureFilePermissions("token")
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error = %v, want it to contain %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestSecureFilePermissionsAppliesOwnerOnlyDACL(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "token")
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := secureFilePermissions(path); err != nil {
+		t.Fatalf("secureFilePermissions: %v", err)
+	}
+
+	descriptor, err := windows.GetNamedSecurityInfo(
+		path,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION,
+	)
+	if err != nil {
+		t.Fatalf("GetNamedSecurityInfo: %v", err)
+	}
+	control, _, err := descriptor.Control()
+	if err != nil {
+		t.Fatalf("read security descriptor control: %v", err)
+	}
+	if control&windows.SE_DACL_PROTECTED == 0 {
+		t.Fatal("token DACL still permits inherited access")
+	}
+
+	dacl, _, err := descriptor.DACL()
+	if err != nil {
+		t.Fatalf("read token DACL: %v", err)
+	}
+	if dacl == nil {
+		t.Fatal("token has no DACL")
+	}
+	if dacl.AceCount != 1 {
+		t.Fatalf("token DACL has %d entries, want 1", dacl.AceCount)
+	}
+
+	var ace *windows.ACCESS_ALLOWED_ACE
+	if err := windows.GetAce(dacl, 0, &ace); err != nil {
+		t.Fatalf("GetAce: %v", err)
+	}
+	aceSID := (*windows.SID)(unsafe.Pointer(&ace.SidStart))
+	processSID, err := currentProcessUserSID()
+	if err != nil {
+		t.Fatalf("currentProcessUserSID: %v", err)
+	}
+	if !aceSID.Equals(processSID) {
+		t.Fatalf("token DACL SID = %s, want current process SID %s", aceSID, processSID)
+	}
+}
+
+func TestSecureDirPermissionsDoesNotChangeSharedDirectoryACL(t *testing.T) {
+	withWindowsACLStubs(t)
+
+	currentProcessUserSID = func() (*windows.SID, error) {
+		t.Fatal("secureDirPermissions must not look up the user SID")
+		return nil, nil
+	}
+	setNamedSecurityInfo = func(
+		string,
+		windows.SE_OBJECT_TYPE,
+		windows.SECURITY_INFORMATION,
+		*windows.SID,
+		*windows.SID,
+		*windows.ACL,
+		*windows.ACL,
+	) error {
+		t.Fatal("secureDirPermissions must not alter the shared directory DACL")
+		return nil
+	}
+
+	if err := secureDirPermissions(`C:\Users\alice\.rampart`); err != nil {
+		t.Fatalf("secureDirPermissions: %v", err)
+	}
+}

--- a/cmd/rampart/cli/token_windows_test.go
+++ b/cmd/rampart/cli/token_windows_test.go
@@ -17,10 +17,12 @@ func withWindowsACLStubs(t *testing.T) {
 	t.Helper()
 	originalCurrentProcessUserSID := currentProcessUserSID
 	originalACLFromEntries := aclFromEntries
+	originalGetNamedSecurityInfo := getNamedSecurityInfo
 	originalSetNamedSecurityInfo := setNamedSecurityInfo
 	t.Cleanup(func() {
 		currentProcessUserSID = originalCurrentProcessUserSID
 		aclFromEntries = originalACLFromEntries
+		getNamedSecurityInfo = originalGetNamedSecurityInfo
 		setNamedSecurityInfo = originalSetNamedSecurityInfo
 	})
 }
@@ -226,4 +228,216 @@ func TestSecureDirPermissionsDoesNotChangeSharedDirectoryACL(t *testing.T) {
 	if err := secureDirPermissions(`C:\Users\alice\.rampart`); err != nil {
 		t.Fatalf("secureDirPermissions: %v", err)
 	}
+}
+
+func TestEnsureRampartDirAccessibleLeavesAccessibleProtectedACLAlone(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), ".rampart")
+	if err := os.Mkdir(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	processSID, err := currentProcessUserSID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	acl, err := windows.ACLFromEntries([]windows.EXPLICIT_ACCESS{
+		{
+			AccessPermissions: windows.GENERIC_ALL,
+			AccessMode:        windows.SET_ACCESS,
+			Inheritance:       windows.NO_INHERITANCE,
+			Trustee: windows.TRUSTEE{
+				TrusteeForm:  windows.TRUSTEE_IS_SID,
+				TrusteeType:  windows.TRUSTEE_IS_USER,
+				TrusteeValue: windows.TrusteeValueFromSID(processSID),
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := windows.SetNamedSecurityInfo(
+		dir,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION,
+		nil,
+		nil,
+		acl,
+		nil,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ensureRampartDirAccessible(dir); err != nil {
+		t.Fatalf("ensureRampartDirAccessible: %v", err)
+	}
+	descriptor, err := windows.GetNamedSecurityInfo(
+		dir,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	control, _, err := descriptor.Control()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if control&windows.SE_DACL_PROTECTED == 0 {
+		t.Fatal("accessible custom protected DACL was unexpectedly changed")
+	}
+}
+
+func TestServePreRunRepairsLegacyDirectoryLockout(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+	dir := filepath.Join(home, ".rampart")
+	if err := os.Mkdir(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	lockLegacyRampartDir(t, dir)
+
+	if err := probeDirectoryWrite(dir); !errors.Is(err, windows.ERROR_ACCESS_DENIED) {
+		t.Fatalf("legacy lock probe error = %v, want access denied", err)
+	}
+
+	cmd := newServeCmd(&rootOptions{configPath: "rampart.yaml"}, nil)
+	if cmd.PreRunE == nil {
+		t.Fatal("serve has no early Rampart directory recovery hook")
+	}
+	if err := cmd.PreRunE(cmd, nil); err != nil {
+		t.Fatalf("serve pre-run recovery: %v", err)
+	}
+	if err := probeDirectoryWrite(dir); err != nil {
+		t.Fatalf("repaired directory is not writable: %v", err)
+	}
+
+	descriptor, err := windows.GetNamedSecurityInfo(
+		dir,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	control, _, err := descriptor.Control()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if control&windows.SE_DACL_PROTECTED != 0 {
+		t.Fatal("legacy directory DACL is still protected from inheritance")
+	}
+	dacl, _, err := descriptor.DACL()
+	if err != nil {
+		t.Fatal(err)
+	}
+	processSID, err := currentProcessUserSID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !aclContainsSID(t, dacl, processSID) {
+		t.Fatalf("repaired directory DACL does not contain process SID %s", processSID)
+	}
+}
+
+func TestHookRepairsLegacyDirectoryBeforeCommandWork(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+	dir := filepath.Join(home, ".rampart")
+	if err := os.Mkdir(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	lockLegacyRampartDir(t, dir)
+
+	cmd := newHookCmd(&rootOptions{configPath: "rampart.yaml"})
+	cmd.SetArgs([]string{"--mode", "invalid"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "invalid mode") {
+		t.Fatalf("hook error = %v, want invalid mode after recovery", err)
+	}
+	if err := probeDirectoryWrite(dir); err != nil {
+		t.Fatalf("hook did not repair legacy directory before command work: %v", err)
+	}
+}
+
+func lockLegacyRampartDir(t *testing.T, dir string) {
+	t.Helper()
+	processSID, err := currentProcessUserSID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	recoveryACL, err := windows.ACLFromEntries([]windows.EXPLICIT_ACCESS{
+		{
+			AccessPermissions: windows.GENERIC_ALL,
+			AccessMode:        windows.SET_ACCESS,
+			Inheritance:       windows.SUB_CONTAINERS_AND_OBJECTS_INHERIT,
+			Trustee: windows.TRUSTEE{
+				TrusteeForm:  windows.TRUSTEE_IS_SID,
+				TrusteeType:  windows.TRUSTEE_IS_USER,
+				TrusteeValue: windows.TrusteeValueFromSID(processSID),
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = windows.SetNamedSecurityInfo(
+			dir,
+			windows.SE_FILE_OBJECT,
+			windows.DACL_SECURITY_INFORMATION|windows.UNPROTECTED_DACL_SECURITY_INFORMATION,
+			nil,
+			nil,
+			recoveryACL,
+			nil,
+		)
+	})
+
+	unrelatedSID, err := windows.StringToSid("S-1-5-19")
+	if err != nil {
+		t.Fatal(err)
+	}
+	lockedACL, err := windows.ACLFromEntries([]windows.EXPLICIT_ACCESS{
+		{
+			AccessPermissions: windows.GENERIC_ALL,
+			AccessMode:        windows.SET_ACCESS,
+			Inheritance:       windows.NO_INHERITANCE,
+			Trustee: windows.TRUSTEE{
+				TrusteeForm:  windows.TRUSTEE_IS_SID,
+				TrusteeType:  windows.TRUSTEE_IS_USER,
+				TrusteeValue: windows.TrusteeValueFromSID(unrelatedSID),
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := windows.SetNamedSecurityInfo(
+		dir,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION,
+		nil,
+		nil,
+		lockedACL,
+		nil,
+	); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func aclContainsSID(t *testing.T, acl *windows.ACL, want *windows.SID) bool {
+	t.Helper()
+	if acl == nil {
+		return false
+	}
+	for i := uint32(0); i < uint32(acl.AceCount); i++ {
+		var ace *windows.ACCESS_ALLOWED_ACE
+		if err := windows.GetAce(acl, i, &ace); err != nil {
+			t.Fatalf("GetAce(%d): %v", i, err)
+		}
+		sid := (*windows.SID)(unsafe.Pointer(&ace.SidStart))
+		if sid.Equals(want) {
+			return true
+		}
+	}
+	return false
 }

--- a/docs-site/getting-started/installation.md
+++ b/docs-site/getting-started/installation.md
@@ -119,6 +119,8 @@ rampart --version
 
 Rampart works on Windows with some limitations:
 
+> **Upgrading from Rampart 1.2.x:** rerun `irm https://rampart.sh/install.ps1 | iex`. The installer repairs the affected legacy `~\.rampart` ACL before replacing the binary. Do not rely on `rampart upgrade` when the existing binary is inaccessible.
+
 | Feature | Windows | macOS/Linux |
 |---------|---------|-------------|
 | `rampart serve` | ✅ Foreground only | ✅ Background supported |

--- a/docs-site/getting-started/upgrade.md
+++ b/docs-site/getting-started/upgrade.md
@@ -25,6 +25,16 @@ brew upgrade rampart
 go install github.com/peg/rampart/cmd/rampart@latest
 ```
 
+### Windows
+
+Rerun the official PowerShell installer:
+
+```powershell
+irm https://rampart.sh/install.ps1 | iex
+```
+
+For the v1.2.x to v1.3.0 upgrade, use this installer instead of `rampart upgrade`. The installer can repair the affected legacy `~\.rampart` ACL before accessing the existing binary; an installed `rampart.exe` inside that locked directory may be unable to start and repair itself.
+
 ### Manual Binary
 
 Download the latest release from [GitHub Releases](https://github.com/peg/rampart/releases):

--- a/docs-site/guides/windows.md
+++ b/docs-site/guides/windows.md
@@ -75,9 +75,11 @@ rampart test "rm -rf /"
 |---------|--------|-------|
 | `rampart serve --background` | ❌ Unix only | Uses fork/exec |
 | `rampart serve stop` | ❌ Unix only | Uses SIGTERM |
-| `rampart upgrade` | ✅ Works | Downloads `.zip` asset, replaces `rampart.exe` |
+| `rampart upgrade` | ⚠️ Re-run installer | Required when upgrading affected v1.2.x installations |
 | `rampart wrap` | ❌ Unix only | Uses `$SHELL` |
 | `rampart preload` | ❌ Linux only | Uses LD_PRELOAD |
+
+For the v1.2.x to v1.3.0 upgrade, rerun `irm https://rampart.sh/install.ps1 | iex`. The installer repairs the affected legacy `~\.rampart` ACL before replacing the binary. If that directory is locked, the existing `rampart.exe` may not be able to start `rampart upgrade`.
 
 ### Path Matching
 

--- a/docs-site/reference/threat-model.md
+++ b/docs-site/reference/threat-model.md
@@ -220,10 +220,10 @@ These policies are active automatically when using the standard or paranoid prof
 v0.6.6 added Windows policy parity. Key differences from Linux/macOS:
 
 - **No LD_PRELOAD:** `rampart preload` is not available. Use native hooks or wrap mode instead.
-- **No POSIX file permissions:** `chmod 0600` is not enforced by the OS. Token files and signing keys are created with default permissions; use Windows ACLs for hardening.
+- **No POSIX file permissions:** `chmod 0600` is not enforced by the OS. Rampart protects its persisted token with an owner-only Windows DACL derived from the current process SID; other sensitive files need explicit Windows ACL hardening.
 - **Binary upgrade:** Windows forbids overwriting a running executable. `rampart upgrade` renames the current binary to `.rampart.exe.old` first, then installs the new one.
 - **Path separators:** Rampart normalizes backslashes to forward slashes internally for consistent policy matching.
-- **Service management:** `rampart serve install` creates a Windows service (not systemd/launchd). Auto-restart is configured by default.
+- **Service management:** automatic service installation is currently supported on Linux and macOS only. On Windows, run `rampart serve` directly or configure Task Scheduler/NSSM.
 
 ## Deployment Recommendations
 

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -223,7 +223,7 @@ v0.6.6 added Windows policy parity. Key differences from Linux/macOS:
 - **No POSIX file permissions** — `chmod 0600` is not enforced by the OS. Rampart protects its persisted token with an owner-only Windows DACL derived from the current process SID; other sensitive files need explicit Windows ACL hardening.
 - **Binary upgrade** — Windows forbids overwriting a running executable. `rampart upgrade` renames the current binary to `.rampart.exe.old` first, then installs the new one.
 - **Path separators** — Rampart normalizes backslashes to forward slashes internally for consistent policy matching.
-- **Service management** — `rampart serve install` creates a Windows service (not systemd/launchd). Auto-restart is configured by default.
+- **Service management** — automatic service installation is currently supported on Linux and macOS only. On Windows, run `rampart serve` directly or configure Task Scheduler/NSSM.
 
 ## Deployment Recommendations
 

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -220,7 +220,7 @@ These policies are active automatically when using the standard or paranoid prof
 v0.6.6 added Windows policy parity. Key differences from Linux/macOS:
 
 - **No LD_PRELOAD** — `rampart preload` is not available. Use native hooks or wrap mode instead.
-- **No POSIX file permissions** — `chmod 0600` is not enforced by the OS. Token files and signing keys are created with default permissions; use Windows ACLs for hardening.
+- **No POSIX file permissions** — `chmod 0600` is not enforced by the OS. Rampart protects its persisted token with an owner-only Windows DACL derived from the current process SID; other sensitive files need explicit Windows ACL hardening.
 - **Binary upgrade** — Windows forbids overwriting a running executable. `rampart upgrade` renames the current binary to `.rampart.exe.old` first, then installs the new one.
 - **Path separators** — Rampart normalizes backslashes to forward slashes internally for consistent policy matching.
 - **Service management** — `rampart serve install` creates a Windows service (not systemd/launchd). Auto-restart is configured by default.

--- a/docs/guides/windows.md
+++ b/docs/guides/windows.md
@@ -70,9 +70,11 @@ rampart test "rm -rf /"
 |---------|--------|-------|
 | `rampart serve --background` | ❌ Unix only | Uses fork/exec |
 | `rampart serve stop` | ❌ Unix only | Uses SIGTERM |
-| `rampart upgrade` | ✅ Works | Downloads `.zip` asset, replaces `rampart.exe` |
+| `rampart upgrade` | ⚠️ Re-run installer | Required when upgrading affected v1.2.x installations |
 | `rampart wrap` | ❌ Unix only | Uses `$SHELL` |
 | `rampart preload` | ❌ Linux only | Uses LD_PRELOAD |
+
+For the v1.2.x to v1.3.0 upgrade, rerun `irm https://rampart.sh/install.ps1 | iex`. The installer repairs the affected legacy `~\.rampart` ACL before replacing the binary. If that directory is locked, the existing `rampart.exe` may not be able to start `rampart upgrade`.
 
 ### Path Matching
 

--- a/docs/install.ps1
+++ b/docs/install.ps1
@@ -12,6 +12,7 @@ $ErrorActionPreference = "Stop"
 
 $RepoOwner = "peg"
 $RepoName = "rampart"
+$RampartDir = "$env:USERPROFILE\.rampart"
 $InstallDir = "$env:USERPROFILE\.rampart\bin"
 
 function Write-Status($msg) { Write-Host "  $msg" -ForegroundColor Cyan }
@@ -19,9 +20,100 @@ function Write-Success($msg) { Write-Host "[OK] $msg" -ForegroundColor Green }
 function Write-Warn($msg) { Write-Host "[!] $msg" -ForegroundColor Yellow }
 function Write-Err($msg) { Write-Host "[X] $msg" -ForegroundColor Red }
 
+function Test-IsUnauthorizedAccess($errorRecord) {
+    $exception = $errorRecord.Exception
+    while ($null -ne $exception) {
+        if ($exception -is [System.UnauthorizedAccessException]) { return $true }
+        $exception = $exception.InnerException
+    }
+    return $false
+}
+
+function Test-DirectoryExistsFromParent($path) {
+    $parent = Split-Path -Parent $path
+    $leaf = Split-Path -Leaf $path
+    foreach ($candidate in [System.IO.Directory]::EnumerateDirectories(
+        $parent,
+        $leaf,
+        [System.IO.SearchOption]::TopDirectoryOnly
+    )) {
+        if ([System.StringComparer]::OrdinalIgnoreCase.Equals($candidate, $path)) {
+            return $true
+        }
+    }
+    return $false
+}
+
+function Test-DirectoryWritable($path) {
+    $probe = Join-Path $path ".rampart-installer-$([Guid]::NewGuid().ToString('N')).tmp"
+    try {
+        [System.IO.File]::WriteAllText($probe, "")
+        [System.IO.File]::Delete($probe)
+        return $true
+    } catch {
+        try { [System.IO.File]::Delete($probe) } catch { }
+        if (Test-IsUnauthorizedAccess $_) { return $false }
+        throw
+    }
+}
+
+function Repair-LegacyRampartDirectoryAcl {
+    if (-not (Test-DirectoryExistsFromParent $RampartDir)) { return }
+    if (Test-DirectoryWritable $RampartDir) { return }
+
+    $currentSid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User
+    $acl = Get-Acl -LiteralPath $RampartDir
+    $ownerSid = $acl.GetOwner([System.Security.Principal.SecurityIdentifier])
+    if ($ownerSid.Value -ne $currentSid.Value) {
+        throw "Refusing to repair $RampartDir because it is not owned by the current user."
+    }
+    if (-not $acl.AreAccessRulesProtected) {
+        throw "Refusing to repair $RampartDir because it does not have the legacy protected ACL."
+    }
+
+    $explicitRules = $acl.GetAccessRules(
+        $true,
+        $false,
+        [System.Security.Principal.SecurityIdentifier]
+    )
+    foreach ($rule in $explicitRules) {
+        if ($rule.IdentityReference.Value -eq $currentSid.Value) {
+            throw "Refusing to replace an existing explicit ACL for the current user on $RampartDir."
+        }
+    }
+
+    $accessRule = [System.Security.AccessControl.FileSystemAccessRule]::new(
+        $currentSid,
+        [System.Security.AccessControl.FileSystemRights]::FullControl,
+        [System.Security.AccessControl.InheritanceFlags]::None,
+        [System.Security.AccessControl.PropagationFlags]::None,
+        [System.Security.AccessControl.AccessControlType]::Allow
+    )
+    [void]$acl.AddAccessRule($accessRule)
+    $acl.SetAccessRuleProtection($false, $true)
+    Set-Acl -LiteralPath $RampartDir -AclObject $acl
+
+    if (-not (Test-DirectoryWritable $RampartDir)) {
+        throw "The ACL repair completed but $RampartDir is still inaccessible."
+    }
+    Write-Success "Repaired permissions from an affected Rampart 1.2.x installation"
+}
+
 Write-Host ""
 Write-Host "Rampart Installer" -ForegroundColor White
 Write-Host ""
+
+try {
+    Repair-LegacyRampartDirectoryAcl
+} catch {
+    $currentSid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value
+    Write-Err "Cannot safely access $RampartDir`: $_"
+    Write-Host ""
+    Write-Host "  To repair it manually, run PowerShell as Administrator:" -ForegroundColor Yellow
+    Write-Host "    icacls `"$RampartDir`" /grant `"*$($currentSid):F`"" -ForegroundColor Cyan
+    Write-Host "    icacls `"$RampartDir`" /inheritance:e" -ForegroundColor Cyan
+    exit 1
+}
 
 # Detect architecture
 $arch = if ([Environment]::Is64BitOperatingSystem) {
@@ -136,7 +228,8 @@ if (Test-Path $InstallDir) {
         Write-Host "    2. Run PowerShell as Administrator and execute:" -ForegroundColor Yellow
         Write-Host ""
         Write-Host "       takeown /f `"$InstallDir`" /r /d y" -ForegroundColor Cyan
-        Write-Host "       icacls `"$InstallDir`" /grant `"$($env:USERNAME):F`" /t" -ForegroundColor Cyan
+        $currentSid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value
+        Write-Host "       icacls `"$InstallDir`" /grant `"*$($currentSid):F`" /t" -ForegroundColor Cyan
         Write-Host "       Remove-Item -Recurse -Force `"$InstallDir`"" -ForegroundColor Cyan
         Write-Host ""
         Write-Host "    3. Re-run this installer" -ForegroundColor Yellow

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/sys v0.38.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -54,7 +55,6 @@ require (
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
-	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
 	google.golang.org/protobuf v1.36.8 // indirect
 )

--- a/install.ps1
+++ b/install.ps1
@@ -9,6 +9,7 @@ $ErrorActionPreference = "Stop"
 
 $RepoOwner = "peg"
 $RepoName = "rampart"
+$RampartDir = "$env:USERPROFILE\.rampart"
 $InstallDir = "$env:USERPROFILE\.rampart\bin"
 
 function Write-Status($msg) { Write-Host "  $msg" -ForegroundColor Cyan }
@@ -16,9 +17,100 @@ function Write-Success($msg) { Write-Host "✓ $msg" -ForegroundColor Green }
 function Write-Warn($msg) { Write-Host "⚠ $msg" -ForegroundColor Yellow }
 function Write-Err($msg) { Write-Host "✗ $msg" -ForegroundColor Red }
 
+function Test-IsUnauthorizedAccess($errorRecord) {
+    $exception = $errorRecord.Exception
+    while ($null -ne $exception) {
+        if ($exception -is [System.UnauthorizedAccessException]) { return $true }
+        $exception = $exception.InnerException
+    }
+    return $false
+}
+
+function Test-DirectoryExistsFromParent($path) {
+    $parent = Split-Path -Parent $path
+    $leaf = Split-Path -Leaf $path
+    foreach ($candidate in [System.IO.Directory]::EnumerateDirectories(
+        $parent,
+        $leaf,
+        [System.IO.SearchOption]::TopDirectoryOnly
+    )) {
+        if ([System.StringComparer]::OrdinalIgnoreCase.Equals($candidate, $path)) {
+            return $true
+        }
+    }
+    return $false
+}
+
+function Test-DirectoryWritable($path) {
+    $probe = Join-Path $path ".rampart-installer-$([Guid]::NewGuid().ToString('N')).tmp"
+    try {
+        [System.IO.File]::WriteAllText($probe, "")
+        [System.IO.File]::Delete($probe)
+        return $true
+    } catch {
+        try { [System.IO.File]::Delete($probe) } catch { }
+        if (Test-IsUnauthorizedAccess $_) { return $false }
+        throw
+    }
+}
+
+function Repair-LegacyRampartDirectoryAcl {
+    if (-not (Test-DirectoryExistsFromParent $RampartDir)) { return }
+    if (Test-DirectoryWritable $RampartDir) { return }
+
+    $currentSid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User
+    $acl = Get-Acl -LiteralPath $RampartDir
+    $ownerSid = $acl.GetOwner([System.Security.Principal.SecurityIdentifier])
+    if ($ownerSid.Value -ne $currentSid.Value) {
+        throw "Refusing to repair $RampartDir because it is not owned by the current user."
+    }
+    if (-not $acl.AreAccessRulesProtected) {
+        throw "Refusing to repair $RampartDir because it does not have the legacy protected ACL."
+    }
+
+    $explicitRules = $acl.GetAccessRules(
+        $true,
+        $false,
+        [System.Security.Principal.SecurityIdentifier]
+    )
+    foreach ($rule in $explicitRules) {
+        if ($rule.IdentityReference.Value -eq $currentSid.Value) {
+            throw "Refusing to replace an existing explicit ACL for the current user on $RampartDir."
+        }
+    }
+
+    $accessRule = [System.Security.AccessControl.FileSystemAccessRule]::new(
+        $currentSid,
+        [System.Security.AccessControl.FileSystemRights]::FullControl,
+        [System.Security.AccessControl.InheritanceFlags]::None,
+        [System.Security.AccessControl.PropagationFlags]::None,
+        [System.Security.AccessControl.AccessControlType]::Allow
+    )
+    [void]$acl.AddAccessRule($accessRule)
+    $acl.SetAccessRuleProtection($false, $true)
+    Set-Acl -LiteralPath $RampartDir -AclObject $acl
+
+    if (-not (Test-DirectoryWritable $RampartDir)) {
+        throw "The ACL repair completed but $RampartDir is still inaccessible."
+    }
+    Write-Success "Repaired permissions from an affected Rampart 1.2.x installation"
+}
+
 Write-Host ""
 Write-Host "🛡️  Rampart Installer" -ForegroundColor White
 Write-Host ""
+
+try {
+    Repair-LegacyRampartDirectoryAcl
+} catch {
+    $currentSid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value
+    Write-Err "Cannot safely access $RampartDir`: $_"
+    Write-Host ""
+    Write-Host "  To repair it manually, run PowerShell as Administrator:" -ForegroundColor Yellow
+    Write-Host "    icacls `"$RampartDir`" /grant `"*$($currentSid):F`"" -ForegroundColor Cyan
+    Write-Host "    icacls `"$RampartDir`" /inheritance:e" -ForegroundColor Cyan
+    exit 1
+}
 
 # Detect architecture
 $arch = if ([Environment]::Is64BitOperatingSystem) {
@@ -133,7 +225,8 @@ if (Test-Path $InstallDir) {
         Write-Host "    2. Run PowerShell as Administrator and execute:" -ForegroundColor Yellow
         Write-Host ""
         Write-Host "       takeown /f `"$InstallDir`" /r /d y" -ForegroundColor Cyan
-        Write-Host "       icacls `"$InstallDir`" /grant `"$($env:USERNAME):F`" /t" -ForegroundColor Cyan
+        $currentSid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value
+        Write-Host "       icacls `"$InstallDir`" /grant `"*$($currentSid):F`" /t" -ForegroundColor Cyan
         Write-Host "       Remove-Item -Recurse -Force `"$InstallDir`"" -ForegroundColor Cyan
         Write-Host ""
         Write-Host "    3. Re-run this installer" -ForegroundColor Yellow


### PR DESCRIPTION
## Summary

Fixes #340 by replacing the `icacls`/domain-username token hardening path with a native Windows owner-only DACL derived from the current process token SID.

## Root cause

Rampart previously removed inherited ACLs from the entire `~/.rampart` directory while granting access to `DOMAIN\username` in the same `icacls` invocation. On domain and AzureAD machines, account-name resolution can fail after inheritance changes begin. The fallback `os.Chmod` does not repair Windows DACLs, and persistence errors were ignored, allowing both owner lockout and fail-open setup.

## Changes

- Read the current user SID directly from the Windows process token; no domain-controller lookup.
- Build and apply one protected, owner-only file DACL through native Windows security APIs.
- Leave the shared `~/.rampart` directory ACL unchanged; protect only the token file.
- Secure a temporary token file before writing the secret, then atomically replace the destination.
- Return hardening failures instead of continuing with an unprotected token.
- Add Windows unit coverage for SID use, DACL shape, error propagation, and directory behavior.
- Add a Windows integration test that verifies the token DACL is protected and contains exactly the process user SID.
- Document the fix in the v1.3.0 changelog and Windows threat-model notes.

## Validation

- `go test ./...`
- `go vet ./...`
- `GOOS=windows GOARCH=amd64 go build ./...`
- `GOOS=windows GOARCH=amd64 go test -c ./cmd/rampart/cli`

GitHub's Windows runner will execute the new native DACL integration test before this is merged and tagged.