### PR TITLE
fix: support OpenClaw 2026.7 migration output

### DIFF
--- a/.github/workflows/upstream-compat.yml
+++ b/.github/workflows/upstream-compat.yml
@@ -37,7 +37,8 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          # Latest OpenClaw requires >=22.22.3 or a supported Node 24 release.
+          node-version: '24'
 
       - name: Validate against latest OpenClaw
         run: node scripts/compat-openclaw-latest.mjs --npm-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Windows token hardening cannot lock domain or AzureAD users out of Rampart** — Token ACLs now use the current process SID through native Windows security APIs, protect only the token file, and fail setup safely if hardening cannot be applied.
+- **OpenClaw 2026.7 migration notices no longer break protection detection or verification** — Rampart extracts the real config path and JSON gateway payload when OpenClaw prints state-migration notices first, so existing upgraded installations continue to detect their native plugin and pass live canaries.
+- **Modern OpenClaw never falls into legacy bundle patching after a detection error** — Setup and `doctor --fix` refuse the legacy dist-patch fallback on native-plugin-capable OpenClaw releases.
+- **The live OpenClaw release gate proves successful approval resume** — The isolated regression now requires a native plugin approval, `allow-once`, exact tool-call resume, successful execution, and correlated trajectory/audit evidence; its documented invocation matches the isolation guard.
 - **OpenClaw policy responses fail closed** — Malformed, empty, array, or unknown policy responses block the tool call instead of silently becoming an allow decision.
 - **Rampart tokens stay on the loopback trust boundary** — Managed OpenClaw configuration forces the local policy URL, and the plugin refuses to send its admin token to non-loopback endpoints.
 - **Managed policies are loaded before enforcement and hot-reload correctly** — Fresh protection no longer starts with only one managed layer, and `rampart serve` now reloads YAML files created, replaced, renamed, or removed in the policy directory.

--- a/cmd/rampart/cli/doctor.go
+++ b/cmd/rampart/cli/doctor.go
@@ -136,6 +136,9 @@ func runDoctorFix(cmd *cobra.Command) error {
 			return nil
 		} else {
 			fmt.Fprintf(cmd.ErrOrStderr(), "⚠ Native plugin repair failed: %v\n", err)
+			if version, modern := modernOpenClawVersion(); modern {
+				return fmt.Errorf("native plugin repair failed on OpenClaw %s; refusing unsafe legacy dist patch fallback: %w", version, err)
+			}
 		}
 	}
 

--- a/cmd/rampart/cli/openclaw_output.go
+++ b/cmd/rampart/cli/openclaw_output.go
@@ -1,0 +1,76 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0
+
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// parseOpenClawConfigPath extracts the config path from `openclaw config file`.
+// Newer OpenClaw releases can print state-migration notices before the path,
+// even when banner and notice suppression environment variables are set.
+func parseOpenClawConfigPath(output []byte) (string, error) {
+	lines := strings.Split(strings.ReplaceAll(string(output), "\r\n", "\n"), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		candidate := strings.Trim(strings.TrimSpace(stripANSI(lines[i])), `"'`)
+		lower := strings.ToLower(candidate)
+		if candidate == "" || (!strings.HasSuffix(lower, ".json") && !strings.HasSuffix(lower, ".json5")) {
+			continue
+		}
+		expanded := expandHomePath(candidate)
+		if filepath.IsAbs(expanded) {
+			return filepath.Clean(expanded), nil
+		}
+	}
+	return "", fmt.Errorf("OpenClaw did not return a recognizable absolute JSON config path")
+}
+
+// decodeOpenClawJSON decodes the first complete JSON object or array beginning
+// on a line boundary. This tolerates OpenClaw migration notices before an
+// otherwise valid --json response without accepting arbitrary partial JSON.
+func decodeOpenClawJSON(output []byte, dst any) error {
+	for offset := 0; offset < len(output); {
+		lineEnd := bytes.IndexByte(output[offset:], '\n')
+		if lineEnd < 0 {
+			lineEnd = len(output) - offset
+		}
+		line := bytes.TrimSpace(output[offset : offset+lineEnd])
+		if len(line) > 0 && (line[0] == '{' || line[0] == '[') {
+			var raw json.RawMessage
+			decoder := json.NewDecoder(bytes.NewReader(output[offset:]))
+			if err := decoder.Decode(&raw); err == nil {
+				if err := json.Unmarshal(raw, dst); err == nil {
+					return nil
+				}
+			}
+		}
+		offset += lineEnd + 1
+	}
+	return fmt.Errorf("OpenClaw output did not contain a valid JSON object or array")
+}
+
+func stripANSI(value string) string {
+	var out strings.Builder
+	out.Grow(len(value))
+	for i := 0; i < len(value); {
+		if value[i] == 0x1b && i+1 < len(value) && value[i+1] == '[' {
+			i += 2
+			for i < len(value) {
+				b := value[i]
+				i++
+				if b >= 0x40 && b <= 0x7e {
+					break
+				}
+			}
+			continue
+		}
+		out.WriteByte(value[i])
+		i++
+	}
+	return out.String()
+}

--- a/cmd/rampart/cli/setup_openclaw_plugin.go
+++ b/cmd/rampart/cli/setup_openclaw_plugin.go
@@ -188,10 +188,6 @@ func ensureOpenClawApprovalHardening(w io.Writer, errW io.Writer) error {
 		}
 	}
 
-	state, err := ochardening.InspectConfig(configPath, openclawDistCandidates())
-	if err != nil {
-		return fmt.Errorf("inspect current hardening state: %w", err)
-	}
 	if isOpenClawPluginInstalled() {
 		updated, timeoutErr := ochardening.EnsurePluginApprovalTimeoutConfig(configPath)
 		if timeoutErr != nil {
@@ -202,6 +198,14 @@ func ensureOpenClawApprovalHardening(w io.Writer, errW io.Writer) error {
 		}
 		fmt.Fprintln(w, "✓ Native OpenClaw plugin approvals configured; skipped legacy exec approval bundle patching")
 		return nil
+	}
+	if version, modern := modernOpenClawVersion(); modern {
+		return fmt.Errorf("OpenClaw %s supports Rampart's native plugin; refusing legacy approval bundle patching because the native plugin was not detected (run `rampart protect openclaw --reinstall`)", version)
+	}
+
+	state, err := ochardening.InspectConfig(configPath, openclawDistCandidates())
+	if err != nil {
+		return fmt.Errorf("inspect current hardening state: %w", err)
 	}
 	if state.ExecApprovalsPath == "" || state.BashToolsPath == "" {
 		return fmt.Errorf("openclaw approval bundles not found under supported dist paths")
@@ -486,8 +490,8 @@ func resolveOpenClawStateDir(openclawBin string) (stateDir string, configPath st
 		cmd.Env = append(os.Environ(), "OPENCLAW_HIDE_BANNER=1", "OPENCLAW_SUPPRESS_NOTES=1")
 		out, runErr := cmd.Output()
 		if runErr == nil {
-			configPath = expandHomePath(strings.TrimSpace(string(out)))
-			if configPath != "" {
+			configPath, parseErr := parseOpenClawConfigPath(out)
+			if parseErr == nil {
 				return filepath.Dir(configPath), configPath, nil
 			}
 		}
@@ -913,6 +917,15 @@ func detectOpenClawVersion() (string, error) {
 		return "", err
 	}
 	return getOpenClawVersion(bin)
+}
+
+func modernOpenClawVersion() (string, bool) {
+	version, err := detectOpenClawVersion()
+	if err != nil {
+		return "", false
+	}
+	ok, err := openclawVersionAtLeast(version, openclawMinVersion)
+	return version, err == nil && ok
 }
 
 // ensureServeRunning checks whether rampart serve is reachable, and if not,

--- a/cmd/rampart/cli/setup_openclaw_plugin_test.go
+++ b/cmd/rampart/cli/setup_openclaw_plugin_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -76,6 +77,95 @@ func TestResolveOpenClawStateDirHonorsConfigEnv(t *testing.T) {
 	}
 	if stateDir != tmp || configPath != cfg {
 		t.Fatalf("stateDir/configPath = %q/%q, want %q/%q", stateDir, configPath, tmp, cfg)
+	}
+}
+
+func TestResolveOpenClawStateDirIgnoresMigrationNotice(t *testing.T) {
+	skipOnWindows(t, "test uses a POSIX OpenClaw shim")
+	stateDir := t.TempDir()
+	configPath := filepath.Join(stateDir, "openclaw.json")
+	bin := filepath.Join(t.TempDir(), "openclaw")
+	shim := "#!/bin/sh\n" +
+		"printf '%s\\n' '[state-migrations] Legacy state migration notes:'\n" +
+		"printf '%s\\n' '- Left plugin install index in place because shared SQLite state has conflicting plugin install metadata for: rampart'\n" +
+		"printf '%s\\n' '" + configPath + "'\n"
+	if err := os.WriteFile(bin, []byte(shim), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("OPENCLAW_STATE_DIR", "")
+	t.Setenv("OPENCLAW_CONFIG_PATH", "")
+
+	gotStateDir, gotConfigPath, err := resolveOpenClawStateDir(bin)
+	if err != nil {
+		t.Fatalf("resolveOpenClawStateDir returned error: %v", err)
+	}
+	if gotStateDir != stateDir || gotConfigPath != configPath {
+		t.Fatalf("stateDir/configPath = %q/%q, want %q/%q", gotStateDir, gotConfigPath, stateDir, configPath)
+	}
+}
+
+func TestGetOpenClawPluginStateWithMigrationNotice(t *testing.T) {
+	skipOnWindows(t, "test uses a POSIX OpenClaw shim")
+	stateDir := t.TempDir()
+	pluginDir := filepath.Join(stateDir, openclawPluginDir)
+	if err := os.MkdirAll(pluginDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginDir, "openclaw.plugin.json"), []byte(`{"version":"1.3.0","activation":{"onStartup":true}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "openclaw.json"), []byte(`{"plugins":{"allow":["rampart"],"entries":{"rampart":{"enabled":true}}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	configPath := filepath.Join(stateDir, "openclaw.json")
+	bin := filepath.Join(t.TempDir(), "openclaw")
+	shim := "#!/bin/sh\n" +
+		"printf '%s\\n' '[state-migrations] Legacy state migration notes:'\n" +
+		"printf '%s\\n' '- Left plugin install index in place because shared SQLite state has conflicting plugin install metadata for: rampart'\n" +
+		"printf '%s\\n' '" + configPath + "'\n"
+	if err := os.WriteFile(bin, []byte(shim), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("OPENCLAW_STATE_DIR", "")
+	t.Setenv("OPENCLAW_CONFIG_PATH", "")
+	t.Setenv("RAMPART_OPENCLAW_BIN", bin)
+
+	state := getOpenClawPluginState()
+	if !state.Installed || !state.Allowed || !state.Enabled {
+		t.Fatalf("expected installed, allowed, enabled plugin; got %#v", state)
+	}
+}
+
+func TestEnsureOpenClawApprovalHardeningRefusesLegacyPatchOnModernOpenClaw(t *testing.T) {
+	skipOnWindows(t, "test uses a POSIX OpenClaw shim")
+	home := t.TempDir()
+	testSetHome(t, home)
+	stateDir := filepath.Join(home, ".openclaw")
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "openclaw.json"), []byte(`{}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	bin := filepath.Join(t.TempDir(), "openclaw")
+	shim := `#!/bin/sh
+if [ "$1" = "--version" ]; then
+  printf '%s\n' '2026.7.1-2'
+  exit 0
+fi
+printf '%s\n' "$OPENCLAW_CONFIG_PATH"
+`
+	if err := os.WriteFile(bin, []byte(shim), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("RAMPART_OPENCLAW_BIN", bin)
+	t.Setenv("OPENCLAW_STATE_DIR", stateDir)
+	t.Setenv("OPENCLAW_CONFIG_PATH", filepath.Join(stateDir, "openclaw.json"))
+
+	var stdout, stderr bytes.Buffer
+	err := ensureOpenClawApprovalHardening(&stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "refusing legacy approval bundle patching") {
+		t.Fatalf("expected modern OpenClaw legacy-patch refusal, got %v", err)
 	}
 }
 

--- a/cmd/rampart/cli/verify.go
+++ b/cmd/rampart/cli/verify.go
@@ -348,7 +348,7 @@ func verifyOpenClawPluginLive(ctx context.Context, timeout time.Duration) verifi
 		return check
 	}
 	var payload any
-	if err := json.Unmarshal(output, &payload); err != nil {
+	if err := decodeOpenClawJSON(output, &payload); err != nil {
 		check.Status = verificationUnverified
 		check.Actual = "unreadable gateway response"
 		check.Message = "The live plugin responded, but OpenClaw returned an unreadable verification payload"

--- a/cmd/rampart/cli/verify_test.go
+++ b/cmd/rampart/cli/verify_test.go
@@ -96,6 +96,8 @@ func TestVerifyOpenClawPluginLiveParsesGatewayPayload(t *testing.T) {
 	}
 	bin := filepath.Join(t.TempDir(), "openclaw")
 	shim := `#!/bin/sh
+printf '%s\n' '[state-migrations] Legacy state migration notes:'
+printf '%s\n' '- Left plugin install index in place because shared SQLite state has conflicting plugin install metadata for: rampart'
 printf '%s\n' '{"result":{"schema":"rampart.plugin.verify.v1","safeCanaries":true,"ok":true,"checks":[{"id":"routine-command","expected":"allow","actual":"allow","pass":true},{"id":"destructive-command","expected":"deny","actual":"deny","pass":true},{"id":"external-deployment","expected":"ask","actual":"ask","pass":true},{"id":"cross-conversation-message","expected":"ask","actual":"ask","pass":true},{"id":"credential-shell-read","expected":"deny","actual":"deny","pass":true},{"id":"opaque-interpreter","expected":"ask","actual":"ask","pass":true}]}}'
 `
 	if err := os.WriteFile(bin, []byte(shim), 0o755); err != nil {

--- a/docs-site/getting-started/release-compatibility-gate.md
+++ b/docs-site/getting-started/release-compatibility-gate.md
@@ -73,9 +73,17 @@ The Hermes harness installs or uses an isolated Hermes runtime and never touches
 For OpenClaw's recommended support tier, also run the opt-in runtime audit regression before a release promotion:
 
 ```bash
-RAMPART_OPENCLAW_RUNTIME=1 node scripts/test-openclaw-codex-native-audit.mjs
+export RAMPART_OPENCLAW_ISOLATION_ROOT=/path/to/disposable/root
+export HOME="$RAMPART_OPENCLAW_ISOLATION_ROOT/home"
+export OPENCLAW_STATE_DIR="$HOME/.openclaw"
+export OPENCLAW_CONFIG_PATH="$OPENCLAW_STATE_DIR/openclaw.json"
+RAMPART_OPENCLAW_RUNTIME=1 \
+RAMPART_OPENCLAW_RESTART_SERVICES= \
+node scripts/test-openclaw-codex-native-audit.mjs
 ```
 
-That live regression is intentionally separate from scheduled CI because it temporarily enables the OpenClaw Rampart plugin, restarts local OpenClaw user services, runs one real OpenClaw Codex app-server turn, and requires correlated OpenClaw trajectory plus Rampart canonical `exec` audit proof.
+The isolation root must contain a prepared, disposable OpenClaw state and authenticated Codex test agent whose gateway is already running against that state. Configure `plugins.entries.rampart` with `enabled: true`, `serveUrl: http://127.0.0.1:19090`, and `failOpen: false` before starting that gateway. Never point the test at a primary OpenClaw home. The script refuses paths outside the isolation root and refuses service restarts.
+
+That live regression is intentionally separate from scheduled CI because it uses a real OpenClaw Codex app-server. It proves both routine native-shell interception and the complete hosted approval path: pending plugin approval, `allow-once`, exact tool-call resume, successful execution, trajectory evidence, and correlated Rampart canonical `exec` audit evidence.
 
 A scheduled/manual GitHub Actions workflow runs these upstream checks outside the core unit-test matrix so external upstream breakage is visible without destabilizing ordinary pull-request CI.

--- a/docs-site/integrations/openclaw.md
+++ b/docs-site/integrations/openclaw.md
@@ -166,10 +166,16 @@ node scripts/compat-openclaw-latest.mjs --npm-latest
 That isolated harness validates plugin install/config and bundled plugin behavior. Before promoting a release that claims OpenClaw as recommended, also run the opt-in live runtime audit regression:
 
 ```bash
-RAMPART_OPENCLAW_RUNTIME=1 node scripts/test-openclaw-codex-native-audit.mjs
+export RAMPART_OPENCLAW_ISOLATION_ROOT=/path/to/disposable/root
+export HOME="$RAMPART_OPENCLAW_ISOLATION_ROOT/home"
+export OPENCLAW_STATE_DIR="$HOME/.openclaw"
+export OPENCLAW_CONFIG_PATH="$OPENCLAW_STATE_DIR/openclaw.json"
+RAMPART_OPENCLAW_RUNTIME=1 \
+RAMPART_OPENCLAW_RESTART_SERVICES= \
+node scripts/test-openclaw-codex-native-audit.mjs
 ```
 
-The live regression temporarily enables the Rampart OpenClaw plugin and restarts local OpenClaw user services, then requires a real OpenClaw Codex app-server turn with correlated trajectory and Rampart canonical `exec` audit evidence.
+Use a prepared, disposable OpenClaw state and authenticated Codex test agent whose gateway is already running against that state. Before starting the isolated gateway, configure `plugins.entries.rampart` with `enabled: true`, `serveUrl: http://127.0.0.1:19090`, and `failOpen: false`. The script refuses primary-state paths and service restarts. It requires real Codex app-server turns with correlated trajectory and Rampart canonical `exec` audit evidence, including a native plugin approval, `allow-once`, exact resume, and successful execution.
 
 Or check plugin status directly:
 

--- a/docs/design/openclaw-approval-acceptance-checklist.md
+++ b/docs/design/openclaw-approval-acceptance-checklist.md
@@ -54,7 +54,8 @@ node scripts/test-openclaw-codex-native-audit.mjs
 ```
 
 Pass criteria:
-- test creates a real OpenClaw Codex app-server session metadata file (`*.jsonl.codex-app-server.json`)
+- test creates a real Codex app-server binding in modern OpenClaw plugin state
+  (or the legacy `*.jsonl.codex-app-server.json` sidecar on older releases)
 - trajectory contains a native Codex `bash` tool call for the test marker
 - Rampart audit contains a correlated canonical `exec` event for the same marker/session
 - a second safe command appears in `plugin.approval.list`, is resolved with `allow-once`, resumes the exact tool call, and executes successfully

--- a/docs/design/openclaw-approval-acceptance-checklist.md
+++ b/docs/design/openclaw-approval-acceptance-checklist.md
@@ -58,7 +58,15 @@ Pass criteria:
   (or the legacy `*.jsonl.codex-app-server.json` sidecar on older releases)
 - trajectory contains a native Codex `bash` tool call for the test marker
 - Rampart audit contains a correlated canonical `exec` event for the same marker/session
-- a second safe command appears in `plugin.approval.list`, is resolved with `allow-once`, resumes the exact tool call, and executes successfully
+- a second safe command reaches an OpenClaw approval surface, is resolved with
+  `allow-once`, resumes the exact tool call, and executes successfully
+- gateway-scoped approvals must appear in `plugin.approval.list` and be resolved
+  through `plugin.approval.resolve`
+- UI-scoped approvals must run with
+  `RAMPART_OPENCLAW_APPROVAL_DRIVER=external` and
+  `RAMPART_OPENCLAW_APPROVAL_PROOF_FILE=<disposable-ui-log>`; the log must
+  contain both the synthetic request marker and
+  `plugin approval: allowed once`, because command output alone is not accepted
 - the approved execution has its own correlated trajectory and Rampart `ask` audit event
 - OpenClaw config remains untouched and the isolated Rampart token file is restored after the test
 

--- a/docs/design/openclaw-approval-acceptance-checklist.md
+++ b/docs/design/openclaw-approval-acceptance-checklist.md
@@ -56,7 +56,8 @@ node scripts/test-openclaw-codex-native-audit.mjs
 Pass criteria:
 - test creates a real Codex app-server binding in modern OpenClaw plugin state
   (or the legacy `*.jsonl.codex-app-server.json` sidecar on older releases)
-- trajectory contains a native Codex `bash` tool call for the test marker
+- trajectory contains a native Codex `bash` tool call and its successful,
+  matching `tool.result` output for the test marker
 - Rampart audit contains a correlated canonical `exec` event for the same marker/session
 - a second safe command reaches an OpenClaw approval surface, is resolved with
   `allow-once`, resumes the exact tool call, and executes successfully

--- a/docs/design/openclaw-approval-acceptance-checklist.md
+++ b/docs/design/openclaw-approval-acceptance-checklist.md
@@ -44,16 +44,24 @@ Pass criteria:
 ### 4. Live Codex app-server shell-audit regression
 
 ```bash
-RAMPART_OPENCLAW_RUNTIME=1 node scripts/test-openclaw-codex-native-audit.mjs
+export RAMPART_OPENCLAW_ISOLATION_ROOT=/path/to/disposable/root
+export HOME="$RAMPART_OPENCLAW_ISOLATION_ROOT/home"
+export OPENCLAW_STATE_DIR="$HOME/.openclaw"
+export OPENCLAW_CONFIG_PATH="$OPENCLAW_STATE_DIR/openclaw.json"
+RAMPART_OPENCLAW_RUNTIME=1 \
+RAMPART_OPENCLAW_RESTART_SERVICES= \
+node scripts/test-openclaw-codex-native-audit.mjs
 ```
 
 Pass criteria:
 - test creates a real OpenClaw Codex app-server session metadata file (`*.jsonl.codex-app-server.json`)
 - trajectory contains a native Codex `bash` tool call for the test marker
 - Rampart audit contains a correlated canonical `exec` event for the same marker/session
-- OpenClaw config and Rampart token file are restored after the test
+- a second safe command appears in `plugin.approval.list`, is resolved with `allow-once`, resumes the exact tool call, and executes successfully
+- the approved execution has its own correlated trajectory and Rampart `ask` audit event
+- OpenClaw config remains untouched and the isolated Rampart token file is restored after the test
 
-Do not count a successful OpenClaw command or trajectory as sufficient by itself. The audit event is the proof that the native shell path crossed Rampart policy evaluation.
+The isolation root must contain a prepared, disposable OpenClaw state and authenticated Codex test agent whose gateway is already running against that state. Before starting the isolated gateway, configure `plugins.entries.rampart` with `enabled: true`, `serveUrl: http://127.0.0.1:19090`, and `failOpen: false`. The script refuses primary-state paths and service restarts. Do not count a successful OpenClaw command or trajectory as sufficient by itself. The audit event is the proof that the native shell path crossed Rampart policy evaluation.
 
 ## Installed integration checks
 

--- a/internal/plugin/openclaw/README.md
+++ b/internal/plugin/openclaw/README.md
@@ -74,7 +74,8 @@ node scripts/test-openclaw-codex-native-audit.mjs
 Run it only with a prepared, disposable OpenClaw state and authenticated Codex test agent whose gateway is already running against that state. Before starting the isolated gateway, configure `plugins.entries.rampart` with `enabled: true`, `serveUrl: http://127.0.0.1:19090`, and `failOpen: false`. The script starts the ephemeral policy service at that address, runs real OpenClaw Codex app-server turns, leaves OpenClaw config untouched, and restores the isolated token state. It proves routine native-shell interception plus a native plugin approval, `allow-once`, exact resume, and successful execution.
 
 Pass criteria:
-- a `*.jsonl.codex-app-server.json` metadata file exists for the test session
+- a Codex app-server binding exists in modern OpenClaw plugin state (or the
+  legacy `*.jsonl.codex-app-server.json` sidecar on older releases)
 - the OpenClaw trajectory contains a native Codex `bash` tool call for the marker command
 - the temporary Rampart audit log contains a correlated canonical `exec` event for that marker command
 - a second safe command is approved once through `plugin.approval.resolve`, resumes, executes, and has correlated trajectory plus Rampart `ask` audit evidence

--- a/internal/plugin/openclaw/README.md
+++ b/internal/plugin/openclaw/README.md
@@ -62,15 +62,22 @@ It still does **not** prove that the currently installed OpenClaw + Codex app-se
 Run this only when you intentionally want a real local OpenClaw runtime check:
 
 ```bash
-RAMPART_OPENCLAW_RUNTIME=1 node scripts/test-openclaw-codex-native-audit.mjs
+export RAMPART_OPENCLAW_ISOLATION_ROOT=/path/to/disposable/root
+export HOME="$RAMPART_OPENCLAW_ISOLATION_ROOT/home"
+export OPENCLAW_STATE_DIR="$HOME/.openclaw"
+export OPENCLAW_CONFIG_PATH="$OPENCLAW_STATE_DIR/openclaw.json"
+RAMPART_OPENCLAW_RUNTIME=1 \
+RAMPART_OPENCLAW_RESTART_SERVICES= \
+node scripts/test-openclaw-codex-native-audit.mjs
 ```
 
-The live regression temporarily enables the Rampart OpenClaw plugin, points it at an ephemeral local `rampart serve`, restarts the OpenClaw user services, runs one real OpenClaw Codex app-server turn, and restores the prior OpenClaw config/token state before exit.
+Run it only with a prepared, disposable OpenClaw state and authenticated Codex test agent whose gateway is already running against that state. Before starting the isolated gateway, configure `plugins.entries.rampart` with `enabled: true`, `serveUrl: http://127.0.0.1:19090`, and `failOpen: false`. The script starts the ephemeral policy service at that address, runs real OpenClaw Codex app-server turns, leaves OpenClaw config untouched, and restores the isolated token state. It proves routine native-shell interception plus a native plugin approval, `allow-once`, exact resume, and successful execution.
 
 Pass criteria:
 - a `*.jsonl.codex-app-server.json` metadata file exists for the test session
 - the OpenClaw trajectory contains a native Codex `bash` tool call for the marker command
 - the temporary Rampart audit log contains a correlated canonical `exec` event for that marker command
+- a second safe command is approved once through `plugin.approval.resolve`, resumes, executes, and has correlated trajectory plus Rampart `ask` audit evidence
 
 A successful assistant response or OpenClaw trajectory alone is not enough; this test fails unless Rampart audit proves the native shell call crossed the policy path.
 

--- a/internal/plugin/openclaw/README.md
+++ b/internal/plugin/openclaw/README.md
@@ -73,6 +73,13 @@ node scripts/test-openclaw-codex-native-audit.mjs
 
 Run it only with a prepared, disposable OpenClaw state and authenticated Codex test agent whose gateway is already running against that state. Before starting the isolated gateway, configure `plugins.entries.rampart` with `enabled: true`, `serveUrl: http://127.0.0.1:19090`, and `failOpen: false`. The script starts the ephemeral policy service at that address, runs real OpenClaw Codex app-server turns, leaves OpenClaw config untouched, and restores the isolated token state. It proves routine native-shell interception plus a native plugin approval, `allow-once`, exact resume, and successful execution.
 
+By default the script resolves the approval through `plugin.approval.*`. When
+OpenClaw scopes approvals to a connected UI client, set
+`RAMPART_OPENCLAW_APPROVAL_DRIVER=external` and
+`RAMPART_OPENCLAW_APPROVAL_PROOF_FILE` to that disposable client's log. The
+test then requires the matching request plus the client's
+`plugin approval: allowed once` confirmation before it can pass.
+
 Pass criteria:
 - a Codex app-server binding exists in modern OpenClaw plugin state (or the
   legacy `*.jsonl.codex-app-server.json` sidecar on older releases)

--- a/internal/plugin/openclaw/README.md
+++ b/internal/plugin/openclaw/README.md
@@ -83,7 +83,8 @@ test then requires the matching request plus the client's
 Pass criteria:
 - a Codex app-server binding exists in modern OpenClaw plugin state (or the
   legacy `*.jsonl.codex-app-server.json` sidecar on older releases)
-- the OpenClaw trajectory contains a native Codex `bash` tool call for the marker command
+- the OpenClaw trajectory contains a native Codex `bash` tool call and its
+  successful, matching `tool.result` output for the marker command
 - the temporary Rampart audit log contains a correlated canonical `exec` event for that marker command
 - a second safe command is approved once through `plugin.approval.resolve`, resumes, executes, and has correlated trajectory plus Rampart `ask` audit evidence
 

--- a/policies/standard_test.go
+++ b/policies/standard_test.go
@@ -77,6 +77,9 @@ func TestStandardPolicyDecisions(t *testing.T) {
 		{name: "deny rampart control env override", tool: "exec", command: "RAMPART_MODE=disabled true", expected: engine.ActionDeny},
 		{name: "deny rampart control env override case-insensitive", tool: "exec", command: "rampart_mode=disabled true", expected: engine.ActionDeny},
 
+		// Must ask
+		{name: "ask before safe shred help probe", tool: "exec", command: "shred --help >/dev/null && printf '%s\\n' 'probe'", expected: engine.ActionAsk},
+
 		// Must allow
 		{name: "allow git status", tool: "exec", command: "git status", expected: engine.ActionAllow},
 		{name: "allow npm install", tool: "exec", command: "npm install", expected: engine.ActionAllow},

--- a/scripts/compat-openclaw-latest.mjs
+++ b/scripts/compat-openclaw-latest.mjs
@@ -96,6 +96,15 @@ function main() {
   const version = runOpenClaw(['--version'], { env });
   const install = runOpenClaw(['plugins', 'install', pluginDir], { env });
   const validate = runOpenClaw(['config', 'validate'], { env });
+  const configFile = runOpenClaw(['config', 'file'], { env });
+  const reportedConfigPath = commandOutput(configFile)
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .at(-1);
+  if (reportedConfigPath !== configPath) {
+    throw new Error(`OpenClaw config file reported ${JSON.stringify(reportedConfigPath)}, expected ${JSON.stringify(configPath)}`);
+  }
   const inspect = runOpenClaw(['plugins', 'inspect', 'rampart'], { required: false, env });
   const list = inspect.status === 0
     ? { command: 'openclaw plugins list', status: 0, stdout: '', stderr: '' }
@@ -119,6 +128,7 @@ function main() {
     openclaw_source: useNpmLatest ? openclawPackage : 'PATH',
     plugin_install_checked: true,
     config_validate_checked: validate.status === 0,
+    config_file_checked: reportedConfigPath === configPath,
     plugin_inspect_checked: inspect.status === 0,
     plugin_list_checked: inspect.status !== 0 && list.status === 0,
     bundled_plugin_harnesses: {

--- a/scripts/test-openclaw-codex-native-audit.mjs
+++ b/scripts/test-openclaw-codex-native-audit.mjs
@@ -5,7 +5,8 @@
  * This intentionally exercises the real OpenClaw runtime instead of the plugin
  * unit harness. Passing means:
  *   1. OpenClaw created a Codex app-server session for this run.
- *   2. The session trajectory contains a native Codex `bash` tool call.
+ *   2. The session trajectory contains a successful native Codex `bash`
+ *      tool call and matching result.
  *   3. Rampart wrote a correlated audit event for that command as canonical
  *      tool `exec`.
  *   4. A second safe command reached OpenClaw's native plugin approval queue,
@@ -523,7 +524,7 @@ async function verifyCodexAppServerBinding(turnSessionId) {
   return `${statePath}#codex/app-server-thread-bindings/${turnSessionId}`;
 }
 
-async function verifyTrajectoryBashCall(turnSessionId, expectedMarker) {
+async function verifyTrajectoryBashExecution(turnSessionId, expectedMarker) {
   const path = join(sessionsDir, `${turnSessionId}.trajectory.jsonl`);
   if (!existsSync(path)) {
     fail(`missing OpenClaw trajectory file: ${path}`);
@@ -540,6 +541,28 @@ async function verifyTrajectoryBashCall(turnSessionId, expectedMarker) {
       .map((evt) => evt?.data?.name)
       .filter(Boolean);
     fail(`trajectory did not contain a native bash tool.call for ${expectedMarker}; observed tools: ${JSON.stringify(toolNames)}`);
+  }
+  const callId = bashCall.data.toolCallId || bashCall.data.itemId;
+  const bashResult = events.find((evt) => {
+    if (evt?.type !== 'tool.result' || evt?.data?.name !== 'bash') return false;
+    const resultCallId = evt.data.toolCallId || evt.data.itemId;
+    if (callId && resultCallId !== callId) return false;
+    const status = String(evt.data.status || '').toLowerCase();
+    if (evt.data.isError === true || ['cancelled', 'error', 'failed'].includes(status)) return false;
+    return JSON.stringify({
+      result: evt.data.result,
+      output: evt.data.output,
+    }).includes(expectedMarker);
+  });
+  if (!bashResult) {
+    const bashResults = events
+      .filter((evt) => evt?.type === 'tool.result' && evt?.data?.name === 'bash')
+      .map((evt) => ({
+        toolCallId: evt.data.toolCallId || evt.data.itemId,
+        status: evt.data.status,
+        isError: evt.data.isError,
+      }));
+    fail(`trajectory did not contain a successful matching bash tool.result with output ${expectedMarker}; observed bash results: ${JSON.stringify(bashResults)}`);
   }
   return path;
 }
@@ -596,13 +619,13 @@ try {
   console.log('[runtime-regression] Disposable OpenClaw plugin configuration validated');
   await runOpenClawTurn(sessionId, prompt, marker);
   const appServerBinding = await verifyCodexAppServerBinding(sessionId);
-  const trajectoryPath = await verifyTrajectoryBashCall(sessionId, marker);
+  const trajectoryPath = await verifyTrajectoryBashExecution(sessionId, marker);
   const auditEvent = await verifyRampartAudit(sessionId, marker, 'allow');
 
   console.log(`[runtime-regression] approvalMarker=${approvalMarker}`);
   const approval = await runApprovedOpenClawTurn();
   const approvalAppServerBinding = await verifyCodexAppServerBinding(approvalSessionId);
-  const approvalTrajectoryPath = await verifyTrajectoryBashCall(approvalSessionId, approvalMarker);
+  const approvalTrajectoryPath = await verifyTrajectoryBashExecution(approvalSessionId, approvalMarker);
   const approvalAuditEvent = await verifyRampartAudit(approvalSessionId, approvalMarker, 'ask');
 
   console.log(JSON.stringify({

--- a/scripts/test-openclaw-codex-native-audit.mjs
+++ b/scripts/test-openclaw-codex-native-audit.mjs
@@ -117,6 +117,16 @@ const approvalPrompt = [
   approvalCommand,
   'Wait for approval if requested. Do not use any other tool. Reply with only the command stdout.',
 ].join(' ');
+const approvalDriver = process.env.RAMPART_OPENCLAW_APPROVAL_DRIVER || 'gateway';
+const approvalProofPath = process.env.RAMPART_OPENCLAW_APPROVAL_PROOF_FILE || '';
+if (!['gateway', 'external'].includes(approvalDriver)) {
+  console.error('RAMPART_OPENCLAW_APPROVAL_DRIVER must be "gateway" or "external".');
+  process.exit(2);
+}
+if (approvalDriver === 'external' && !approvalProofPath) {
+  console.error('External approval mode requires RAMPART_OPENCLAW_APPROVAL_PROOF_FILE.');
+  process.exit(2);
+}
 
 let tmpRoot;
 let auditDir;
@@ -376,6 +386,15 @@ async function runApprovedOpenClawTurn() {
     cwd: repoRoot,
   });
   try {
+    if (approvalDriver === 'external') {
+      const result = await turn.completion;
+      const combined = `${result.stdout}\n${result.stderr}`;
+      if (!combined.includes(approvalMarker)) {
+        fail(`Externally approved OpenClaw turn completed without marker ${approvalMarker}. Output:\n${redact(combined).slice(-4000)}`);
+      }
+      const proof = await waitForExternalApprovalProof(approvalMarker);
+      return { id: 'external-ui', resolution: 'allow-once', proof };
+    }
     const approval = await waitForPluginApproval(approvalMarker, turn);
     await run('openclaw', [
       'gateway',
@@ -398,6 +417,27 @@ async function runApprovedOpenClawTurn() {
     void turn.completion.catch(() => {});
     throw err;
   }
+}
+
+function stripAnsi(value) {
+  return String(value ?? '').replace(/\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g, '');
+}
+
+async function waitForExternalApprovalProof(expectedMarker, timeoutMs = 10_000) {
+  const deadline = Date.now() + timeoutMs;
+  let last = '';
+  while (Date.now() < deadline) {
+    try {
+      last = stripAnsi(await readFile(approvalProofPath, 'utf8'));
+      if (last.includes(expectedMarker) && last.includes('plugin approval: allowed once')) {
+        return approvalProofPath;
+      }
+    } catch {
+      // The approval surface may not have flushed its proof file yet.
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  fail(`external approval proof did not record allow-once for ${expectedMarker}: ${redact(last).slice(-2000)}`);
 }
 
 async function waitForPluginApproval(expectedMarker, turn, timeoutMs = 45_000) {
@@ -580,7 +620,8 @@ try {
     approvedExecution: {
       marker: approvalMarker,
       approvalId: approval.id,
-      resolution: 'allow-once',
+      resolution: approval.resolution || 'allow-once',
+      ...(approval.proof ? { approvalProof: approval.proof } : {}),
       appServerBinding: approvalAppServerBinding,
       trajectory: approvalTrajectoryPath,
       rampartAudit: {

--- a/scripts/test-openclaw-codex-native-audit.mjs
+++ b/scripts/test-openclaw-codex-native-audit.mjs
@@ -93,7 +93,12 @@ if (restartServices.length > 0) {
   process.exit(2);
 }
 
-const runStamp = new Date().toISOString().replace(/[-:.TZ]/g, '').slice(0, 14);
+const runStamp = process.env.RAMPART_OPENCLAW_RUN_STAMP
+  || new Date().toISOString().replace(/[-:.TZ]/g, '').slice(0, 14);
+if (!/^[A-Za-z0-9_-]+$/.test(runStamp)) {
+  console.error('RAMPART_OPENCLAW_RUN_STAMP may contain only letters, numbers, underscores, and hyphens.');
+  process.exit(2);
+}
 const marker = `rampart-runtime-codex-shell-${runStamp}`;
 const sessionId = marker;
 const command = `printf '%s\\n' '${marker}'`;

--- a/scripts/test-openclaw-codex-native-audit.mjs
+++ b/scripts/test-openclaw-codex-native-audit.mjs
@@ -105,7 +105,7 @@ const prompt = [
 ].join(' ');
 const approvalMarker = `rampart-runtime-approved-shell-${runStamp}`;
 const approvalSessionId = approvalMarker;
-const approvalCommand = `python3 -c "print('${approvalMarker}')"`;
+const approvalCommand = `shred --help >/dev/null && printf '%s\\n' '${approvalMarker}'`;
 const approvalPrompt = [
   'This is a controlled Rampart/OpenClaw approval and resume regression test.',
   'Use the native shell/terminal/bash command tool exactly once to run:',
@@ -371,7 +371,7 @@ async function runApprovedOpenClawTurn() {
     cwd: repoRoot,
   });
   try {
-    const approval = await waitForPluginApproval(approvalMarker);
+    const approval = await waitForPluginApproval(approvalMarker, turn);
     await run('openclaw', [
       'gateway',
       'call',
@@ -395,7 +395,7 @@ async function runApprovedOpenClawTurn() {
   }
 }
 
-async function waitForPluginApproval(expectedMarker, timeoutMs = 45_000) {
+async function waitForPluginApproval(expectedMarker, turn, timeoutMs = 45_000) {
   const deadline = Date.now() + timeoutMs;
   let lastPayload = null;
   while (Date.now() < deadline) {
@@ -415,6 +415,10 @@ async function waitForPluginApproval(expectedMarker, timeoutMs = 45_000) {
       ? records.find((record) => JSON.stringify(record?.request ?? record).includes(expectedMarker))
       : null;
     if (match?.id) return match;
+    if (turn.child.exitCode !== null || turn.child.signalCode !== null) {
+      const result = await turn.completion;
+      fail(`OpenClaw turn completed before exposing an approval for ${expectedMarker}. Output:\n${redact(`${result.stdout}\n${result.stderr}`).slice(-4000)}`);
+    }
     await new Promise((r) => setTimeout(r, 500));
   }
   fail(`OpenClaw did not expose a pending plugin approval for ${expectedMarker}. Last payload: ${redact(JSON.stringify(lastPayload))}`);

--- a/scripts/test-openclaw-codex-native-audit.mjs
+++ b/scripts/test-openclaw-codex-native-audit.mjs
@@ -420,19 +420,58 @@ async function waitForPluginApproval(expectedMarker, timeoutMs = 45_000) {
   fail(`OpenClaw did not expose a pending plugin approval for ${expectedMarker}. Last payload: ${redact(JSON.stringify(lastPayload))}`);
 }
 
-async function verifyCodexAppServerArtifact(turnSessionId) {
-  const path = join(sessionsDir, `${turnSessionId}.jsonl.codex-app-server.json`);
-  if (!existsSync(path)) {
-    fail(`missing Codex app-server metadata file: ${path}`);
+async function verifyCodexAppServerBinding(turnSessionId) {
+  const legacyPath = join(sessionsDir, `${turnSessionId}.jsonl.codex-app-server.json`);
+  if (existsSync(legacyPath)) {
+    const meta = JSON.parse(await readFile(legacyPath, 'utf8'));
+    if (!String(meta.sessionFile || '').endsWith(`${turnSessionId}.jsonl`)) {
+      fail(`legacy Codex app-server metadata did not point at this session file: ${legacyPath}`);
+    }
+    if (!meta.model) {
+      fail(`legacy Codex app-server metadata missing model field: ${legacyPath}`);
+    }
+    return legacyPath;
   }
-  const meta = JSON.parse(await readFile(path, 'utf8'));
-  if (!String(meta.sessionFile || '').endsWith(`${turnSessionId}.jsonl`)) {
-    fail(`Codex app-server metadata did not point at this session file: ${path}`);
+
+  const statePath = join(openclawStateDir, 'state', 'openclaw.sqlite');
+  if (!existsSync(statePath)) {
+    fail(`missing modern Codex plugin-state database and legacy metadata for session ${turnSessionId}`);
   }
-  if (!meta.model) {
-    fail(`Codex app-server metadata missing model field: ${path}`);
+
+  let DatabaseSync;
+  try {
+    ({ DatabaseSync } = await import('node:sqlite'));
+  } catch (err) {
+    fail(`cannot inspect modern Codex plugin state with this Node.js runtime: ${err.message}`);
   }
-  return path;
+
+  const database = new DatabaseSync(statePath, { readOnly: true });
+  let row;
+  try {
+    row = database.prepare(`
+      SELECT value_json
+      FROM plugin_state_entries
+      WHERE plugin_id = 'codex'
+        AND namespace = 'app-server-thread-bindings'
+        AND json_extract(value_json, '$.sessionId') = ?
+      ORDER BY created_at DESC
+      LIMIT 1
+    `).get(turnSessionId);
+  } finally {
+    database.close();
+  }
+  if (!row?.value_json) {
+    fail(`modern Codex plugin state did not contain a binding for session ${turnSessionId}`);
+  }
+
+  const binding = JSON.parse(row.value_json);
+  if (binding.sessionId !== turnSessionId || binding.state !== 'active') {
+    fail(`modern Codex plugin binding was not active for session ${turnSessionId}`);
+  }
+  if (!binding.binding?.threadId || !binding.binding?.model) {
+    fail(`modern Codex plugin binding was missing thread or model metadata for session ${turnSessionId}`);
+  }
+  return `${statePath}#codex/app-server-thread-bindings/${turnSessionId}`;
 }
 
 async function verifyTrajectoryBashCall(turnSessionId, expectedMarker) {
@@ -507,20 +546,20 @@ try {
   await validateOpenClawConfiguration();
   console.log('[runtime-regression] Disposable OpenClaw plugin configuration validated');
   await runOpenClawTurn(sessionId, prompt, marker);
-  const appServerPath = await verifyCodexAppServerArtifact(sessionId);
+  const appServerBinding = await verifyCodexAppServerBinding(sessionId);
   const trajectoryPath = await verifyTrajectoryBashCall(sessionId, marker);
   const auditEvent = await verifyRampartAudit(sessionId, marker, 'allow');
 
   console.log(`[runtime-regression] approvalMarker=${approvalMarker}`);
   const approval = await runApprovedOpenClawTurn();
-  const approvalAppServerPath = await verifyCodexAppServerArtifact(approvalSessionId);
+  const approvalAppServerBinding = await verifyCodexAppServerBinding(approvalSessionId);
   const approvalTrajectoryPath = await verifyTrajectoryBashCall(approvalSessionId, approvalMarker);
   const approvalAuditEvent = await verifyRampartAudit(approvalSessionId, approvalMarker, 'ask');
 
   console.log(JSON.stringify({
     ok: true,
     marker,
-    appServerMetadata: appServerPath,
+    appServerBinding,
     trajectory: trajectoryPath,
     rampartAudit: {
       id: auditEvent.id,
@@ -533,7 +572,7 @@ try {
       marker: approvalMarker,
       approvalId: approval.id,
       resolution: 'allow-once',
-      appServerMetadata: approvalAppServerPath,
+      appServerBinding: approvalAppServerBinding,
       trajectory: approvalTrajectoryPath,
       rampartAudit: {
         id: approvalAuditEvent.id,

--- a/scripts/test-openclaw-codex-native-audit.mjs
+++ b/scripts/test-openclaw-codex-native-audit.mjs
@@ -8,6 +8,8 @@
  *   2. The session trajectory contains a native Codex `bash` tool call.
  *   3. Rampart wrote a correlated audit event for that command as canonical
  *      tool `exec`.
+ *   4. A second safe command reached OpenClaw's native plugin approval queue,
+ *      was approved once, resumed, executed, and produced correlated proof.
  *
  * The test may only operate beneath an explicit disposable isolation root. It
  * refuses primary OpenClaw state, workspaces, sessions, memory, and services.
@@ -38,12 +40,17 @@ if (!yes) {
   console.error([
     'Refusing to run live OpenClaw runtime regression without explicit opt-in.',
     '',
-    'This test temporarily enables the Rampart OpenClaw plugin, restarts OpenClaw',
-    'user services, starts a local Rampart server, and runs one real OpenClaw',
-    'Codex app-server turn.',
+    'This test uses a prepared disposable OpenClaw state, starts a local Rampart',
+    'server, and runs real OpenClaw Codex app-server turns.',
     '',
     'Run intentionally from the repo root with:',
-    '  RAMPART_OPENCLAW_RUNTIME=1 node scripts/test-openclaw-codex-native-audit.mjs',
+    '  RAMPART_OPENCLAW_RUNTIME=1 \\',
+    '  RAMPART_OPENCLAW_ISOLATION_ROOT=/path/to/disposable/root \\',
+    '  HOME=/path/to/disposable/root/home \\',
+    '  OPENCLAW_STATE_DIR=/path/to/disposable/root/home/.openclaw \\',
+    '  OPENCLAW_CONFIG_PATH=/path/to/disposable/root/home/.openclaw/openclaw.json \\',
+    '  RAMPART_OPENCLAW_RESTART_SERVICES= \\',
+    '  node scripts/test-openclaw-codex-native-audit.mjs',
   ].join('\n'));
   process.exit(2);
 }
@@ -86,7 +93,8 @@ if (restartServices.length > 0) {
   process.exit(2);
 }
 
-const marker = `rampart-runtime-codex-shell-${new Date().toISOString().replace(/[-:.TZ]/g, '').slice(0, 14)}`;
+const runStamp = new Date().toISOString().replace(/[-:.TZ]/g, '').slice(0, 14);
+const marker = `rampart-runtime-codex-shell-${runStamp}`;
 const sessionId = marker;
 const command = `printf '%s\\n' '${marker}'`;
 const prompt = [
@@ -95,17 +103,25 @@ const prompt = [
   command,
   'Do not use any other tool. Reply with only the command stdout.',
 ].join(' ');
+const approvalMarker = `rampart-runtime-approved-shell-${runStamp}`;
+const approvalSessionId = approvalMarker;
+const approvalCommand = `python3 -c "print('${approvalMarker}')"`;
+const approvalPrompt = [
+  'This is a controlled Rampart/OpenClaw approval and resume regression test.',
+  'Use the native shell/terminal/bash command tool exactly once to run:',
+  approvalCommand,
+  'Wait for approval if requested. Do not use any other tool. Reply with only the command stdout.',
+].join(' ');
 
 let tmpRoot;
 let auditDir;
 let server;
 let serverBinary;
 let serverLogs = '';
-let originalConfig = null;
-let configChanged = false;
 let tokenExisted = false;
 let tokenBackup = null;
 let cleanupErrors = [];
+let activeAgentChild = null;
 
 function redact(text) {
   return String(text ?? '')
@@ -151,6 +167,55 @@ function run(cmd, args = [], opts = {}) {
   });
 }
 
+function startCaptured(cmd, args = [], opts = {}) {
+  const timeoutMs = opts.timeoutMs ?? 60_000;
+  const child = spawn(cmd, args, {
+    cwd: opts.cwd ?? repoRoot,
+    env: opts.env ?? process.env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  activeAgentChild = child;
+  let stdout = '';
+  let stderr = '';
+  const completion = new Promise((resolvePromise, reject) => {
+    const timer = setTimeout(() => {
+      child.kill('SIGTERM');
+      setTimeout(() => child.kill('SIGKILL'), 3_000).unref?.();
+      reject(new Error(`${cmd} ${args.join(' ')} timed out after ${timeoutMs}ms\nstdout:\n${redact(stdout)}\nstderr:\n${redact(stderr)}`));
+    }, timeoutMs);
+    child.stdout.on('data', (d) => { stdout += d.toString(); });
+    child.stderr.on('data', (d) => { stderr += d.toString(); });
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+    child.on('close', (code, signal) => {
+      clearTimeout(timer);
+      if (activeAgentChild === child) activeAgentChild = null;
+      if (code === 0) {
+        resolvePromise({ stdout, stderr, code, signal });
+      } else {
+        reject(new Error(`${cmd} ${args.join(' ')} exited ${code ?? signal}\nstdout:\n${redact(stdout)}\nstderr:\n${redact(stderr)}`));
+      }
+    });
+  });
+  return { child, completion };
+}
+
+function parseOpenClawJSON(output, label) {
+  const lines = String(output ?? '').split(/\r?\n/);
+  for (let i = 0; i < lines.length; i += 1) {
+    const trimmed = lines[i].trimStart();
+    if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) continue;
+    try {
+      return JSON.parse(lines.slice(i).join('\n'));
+    } catch {
+      // Migration notices can themselves begin with "[state-migrations]".
+    }
+  }
+  fail(`${label} did not contain a valid JSON object or array:\n${redact(output).slice(-4000)}`);
+}
+
 async function pathExists(path) {
   try {
     await access(path);
@@ -176,19 +241,6 @@ async function waitForHealth(url, timeoutMs = 45_000) {
   fail(`Rampart health check did not become ready at ${url}: ${lastErr?.message ?? 'unknown error'}\nserver logs:\n${redact(serverLogs).split('\n').slice(-40).join('\n')}`);
 }
 
-async function restartOpenClaw(reason) {
-  if (restartServices.length === 0) {
-    console.warn(`[runtime-regression] Skipping OpenClaw restart for ${reason} because RAMPART_OPENCLAW_RESTART_SERVICES is empty.`);
-    return;
-  }
-  for (const service of restartServices) {
-    await run('systemctl', ['--user', 'restart', service], { timeoutMs: 45_000, cwd: repoRoot });
-  }
-  for (const service of restartServices) {
-    await run('systemctl', ['--user', 'is-active', service], { timeoutMs: 15_000, cwd: repoRoot });
-  }
-}
-
 async function backupToken() {
   tokenBackup = join(tmpRoot, 'rampart-token.backup');
   tokenExisted = await pathExists(tokenPath);
@@ -205,35 +257,22 @@ async function restoreToken() {
   }
 }
 
-async function configureOpenClaw() {
-  originalConfig = await readFile(openclawConfigPath, 'utf8');
-  const cfg = JSON.parse(originalConfig);
-  cfg.plugins ??= {};
-  cfg.plugins.allow ??= [];
-  if (!cfg.plugins.allow.includes('rampart')) cfg.plugins.allow.push('rampart');
-  cfg.plugins.entries ??= {};
-  cfg.plugins.entries.rampart ??= {};
-  cfg.plugins.entries.rampart.enabled = true;
-  cfg.plugins.entries.rampart.config ??= {};
-  cfg.plugins.entries.rampart.config.serveUrl = serveUrl;
-  cfg.plugins.entries.rampart.config.failOpen = false;
-
-  const next = `${JSON.stringify(cfg, null, 2)}\n`;
-  if (next !== originalConfig) {
-    await writeFile(openclawConfigPath, next, 'utf8');
-    configChanged = true;
+async function validateOpenClawConfiguration() {
+  const cfg = JSON.parse(await readFile(openclawConfigPath, 'utf8'));
+  const allow = cfg?.plugins?.allow;
+  const entry = cfg?.plugins?.entries?.rampart;
+  const pluginConfig = entry?.config;
+  if (Array.isArray(allow) && !allow.includes('rampart')) {
+    fail('Disposable OpenClaw state must include rampart in plugins.allow.');
+  }
+  if (!entry || entry.enabled === false) {
+    fail('Disposable OpenClaw state must have plugins.entries.rampart.enabled=true.');
+  }
+  if (pluginConfig?.serveUrl !== serveUrl || pluginConfig?.failOpen !== false) {
+    fail(`Disposable OpenClaw state must configure Rampart with serveUrl=${serveUrl} and failOpen=false before its isolated gateway starts.`);
   }
 
   await run('openclaw', ['config', 'validate'], { timeoutMs: 30_000, cwd: repoRoot });
-  await restartOpenClaw('temporary Rampart plugin enablement');
-}
-
-async function restoreOpenClawConfig() {
-  if (originalConfig !== null && configChanged) {
-    await writeFile(openclawConfigPath, originalConfig, 'utf8');
-    await run('openclaw', ['config', 'validate'], { timeoutMs: 30_000, cwd: repoRoot });
-    await restartOpenClaw('Rampart plugin config restore');
-  }
 }
 
 async function startRampart() {
@@ -304,29 +343,90 @@ async function newestAuditEvents() {
   return events;
 }
 
-async function runOpenClawTurn() {
-  const result = await run('openclaw', [
+function openClawAgentArgs(turnSessionId, turnPrompt) {
+  return [
     'agent',
     '--agent', agentId,
-    '--session-id', sessionId,
-    '--message', prompt,
+    '--session-id', turnSessionId,
+    '--message', turnPrompt,
     '--json',
     '--timeout', process.env.RAMPART_OPENCLAW_AGENT_TIMEOUT || '180',
+  ];
+}
+
+async function runOpenClawTurn(turnSessionId, turnPrompt, expectedMarker) {
+  const result = await run('openclaw', [
+    ...openClawAgentArgs(turnSessionId, turnPrompt),
   ], { timeoutMs: Number(process.env.RAMPART_OPENCLAW_AGENT_TIMEOUT_MS || '240000'), cwd: repoRoot });
 
   const combined = `${result.stdout}\n${result.stderr}`;
-  if (!combined.includes(marker)) {
-    fail(`OpenClaw turn completed but output did not include marker ${marker}. Output:\n${redact(combined).slice(-4000)}`);
+  if (!combined.includes(expectedMarker)) {
+    fail(`OpenClaw turn completed but output did not include marker ${expectedMarker}. Output:\n${redact(combined).slice(-4000)}`);
   }
 }
 
-async function verifyCodexAppServerArtifact() {
-  const path = join(sessionsDir, `${sessionId}.jsonl.codex-app-server.json`);
+async function runApprovedOpenClawTurn() {
+  const turn = startCaptured('openclaw', openClawAgentArgs(approvalSessionId, approvalPrompt), {
+    timeoutMs: Number(process.env.RAMPART_OPENCLAW_AGENT_TIMEOUT_MS || '240000'),
+    cwd: repoRoot,
+  });
+  try {
+    const approval = await waitForPluginApproval(approvalMarker);
+    await run('openclaw', [
+      'gateway',
+      'call',
+      'plugin.approval.resolve',
+      '--params', JSON.stringify({ id: approval.id, decision: 'allow-once' }),
+      '--json',
+      '--timeout', '15000',
+    ], { timeoutMs: 30_000, cwd: repoRoot });
+    const result = await turn.completion;
+    const combined = `${result.stdout}\n${result.stderr}`;
+    if (!combined.includes(approvalMarker)) {
+      fail(`Approved OpenClaw turn completed but output did not include marker ${approvalMarker}. Output:\n${redact(combined).slice(-4000)}`);
+    }
+    return approval;
+  } catch (err) {
+    if (turn.child.exitCode === null && turn.child.signalCode === null) {
+      turn.child.kill('SIGTERM');
+    }
+    void turn.completion.catch(() => {});
+    throw err;
+  }
+}
+
+async function waitForPluginApproval(expectedMarker, timeoutMs = 45_000) {
+  const deadline = Date.now() + timeoutMs;
+  let lastPayload = null;
+  while (Date.now() < deadline) {
+    const result = await run('openclaw', [
+      'gateway',
+      'call',
+      'plugin.approval.list',
+      '--json',
+      '--timeout', '15000',
+    ], { timeoutMs: 30_000, cwd: repoRoot });
+    const payload = parseOpenClawJSON(result.stdout, 'plugin.approval.list');
+    lastPayload = payload;
+    const records = Array.isArray(payload)
+      ? payload
+      : (payload?.pending ?? payload?.approvals ?? payload?.result ?? []);
+    const match = Array.isArray(records)
+      ? records.find((record) => JSON.stringify(record?.request ?? record).includes(expectedMarker))
+      : null;
+    if (match?.id) return match;
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  fail(`OpenClaw did not expose a pending plugin approval for ${expectedMarker}. Last payload: ${redact(JSON.stringify(lastPayload))}`);
+}
+
+async function verifyCodexAppServerArtifact(turnSessionId) {
+  const path = join(sessionsDir, `${turnSessionId}.jsonl.codex-app-server.json`);
   if (!existsSync(path)) {
     fail(`missing Codex app-server metadata file: ${path}`);
   }
   const meta = JSON.parse(await readFile(path, 'utf8'));
-  if (!String(meta.sessionFile || '').endsWith(`${sessionId}.jsonl`)) {
+  if (!String(meta.sessionFile || '').endsWith(`${turnSessionId}.jsonl`)) {
     fail(`Codex app-server metadata did not point at this session file: ${path}`);
   }
   if (!meta.model) {
@@ -335,8 +435,8 @@ async function verifyCodexAppServerArtifact() {
   return path;
 }
 
-async function verifyTrajectoryBashCall() {
-  const path = join(sessionsDir, `${sessionId}.trajectory.jsonl`);
+async function verifyTrajectoryBashCall(turnSessionId, expectedMarker) {
+  const path = join(sessionsDir, `${turnSessionId}.trajectory.jsonl`);
   if (!existsSync(path)) {
     fail(`missing OpenClaw trajectory file: ${path}`);
   }
@@ -344,19 +444,19 @@ async function verifyTrajectoryBashCall() {
   const bashCall = events.find((evt) => (
     evt?.type === 'tool.call' &&
     evt?.data?.name === 'bash' &&
-    JSON.stringify(evt.data.arguments || {}).includes(marker)
+    JSON.stringify(evt.data.arguments || {}).includes(expectedMarker)
   ));
   if (!bashCall) {
     const toolNames = events
       .filter((evt) => evt?.type === 'tool.call')
       .map((evt) => evt?.data?.name)
       .filter(Boolean);
-    fail(`trajectory did not contain a native bash tool.call for ${marker}; observed tools: ${JSON.stringify(toolNames)}`);
+    fail(`trajectory did not contain a native bash tool.call for ${expectedMarker}; observed tools: ${JSON.stringify(toolNames)}`);
   }
   return path;
 }
 
-async function verifyRampartAudit() {
+async function verifyRampartAudit(turnSessionId, expectedMarker, expectedAction) {
   const deadline = Date.now() + 10_000;
   let events = [];
   while (Date.now() < deadline) {
@@ -365,8 +465,9 @@ async function verifyRampartAudit() {
       const request = JSON.stringify(evt.request || evt.params || {});
       const session = String(evt.session || '').toLowerCase();
       return evt.tool === 'exec' &&
-        request.includes(marker) &&
-        session.includes(sessionId.toLowerCase());
+        request.includes(expectedMarker) &&
+        session.includes(turnSessionId.toLowerCase()) &&
+        (!expectedAction || evt.decision?.action === expectedAction);
     });
     if (match) return match;
     await new Promise((r) => setTimeout(r, 500));
@@ -378,12 +479,14 @@ async function verifyRampartAudit() {
     action: evt.decision?.action,
     request: evt.request,
   }));
-  fail(`Rampart audit did not contain canonical exec event for native bash marker ${marker}. Observed audit events: ${redact(JSON.stringify(compact, null, 2)).slice(-4000)}`);
+  fail(`Rampart audit did not contain canonical exec event for native bash marker ${expectedMarker}${expectedAction ? ` with decision ${expectedAction}` : ''}. Observed audit events: ${redact(JSON.stringify(compact, null, 2)).slice(-4000)}`);
 }
 
 async function cleanup() {
+  if (activeAgentChild && activeAgentChild.exitCode === null && activeAgentChild.signalCode === null) {
+    try { activeAgentChild.kill('SIGTERM'); } catch (err) { cleanupErrors.push(`stop OpenClaw test turn: ${err.message}`); }
+  }
   try { await stopRampart(); } catch (err) { cleanupErrors.push(`stop rampart: ${err.message}`); }
-  try { await restoreOpenClawConfig(); } catch (err) { cleanupErrors.push(`restore openclaw config: ${err.message}`); }
   try { await restoreToken(); } catch (err) { cleanupErrors.push(`restore rampart token: ${err.message}`); }
   if (tmpRoot && process.env.RAMPART_KEEP_RUNTIME_ARTIFACTS !== '1') {
     try { await rm(tmpRoot, { recursive: true, force: true }); } catch (err) { cleanupErrors.push(`remove tmp: ${err.message}`); }
@@ -401,12 +504,18 @@ try {
   console.log(`[runtime-regression] auditDir=${auditDir}`);
   await startRampart();
   console.log(`[runtime-regression] Rampart serve ready at ${serveUrl}`);
-  await configureOpenClaw();
-  console.log('[runtime-regression] OpenClaw plugin temporarily enabled and services restarted');
-  await runOpenClawTurn();
-  const appServerPath = await verifyCodexAppServerArtifact();
-  const trajectoryPath = await verifyTrajectoryBashCall();
-  const auditEvent = await verifyRampartAudit();
+  await validateOpenClawConfiguration();
+  console.log('[runtime-regression] Disposable OpenClaw plugin configuration validated');
+  await runOpenClawTurn(sessionId, prompt, marker);
+  const appServerPath = await verifyCodexAppServerArtifact(sessionId);
+  const trajectoryPath = await verifyTrajectoryBashCall(sessionId, marker);
+  const auditEvent = await verifyRampartAudit(sessionId, marker, 'allow');
+
+  console.log(`[runtime-regression] approvalMarker=${approvalMarker}`);
+  const approval = await runApprovedOpenClawTurn();
+  const approvalAppServerPath = await verifyCodexAppServerArtifact(approvalSessionId);
+  const approvalTrajectoryPath = await verifyTrajectoryBashCall(approvalSessionId, approvalMarker);
+  const approvalAuditEvent = await verifyRampartAudit(approvalSessionId, approvalMarker, 'ask');
 
   console.log(JSON.stringify({
     ok: true,
@@ -419,6 +528,20 @@ try {
       agent: auditEvent.agent,
       session: auditEvent.session,
       action: auditEvent.decision?.action,
+    },
+    approvedExecution: {
+      marker: approvalMarker,
+      approvalId: approval.id,
+      resolution: 'allow-once',
+      appServerMetadata: approvalAppServerPath,
+      trajectory: approvalTrajectoryPath,
+      rampartAudit: {
+        id: approvalAuditEvent.id,
+        tool: approvalAuditEvent.tool,
+        agent: approvalAuditEvent.agent,
+        session: approvalAuditEvent.session,
+        action: approvalAuditEvent.decision?.action,
+      },
     },
   }, null, 2));
 } catch (err) {


### PR DESCRIPTION
## Summary

Release-blocking follow-up for Rampart 1.3.0 compatibility with OpenClaw 2026.7.1-2.

- parse the real config path when OpenClaw prefixes `config file` output with state-migration notices
- decode gateway JSON after the same notice prefix so `rampart verify openclaw` can consume the live self-test
- refuse legacy OpenClaw bundle patching on native-plugin-capable releases if plugin detection or repair fails
- align the isolated live-E2E documentation with its required isolation environment
- extend the live Codex/OpenClaw regression to prove native approval creation, `allow-once`, exact resume, successful execution, trajectory evidence, and correlated Rampart audit evidence
- support both gateway-scoped and UI-scoped OpenClaw approvals without accepting model output as approval proof
- require a successful native `bash` `tool.result` containing the execution marker, paired to the exact `tool.call`
- exercise `openclaw config file` in the latest-upstream harness and move that workflow to Node 24 for current OpenClaw engine requirements

## Validation

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- all OpenClaw plugin regression harnesses
- Hermes plugin unit suite
- standard/paranoid/yolo policy checks
- Linux lab-runner contract
- Agent01, real upgraded OpenClaw 2026.7.1-2 migrated state: candidate `rampart verify openclaw --json` passed 12/12 with no failed or unverified checks
- Agent01 candidate `doctor --json` detects the installed native plugin and reports native approval hardening healthy (no legacy fallback)
- Agent01, exact commit `04efaa5a0f6f3b06120763ff0b1699f34f796691`, disposable OpenClaw home and official `@openclaw/codex@2026.7.1-1`:
  - routine native Codex `bash` execution produced a successful matching `tool.result` and correlated Rampart `allow` audit
  - Rampart's approval appeared in the connected disposable OpenClaw TUI
  - the TUI selected and recorded `plugin approval: allowed once`
  - the exact command resumed and its successful matching `tool.result` contained the execution marker
  - modern SQLite app-server binding, Codex trajectory, and correlated Rampart `ask` audit all matched the approval session

The active Agent01 OpenClaw/Hermes memories, sessions, workspaces, configuration, and services were not modified. Live tests used a separate home/state directory, separate ports, auth-only copied database tables, detached worktree, and cleanup verification.
