### PR TITLE
chore: prepare v1.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-07-25
+
 ### Added
 
 - **Native Codex lifecycle-hook integration** — `rampart setup codex` now

--- a/cmd/rampart/cli/setup_openclaw_plugin_test.go
+++ b/cmd/rampart/cli/setup_openclaw_plugin_test.go
@@ -111,7 +111,7 @@ func TestGetOpenClawPluginStateWithMigrationNotice(t *testing.T) {
 	if err := os.MkdirAll(pluginDir, 0o700); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(pluginDir, "openclaw.plugin.json"), []byte(`{"version":"1.3.0","activation":{"onStartup":true}}`), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(pluginDir, "openclaw.plugin.json"), []byte(`{"version":"1.4.0","activation":{"onStartup":true}}`), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(stateDir, "openclaw.json"), []byte(`{"plugins":{"allow":["rampart"],"entries":{"rampart":{"enabled":true}}}}`), 0o600); err != nil {

--- a/cmd/rampart/cli/verify_test.go
+++ b/cmd/rampart/cli/verify_test.go
@@ -102,7 +102,7 @@ func TestVerifyOpenClawPluginLiveParsesGatewayPayload(t *testing.T) {
 	if err := os.MkdirAll(pluginDir, 0o700); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(pluginDir, "openclaw.plugin.json"), []byte(`{"version":"1.3.0","activation":{"onStartup":true}}`), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(pluginDir, "openclaw.plugin.json"), []byte(`{"version":"1.4.0","activation":{"onStartup":true}}`), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	bundled, err := ocplugin.PluginFS.ReadFile("index.js")

--- a/docs-site/getting-started/installation.md
+++ b/docs-site/getting-started/installation.md
@@ -97,7 +97,7 @@ volumes:
   rampart-audit:
 ```
 
-Available tags include full versions such as `1.3.0`, minor versions such as `1.3`, and `latest` for the current stable release. Prereleases use their full tag, for example `1.3.0-rc.1`, and do not move `latest`. Pin to a specific version tag for reproducibility. Images are published on [GitHub Container Registry](https://github.com/peg/rampart/pkgs/container/rampart).
+Available tags include full versions such as `1.4.0`, minor versions such as `1.4`, and `latest` for the current stable release. Prereleases use their full tag, for example `1.4.0-rc.1`, and do not move `latest`. Pin to a specific version tag for reproducibility. Images are published on [GitHub Container Registry](https://github.com/peg/rampart/pkgs/container/rampart).
 
 ## Build from Source
 

--- a/docs-site/getting-started/troubleshooting.md
+++ b/docs-site/getting-started/troubleshooting.md
@@ -165,7 +165,7 @@ rampart test --tool read "/etc/shadow"
 
 ```bash
 openclaw plugins list
-# Should show: rampart  1.3.0  ✓ active
+# Should show: rampart  1.4.0  ✓ active
 
 rampart doctor
 # Should show: ✓ OpenClaw plugin: installed (before_tool_call hook active)

--- a/docs-site/index.html
+++ b/docs-site/index.html
@@ -27,7 +27,7 @@
       "url": "https://rampart.sh",
       "applicationCategory": "SecurityApplication",
       "operatingSystem": "Linux, macOS, Windows",
-      "softwareVersion": "1.3.0",
+      "softwareVersion": "1.4.0",
       "offers": {
         "@type": "Offer",
         "price": "0",
@@ -1112,7 +1112,7 @@
 <section class="hero">
     <div class="container hero-grid">
         <div>
-            <div class="eyebrow"><span class="eyebrow-dot"></span>v1.3.0 · zero-config OpenClaw protection</div>
+            <div class="eyebrow"><span class="eyebrow-dot"></span>v1.4.0 · native agent enforcement</div>
             <h1>Your agent has root.<br><span class="accent">That’s the problem.</span></h1>
             <p class="hero-sub">Rampart sits in the execution path. Run <code>rampart protect openclaw</code> for a managed, fail-closed OpenClaw guard that verifies itself, or use <code>rampart quickstart</code> for other supported agents.</p>
             <div class="install-cluster">

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -230,10 +230,7 @@ verify -> outcomes.approval
 
 [:octicons-arrow-right-24: See all integration guides](integrations/index.md)
 
-## In development for v1.4
-
-The following work is available on the `staging` branch and remains subject to
-release-candidate validation:
+## What's New in v1.4
 
 - **Native Codex lifecycle hooks** — One user-level setup covers Codex CLI, IDE,
   and desktop host-exposed shell, file, patch, MCP, web, and delegated-agent

--- a/docs-site/integrations/openclaw.md
+++ b/docs-site/integrations/openclaw.md
@@ -181,7 +181,7 @@ Or check plugin status directly:
 
 ```bash
 openclaw plugins list
-# rampart  v1.3.0  active
+# rampart  v1.4.0  active
 ```
 
 ## Troubleshooting

--- a/docs-site/reference/threat-model.md
+++ b/docs-site/reference/threat-model.md
@@ -1,6 +1,6 @@
 # Threat Model
 
-> Last reviewed: 2026-07-20 | Applies to: v1.3.0
+> Last reviewed: 2026-07-25 | Applies to: v1.4.0
 
 Rampart evaluates AI-agent tool calls against policy before an action proceeds. It is a policy enforcement layer, not a replacement for OS sandboxing, hypervisors, or workload isolation. This document defines the threats Rampart is designed to reduce and the boundaries operators should pair it with.
 

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -1,6 +1,6 @@
 # Threat Model
 
-> Last reviewed: 2026-07-20 | Applies to: v1.3.0
+> Last reviewed: 2026-07-25 | Applies to: v1.4.0
 
 Rampart is a policy engine for AI agents — not a sandbox, not a hypervisor, not a full isolation boundary. This document describes what Rampart protects against, what it doesn't, and why.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -27,7 +27,7 @@
       "url": "https://rampart.sh",
       "applicationCategory": "SecurityApplication",
       "operatingSystem": "Linux, macOS, Windows",
-      "softwareVersion": "1.3.0",
+      "softwareVersion": "1.4.0",
       "offers": {
         "@type": "Offer",
         "price": "0",
@@ -1112,7 +1112,7 @@
 <section class="hero">
     <div class="container hero-grid">
         <div>
-            <div class="eyebrow"><span class="eyebrow-dot"></span>v1.3.0 · zero-config OpenClaw protection</div>
+            <div class="eyebrow"><span class="eyebrow-dot"></span>v1.4.0 · native agent enforcement</div>
             <h1>Your agent has root.<br><span class="accent">That’s the problem.</span></h1>
             <p class="hero-sub">Rampart sits in the execution path. Run <code>rampart protect openclaw</code> for a managed, fail-closed OpenClaw guard that verifies itself, or use <code>rampart quickstart</code> for other supported agents.</p>
             <div class="install-cluster">

--- a/docs/install
+++ b/docs/install
@@ -7,8 +7,8 @@
 # Usage: curl -fsSL https://rampart.sh/install | sh
 #        curl -fsSL https://rampart.sh/install | sh -s -- --version v0.1.0
 #        curl -fsSL https://rampart.sh/install | sh -s -- --auto-setup
-#        RAMPART_INSTALL_DRY_RUN=1 sh install.sh --version v1.3.0
-#        RAMPART_VERSION=v1.3.0 RAMPART_INSTALL_DIR=$HOME/.local/bin sh install.sh
+#        RAMPART_INSTALL_DRY_RUN=1 sh install.sh --version v1.4.0
+#        RAMPART_VERSION=v1.4.0 RAMPART_INSTALL_DIR=$HOME/.local/bin sh install.sh
 set -e
 
 REPO="peg/rampart"

--- a/docs/install.sh
+++ b/docs/install.sh
@@ -7,8 +7,8 @@
 # Usage: curl -fsSL https://rampart.sh/install | sh
 #        curl -fsSL https://rampart.sh/install | sh -s -- --version v0.1.0
 #        curl -fsSL https://rampart.sh/install | sh -s -- --auto-setup
-#        RAMPART_INSTALL_DRY_RUN=1 sh install.sh --version v1.3.0
-#        RAMPART_VERSION=v1.3.0 RAMPART_INSTALL_DIR=$HOME/.local/bin sh install.sh
+#        RAMPART_INSTALL_DRY_RUN=1 sh install.sh --version v1.4.0
+#        RAMPART_VERSION=v1.4.0 RAMPART_INSTALL_DIR=$HOME/.local/bin sh install.sh
 set -e
 
 REPO="peg/rampart"

--- a/install.sh
+++ b/install.sh
@@ -7,8 +7,8 @@
 # Usage: curl -fsSL https://rampart.sh/install | sh
 #        curl -fsSL https://rampart.sh/install | sh -s -- --version v0.1.0
 #        curl -fsSL https://rampart.sh/install | sh -s -- --auto-setup
-#        RAMPART_INSTALL_DRY_RUN=1 sh install.sh --version v1.3.0
-#        RAMPART_VERSION=v1.3.0 RAMPART_INSTALL_DIR=$HOME/.local/bin sh install.sh
+#        RAMPART_INSTALL_DRY_RUN=1 sh install.sh --version v1.4.0
+#        RAMPART_VERSION=v1.4.0 RAMPART_INSTALL_DIR=$HOME/.local/bin sh install.sh
 set -e
 
 REPO="peg/rampart"

--- a/internal/plugin/hermes/__init__.py
+++ b/internal/plugin/hermes/__init__.py
@@ -29,7 +29,7 @@ from pathlib import Path
 from typing import Any, Callable, Mapping
 from urllib.parse import quote
 
-VERSION = "1.3.0"
+VERSION = "1.4.0"
 
 DEFAULT_SERVE_URL = "http://127.0.0.1:9090"
 DEFAULT_TIMEOUT_MS = 3000

--- a/internal/plugin/hermes/embed_test.go
+++ b/internal/plugin/hermes/embed_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestVersionReadsManifest(t *testing.T) {
-	if got, want := Version(), "1.3.0"; got != want {
+	if got, want := Version(), "1.4.0"; got != want {
 		t.Fatalf("Version() = %q, want %q", got, want)
 	}
 }

--- a/internal/plugin/hermes/plugin.yaml
+++ b/internal/plugin/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: rampart
-version: 1.3.0
+version: 1.4.0
 description: Experimental Rampart policy gate for Hermes Agent pre_tool_call hooks
 author: peg
 provides_hooks:

--- a/internal/plugin/openclaw/index.js
+++ b/internal/plugin/openclaw/index.js
@@ -5,7 +5,7 @@
  * Replaces brittle dist-file patching with the official OpenClaw plugin API.
  *
  * @see https://github.com/peg/rampart
- * @version 1.3.0
+ * @version 1.4.0
  */
 
 import { readFile } from "fs/promises";
@@ -388,7 +388,7 @@ async function auditLog(toolName, params, ctx, outcome, config) {
 export const id = "rampart";
 export const name = "Rampart";
 export const description = "Independent safety guard for unattended AI agent actions";
-export const version = "1.3.0";
+export const version = "1.4.0";
 
 // OpenClaw runs higher-priority before_tool_call hooks first. Rampart should
 // act as the final normal plugin gate so it evaluates the params that will

--- a/internal/plugin/openclaw/openclaw.plugin.json
+++ b/internal/plugin/openclaw/openclaw.plugin.json
@@ -8,7 +8,7 @@
       "hook"
     ]
   },
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": "peg",
   "homepage": "https://rampart.sh",
   "repository": "https://github.com/peg/rampart",

--- a/internal/plugin/openclaw/package.json
+++ b/internal/plugin/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rampart",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Rampart AI agent firewall — OpenClaw native plugin (before_tool_call hook)",
   "type": "module",
   "main": "index.js",

--- a/policies/openclaw.yaml
+++ b/policies/openclaw.yaml
@@ -1,4 +1,4 @@
-# rampart-policy-version: 1.3.0
+# rampart-policy-version: 1.4.0
 # Rampart built-in profile: openclaw
 # Use with: rampart init --profile openclaw
 #

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,8 +7,8 @@
 # Usage: curl -fsSL https://rampart.sh/install | sh
 #        curl -fsSL https://rampart.sh/install | sh -s -- --version v0.1.0
 #        curl -fsSL https://rampart.sh/install | sh -s -- --auto-setup
-#        RAMPART_INSTALL_DRY_RUN=1 sh install.sh --version v1.3.0
-#        RAMPART_VERSION=v1.3.0 RAMPART_INSTALL_DIR=$HOME/.local/bin sh install.sh
+#        RAMPART_INSTALL_DRY_RUN=1 sh install.sh --version v1.4.0
+#        RAMPART_VERSION=v1.4.0 RAMPART_INSTALL_DIR=$HOME/.local/bin sh install.sh
 set -e
 
 REPO="peg/rampart"


### PR DESCRIPTION
## Summary

- move the completed v1.4 work from `Unreleased` into a dated `1.4.0` changelog section
- align bundled OpenClaw and experimental Hermes plugin metadata with `v1.4.0`
- align the managed OpenClaw policy version, current-version examples, landing pages, and threat-model applicability
- update OpenClaw integrity-test fixtures for the new bundled version

## Why

PR #343 merged the complete v1.4 feature and assurance work, but intentionally left release-facing metadata at v1.3.0 while the release was still under review. Tagging without this follow-up would produce a v1.4.0 binary containing stale plugin and public version metadata.

This PR changes release metadata only; it does not expand the enforcement surface or alter the reviewed v1.4 behavior.

## Validation

- post-merge `main` CI for PR #343: green on Linux, macOS, Windows, Docker amd64 runtime/arm64 build, vulnerability scanning, and GoReleaser snapshot
- `go test ./...`
- `go vet ./...`
- `make security-assurance`
- `make lab-runner-test`
- Hermes plugin regression suite
- OpenClaw smoke, alias, and provider-surface regression suites
- installer and landing-page copies remain byte-identical
- `git diff --check`

After merge, wait for this commit's `main` CI to pass before creating the annotated `v1.4.0` tag.
