### PR TITLE
fix whole-call command authorization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,3 +189,23 @@ jobs:
           args: release --snapshot --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  ci-gate:
+    name: CI gate
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: [test, docker-smoke, release-dry-run]
+    steps:
+      - name: Require every CI job
+        env:
+          TEST_RESULT: ${{ needs.test.result }}
+          DOCKER_RESULT: ${{ needs.docker-smoke.result }}
+          RELEASE_RESULT: ${{ needs.release-dry-run.result }}
+        run: |
+          for result in "$TEST_RESULT" "$DOCKER_RESULT" "$RELEASE_RESULT"; do
+            if [ "$result" != success ]; then
+              echo "Required CI job result: $result"
+              exit 1
+            fi
+          done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Execution-granting command rules now authorize the complete shell call** —
+  `allow`, `watch`, and `webhook` rules must explicitly match a compound command
+  or independently cover every executed segment and nested substitution. A
+  benign match such as `git *` can no longer authorize an unrelated sibling
+  command, while restrictive `deny`, `ask`, and approval rules retain their
+  any-dangerous-component behavior.
+
 ## [1.4.0] - 2026-07-25
 
 ### Added

--- a/cmd/rampart/cli/policy.go
+++ b/cmd/rampart/cli/policy.go
@@ -389,13 +389,13 @@ func collectExplanations(cfg *engine.Config, call engine.ToolCall) []explanation
 			OverrideSummary: summarizeOverrideSource(policy),
 		}
 		for i, rule := range policy.Rules {
-			matched, detail := engine.ExplainCondition(rule.When, call)
-			if !matched {
-				continue
-			}
 			action, err := rule.ParseAction()
 			if err != nil {
 				action = engine.ActionDeny
+			}
+			matched, detail := engine.ExplainConditionForAction(rule.When, call, action)
+			if !matched {
+				continue
 			}
 			item.RuleMatched = true
 			item.RuleIndex = i

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -324,7 +324,7 @@ func matchDurableAllowCondition(cond Condition, call ToolCall, counter CallCount
 		return true
 	}
 	if len(cond.CommandMatches) == 0 && len(cond.CommandContains) == 0 && len(cond.CommandEnvAssignments) == 0 {
-		return matchCondition(cond, call, counter)
+		return matchConditionForAction(cond, call, counter, ActionAllow)
 	}
 	if !matchStrictCommandCondition(cond, call) {
 		return false
@@ -336,7 +336,7 @@ func matchDurableAllowCondition(cond Condition, call ToolCall, counter CallCount
 	if cond.IsEmpty() {
 		return true
 	}
-	return matchCondition(cond, call, counter)
+	return matchConditionForAction(cond, call, counter, ActionAllow)
 }
 
 func matchStrictCommandCondition(cond Condition, call ToolCall) bool {
@@ -345,20 +345,8 @@ func matchStrictCommandCondition(cond Condition, call ToolCall) bool {
 		return false
 	}
 	cmdMatch := false
-	if len(cond.CommandMatches) > 0 {
-		cmdMatch = matchAny(cond.CommandMatches, cmd)
-		if norm := NormalizeCommand(cmd); !cmdMatch && norm != cmd {
-			cmdMatch = matchAny(cond.CommandMatches, norm)
-		}
-	}
-	if !cmdMatch {
-		cmdLower := strings.ToLower(cmd)
-		for _, sub := range cond.CommandContains {
-			if strings.Contains(cmdLower, strings.ToLower(sub)) {
-				cmdMatch = true
-				break
-			}
-		}
+	if len(cond.CommandMatches) > 0 || len(cond.CommandContains) > 0 {
+		cmdMatch, _ = matchGrantCommandField(cond, cmd)
 	}
 	if !cmdMatch {
 		cmdMatch = matchFirstCommandEnvAssignment(cond.CommandEnvAssignments, cmd) != ""
@@ -732,12 +720,11 @@ func (e *Engine) evaluatePolicy(p Policy, call ToolCall) evaluatePolicyResult {
 			continue
 		}
 
-		if !matchCondition(rule.When, call, e.callCounter) {
-			continue
-		}
-
 		action, err := rule.ParseAction()
 		if err != nil {
+			if !matchConditionForAction(rule.When, call, e.callCounter, ActionDeny) {
+				continue
+			}
 			e.logger.Error("engine: invalid rule action",
 				"policy", p.Name,
 				"action", rule.Action,
@@ -745,6 +732,9 @@ func (e *Engine) evaluatePolicy(p Policy, call ToolCall) evaluatePolicyResult {
 			)
 			// Fail closed: invalid rule = deny.
 			return evaluatePolicyResult{ActionDeny, "invalid rule action; failing closed", nil, i, true}
+		}
+		if !matchConditionForAction(rule.When, call, e.callCounter, action) {
+			continue
 		}
 
 		return evaluatePolicyResult{action, rule.Message, &p.Rules[i], i, true}

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -103,6 +103,30 @@ policies:
 	}
 }
 
+func TestEvaluate_AllowRuleDoesNotAuthorizeUnmatchedSibling(t *testing.T) {
+	e := setupEngine(t, `
+version: "1"
+default_action: deny
+policies:
+  - name: allow-git
+    match:
+      tool: exec
+    rules:
+      - action: allow
+        when:
+          command_matches: ["git *"]
+`)
+
+	require.Equal(t, ActionAllow, e.Evaluate(execCall("main", "git status && git log -1")).Action)
+	require.Equal(t, ActionDeny, e.Evaluate(execCall("main", "git status && rm -rf /tmp/rampart-canary")).Action)
+}
+
+func TestMatchDurableAllowCondition_RequiresWholeCommandCoverage(t *testing.T) {
+	cond := Condition{CommandMatches: []string{"git *"}}
+	require.True(t, matchDurableAllowCondition(cond, execCall("main", "git status && git log -1"), nil))
+	require.False(t, matchDurableAllowCondition(cond, execCall("main", "git status && rm -rf /tmp/rampart-canary"), nil))
+}
+
 func TestEvaluate_DenyWinsOverAllow(t *testing.T) {
 	e := setupEngine(t, `
 version: "1"

--- a/internal/engine/matcher.go
+++ b/internal/engine/matcher.go
@@ -466,6 +466,20 @@ func ExplainCondition(cond Condition, call ToolCall) (bool, string) {
 	return false, ""
 }
 
+// ExplainConditionForAction keeps policy explanations aligned with the
+// action-aware enforcement path. ExplainCondition retains the conservative
+// restrictive-rule behavior for callers that do not know the action.
+func ExplainConditionForAction(cond Condition, call ToolCall, action Action) (bool, string) {
+	if !matchConditionForAction(cond, call, nil, action) {
+		return false, ""
+	}
+	if actionGrantsExecution(action) &&
+		(len(cond.CommandMatches) > 0 || len(cond.CommandContains) > 0) {
+		return matchGrantCommandField(cond, call.Command())
+	}
+	return ExplainCondition(cond, call)
+}
+
 // matchFirst returns the first pattern that matches value, or "".
 func matchFirst(patterns []string, value string) string {
 	for _, p := range patterns {
@@ -585,6 +599,155 @@ func appendEnvAssignmentName(name string, seen map[string]bool, names *[]string)
 	}
 	seen[name] = true
 	*names = append(*names, name)
+}
+
+// actionGrantsExecution reports whether a matching rule can permit the call to
+// run. These actions must cover the complete shell expression; matching one
+// harmless component must never authorize an unrelated sibling command.
+func actionGrantsExecution(action Action) bool {
+	return action == ActionAllow || action == ActionWatch || action == ActionWebhook
+}
+
+type grantCommandAnalysis struct {
+	normalized string
+	components []string
+	composite  bool
+}
+
+// analyzeGrantCommand returns every independently executed command represented
+// by a shell expression, including nested command substitutions.
+func analyzeGrantCommand(command string) grantCommandAnalysis {
+	normalized := NormalizeCommand(command)
+	if normalized == "" {
+		normalized = command
+	}
+	segments := SplitCompoundCommand(normalized)
+	subcommands := ExtractSubcommands(command)
+	analysis := grantCommandAnalysis{
+		normalized: normalized,
+		composite:  len(segments) > 1 || len(subcommands) > 0,
+	}
+	if !analysis.composite {
+		if component := strings.TrimSpace(normalized); component != "" {
+			analysis.components = []string{component}
+		}
+		return analysis
+	}
+
+	seen := make(map[string]bool)
+	appendComponent := func(component string) {
+		component = strings.TrimSpace(component)
+		if component == "" || seen[component] {
+			return
+		}
+		seen[component] = true
+		analysis.components = append(analysis.components, component)
+	}
+	for _, segment := range segments {
+		appendComponent(segment)
+	}
+	for _, subcommand := range subcommands {
+		normalizedSubcommand := NormalizeCommand(subcommand)
+		if normalizedSubcommand == "" {
+			normalizedSubcommand = subcommand
+		}
+		for _, segment := range SplitCompoundCommand(normalizedSubcommand) {
+			appendComponent(segment)
+		}
+	}
+	return analysis
+}
+
+func isCompositeCommand(command string) bool {
+	analysis := analyzeGrantCommand(command)
+	return analysis.composite
+}
+
+func matchGrantComponent(cond Condition, component string) (bool, string) {
+	if matched := matchFirst(cond.CommandMatches, component); matched != "" {
+		return true, fmt.Sprintf("command_matches [%q]", matched)
+	}
+	componentLower := strings.ToLower(component)
+	for _, substring := range cond.CommandContains {
+		// An empty substring is rejected for execution-granting rules even when
+		// a Condition is constructed programmatically instead of loaded.
+		if substring != "" && strings.Contains(componentLower, strings.ToLower(substring)) {
+			return true, fmt.Sprintf("command_contains [%q]", substring)
+		}
+	}
+	return false, ""
+}
+
+// matchGrantCommandField requires an allow/watch/webhook rule to either match
+// an explicitly composite pattern or cover every command the shell will run.
+func matchGrantCommandField(cond Condition, command string) (bool, string) {
+	analysis := analyzeGrantCommand(command)
+	if len(analysis.components) == 0 {
+		return false, ""
+	}
+
+	if matchAny(cond.CommandNotMatches, command) ||
+		(analysis.normalized != command && matchAny(cond.CommandNotMatches, analysis.normalized)) {
+		return false, ""
+	}
+	for _, component := range analysis.components {
+		if matchAny(cond.CommandNotMatches, component) {
+			return false, ""
+		}
+	}
+
+	if analysis.composite {
+		for _, pattern := range cond.CommandMatches {
+			if !isCompositeCommand(pattern) {
+				continue
+			}
+			if MatchGlob(pattern, command) ||
+				(analysis.normalized != command && MatchGlob(pattern, analysis.normalized)) {
+				return true, fmt.Sprintf("command_matches [%q] (explicit composite)", pattern)
+			}
+		}
+	}
+
+	detail := ""
+	for _, component := range analysis.components {
+		matched, componentDetail := matchGrantComponent(cond, component)
+		if !matched {
+			return false, ""
+		}
+		if detail == "" {
+			detail = componentDetail
+		}
+	}
+	if len(analysis.components) > 1 {
+		detail += " (all executed components)"
+	}
+	return true, detail
+}
+
+func matchConditionForAction(cond Condition, call ToolCall, counter CallCounter, action Action) bool {
+	if !actionGrantsExecution(action) ||
+		(len(cond.CommandMatches) == 0 && len(cond.CommandContains) == 0) {
+		return matchCondition(cond, call, counter)
+	}
+	if cond.Default || cond.IsEmpty() {
+		return matchCondition(cond, call, counter)
+	}
+	commandMatched, _ := matchGrantCommandField(cond, call.Command())
+	if !commandMatched {
+		return false
+	}
+
+	// The command fields were evaluated above with whole-call semantics. Match
+	// every remaining field once so counters and other stateful conditions are
+	// not evaluated per shell component.
+	remaining := cond
+	remaining.CommandMatches = nil
+	remaining.CommandContains = nil
+	remaining.CommandNotMatches = nil
+	if remaining.IsEmpty() {
+		return true
+	}
+	return matchCondition(remaining, call, counter)
 }
 
 func matchCondition(cond Condition, call ToolCall, counter CallCounter) bool {

--- a/internal/engine/matcher_test.go
+++ b/internal/engine/matcher_test.go
@@ -242,6 +242,126 @@ func TestMatchCondition_CommandContains(t *testing.T) {
 	}
 }
 
+func TestMatchConditionForAction_RequiresWholeCommandCoverage(t *testing.T) {
+	tests := []struct {
+		name   string
+		cond   Condition
+		cmd    string
+		action Action
+		want   bool
+	}{
+		{
+			name:   "plain allow remains compatible",
+			cond:   Condition{CommandMatches: []string{"git *"}},
+			cmd:    "git status",
+			action: ActionAllow,
+			want:   true,
+		},
+		{
+			name:   "normalized wrapper remains compatible",
+			cond:   Condition{CommandMatches: []string{"git *"}},
+			cmd:    "bash -c 'git status'",
+			action: ActionAllow,
+			want:   true,
+		},
+		{
+			name:   "all compound components covered",
+			cond:   Condition{CommandMatches: []string{"git *"}},
+			cmd:    "git status && git log -1",
+			action: ActionAllow,
+			want:   true,
+		},
+		{
+			name:   "unrelated compound component rejected",
+			cond:   Condition{CommandMatches: []string{"git *"}},
+			cmd:    "git status && rm -rf /tmp/rampart-canary",
+			action: ActionAllow,
+			want:   false,
+		},
+		{
+			name:   "explicit composite pattern allowed",
+			cond:   Condition{CommandMatches: []string{"git status && rm -rf /tmp/rampart-*"}},
+			cmd:    "git status && rm -rf /tmp/rampart-canary",
+			action: ActionAllow,
+			want:   true,
+		},
+		{
+			name:   "nested substitution requires parent coverage",
+			cond:   Condition{CommandMatches: []string{"git *"}},
+			cmd:    "echo $(git status)",
+			action: ActionAllow,
+			want:   false,
+		},
+		{
+			name:   "contains requires every component",
+			cond:   Condition{CommandContains: []string{"git"}},
+			cmd:    "git status && rm -rf /tmp/rampart-canary",
+			action: ActionWatch,
+			want:   false,
+		},
+		{
+			name:   "empty contains cannot grant",
+			cond:   Condition{CommandContains: []string{""}},
+			cmd:    "anything",
+			action: ActionAllow,
+			want:   false,
+		},
+		{
+			name:   "deny still catches any dangerous component",
+			cond:   Condition{CommandMatches: []string{"rm -rf *"}},
+			cmd:    "git status && rm -rf /tmp/rampart-canary",
+			action: ActionDeny,
+			want:   true,
+		},
+		{
+			name:   "approval still catches any dangerous component",
+			cond:   Condition{CommandMatches: []string{"rm -rf *"}},
+			cmd:    "git status && rm -rf /tmp/rampart-canary",
+			action: ActionRequireApproval,
+			want:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			call := ToolCall{Tool: "exec", Params: map[string]any{"command": tt.cmd}}
+			if got := matchConditionForAction(tt.cond, call, nil, tt.action); got != tt.want {
+				t.Fatalf("matchConditionForAction(%q, %s) = %v, want %v", tt.cmd, tt.action, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExplainConditionForAction_RejectsPartialGrant(t *testing.T) {
+	cond := Condition{CommandMatches: []string{"git *"}}
+	call := ToolCall{Tool: "exec", Params: map[string]any{"command": "git status && rm -rf /tmp/rampart-canary"}}
+
+	matched, detail := ExplainConditionForAction(cond, call, ActionAllow)
+	if matched || detail != "" {
+		t.Fatalf("allow explanation reported partial grant: matched=%v detail=%q", matched, detail)
+	}
+	matched, detail = ExplainConditionForAction(cond, call, ActionDeny)
+	if !matched || detail == "" {
+		t.Fatalf("restrictive explanation lost component match: matched=%v detail=%q", matched, detail)
+	}
+}
+
+func TestMatchConditionForAction_ActionClasses(t *testing.T) {
+	cond := Condition{CommandMatches: []string{"git *"}}
+	call := ToolCall{Tool: "exec", Params: map[string]any{"command": "git status && rm -rf /tmp/rampart-canary"}}
+
+	for _, action := range []Action{ActionAllow, ActionWatch, ActionWebhook} {
+		if matchConditionForAction(cond, call, nil, action) {
+			t.Fatalf("%s must not grant a partially matched call", action)
+		}
+	}
+	for _, action := range []Action{ActionDeny, ActionAsk, ActionRequireApproval} {
+		if !matchConditionForAction(cond, call, nil, action) {
+			t.Fatalf("%s must retain any-component matching", action)
+		}
+	}
+}
+
 func TestMatchGlob_DoubleStarLimit(t *testing.T) {
 	// Two ** segments are fully supported.
 	if !MatchGlob("**/foo/**", "/a/b/foo/c/d") {


### PR DESCRIPTION
## What changed

- make `allow`, `watch`, and `webhook` command rules authorize the complete shell call
- require every independently executed compound segment and nested substitution to be covered, unless the policy explicitly matches the composite expression
- preserve any-component matching for `deny`, `ask`, and `require_approval`
- apply the same behavior to durable user overrides and `policy explain`

## Why

A broad execution-granting pattern such as `git *` could match the raw string `git status && rm -rf ...`, allowing an unrelated sibling command because the glob spanned the shell operator. Restrictive rules intentionally need the opposite behavior: one dangerous component should still make the complete call match.

## Impact

Existing single-command grants and normalized wrappers such as `bash -c 'git status'` remain compatible. Compound grants now need either an explicitly compound pattern or coverage for every command the shell executes. This is intended for the v1.4.1 security patch release.

## Validation

- `go test ./... -count=1`
- `go test -race ./internal/engine ./cmd/rampart/cli -count=1`
- `go vet ./...`
- `git diff --check`

Staticcheck was not used because the locally installed binary was built with Go 1.24.5 and cannot load Rampart's Go 1.25.12 module.
