### PR TITLE
Tie integration claims to the runtime registry

### DIFF
--- a/assurance/README.md
+++ b/assurance/README.md
@@ -3,9 +3,12 @@
 This directory turns Rampart's security claims into reviewable data and
 executable evidence.
 
-- `integrations.yaml` records the current boundary, coverage, degraded behavior,
-  approval behavior, verification level, evidence, and limitations of each
-  agent-harness integration.
+- `integrations.yaml` uses each canonical runtime target as its id and records
+  bare `rampart protect` eligibility, boundary, coverage, degraded behavior,
+  approval behavior,
+  verification level, evidence, and limitations of each agent-harness
+  integration. Its current schema is `rampart.assurance.v2`; tests keep its
+  runtime and public support claims synchronized.
 - `corpus.yaml` is the shared adversarial decision corpus. The assurance tests
   run every case through the real policy engine and bundled policy profiles.
 

--- a/assurance/integrations.yaml
+++ b/assurance/integrations.yaml
@@ -1,7 +1,9 @@
-schema_version: rampart.assurance.v1
-baseline_release: v1.4.1
-reviewed_at: "2026-07-28"
+schema_version: rampart.assurance.v2
+baseline_release: v1.5.0
+reviewed_at: "2026-07-29"
 
+# Version 2 uses the canonical Rampart command target as each integration id
+# and requires an explicit declaration of bare `rampart protect` eligibility.
 # This manifest records the guarantees Rampart can support with evidence today.
 # "tested" means the Rampart adapter or mapping is exercised in isolation.
 # "verified" means a completed live host-boundary run is recorded as evidence,
@@ -13,6 +15,7 @@ integrations:
     setup_command: rampart protect openclaw
     boundary: native_plugin
     platforms: [linux, macos]
+    auto_protect: true
     service_required: true
     upstream_ci: rolling_latest
     coverage:
@@ -57,12 +60,13 @@ integrations:
       - OpenClaw after_tool_call is observational, so the native plugin does not claim blocking response redaction.
       - MCP and delegated-agent coverage need dedicated live canaries.
 
-  - id: claude_code
+  - id: claude-code
     display_name: Claude Code
     support_tier: supported
     setup_command: rampart setup claude-code
     boundary: native_hook
     platforms: [linux, macos, windows]
+    auto_protect: true
     service_required: false
     upstream_ci: none
     coverage:
@@ -112,6 +116,7 @@ integrations:
     setup_command: rampart setup cline
     boundary: native_hook
     platforms: [linux, macos, windows]
+    auto_protect: true
     service_required: false
     upstream_ci: none
     coverage:
@@ -152,12 +157,13 @@ integrations:
       - Current Cline CLI launches post-tool file hooks asynchronously and ignores their control response, so CLI post-tool decisions are audit evidence rather than continuation blocking.
       - Cline has no native Rampart approval-resume path; ask decisions cancel with context.
 
-  - id: codex_cli
+  - id: codex
     display_name: Codex
     support_tier: supported
     setup_command: rampart setup codex
     boundary: native_hook
     platforms: [linux, macos, windows]
+    auto_protect: true
     service_required: false
     upstream_ci: none
     coverage:
@@ -206,6 +212,7 @@ integrations:
     setup_command: rampart setup hermes
     boundary: native_plugin
     platforms: [linux, macos]
+    auto_protect: false
     service_required: true
     upstream_ci: rolling_latest
     coverage:
@@ -248,12 +255,13 @@ integrations:
       - Unknown plugin and MCP tool names deny until Rampart has an explicit typed mapping for them.
       - Delegated-agent and approved-execution E2E are not yet present.
 
-  - id: gemini_cli
+  - id: gemini
     display_name: Gemini CLI
     support_tier: experimental
     setup_command: rampart setup gemini
     boundary: native_hook
     platforms: [linux, macos]
+    auto_protect: false
     service_required: false
     upstream_ci: rolling_latest
     coverage:
@@ -300,6 +308,7 @@ integrations:
     setup_command: rampart setup antigravity
     boundary: native_plugin
     platforms: [linux, macos, windows]
+    auto_protect: true
     service_required: false
     upstream_ci: none
     coverage:
@@ -338,12 +347,13 @@ integrations:
       - The ordinary verifier exercises plugin installation and the live Rampart adapter without invoking a model; authenticated host proof is a maintainer-only opt-in check.
       - A rolling-latest Antigravity compatibility job and physical Windows host proof are still pending.
 
-  - id: github_copilot
+  - id: copilot
     display_name: GitHub Copilot CLI / VS Code
     support_tier: supported
     setup_command: rampart setup copilot
     boundary: native_hook
     platforms: [linux, macos, windows]
+    auto_protect: true
     service_required: false
     upstream_ci: rolling_latest
     coverage:

--- a/cmd/rampart/cli/integration_driver_test.go
+++ b/cmd/rampart/cli/integration_driver_test.go
@@ -6,8 +6,102 @@ package cli
 import (
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
+
+	"github.com/peg/rampart/internal/assurance"
 )
+
+func TestIntegrationDriversMatchAssuranceManifest(t *testing.T) {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve integration driver test path")
+	}
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(filename), "..", "..", ".."))
+	manifest, err := assurance.LoadManifest(filepath.Join(repoRoot, "assurance", "integrations.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := manifest.Validate(repoRoot); err != nil {
+		t.Fatal(err)
+	}
+
+	byTarget := make(map[string]assurance.Integration, len(manifest.Integrations))
+	for _, integration := range manifest.Integrations {
+		byTarget[integration.ID] = integration
+	}
+
+	driverTargets := make(map[string]bool)
+	for _, driver := range supportedIntegrationDrivers() {
+		driverTargets[driver.ID] = true
+		integration, found := byTarget[driver.ID]
+		if !found {
+			t.Errorf("runtime integration driver %q is missing from assurance/integrations.yaml", driver.ID)
+			continue
+		}
+		if driver.DisplayName != integration.DisplayName {
+			t.Errorf("driver %q display name = %q, manifest = %q", driver.ID, driver.DisplayName, integration.DisplayName)
+		}
+		if driver.VerifyTarget != integration.ID {
+			t.Errorf("driver %q verify target = %q, manifest id = %q", driver.ID, driver.VerifyTarget, integration.ID)
+		}
+		if integration.AutoProtect == nil || driver.AutoProtect != *integration.AutoProtect {
+			t.Errorf("driver %q auto-protect = %t, manifest = %v", driver.ID, driver.AutoProtect, integration.AutoProtect)
+		}
+		if got := integrationBoundaryKind(driver.Boundary); got != integration.Boundary {
+			t.Errorf("driver %q boundary = %q (%q), manifest = %q", driver.ID, driver.Boundary, got, integration.Boundary)
+		}
+		if diff := platformDifference(driver.Platforms, integration.Platforms); diff != "" {
+			t.Errorf("driver %q platform mismatch: %s", driver.ID, diff)
+		}
+		if strings.HasPrefix(integration.SetupCommand, "rampart setup ") && driver.SetupCommand == nil {
+			t.Errorf("driver %q has no setup command callback for manifest command %q", driver.ID, integration.SetupCommand)
+		}
+	}
+
+	for _, integration := range manifest.Integrations {
+		if integration.AutoProtect != nil && *integration.AutoProtect && !driverTargets[integration.ID] {
+			t.Errorf("manifest integration %q enables bare protect without a runtime driver", integration.ID)
+		}
+	}
+}
+
+func integrationBoundaryKind(boundary string) string {
+	switch {
+	case strings.Contains(boundary, "plugin"):
+		return "native_plugin"
+	case strings.Contains(boundary, "hook"):
+		return "native_hook"
+	default:
+		return ""
+	}
+}
+
+func platformDifference(driverPlatforms, manifestPlatforms []string) string {
+	driverSet := make(map[string]bool, len(driverPlatforms))
+	for _, platform := range driverPlatforms {
+		driverSet[platform] = true
+	}
+	manifestSet := make(map[string]bool, len(manifestPlatforms))
+	for _, platform := range manifestPlatforms {
+		if platform == "macos" {
+			platform = "darwin"
+		}
+		manifestSet[platform] = true
+	}
+	for platform := range driverSet {
+		if !manifestSet[platform] {
+			return "driver includes " + platform + " but manifest does not"
+		}
+	}
+	for platform := range manifestSet {
+		if !driverSet[platform] {
+			return "manifest includes " + platform + " but driver does not"
+		}
+	}
+	return ""
+}
 
 func TestFindIntegrationDriverResolvesCanonicalIDsAndAliases(t *testing.T) {
 	for input, want := range map[string]string{

--- a/docs-site/getting-started/support-matrix.md
+++ b/docs-site/getting-started/support-matrix.md
@@ -18,64 +18,73 @@ For release-candidate validation and latest-agent checks, use the [Release Compa
     <tr>
       <th>Surface</th>
       <th>Best path</th>
+      <th>Bare protect</th>
       <th><code>rampart serve</code></th>
       <th>Approval UX</th>
       <th>Support tier</th>
     </tr>
   </thead>
   <tbody>
-    <tr class="tier-supported">
+    <tr class="tier-supported" data-integration="claude-code">
       <td data-label="Surface"><strong>Claude Code</strong></td>
       <td data-label="Best path">Native hooks<br><code>rampart setup claude-code</code></td>
+      <td data-label="Bare protect">Yes</td>
       <td data-label="rampart serve">Not required for local enforcement;<br>yes for dashboard/headless approval flows</td>
       <td data-label="Approval UX">Claude native approval prompt</td>
       <td data-label="Support tier"><strong>Supported</strong><br>2.1.220 mapping review + isolated shell host proof</td>
     </tr>
-    <tr class="tier-supported">
+    <tr class="tier-supported" data-integration="codex">
       <td data-label="Surface"><strong>Codex CLI, IDE, desktop</strong></td>
       <td data-label="Best path">Native lifecycle hooks<br><code>rampart setup codex</code></td>
+      <td data-label="Bare protect">Yes</td>
       <td data-label="rampart serve">Not required for local allow/deny;<br>required for approval queue</td>
       <td data-label="Approval UX">External Rampart queue; unavailable approval service denies</td>
       <td data-label="Support tier"><strong>Supported</strong><br>opt-in host proof available</td>
     </tr>
-    <tr class="tier-supported">
+    <tr class="tier-supported" data-integration="cline">
       <td data-label="Surface"><strong>Cline</strong></td>
       <td data-label="Best path">Native hooks<br><code>rampart setup cline</code></td>
+      <td data-label="Bare protect">Yes</td>
       <td data-label="rampart serve">Not required for local enforcement</td>
       <td data-label="Approval UX">No native ask UI; approval-required actions cancel with context</td>
       <td data-label="Support tier"><strong>Supported</strong><br>current editor/CLI source contract + adapter/setup tests; no current host proof</td>
     </tr>
-    <tr class="tier-experimental">
+    <tr class="tier-experimental" data-integration="gemini">
       <td data-label="Surface"><strong>Gemini CLI (enterprise/API key)</strong></td>
       <td data-label="Best path">Native lifecycle hooks<br><code>rampart setup gemini</code></td>
+      <td data-label="Bare protect">No</td>
       <td data-label="rampart serve">Not required for local allow/deny;<br>required for external approvals</td>
       <td data-label="Approval UX">External Rampart queue; unavailable approval service denies</td>
       <td data-label="Support tier"><strong>Experimental</strong><br>adapter-tested; authenticated host proof pending; not Antigravity</td>
     </tr>
-    <tr class="tier-supported">
+    <tr class="tier-supported" data-integration="antigravity">
       <td data-label="Surface"><strong>Antigravity CLI / IDE</strong></td>
       <td data-label="Best path">Shared policy plugin<br><code>rampart setup antigravity</code></td>
+      <td data-label="Bare protect">Yes</td>
       <td data-label="rampart serve">Not required for local enforcement</td>
       <td data-label="Approval UX">Native <code>force_ask</code> prompt</td>
       <td data-label="Support tier"><strong>Supported</strong><br>CLI 1.1.7 host-verified; IDE contract-tested, physical IDE proof pending</td>
     </tr>
-    <tr class="tier-supported">
+    <tr class="tier-supported" data-integration="copilot">
       <td data-label="Surface"><strong>GitHub Copilot CLI / VS Code</strong></td>
       <td data-label="Best path">Shared native lifecycle hooks<br><code>rampart setup copilot</code></td>
+      <td data-label="Bare protect">Yes</td>
       <td data-label="rampart serve">Not required for local enforcement</td>
       <td data-label="Approval UX">Native Copilot prompt</td>
       <td data-label="Support tier"><strong>Supported</strong> CLI adapter<br>package startup + adapter evidence; authenticated hook ingestion pending; VS Code is contract-tested Preview</td>
     </tr>
-    <tr class="tier-recommended">
+    <tr class="tier-recommended" data-integration="openclaw">
       <td data-label="Surface"><strong>OpenClaw &gt;= 2026.5.2</strong></td>
       <td data-label="Best path">Managed native guard<br><code>rampart protect openclaw</code></td>
+      <td data-label="Bare protect">Yes</td>
       <td data-label="rampart serve">Required</td>
       <td data-label="Approval UX">First-class plugin approvals / native approval UI</td>
       <td data-label="Support tier"><strong>Verified</strong></td>
     </tr>
-    <tr class="tier-experimental">
+    <tr class="tier-experimental" data-integration="hermes">
       <td data-label="Surface"><strong>Hermes Agent</strong></td>
       <td data-label="Best path">Experimental user plugin<br><code>rampart setup hermes</code></td>
+      <td data-label="Bare protect">No</td>
       <td data-label="rampart serve">Required</td>
       <td data-label="Approval UX"><code>ask</code> blocks until plugin approval/resume support exists</td>
       <td data-label="Support tier"><strong>Experimental</strong><br>0.19.0 shell deny/allow host proof; native approval/resume pending</td>
@@ -83,6 +92,7 @@ For release-candidate validation and latest-agent checks, use the [Release Compa
     <tr class="tier-supported">
       <td data-label="Surface"><strong>OpenClaw 2026.4.29 - 2026.5.1</strong></td>
       <td data-label="Best path">Native plugin<br><code>rampart setup openclaw</code></td>
+      <td data-label="Bare protect">Yes</td>
       <td data-label="rampart serve">Required</td>
       <td data-label="Approval UX">Native plugin startup/interception; approval delivery was not the launch baseline</td>
       <td data-label="Support tier">Supported</td>
@@ -90,6 +100,7 @@ For release-candidate validation and latest-agent checks, use the [Release Compa
     <tr class="tier-supported">
       <td data-label="Surface"><strong>OpenClaw 2026.3.28 - 2026.4.28</strong></td>
       <td data-label="Best path">Native plugin<br><code>rampart setup openclaw</code></td>
+      <td data-label="Bare protect">Yes</td>
       <td data-label="rampart serve">Required</td>
       <td data-label="Approval UX">Native enforcement; approval UX less polished than current builds</td>
       <td data-label="Support tier">Supported</td>
@@ -97,6 +108,7 @@ For release-candidate validation and latest-agent checks, use the [Release Compa
     <tr class="tier-legacy">
       <td data-label="Surface"><strong>OpenClaw &lt; 2026.3.28</strong></td>
       <td data-label="Best path">Legacy shim + bridge + patching</td>
+      <td data-label="Bare protect">Yes</td>
       <td data-label="rampart serve">Required</td>
       <td data-label="Approval UX">Legacy bridge/shim behavior</td>
       <td data-label="Support tier">Legacy compatibility</td>
@@ -104,6 +116,7 @@ For release-candidate validation and latest-agent checks, use the [Release Compa
     <tr class="tier-supported">
       <td data-label="Surface"><strong>Cursor / Claude Desktop</strong></td>
       <td data-label="Best path">MCP proxy<br><code>rampart mcp --</code></td>
+      <td data-label="Bare protect">No</td>
       <td data-label="rampart serve">Required</td>
       <td data-label="Approval UX">MCP error / proxy-mediated behavior</td>
       <td data-label="Support tier">Supported</td>
@@ -111,6 +124,7 @@ For release-candidate validation and latest-agent checks, use the [Release Compa
     <tr class="tier-supported">
       <td data-label="Surface"><strong>Custom / Python / CI</strong></td>
       <td data-label="Best path">HTTP API</td>
+      <td data-label="Bare protect">No</td>
       <td data-label="rampart serve">Required</td>
       <td data-label="Approval UX">Caller-defined</td>
       <td data-label="Support tier">Supported</td>

--- a/internal/assurance/manifest.go
+++ b/internal/assurance/manifest.go
@@ -16,9 +16,9 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const ManifestSchemaVersion = "rampart.assurance.v1"
+const ManifestSchemaVersion = "rampart.assurance.v2"
 
-var integrationIDPattern = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
+var integrationIDPattern = regexp.MustCompile(`^[a-z][a-z0-9-]*$`)
 
 type Manifest struct {
 	SchemaVersion   string        `yaml:"schema_version"`
@@ -34,6 +34,7 @@ type Integration struct {
 	SetupCommand    string            `yaml:"setup_command"`
 	Boundary        string            `yaml:"boundary"`
 	Platforms       []string          `yaml:"platforms"`
+	AutoProtect     *bool             `yaml:"auto_protect"`
 	ServiceRequired bool              `yaml:"service_required"`
 	UpstreamCI      string            `yaml:"upstream_ci"`
 	Coverage        map[string]string `yaml:"coverage"`
@@ -121,6 +122,9 @@ func (m *Manifest) Validate(repoRoot string) error {
 		if len(integration.Platforms) == 0 {
 			problems = append(problems, prefix+": platforms must not be empty")
 		}
+		if integration.AutoProtect == nil {
+			problems = append(problems, prefix+": auto_protect must be explicitly true or false")
+		}
 		for _, platform := range integration.Platforms {
 			if !oneOf(platform, "linux", "macos", "windows") {
 				problems = append(problems, prefix+": invalid platform "+platform)
@@ -177,6 +181,14 @@ func (m *Manifest) Validate(repoRoot string) error {
 			}
 			if !hasEvidenceKind(integration.Evidence, "live") {
 				problems = append(problems, prefix+": verified tier requires live evidence")
+			}
+		}
+		if integration.AutoProtect != nil && *integration.AutoProtect {
+			if integration.SupportTier == "experimental" || integration.SupportTier == "limited" {
+				problems = append(problems, prefix+": auto_protect requires verified or supported tier")
+			}
+			if integration.Verification.Level != "active" || !integration.Verification.SafeCanaries {
+				problems = append(problems, prefix+": auto_protect requires active safe verification")
 			}
 		}
 

--- a/internal/assurance/manifest_test.go
+++ b/internal/assurance/manifest_test.go
@@ -103,8 +103,30 @@ func TestPublicSupportMatrixNamesEveryAssuredIntegration(t *testing.T) {
 	}
 	page := strings.ToLower(string(data))
 	for _, integration := range manifest.Integrations {
-		if !strings.Contains(page, strings.ToLower(integration.DisplayName)) {
-			t.Errorf("public support matrix does not name assured integration %q", integration.DisplayName)
+		marker := `data-integration="` + strings.ToLower(integration.ID) + `"`
+		start := strings.Index(page, marker)
+		if start < 0 {
+			t.Errorf("public support matrix does not contain assured integration %q", integration.ID)
+			continue
+		}
+		end := strings.Index(page[start:], "</tr>")
+		if end < 0 {
+			t.Errorf("public support matrix row for %q is not closed", integration.DisplayName)
+			continue
+		}
+		row := page[start : start+end]
+		if !strings.Contains(row, strings.ToLower(integration.DisplayName)) {
+			t.Errorf("public support matrix row for %q does not contain display name %q", integration.ID, integration.DisplayName)
+		}
+		if !strings.Contains(row, strings.ToLower(integration.SetupCommand)) {
+			t.Errorf("public support matrix row for %q does not contain setup command %q", integration.DisplayName, integration.SetupCommand)
+		}
+		wantAuto := "no"
+		if integration.AutoProtect != nil && *integration.AutoProtect {
+			wantAuto = "yes"
+		}
+		if !strings.Contains(row, `data-label="bare protect">`+wantAuto) {
+			t.Errorf("public support matrix row for %q does not report bare protect as %q", integration.DisplayName, wantAuto)
 		}
 	}
 }
@@ -123,6 +145,7 @@ func TestReleaseMetadataIsSynchronized(t *testing.T) {
 	version := string(matches[1])
 
 	expectations := map[string][]string{
+		"assurance/integrations.yaml":                   {"baseline_release: v" + version},
 		"internal/plugin/openclaw/package.json":         {`"version": "` + version + `"`},
 		"internal/plugin/openclaw/openclaw.plugin.json": {`"version": "` + version + `"`},
 		"internal/plugin/openclaw/index.js":             {`export const version = "` + version + `";`},
@@ -250,6 +273,7 @@ func TestVerifiedTierCannotUsePolicyOnlyEvidence(t *testing.T) {
 			SetupCommand: "rampart protect example",
 			Boundary:     "native_hook",
 			Platforms:    []string{"linux"},
+			AutoProtect:  boolPointer(false),
 			UpstreamCI:   "none",
 			Approval:     "native",
 			Coverage: map[string]string{
@@ -274,6 +298,10 @@ func TestVerifiedTierCannotUsePolicyOnlyEvidence(t *testing.T) {
 	}
 }
 
+func boolPointer(value bool) *bool {
+	return &value
+}
+
 func TestEvidenceCannotEscapeRepository(t *testing.T) {
 	root := repositoryRoot(t)
 	manifest, err := LoadManifest(filepath.Join(root, "assurance", "integrations.yaml"))
@@ -285,6 +313,41 @@ func TestEvidenceCannotEscapeRepository(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "repository-relative") {
 		t.Fatalf("expected unsafe evidence path failure, got %v", err)
 	}
+}
+
+func TestRuntimeMetadataMustBeExplicitAndConsistent(t *testing.T) {
+	root := repositoryRoot(t)
+	load := func(t *testing.T) *Manifest {
+		t.Helper()
+		manifest, err := LoadManifest(filepath.Join(root, "assurance", "integrations.yaml"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		return manifest
+	}
+
+	t.Run("auto protect is required", func(t *testing.T) {
+		manifest := load(t)
+		manifest.Integrations[0].AutoProtect = nil
+		err := manifest.Validate(root)
+		if err == nil || !strings.Contains(err.Error(), "auto_protect must be explicitly true or false") {
+			t.Fatalf("expected missing auto-protect failure, got %v", err)
+		}
+	})
+
+	t.Run("experimental integrations are explicit", func(t *testing.T) {
+		manifest := load(t)
+		for index := range manifest.Integrations {
+			if manifest.Integrations[index].SupportTier == "experimental" {
+				manifest.Integrations[index].AutoProtect = boolPointer(true)
+				break
+			}
+		}
+		err := manifest.Validate(root)
+		if err == nil || !strings.Contains(err.Error(), "auto_protect requires verified or supported tier") {
+			t.Fatalf("expected experimental auto-protect failure, got %v", err)
+		}
+	})
 }
 
 func TestEvidencePathsUsePortableRepositorySyntax(t *testing.T) {


### PR DESCRIPTION
## What changed

- upgrades the existing public assurance manifest to `rampart.assurance.v2`
- uses canonical Rampart command targets as integration IDs
- records whether each integration participates in bare `rampart protect`
- rejects experimental or limited integrations that accidentally opt into automatic protection
- checks runtime driver names, boundaries, platforms, setup callbacks, verification targets, and auto-protection flags against the manifest
- keeps the assurance baseline synchronized with the current release
- adds an Auto-protect column to the public support matrix and validates each row against the manifest

## Why

Rampart already had a detailed machine-readable assurance manifest, so adding a second capability catalog would create more drift. This focused change makes the existing manifest authoritative and closes a real gap: it still identified v1.4.1 as its baseline after v1.5.0 shipped.

## Impact

There is no agent runtime or policy behavior change. This is a maintenance and claims-integrity boundary: future runtime, release, and website capability drift fails tests instead of silently reaching users.

## Validation

- `go test ./...`
- `go vet ./...`
- `scripts/security-assurance.sh`
- `git diff --check`

The local machine does not currently have MkDocs installed; the repository's docs workflow will validate the rendered site.