### PR TITLE
Add verified protection evidence to status

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,16 @@ Recheck the boundary at any time:
 
 ```bash
 rampart verify openclaw
+rampart status
 ```
+
+`rampart status` separates installed configuration from behavioral evidence.
+It reports OpenClaw's live plugin check as `HOST VERIFIED` and native-hook
+adapter canaries as `ADAPTER VERIFIED`, with stale evidence invalidated after
+Rampart, the configured boundary, the policy endpoint, local policy state, or a
+detected host executable changes.
+Verification receipts contain only check IDs/outcomes and fingerprints—never
+prompts, commands, credentials, host output, or agent memory.
 
 Direct setup for supported integration paths remains available:
 
@@ -699,7 +708,7 @@ rampart serve stop                           # Stop background server
 rampart doctor                               # Health check (colored output)
 rampart doctor --fix                         # Auto-apply missing patches
 rampart doctor --json                        # Machine-readable (exit 1 on issues)
-rampart status                               # Quick dashboard: what's protected
+rampart status                               # Quick dashboard: configuration + assurance evidence
 rampart watch                                # Live TUI event stream
 
 # Policy

--- a/cmd/rampart/cli/assurance_status.go
+++ b/cmd/rampart/cli/assurance_status.go
@@ -1,0 +1,470 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0
+
+package cli
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/peg/rampart/internal/build"
+)
+
+const (
+	verificationReceiptSchemaVersion = "rampart.verification-receipt.v1"
+	maxVerificationReceiptBytes      = 64 << 10
+	maxPolicyFingerprintBytes        = 2 << 20
+	verificationReceiptLifetime      = 7 * 24 * time.Hour
+)
+
+type assuranceLevel string
+
+const (
+	assuranceDetected        assuranceLevel = "detected"
+	assuranceConfigured      assuranceLevel = "configured"
+	assurancePolicyVerified  assuranceLevel = "policy_verified"
+	assuranceAdapterVerified assuranceLevel = "adapter_verified"
+	assuranceHostVerified    assuranceLevel = "host_verified"
+	assuranceUnverified      assuranceLevel = "unverified"
+	assuranceDegraded        assuranceLevel = "degraded"
+)
+
+type verificationReceiptCheck struct {
+	ID     string             `json:"id"`
+	Status verificationStatus `json:"status"`
+}
+
+// verificationReceipt intentionally excludes check messages, command payloads,
+// host output, and filesystem paths. It is a local status cache, not an audit
+// record or a tamper-resistant attestation.
+type verificationReceipt struct {
+	SchemaVersion          string                     `json:"schema_version"`
+	IntegrationID          string                     `json:"integration_id"`
+	AssuranceLevel         assuranceLevel             `json:"assurance_level"`
+	CheckedAt              time.Time                  `json:"checked_at"`
+	ExpiresAt              time.Time                  `json:"expires_at"`
+	RampartVersion         string                     `json:"rampart_version"`
+	RampartCommit          string                     `json:"rampart_commit,omitempty"`
+	EnvironmentFingerprint string                     `json:"environment_fingerprint"`
+	SafeCanaries           bool                       `json:"safe_canaries"`
+	Summary                verificationSummary        `json:"summary"`
+	Checks                 []verificationReceiptCheck `json:"checks"`
+}
+
+type integrationAssuranceStatus struct {
+	ID                  string         `json:"id"`
+	DisplayName         string         `json:"display_name"`
+	Boundary            string         `json:"boundary"`
+	ServiceRequired     bool           `json:"service_required"`
+	Installed           bool           `json:"installed"`
+	Configured          bool           `json:"configured"`
+	AssuranceLevel      assuranceLevel `json:"assurance_level"`
+	EvidenceSource      string         `json:"evidence_source,omitempty"`
+	CheckedAt           *time.Time     `json:"checked_at,omitempty"`
+	EvidenceExpiresAt   *time.Time     `json:"evidence_expires_at,omitempty"`
+	VerificationCommand string         `json:"verification_command"`
+	RecommendedCommand  string         `json:"recommended_command,omitempty"`
+	StaleReason         string         `json:"stale_reason,omitempty"`
+}
+
+func assuranceLevelForReport(report verificationReport) assuranceLevel {
+	if report.Summary.Failed > 0 {
+		return assuranceDegraded
+	}
+	if report.Summary.Unverified > 0 || report.Summary.Checks == 0 {
+		return assuranceUnverified
+	}
+	if report.Target == "policy" {
+		return assurancePolicyVerified
+	}
+	driver, ok := findIntegrationDriver(report.Target)
+	if !ok || driver.ProofLevel == "" {
+		return assuranceUnverified
+	}
+	return driver.ProofLevel
+}
+
+func verificationReceiptPath(integrationID string) (string, error) {
+	driver, ok := findIntegrationDriver(integrationID)
+	if !ok || driver.ID != integrationID {
+		return "", fmt.Errorf("unknown integration %q", integrationID)
+	}
+	dir, err := rampartDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "verification", integrationID+".json"), nil
+}
+
+func writeVerificationReceipt(report verificationReport) error {
+	driver, ok := findIntegrationDriver(report.Target)
+	if !ok || driver.ID != report.Target {
+		return nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("resolve home: %w", err)
+	}
+	policyEndpoint := report.policyEndpoint
+	if policyEndpoint == "" {
+		policyEndpoint = resolveServeURL("")
+	}
+	fingerprint, err := integrationEnvironmentFingerprintAt(driver, home, policyEndpoint)
+	if err != nil {
+		return err
+	}
+	checkedAt, err := time.Parse(time.RFC3339, report.GeneratedAt)
+	if err != nil {
+		return fmt.Errorf("parse verification time: %w", err)
+	}
+	receipt := verificationReceipt{
+		SchemaVersion:          verificationReceiptSchemaVersion,
+		IntegrationID:          driver.ID,
+		AssuranceLevel:         assuranceLevelForReport(report),
+		CheckedAt:              checkedAt,
+		ExpiresAt:              checkedAt.Add(verificationReceiptLifetime),
+		RampartVersion:         build.Version,
+		RampartCommit:          build.Commit,
+		EnvironmentFingerprint: fingerprint,
+		SafeCanaries:           report.SafeCanaries,
+		Summary:                report.Summary,
+		Checks:                 make([]verificationReceiptCheck, 0, len(report.Checks)),
+	}
+	for _, check := range report.Checks {
+		receipt.Checks = append(receipt.Checks, verificationReceiptCheck{ID: check.ID, Status: check.Status})
+	}
+	if err := validateVerificationReceipt(receipt, driver.ID); err != nil {
+		return fmt.Errorf("validate receipt: %w", err)
+	}
+	data, err := json.Marshal(receipt)
+	if err != nil {
+		return fmt.Errorf("encode receipt: %w", err)
+	}
+	path, err := verificationReceiptPath(driver.ID)
+	if err != nil {
+		return err
+	}
+	verificationDir := filepath.Dir(path)
+	if info, statErr := os.Lstat(verificationDir); statErr == nil {
+		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+			return fmt.Errorf("verification receipt directory is not a regular directory")
+		}
+		if err := secureDirPermissions(verificationDir); err != nil {
+			return fmt.Errorf("secure verification receipt directory: %w", err)
+		}
+	} else if !os.IsNotExist(statErr) {
+		return fmt.Errorf("inspect verification receipt directory: %w", statErr)
+	}
+	if info, statErr := os.Lstat(path); statErr == nil && (info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular()) {
+		return fmt.Errorf("verification receipt path is not a regular file")
+	} else if statErr != nil && !os.IsNotExist(statErr) {
+		return fmt.Errorf("inspect verification receipt: %w", statErr)
+	}
+	if err := atomicWriteRecoverablePrivateFile(path, append(data, '\n')); err != nil {
+		return fmt.Errorf("write verification receipt: %w", err)
+	}
+	return nil
+}
+
+func readVerificationReceipt(integrationID string) (verificationReceipt, error) {
+	path, err := verificationReceiptPath(integrationID)
+	if err != nil {
+		return verificationReceipt{}, err
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return verificationReceipt{}, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return verificationReceipt{}, fmt.Errorf("receipt is not a regular file")
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return verificationReceipt{}, err
+	}
+	defer file.Close()
+	data, err := io.ReadAll(io.LimitReader(file, maxVerificationReceiptBytes+1))
+	if err != nil {
+		return verificationReceipt{}, err
+	}
+	if len(data) > maxVerificationReceiptBytes {
+		return verificationReceipt{}, fmt.Errorf("receipt exceeds %d bytes", maxVerificationReceiptBytes)
+	}
+	var receipt verificationReceipt
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&receipt); err != nil {
+		return verificationReceipt{}, err
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return verificationReceipt{}, fmt.Errorf("receipt contains trailing data")
+		}
+		return verificationReceipt{}, err
+	}
+	if err := validateVerificationReceipt(receipt, integrationID); err != nil {
+		return verificationReceipt{}, err
+	}
+	return receipt, nil
+}
+
+func validateVerificationReceipt(receipt verificationReceipt, integrationID string) error {
+	if receipt.SchemaVersion != verificationReceiptSchemaVersion {
+		return fmt.Errorf("unsupported receipt schema")
+	}
+	if receipt.IntegrationID != integrationID {
+		return fmt.Errorf("receipt integration mismatch")
+	}
+	if receipt.CheckedAt.IsZero() || receipt.ExpiresAt.IsZero() || !receipt.ExpiresAt.After(receipt.CheckedAt) || receipt.ExpiresAt.Sub(receipt.CheckedAt) > verificationReceiptLifetime {
+		return fmt.Errorf("invalid receipt lifetime")
+	}
+	switch receipt.AssuranceLevel {
+	case assuranceAdapterVerified, assuranceHostVerified, assuranceUnverified, assuranceDegraded:
+	default:
+		return fmt.Errorf("invalid assurance level")
+	}
+	if !receipt.SafeCanaries || strings.TrimSpace(receipt.EnvironmentFingerprint) == "" {
+		return fmt.Errorf("receipt lacks safe verification evidence")
+	}
+	if receipt.Summary.Checks != len(receipt.Checks) {
+		return fmt.Errorf("receipt check count mismatch")
+	}
+	calculated := verificationSummary{Checks: len(receipt.Checks)}
+	seen := make(map[string]bool, len(receipt.Checks))
+	for _, check := range receipt.Checks {
+		if strings.TrimSpace(check.ID) == "" {
+			return fmt.Errorf("receipt contains an unnamed check")
+		}
+		if seen[check.ID] {
+			return fmt.Errorf("receipt contains duplicate check %q", check.ID)
+		}
+		seen[check.ID] = true
+		switch check.Status {
+		case verificationPass:
+			calculated.Passed++
+		case verificationFail:
+			calculated.Failed++
+		case verificationUnverified:
+			calculated.Unverified++
+		default:
+			return fmt.Errorf("receipt contains an invalid check status")
+		}
+	}
+	if calculated != receipt.Summary {
+		return fmt.Errorf("receipt summary does not match checks")
+	}
+	expected := assuranceLevelForReport(verificationReport{Target: integrationID, Summary: calculated})
+	if receipt.AssuranceLevel != expected {
+		return fmt.Errorf("receipt assurance does not match checks")
+	}
+	return nil
+}
+
+func integrationEnvironmentFingerprint(driver integrationDriver, home string) (string, error) {
+	return integrationEnvironmentFingerprintAt(driver, home, resolveServeURL(""))
+}
+
+func integrationEnvironmentFingerprintAt(driver integrationDriver, home, policyEndpoint string) (string, error) {
+	configured := integrationConfiguredForAssurance(driver, home)
+	installed := driver.Installed != nil && driver.Installed(home)
+	hash := sha256.New()
+	fmt.Fprintf(hash, "%s\n%s\n%s\n%s\n%s\n%s\n%t\n%t\nendpoint:%s\n", driver.ID, driver.Boundary, build.Version, build.Commit, runtime.GOOS, runtime.GOARCH, installed, configured, strings.TrimRight(policyEndpoint, "/"))
+	if executable, err := os.Executable(); err == nil {
+		resolved := executable
+		if value, resolveErr := filepath.EvalSymlinks(executable); resolveErr == nil {
+			resolved = value
+		}
+		if info, statErr := os.Stat(resolved); statErr == nil {
+			fmt.Fprintf(hash, "rampart:%s:%d:%d\n", resolved, info.Size(), info.ModTime().UnixNano())
+		}
+	}
+
+	for _, executable := range driver.Executables {
+		path, err := execLookPath(executable)
+		if err != nil {
+			fmt.Fprintf(hash, "%s:missing\n", executable)
+			continue
+		}
+		resolved := path
+		if value, resolveErr := filepath.EvalSymlinks(path); resolveErr == nil {
+			resolved = value
+		}
+		info, statErr := os.Stat(resolved)
+		if statErr != nil {
+			return "", fmt.Errorf("inspect %s executable: %w", executable, statErr)
+		}
+		fmt.Fprintf(hash, "%s:%s:%d:%d\n", executable, resolved, info.Size(), info.ModTime().UnixNano())
+	}
+	policyDir := filepath.Join(home, ".rampart", "policies")
+	entries, err := os.ReadDir(policyDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			fmt.Fprintln(hash, "policies:missing")
+			return hex.EncodeToString(hash.Sum(nil)), nil
+		}
+		return "", fmt.Errorf("inspect policy directory: %w", err)
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || (!strings.HasSuffix(name, ".yaml") && !strings.HasSuffix(name, ".yml")) {
+			continue
+		}
+		info, statErr := os.Lstat(filepath.Join(policyDir, name))
+		if statErr != nil {
+			return "", fmt.Errorf("inspect policy %s: %w", name, statErr)
+		}
+		fmt.Fprintf(hash, "policy:%s:%s:%d:%d\n", name, info.Mode().Type(), info.Size(), info.ModTime().UnixNano())
+		if !info.Mode().IsRegular() {
+			continue
+		}
+		file, openErr := os.Open(filepath.Join(policyDir, name))
+		if openErr != nil {
+			return "", fmt.Errorf("read policy %s: %w", name, openErr)
+		}
+		copied, copyErr := io.Copy(hash, io.LimitReader(file, maxPolicyFingerprintBytes+1))
+		closeErr := file.Close()
+		if copyErr != nil {
+			return "", fmt.Errorf("fingerprint policy %s: %w", name, copyErr)
+		}
+		if closeErr != nil {
+			return "", fmt.Errorf("close policy %s: %w", name, closeErr)
+		}
+		if copied > maxPolicyFingerprintBytes {
+			fmt.Fprintln(hash, "policy-content:truncated")
+		} else {
+			fmt.Fprintln(hash)
+		}
+	}
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+func integrationConfiguredForAssurance(driver integrationDriver, home string) bool {
+	if driver.Configured == nil || !driver.Configured(home) {
+		return false
+	}
+	switch driver.ID {
+	case "claude-code":
+		assessment := claudeHookLoadAssessmentForHome(home)
+		return !assessment.Blocked && !assessment.Unverified
+	case "copilot":
+		workingDir, _ := os.Getwd()
+		_, disabled := copilotCLIUserHooksDisabled(home, workingDir)
+		return !disabled
+	default:
+		return true
+	}
+}
+
+func collectIntegrationAssuranceStatuses(now time.Time, serverRunning bool) []integrationAssuranceStatus {
+	home, err := os.UserHomeDir()
+	if err != nil || strings.TrimSpace(home) == "" {
+		return []integrationAssuranceStatus{}
+	}
+	statuses := make([]integrationAssuranceStatus, 0)
+	for _, driver := range supportedIntegrationDrivers() {
+		installed := driver.Installed != nil && driver.Installed(home)
+		configured := integrationConfiguredForAssurance(driver, home)
+		if !installed && !configured {
+			continue
+		}
+		receipt, receiptErr := readVerificationReceipt(driver.ID)
+		status := integrationAssuranceStatus{
+			ID: driver.ID, DisplayName: driver.DisplayName, Boundary: driver.Boundary,
+			Installed: installed, Configured: configured, ServiceRequired: driver.ServiceRequired,
+			AssuranceLevel:      assuranceDetected,
+			VerificationCommand: "rampart verify " + driver.VerifyTarget,
+		}
+		if driver.AutoProtect {
+			status.RecommendedCommand = "rampart protect " + driver.ID
+		} else {
+			status.RecommendedCommand = "rampart setup " + driver.ID
+		}
+		if configured {
+			status.AssuranceLevel = assuranceConfigured
+			status.RecommendedCommand = status.VerificationCommand
+		}
+		if receiptErr != nil {
+			if !os.IsNotExist(receiptErr) {
+				status.StaleReason = "verification receipt is unreadable"
+			}
+			statuses = append(statuses, status)
+			continue
+		}
+		status.CheckedAt = &receipt.CheckedAt
+		status.EvidenceExpiresAt = &receipt.ExpiresAt
+		status.EvidenceSource = "local_verification_receipt"
+		if driver.ServiceRequired && !serverRunning {
+			status.StaleReason = "Rampart policy service is unavailable"
+			statuses = append(statuses, status)
+			continue
+		}
+		if receipt.CheckedAt.After(now.Add(5 * time.Minute)) {
+			status.StaleReason = "verification time is in the future"
+			statuses = append(statuses, status)
+			continue
+		}
+		if now.After(receipt.ExpiresAt) {
+			status.StaleReason = "verification evidence expired"
+			statuses = append(statuses, status)
+			continue
+		}
+		if receipt.RampartVersion != build.Version || receipt.RampartCommit != build.Commit {
+			status.StaleReason = "Rampart changed since verification"
+			statuses = append(statuses, status)
+			continue
+		}
+		fingerprint, fingerprintErr := integrationEnvironmentFingerprint(driver, home)
+		if fingerprintErr != nil || fingerprint != receipt.EnvironmentFingerprint {
+			status.StaleReason = "integration environment changed since verification"
+			statuses = append(statuses, status)
+			continue
+		}
+		status.AssuranceLevel = receipt.AssuranceLevel
+		statuses = append(statuses, status)
+	}
+	return statuses
+}
+
+func printIntegrationAssurance(w io.Writer, statuses []integrationAssuranceStatus, now time.Time) {
+	if len(statuses) == 0 {
+		return
+	}
+	fmt.Fprintln(w, "\nAssurance evidence")
+	for _, status := range statuses {
+		icon := "•"
+		switch status.AssuranceLevel {
+		case assuranceHostVerified, assuranceAdapterVerified:
+			icon = "✓"
+		case assuranceDegraded:
+			icon = "✗"
+		case assuranceUnverified:
+			icon = "!"
+		}
+		label := strings.ToUpper(strings.ReplaceAll(string(status.AssuranceLevel), "_", " "))
+		fmt.Fprintf(w, "  %s %-28s %s", icon, status.DisplayName, label)
+		if status.CheckedAt != nil && status.StaleReason == "" {
+			age := now.Sub(*status.CheckedAt)
+			if age < 0 {
+				age = 0
+			}
+			fmt.Fprintf(w, " · checked %s", formatAgo(age))
+		}
+		fmt.Fprintln(w)
+		if status.StaleReason != "" {
+			fmt.Fprintf(w, "      Evidence stale: %s; run `%s`\n", status.StaleReason, status.VerificationCommand)
+		} else if status.AssuranceLevel == assuranceConfigured || status.AssuranceLevel == assuranceDetected || status.AssuranceLevel == assuranceUnverified || status.AssuranceLevel == assuranceDegraded {
+			fmt.Fprintf(w, "      Run `%s`\n", status.RecommendedCommand)
+		}
+	}
+}

--- a/cmd/rampart/cli/assurance_status_test.go
+++ b/cmd/rampart/cli/assurance_status_test.go
@@ -1,0 +1,228 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestVerificationReceiptPromotesConfiguredIntegration(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+	installCodexAssuranceFixture(t, home)
+
+	checkedAt := time.Now().UTC().Truncate(time.Second)
+	report := passingAssuranceReport("codex", checkedAt)
+	if err := writeVerificationReceipt(report); err != nil {
+		t.Fatalf("writeVerificationReceipt: %v", err)
+	}
+
+	status, ok := findAssuranceStatus(collectIntegrationAssuranceStatuses(checkedAt.Add(time.Minute), false), "codex")
+	if !ok {
+		t.Fatal("Codex assurance status missing")
+	}
+	if status.AssuranceLevel != assuranceAdapterVerified || !status.Configured {
+		t.Fatalf("Codex assurance status = %#v", status)
+	}
+	if status.RecommendedCommand != "rampart verify codex" || status.EvidenceSource != "local_verification_receipt" {
+		t.Fatalf("Codex evidence guidance = %#v", status)
+	}
+	if status.CheckedAt == nil || !status.CheckedAt.Equal(checkedAt) || status.StaleReason != "" {
+		t.Fatalf("Codex evidence metadata = %#v", status)
+	}
+}
+
+func TestVerificationReceiptInvalidatesAfterConfigurationChange(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+	installCodexAssuranceFixture(t, home)
+
+	checkedAt := time.Now().UTC().Truncate(time.Second)
+	if err := writeVerificationReceipt(passingAssuranceReport("codex", checkedAt)); err != nil {
+		t.Fatalf("writeVerificationReceipt: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".codex", "hooks.json"), []byte(`{"hooks":{}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	status, ok := findAssuranceStatus(collectIntegrationAssuranceStatuses(checkedAt.Add(time.Minute), false), "codex")
+	if !ok {
+		t.Fatal("Codex assurance status missing")
+	}
+	if status.AssuranceLevel == assuranceAdapterVerified || status.StaleReason != "integration environment changed since verification" {
+		t.Fatalf("stale Codex assurance status = %#v", status)
+	}
+}
+
+func TestVerificationReceiptInvalidatesAfterPolicyChange(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+	installCodexAssuranceFixture(t, home)
+	policyDir := filepath.Join(home, ".rampart", "policies")
+	if err := os.MkdirAll(policyDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	policyPath := filepath.Join(policyDir, "guard.yaml")
+	if err := os.WriteFile(policyPath, []byte("version: \"1\"\ndefault_action: deny\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	checkedAt := time.Now().UTC().Truncate(time.Second)
+	if err := writeVerificationReceipt(passingAssuranceReport("codex", checkedAt)); err != nil {
+		t.Fatalf("writeVerificationReceipt: %v", err)
+	}
+	if err := os.WriteFile(policyPath, []byte("version: \"1\"\ndefault_action: allow\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	status, ok := findAssuranceStatus(collectIntegrationAssuranceStatuses(checkedAt.Add(time.Minute), false), "codex")
+	if !ok || status.StaleReason != "integration environment changed since verification" {
+		t.Fatalf("policy-mutated assurance status = %#v, found=%t", status, ok)
+	}
+}
+
+func TestVerificationReceiptInvalidatesWhenPolicyEndpointChanges(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+	installCodexAssuranceFixture(t, home)
+
+	checkedAt := time.Now().UTC().Truncate(time.Second)
+	report := passingAssuranceReport("codex", checkedAt)
+	report.policyEndpoint = "http://127.0.0.1:19090"
+	if err := writeVerificationReceipt(report); err != nil {
+		t.Fatalf("writeVerificationReceipt: %v", err)
+	}
+
+	status, ok := findAssuranceStatus(collectIntegrationAssuranceStatuses(checkedAt.Add(time.Minute), false), "codex")
+	if !ok || status.StaleReason != "integration environment changed since verification" {
+		t.Fatalf("endpoint-mutated assurance status = %#v, found=%t", status, ok)
+	}
+}
+
+func TestVerificationReceiptExpires(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+	installCodexAssuranceFixture(t, home)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	if err := writeVerificationReceipt(passingAssuranceReport("codex", now.Add(-8*24*time.Hour))); err != nil {
+		t.Fatalf("writeVerificationReceipt: %v", err)
+	}
+
+	status, ok := findAssuranceStatus(collectIntegrationAssuranceStatuses(now, false), "codex")
+	if !ok || status.StaleReason != "verification evidence expired" || status.AssuranceLevel != assuranceConfigured {
+		t.Fatalf("expired assurance status = %#v, found=%t", status, ok)
+	}
+}
+
+func TestVerificationReceiptExcludesCheckDetails(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+	installCodexAssuranceFixture(t, home)
+
+	report := passingAssuranceReport("codex", time.Now().UTC().Truncate(time.Second))
+	report.Checks[0].Actual = "/Users/example/private-key"
+	report.Checks[0].Expected = "sensitive expected value"
+	report.Checks[0].Message = "secret message"
+	report.Checks[0].Hint = "secret hint"
+	if err := writeVerificationReceipt(report); err != nil {
+		t.Fatalf("writeVerificationReceipt: %v", err)
+	}
+	path, err := verificationReceiptPath("codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{"private-key", "sensitive expected", "secret message", "secret hint"} {
+		if strings.Contains(string(data), forbidden) {
+			t.Fatalf("verification receipt retained sensitive check detail %q: %s", forbidden, data)
+		}
+	}
+}
+
+func TestVerificationReceiptRefusesSymlinkTarget(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+	installCodexAssuranceFixture(t, home)
+	verificationDir := filepath.Join(home, ".rampart", "verification")
+	if err := os.MkdirAll(verificationDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(t.TempDir(), "outside.json")
+	if err := os.WriteFile(target, []byte("unchanged"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(verificationDir, "codex.json")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	err := writeVerificationReceipt(passingAssuranceReport("codex", time.Now().UTC()))
+	if err == nil || !strings.Contains(err.Error(), "not a regular file") {
+		t.Fatalf("writeVerificationReceipt symlink error = %v", err)
+	}
+	data, readErr := os.ReadFile(target)
+	if readErr != nil || string(data) != "unchanged" {
+		t.Fatalf("receipt write changed symlink target: data=%q err=%v", data, readErr)
+	}
+}
+
+func TestAssuranceLevelMatchesVerificationBoundary(t *testing.T) {
+	now := time.Now().UTC()
+	if got := passingAssuranceReport("openclaw", now).Assurance; got != assuranceHostVerified {
+		t.Fatalf("OpenClaw assurance = %q, want %q", got, assuranceHostVerified)
+	}
+	if got := passingAssuranceReport("claude-code", now).Assurance; got != assuranceAdapterVerified {
+		t.Fatalf("Claude Code assurance = %q, want %q", got, assuranceAdapterVerified)
+	}
+	if got := passingAssuranceReport("policy", now).Assurance; got != assurancePolicyVerified {
+		t.Fatalf("policy assurance = %q, want %q", got, assurancePolicyVerified)
+	}
+	failing := passingAssuranceReport("openclaw", now)
+	failing.Checks[0].Status = verificationFail
+	failing = summarizeVerification(failing)
+	if failing.Assurance != assuranceDegraded {
+		t.Fatalf("failed assurance = %q, want %q", failing.Assurance, assuranceDegraded)
+	}
+}
+
+func installCodexAssuranceFixture(t *testing.T, home string) {
+	t.Helper()
+	path := filepath.Join(home, ".codex", "hooks.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	command, commandWindows := currentCodexHookCommands()
+	if err := installCodexHooks(path, command, commandWindows, false); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func passingAssuranceReport(target string, checkedAt time.Time) verificationReport {
+	return summarizeVerification(verificationReport{
+		SchemaVersion: verifyJSONSchemaVersion,
+		GeneratedAt:   checkedAt.UTC().Format(time.RFC3339),
+		Target:        target,
+		SafeCanaries:  true,
+		Checks: []verificationCheck{
+			{ID: "configuration", Name: "Configuration", Status: verificationPass, Message: "configured"},
+			{ID: "behavior", Name: "Behavior", Status: verificationPass, Message: "blocked"},
+		},
+	})
+}
+
+func findAssuranceStatus(statuses []integrationAssuranceStatus, id string) (integrationAssuranceStatus, bool) {
+	for _, status := range statuses {
+		if status.ID == id {
+			return status, true
+		}
+	}
+	return integrationAssuranceStatus{}, false
+}

--- a/cmd/rampart/cli/firstrun.go
+++ b/cmd/rampart/cli/firstrun.go
@@ -47,11 +47,11 @@ func printStatusHints(w io.Writer, serverRunning bool, protected []string, allow
 	switch {
 	case !serverRunning && len(protected) == 0:
 		// Nothing set up yet
-		fmt.Fprintln(w, "\n→ Get started: rampart init && rampart setup claude-code")
+		fmt.Fprintln(w, "\n→ Get started: rampart protect")
 
 	case !serverRunning && isHookBasedOnly(protected):
 		// Hook-based agents don't need serve for basic allow/deny
-		fmt.Fprintln(w, "\n→ Protection active via hooks. Optional: rampart serve   (for dashboard + approvals)")
+		fmt.Fprintln(w, "\n→ Hooks configured. Optional: rampart serve   (for dashboard + approvals)")
 
 	case !serverRunning:
 		// LD_PRELOAD/shim agents need serve running
@@ -63,7 +63,7 @@ func printStatusHints(w io.Writer, serverRunning bool, protected []string, allow
 
 	case len(protected) == 0:
 		// Serve running but no agents connected
-		fmt.Fprintln(w, "\n→ Next: rampart setup claude-code")
+		fmt.Fprintln(w, "\n→ Next: rampart protect")
 
 	case total == 0:
 		// Everything set up, no events yet

--- a/cmd/rampart/cli/integration_driver.go
+++ b/cmd/rampart/cli/integration_driver.go
@@ -20,25 +20,29 @@ import (
 // deliberately contains only lifecycle operations shared by the CLI. Tool
 // payload normalization remains in the adapter that owns the host protocol.
 type integrationDriver struct {
-	ID           string
-	Aliases      []string
-	DisplayName  string
-	Boundary     string
-	VerifyTarget string
-	Installed    func(home string) bool
-	SetupCommand func(opts *rootOptions) *cobra.Command
-	VerifyChecks func(ctx context.Context, timeout time.Duration) []verificationCheck
-	OpenClaw     bool
-	AutoProtect  bool
-	Platforms    []string
-	Configured   func(home string) bool
+	ID              string
+	Aliases         []string
+	DisplayName     string
+	Boundary        string
+	VerifyTarget    string
+	ProofLevel      assuranceLevel
+	Executables     []string
+	Installed       func(home string) bool
+	SetupCommand    func(opts *rootOptions) *cobra.Command
+	VerifyChecks    func(ctx context.Context, timeout time.Duration) []verificationCheck
+	OpenClaw        bool
+	AutoProtect     bool
+	ServiceRequired bool
+	Platforms       []string
+	Configured      func(home string) bool
 }
 
 func supportedIntegrationDrivers() []integrationDriver {
 	return []integrationDriver{
 		{
 			ID: "openclaw", DisplayName: "OpenClaw", Boundary: "native plugin", VerifyTarget: "openclaw", OpenClaw: true,
-			AutoProtect: true, Platforms: []string{"linux", "darwin"},
+			ProofLevel: assuranceHostVerified, Executables: []string{"openclaw"},
+			AutoProtect: true, ServiceRequired: true, Platforms: []string{"linux", "darwin"},
 			Installed:  func(_ string) bool { return isOpenClawInstalled() },
 			Configured: func(_ string) bool { return isOpenClawPluginConfigured() },
 			VerifyChecks: func(ctx context.Context, timeout time.Duration) []verificationCheck {
@@ -47,6 +51,7 @@ func supportedIntegrationDrivers() []integrationDriver {
 		},
 		{
 			ID: "claude-code", Aliases: []string{"claude"}, DisplayName: "Claude Code", Boundary: "native hooks", VerifyTarget: "claude-code",
+			ProofLevel: assuranceAdapterVerified, Executables: []string{"claude"},
 			AutoProtect: true, Platforms: []string{"linux", "darwin", "windows"},
 			Installed: func(home string) bool {
 				return integrationBinaryOrPathInstalled("claude", claudeConfigDir(home))
@@ -59,6 +64,7 @@ func supportedIntegrationDrivers() []integrationDriver {
 		},
 		{
 			ID: "codex", DisplayName: "Codex", Boundary: "native hooks", VerifyTarget: "codex",
+			ProofLevel: assuranceAdapterVerified, Executables: []string{"codex"},
 			AutoProtect: true, Platforms: []string{"linux", "darwin", "windows"},
 			Installed: func(home string) bool {
 				return integrationBinaryOrPathInstalled("codex", codexHomeDir(home))
@@ -71,6 +77,7 @@ func supportedIntegrationDrivers() []integrationDriver {
 		},
 		{
 			ID: "gemini", Aliases: []string{"gemini-cli"}, DisplayName: "Gemini CLI", Boundary: "experimental native hooks", VerifyTarget: "gemini",
+			ProofLevel: assuranceAdapterVerified, Executables: []string{"gemini"},
 			AutoProtect: false, Platforms: []string{"linux", "darwin"},
 			Installed: func(home string) bool {
 				_, err := execLookPath("gemini")
@@ -84,6 +91,7 @@ func supportedIntegrationDrivers() []integrationDriver {
 		},
 		{
 			ID: "antigravity", Aliases: []string{"agy"}, DisplayName: "Antigravity CLI / IDE", Boundary: "native plugin hook", VerifyTarget: "antigravity",
+			ProofLevel: assuranceAdapterVerified, Executables: []string{"agy"},
 			AutoProtect: true, Platforms: []string{"linux", "darwin", "windows"},
 			Installed: func(home string) bool {
 				return integrationBinaryOrPathInstalled("agy",
@@ -99,6 +107,7 @@ func supportedIntegrationDrivers() []integrationDriver {
 		},
 		{
 			ID: "copilot", Aliases: []string{"copilot-cli", "github-copilot"}, DisplayName: "GitHub Copilot CLI / VS Code", Boundary: "native hooks", VerifyTarget: "copilot",
+			ProofLevel: assuranceAdapterVerified, Executables: []string{"copilot"},
 			AutoProtect: true, Platforms: []string{"linux", "darwin", "windows"},
 			Installed:    func(home string) bool { return copilotInstalledForHome(home) },
 			SetupCommand: func(_ *rootOptions) *cobra.Command { return newSetupCopilotCmd() },
@@ -109,6 +118,7 @@ func supportedIntegrationDrivers() []integrationDriver {
 		},
 		{
 			ID: "cline", DisplayName: "Cline", Boundary: "native hooks", VerifyTarget: "cline",
+			ProofLevel: assuranceAdapterVerified, Executables: []string{"cline"},
 			AutoProtect: true, Platforms: []string{"linux", "darwin", "windows"},
 			Installed: func(home string) bool {
 				return integrationBinaryOrPathInstalled("cline", filepath.Join(home, "Documents", "Cline"), filepath.Join(home, ".cline")) ||

--- a/cmd/rampart/cli/integration_driver_test.go
+++ b/cmd/rampart/cli/integration_driver_test.go
@@ -46,8 +46,21 @@ func TestIntegrationDriversMatchAssuranceManifest(t *testing.T) {
 		if driver.VerifyTarget != integration.ID {
 			t.Errorf("driver %q verify target = %q, manifest id = %q", driver.ID, driver.VerifyTarget, integration.ID)
 		}
+		wantProof := assuranceAdapterVerified
+		if integration.Verification.HostBoundary && integration.Verification.Command == "rampart verify "+driver.VerifyTarget {
+			wantProof = assuranceHostVerified
+		}
+		if driver.ProofLevel != wantProof {
+			t.Errorf("driver %q proof level = %q, manifest host boundary = %t", driver.ID, driver.ProofLevel, integration.Verification.HostBoundary)
+		}
+		if len(driver.Executables) == 0 {
+			t.Errorf("driver %q has no executable identity for receipt invalidation", driver.ID)
+		}
 		if integration.AutoProtect == nil || driver.AutoProtect != *integration.AutoProtect {
 			t.Errorf("driver %q auto-protect = %t, manifest = %v", driver.ID, driver.AutoProtect, integration.AutoProtect)
+		}
+		if driver.ServiceRequired != integration.ServiceRequired {
+			t.Errorf("driver %q service-required = %t, manifest = %t", driver.ID, driver.ServiceRequired, integration.ServiceRequired)
 		}
 		if got := integrationBoundaryKind(driver.Boundary); got != integration.Boundary {
 			t.Errorf("driver %q boundary = %q (%q), manifest = %q", driver.ID, driver.Boundary, got, integration.Boundary)

--- a/cmd/rampart/cli/protect.go
+++ b/cmd/rampart/cli/protect.go
@@ -147,6 +147,7 @@ func runProtectHookDriver(cmd *cobra.Command, rootOpts *rootOptions, driver inte
 	}
 	time.Sleep(150 * time.Millisecond)
 	report := runBehavioralVerification(cmd.Context(), driver.VerifyTarget, resolvedURL, opts.Timeout)
+	receiptErr := writeVerificationReceipt(report)
 	fmt.Fprintln(w)
 	printVerificationReport(w, report)
 	if report.Summary.Failed > 0 {
@@ -154,6 +155,9 @@ func runProtectHookDriver(cmd *cobra.Command, rootOpts *rootOptions, driver inte
 	}
 	if report.Summary.Unverified > 0 {
 		return exitCodeError{code: 2}
+	}
+	if receiptErr != nil {
+		return fmt.Errorf("protect %s: persist assurance evidence: %w", driver.ID, receiptErr)
 	}
 	fmt.Fprintf(w, "\nRampart configuration and adapter verification passed for %s. Restart or reload the host if setup requested it.\n", driver.DisplayName)
 	return nil
@@ -226,6 +230,7 @@ func runProtectOpenClaw(cmd *cobra.Command, opts protectOpenClawOptions) error {
 	// restarted local gateway a chance to expose the plugin verification method.
 	time.Sleep(350 * time.Millisecond)
 	report := runBehavioralVerification(cmd.Context(), "openclaw", resolvedURL, opts.Timeout)
+	receiptErr := writeVerificationReceipt(report)
 	fmt.Fprintln(w)
 	printVerificationReport(w, report)
 	if report.Summary.Failed > 0 {
@@ -233,6 +238,9 @@ func runProtectOpenClaw(cmd *cobra.Command, opts protectOpenClawOptions) error {
 	}
 	if report.Summary.Unverified > 0 {
 		return exitCodeError{code: 2}
+	}
+	if receiptErr != nil {
+		return fmt.Errorf("protect: persist assurance evidence: %w", receiptErr)
 	}
 	fmt.Fprintln(w, "\nRampart is actively protecting OpenClaw.")
 	return nil

--- a/cmd/rampart/cli/status.go
+++ b/cmd/rampart/cli/status.go
@@ -51,6 +51,7 @@ type statusSnapshot struct {
 	generatedAt   time.Time
 	buildVersion  string
 	protected     []string
+	integrations  []integrationAssuranceStatus
 	mode          string
 	defaultAction string
 	serverRunning bool
@@ -62,16 +63,17 @@ type statusSnapshot struct {
 }
 
 type statusJSONOutput struct {
-	SchemaVersion string              `json:"schema_version"`
-	GeneratedAt   time.Time           `json:"generated_at"`
-	BuildVersion  string              `json:"build_version"`
-	Protected     []string            `json:"protected_agents"`
-	Mode          string              `json:"mode"`
-	DefaultAction string              `json:"default_action"`
-	ServerRunning bool                `json:"server_running"`
-	HookOnly      bool                `json:"hook_only"`
-	Today         statusTodayJSON     `json:"today"`
-	LastDeny      *statusLastDenyJSON `json:"last_deny,omitempty"`
+	SchemaVersion string                       `json:"schema_version"`
+	GeneratedAt   time.Time                    `json:"generated_at"`
+	BuildVersion  string                       `json:"build_version"`
+	Protected     []string                     `json:"protected_agents"`
+	Integrations  []integrationAssuranceStatus `json:"integrations"`
+	Mode          string                       `json:"mode"`
+	DefaultAction string                       `json:"default_action"`
+	ServerRunning bool                         `json:"server_running"`
+	HookOnly      bool                         `json:"hook_only"`
+	Today         statusTodayJSON              `json:"today"`
+	LastDeny      *statusLastDenyJSON          `json:"last_deny,omitempty"`
 }
 
 type statusTodayJSON struct {
@@ -107,6 +109,7 @@ func runStatus(w io.Writer, jsonOut bool) error {
 		useColor,
 	)
 	fmt.Fprintln(w, box)
+	printIntegrationAssurance(w, snapshot.integrations, snapshot.generatedAt)
 
 	printStatusHints(w, snapshot.serverRunning, snapshot.protected, snapshot.allow, snapshot.deny, snapshot.pending)
 	return nil
@@ -117,15 +120,17 @@ func collectStatusSnapshot(generatedAt time.Time) statusSnapshot {
 		generatedAt = time.Now().UTC()
 	}
 	protected := detectProtectedAgents()
+	serverRunning := isServeRunningLocal()
 	mode, defaultAction := detectMode()
 	allow, deny, pending, lastDeny := todayEventsAt(generatedAt)
 	return statusSnapshot{
 		generatedAt:   generatedAt,
 		buildVersion:  build.Version,
 		protected:     protected,
+		integrations:  collectIntegrationAssuranceStatuses(generatedAt, serverRunning),
 		mode:          mode,
 		defaultAction: defaultAction,
-		serverRunning: isServeRunningLocal(),
+		serverRunning: serverRunning,
 		hookOnly:      isHookBasedOnly(protected),
 		allow:         allow,
 		deny:          deny,
@@ -139,12 +144,17 @@ func writeStatusJSON(w io.Writer, snapshot statusSnapshot) error {
 	if protected == nil {
 		protected = []string{}
 	}
+	integrations := snapshot.integrations
+	if integrations == nil {
+		integrations = []integrationAssuranceStatus{}
+	}
 
 	out := statusJSONOutput{
 		SchemaVersion: statusSchemaVersion,
 		GeneratedAt:   snapshot.generatedAt,
 		BuildVersion:  snapshot.buildVersion,
 		Protected:     protected,
+		Integrations:  integrations,
 		Mode:          snapshot.mode,
 		DefaultAction: snapshot.defaultAction,
 		ServerRunning: snapshot.serverRunning,
@@ -294,11 +304,11 @@ func buildStatusBox(
 
 	// ── Protected ───────────────────────────────────────────────────────────
 
-	protectedStr := "None — run 'rampart setup' to protect an agent"
+	protectedStr := "None — run 'rampart protect' to protect detected agents"
 	if len(protected) > 0 {
 		protectedStr = strings.Join(protected, ", ")
 	}
-	protectedLine := lbl("Protected") + protectedStr
+	protectedLine := lbl("Configured") + protectedStr
 
 	// ── Mode ────────────────────────────────────────────────────────────────
 

--- a/cmd/rampart/cli/verify.go
+++ b/cmd/rampart/cli/verify.go
@@ -68,12 +68,14 @@ func latestAuditEvent(auditDir string) (audit.Event, error) {
 }
 
 type verificationReport struct {
-	SchemaVersion string              `json:"schema_version"`
-	GeneratedAt   string              `json:"generated_at"`
-	Target        string              `json:"target"`
-	SafeCanaries  bool                `json:"safe_canaries"`
-	Summary       verificationSummary `json:"summary"`
-	Checks        []verificationCheck `json:"checks"`
+	SchemaVersion  string              `json:"schema_version"`
+	GeneratedAt    string              `json:"generated_at"`
+	Target         string              `json:"target"`
+	SafeCanaries   bool                `json:"safe_canaries"`
+	Assurance      assuranceLevel      `json:"assurance_level"`
+	Summary        verificationSummary `json:"summary"`
+	Checks         []verificationCheck `json:"checks"`
+	policyEndpoint string
 }
 
 type behavioralCanary struct {
@@ -132,6 +134,7 @@ implementation.`,
 				return fmt.Errorf("verify: resolve serve URL: %w", err)
 			}
 			report := runBehavioralVerification(cmd.Context(), target, resolvedURL, timeout)
+			receiptErr := writeVerificationReceipt(report)
 			if jsonOut {
 				if err := json.NewEncoder(cmd.OutOrStdout()).Encode(report); err != nil {
 					return fmt.Errorf("verify: encode report: %w", err)
@@ -144,6 +147,9 @@ implementation.`,
 			}
 			if report.Summary.Unverified > 0 {
 				return exitCodeError{code: 2}
+			}
+			if receiptErr != nil {
+				return fmt.Errorf("verify: persist assurance evidence: %w", receiptErr)
 			}
 			return nil
 		},
@@ -240,11 +246,12 @@ func runBehavioralVerification(ctx context.Context, target, serveURL string, tim
 		timeout = 5 * time.Second
 	}
 	report := verificationReport{
-		SchemaVersion: verifyJSONSchemaVersion,
-		GeneratedAt:   time.Now().UTC().Format(time.RFC3339),
-		Target:        target,
-		SafeCanaries:  true,
-		Checks:        make([]verificationCheck, 0),
+		SchemaVersion:  verifyJSONSchemaVersion,
+		GeneratedAt:    time.Now().UTC().Format(time.RFC3339),
+		Target:         target,
+		SafeCanaries:   true,
+		Checks:         make([]verificationCheck, 0),
+		policyEndpoint: strings.TrimRight(serveURL, "/"),
 	}
 
 	if target != "policy" {
@@ -1079,7 +1086,7 @@ func findPluginVerificationResult(value any) (map[string]any, bool) {
 }
 
 func summarizeVerification(report verificationReport) verificationReport {
-	report.Summary.Checks = len(report.Checks)
+	report.Summary = verificationSummary{Checks: len(report.Checks)}
 	for _, check := range report.Checks {
 		switch check.Status {
 		case verificationPass:
@@ -1090,6 +1097,7 @@ func summarizeVerification(report verificationReport) verificationReport {
 			report.Summary.Unverified++
 		}
 	}
+	report.Assurance = assuranceLevelForReport(report)
 	return report
 }
 
@@ -1119,4 +1127,7 @@ func printVerificationReport(w io.Writer, report verificationReport) {
 	}
 	fmt.Fprintln(w)
 	fmt.Fprintf(w, "%d passed, %d failed, %d unverified\n", report.Summary.Passed, report.Summary.Failed, report.Summary.Unverified)
+	if report.Assurance != "" {
+		fmt.Fprintf(w, "Assurance: %s\n", strings.ToUpper(strings.ReplaceAll(string(report.Assurance), "_", " ")))
+	}
 }

--- a/docs-site/guides/agent-install.md
+++ b/docs-site/guides/agent-install.md
@@ -81,13 +81,17 @@ Expected output (example):
 ```
 🛡️ Rampart Status
 
-Protected: OpenClaw (plugin)
+Configured: OpenClaw (plugin)
 Mode: enforce (default_action: allow)
 Today: 0 allow · 0 deny · 0 log
+
+Assurance evidence
+  ✓ OpenClaw                     HOST VERIFIED · checked 2m ago
 ```
 
-Treat `Protected:` as configuration state, then use the integration's
-`rampart verify <agent>` result to confirm that its managed boundary is healthy.
+`Configured` reports the installed boundary. `Assurance evidence` reports the
+strongest recent proof Rampart can support on this machine. Run the suggested
+`rampart verify <agent>` command whenever evidence is missing or stale.
 
 ---
 
@@ -207,7 +211,7 @@ Then add an allow rule for your specific use case. See [Securing Claude Code](ht
 |---------|--------------|
 | `rampart quickstart --yes` | Full non-interactive setup |
 | `rampart doctor` | Health check — hooks, service, permissions |
-| `rampart status` | Show protected agents, mode, today's allow/deny counts |
+| `rampart status` | Show configured agents, assurance evidence, mode, and today's counts |
 | `rampart watch` | Live feed of tool decisions observed by Rampart |
 | `rampart token` | Print bearer token for the dashboard |
 | `rampart policy explain '<command>'` | Trace how a command is evaluated |

--- a/docs-site/reference/cli-commands.md
+++ b/docs-site/reference/cli-commands.md
@@ -50,12 +50,25 @@ rampart verify claude-code     # Verify Claude hook installation and adapter den
 rampart verify cline           # Verify Cline hook installation and adapter denial
 rampart verify codex           # Verify Codex hook installation and adapter denial
 rampart verify gemini          # Verify Gemini hook installation and adapter denial
+rampart verify antigravity     # Verify Antigravity plugin installation and adapter denial
 rampart verify copilot         # Verify shared Copilot hook and dual-host denial
 rampart verify policy          # Verify the local Rampart policy path
 rampart verify openclaw --json # Emit schema rampart.verify.v1
 ```
 
-Verification does not execute commands, read files, send messages, contact external hosts, or add canary events to the audit log. A failed expectation exits with status 1; an incomplete or unreachable check exits with status 2.
+Verification does not execute commands, read files, send messages, contact external hosts, or add canary events to the audit log. A failed expectation exits with status 1; an incomplete or unreachable check exits with status 2. Human and JSON reports identify the resulting `policy_verified`, `adapter_verified`, `host_verified`, `unverified`, or `degraded` assurance level.
+
+For integration targets, a completed run also records a minimal verification
+receipt under `~/.rampart/verification/`. The receipt contains check IDs and
+outcomes, Rampart build identity, an environment fingerprint, and timestamps;
+it does not contain prompts, commands, host output, credentials, or filesystem
+paths. OpenClaw's live plugin verifier earns `host_verified`; the ordinary
+native-hook commands earn `adapter_verified` because they invoke Rampart's
+adapter without asking a model to act. Receipts expire after seven days and are
+treated as stale when Rampart, the configured boundary, the selected policy
+endpoint, local policy-file metadata, or a detected host executable changes.
+They are local status caches, not tamper-resistant
+attestations.
 
 ### `rampart setup claude-code`
 
@@ -367,14 +380,22 @@ If the plugin is missing or the OpenClaw version is too old:
 
 ### `rampart status`
 
-Quick dashboard showing protected agents, enforcement mode, and today's event counts.
+Quick dashboard showing configured agents, the strongest current verification
+evidence, enforcement mode, and today's event counts.
 
 ```bash
 rampart status
 rampart status --json      # Machine-readable snapshot
 ```
 
-`--json` emits a stable status payload (`schema_version: "rampart.status.v1"`) with mode, protection state, server flags, today's counts, and optional last deny details.
+`--json` emits a stable status payload (`schema_version: "rampart.status.v1"`)
+with mode, the backward-compatible `protected_agents` list, per-integration
+`integrations` evidence, server flags, today's counts, and optional last deny
+details. Assurance levels distinguish `detected`, `configured`,
+`adapter_verified`, `host_verified`, `unverified`, and `degraded`; stale
+receipts fall back to current configuration state and explain why proof must be
+rerun. Evidence for a service-required integration is also stale whenever the
+local Rampart policy service is unavailable.
 
 ### `rampart inventory`
 


### PR DESCRIPTION
## What changed

- add typed `policy_verified`, `adapter_verified`, `host_verified`, `unverified`, and `degraded` results to behavioral verification
- persist minimal owner-only verification receipts without prompts, commands, host output, credentials, paths, or agent memory
- invalidate cached evidence after seven days or when Rampart, the integration, selected policy endpoint, local policy state, detected host executable, or required service state changes
- make `rampart status` distinguish detected/configured integrations from current behavioral evidence while preserving the v1 `protected_agents` JSON field
- derive runtime proof/service claims from the assurance manifest in tests
- update CLI guidance and public docs

## Why

Configuration presence is not proof that a real safety boundary is healthy. This makes Rampart's status claims evidence-backed and explicit about the difference between direct adapter verification and OpenClaw's live host-plugin verification.

Receipts are deliberately local status caches, not tamper-resistant attestations.

## Impact

- no policy-engine or hook hot-path changes
- stripped macOS arm64 binary: +33,056 bytes (~0.2%)
- warm isolated `status --json`: approximately 6.7 ms before and 7.7 ms after on an M4 Pro (about +1 ms)
- existing `rampart.status.v1` fields remain; `integrations` is additive

## Validation

- `go test ./... -count=1`
- `go vet ./...`
- `go run honnef.co/go/tools/cmd/staticcheck@v0.7.0 ./...`
- Windows amd64 CLI test binary and application cross-build
- disposable local E2E: isolated HOME → managed Guard → Codex hooks → safe deny canaries → receipt → `status --json` reports `adapter_verified`
- secret-pattern and public-file scope review
