### PR TITLE
Lay v1.6 lifecycle and verification groundwork

### DIFF
--- a/.github/workflows/upstream-compat.yml
+++ b/.github/workflows/upstream-compat.yml
@@ -123,3 +123,28 @@ jobs:
           path: ${{ runner.temp }}/openclaw-container-acceptance
           if-no-files-found: warn
           retention-days: 14
+
+  openclaw-beta:
+    name: OpenClaw beta package advisory gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # Beta breakage is early warning for maintainers, not a claim that an
+    # unreleased upstream version is supported by the current Rampart release.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.25.12'
+
+      - name: Set up Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+
+      - name: Validate source compatibility against OpenClaw beta
+        run: node scripts/compat-openclaw-latest.mjs --npm-latest --openclaw-package=openclaw@beta

--- a/cmd/rampart/cli/protect.go
+++ b/cmd/rampart/cli/protect.go
@@ -8,10 +8,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	osexec "os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -110,7 +112,7 @@ protects each one through its strongest available native boundary.`,
 	cmd.Flags().BoolVar(&noRestart, "no-restart", false, "Do not restart the OpenClaw gateway after configuration")
 	cmd.Flags().BoolVar(&noVerify, "no-verify", false, "Skip active behavioral verification")
 	cmd.Flags().BoolVar(&reinstall, "reinstall", false, "Reinstall the bundled OpenClaw plugin even when it is current")
-	cmd.Flags().StringVar(&serveURL, "serve-url", "", "Rampart service URL override used for verification")
+	cmd.Flags().StringVar(&serveURL, "serve-url", "", "Rampart service URL override used for startup, host configuration, and verification")
 	cmd.Flags().DurationVar(&timeout, "timeout", 5*time.Second, "Timeout for each active verification check")
 	return cmd
 }
@@ -125,12 +127,16 @@ func runProtectHookDriver(cmd *cobra.Command, rootOpts *rootOptions, driver inte
 	w := cmd.OutOrStdout()
 	errW := cmd.ErrOrStderr()
 	fmt.Fprintf(w, "\nProtecting %s through %s...\n", driver.DisplayName, driver.Boundary)
+	resolvedURL, err := resolveServeURLStrict(opts.ServeURL, fmt.Sprintf("http://localhost:%d", defaultServePort))
+	if err != nil {
+		return fmt.Errorf("protect %s: resolve serve URL: %w", driver.ID, err)
+	}
 	guardPath, err := installManagedGuardPolicy()
 	if err != nil {
 		return fmt.Errorf("protect %s: install managed Guard policy: %w", driver.ID, err)
 	}
 	fmt.Fprintf(w, "✓ Managed Guard policy installed at %s\n", guardPath)
-	if err := ensureServeRunning(w, errW); err != nil {
+	if err := ensureServeRunningForURL(w, errW, resolvedURL); err != nil {
 		return fmt.Errorf("protect %s: start Rampart policy service: %w", driver.ID, err)
 	}
 	if err := runIntegrationSetup(cmd, rootOpts, driver); err != nil {
@@ -140,10 +146,6 @@ func runProtectHookDriver(cmd *cobra.Command, rootOpts *rootOptions, driver inte
 		fmt.Fprintf(w, "Rampart protection is configured for %s. Behavioral verification was skipped.\n", driver.DisplayName)
 		fmt.Fprintf(w, "Run `rampart verify %s` to prove the boundary.\n", driver.VerifyTarget)
 		return nil
-	}
-	resolvedURL, err := resolveServeURLStrict(opts.ServeURL, fmt.Sprintf("http://localhost:%d", defaultServePort))
-	if err != nil {
-		return fmt.Errorf("protect %s: resolve serve URL: %w", driver.ID, err)
 	}
 	time.Sleep(150 * time.Millisecond)
 	report := runBehavioralVerification(cmd.Context(), driver.VerifyTarget, resolvedURL, opts.Timeout)
@@ -174,6 +176,14 @@ type protectOpenClawOptions struct {
 func runProtectOpenClaw(cmd *cobra.Command, opts protectOpenClawOptions) error {
 	w := cmd.OutOrStdout()
 	errW := cmd.ErrOrStderr()
+	resolvedURL, err := resolveServeURLStrict(opts.ServeURL, fmt.Sprintf("http://localhost:%d", defaultServePort))
+	if err != nil {
+		return fmt.Errorf("protect: resolve serve URL: %w", err)
+	}
+	resolvedURL, err = normalizeOpenClawServeURL(resolvedURL)
+	if err != nil {
+		return fmt.Errorf("protect: invalid OpenClaw policy service URL: %w", err)
+	}
 	fmt.Fprintln(w, "Protecting OpenClaw with Rampart managed defaults...")
 
 	guardPath, err := installManagedGuardPolicy()
@@ -189,12 +199,12 @@ func runProtectOpenClaw(cmd *cobra.Command, opts protectOpenClawOptions) error {
 
 	state := getOpenClawPluginState()
 	if opts.Reinstall || !openClawPluginCurrent(state) {
-		if err := runSetupOpenClawPlugin(w, errW); err != nil {
+		if err := runSetupOpenClawPluginForServeURL(w, errW, resolvedURL); err != nil {
 			return fmt.Errorf("protect: configure OpenClaw integration: %w", err)
 		}
 	} else {
 		fmt.Fprintf(w, "✓ OpenClaw plugin v%s is installed and enabled\n", ocplugin.Version())
-		if err := ensureServeRunning(w, errW); err != nil {
+		if err := ensureServeRunningForURL(w, errW, resolvedURL); err != nil {
 			return fmt.Errorf("protect: start Rampart policy service: %w", err)
 		}
 	}
@@ -202,7 +212,7 @@ func runProtectOpenClaw(cmd *cobra.Command, opts protectOpenClawOptions) error {
 	if err != nil {
 		return fmt.Errorf("protect: find OpenClaw: %w", err)
 	}
-	if err := configureOpenClawGuardMode(bin, w, errW); err != nil {
+	if err := configureOpenClawGuardMode(bin, resolvedURL, w, errW); err != nil {
 		return fmt.Errorf("protect: enable fail-closed OpenClaw guard mode: %w", err)
 	}
 	fmt.Fprintln(w, "✓ Enabled fail-closed behavior when Rampart is unavailable")
@@ -222,10 +232,6 @@ func runProtectOpenClaw(cmd *cobra.Command, opts protectOpenClawOptions) error {
 		return nil
 	}
 
-	resolvedURL, err := resolveServeURLStrict(opts.ServeURL, fmt.Sprintf("http://localhost:%d", defaultServePort))
-	if err != nil {
-		return fmt.Errorf("protect: resolve serve URL: %w", err)
-	}
 	// The policy directory is hot-reloaded. A short delay also gives a freshly
 	// restarted local gateway a chance to expose the plugin verification method.
 	time.Sleep(350 * time.Millisecond)
@@ -275,7 +281,11 @@ func installManagedGuardPolicy() (string, error) {
 	return dest, nil
 }
 
-func configureOpenClawGuardMode(openclawBin string, w, errW io.Writer) error {
+func configureOpenClawGuardMode(openclawBin, serveURL string, w, errW io.Writer) error {
+	serveURL, err := normalizeOpenClawServeURL(serveURL)
+	if err != nil {
+		return err
+	}
 	stateDir, configPath, err := resolveOpenClawStateDir(openclawBin)
 	if err != nil {
 		return fmt.Errorf("resolve active OpenClaw state: %w", err)
@@ -287,7 +297,7 @@ func configureOpenClawGuardMode(openclawBin string, w, errW io.Writer) error {
 		return fmt.Errorf("repair OpenClaw approval timeout: %w", err)
 	}
 
-	const patch = `{"plugins":{"entries":{"rampart":{"enabled":true,"config":{"failOpen":false,"failOpenTools":null,"serveUrl":"http://localhost:9090"}}}}}`
+	patch := fmt.Sprintf(`{"plugins":{"entries":{"rampart":{"enabled":true,"config":{"failOpen":false,"failOpenTools":null,"serveUrl":%s}}}}}`, strconv.Quote(serveURL))
 	var stdout, stderr bytes.Buffer
 	cmd := osexec.Command(openclawBin, "config", "patch", "--stdin")
 	cmd.Stdin = strings.NewReader(patch)
@@ -315,7 +325,7 @@ func configureOpenClawGuardMode(openclawBin string, w, errW io.Writer) error {
 	legacyWrites := [][]string{
 		{"config", "set", "plugins.entries.rampart.config.failOpenTools", "[]", "--json"},
 		{"config", "set", "plugins.entries.rampart.config.failOpen", "false", "--json"},
-		{"config", "set", "plugins.entries.rampart.config.serveUrl", `"http://localhost:9090"`, "--json"},
+		{"config", "set", "plugins.entries.rampart.config.serveUrl", strconv.Quote(serveURL), "--json"},
 		{"config", "set", "plugins.entries.rampart.enabled", "true", "--json"},
 	}
 	for _, args := range legacyWrites {
@@ -327,6 +337,21 @@ func configureOpenClawGuardMode(openclawBin string, w, errW io.Writer) error {
 		}
 	}
 	return nil
+}
+
+func normalizeOpenClawServeURL(raw string) (string, error) {
+	trimmed := strings.TrimRight(strings.TrimSpace(raw), "/")
+	parsed, err := url.Parse(trimmed)
+	if err != nil || parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+		return "", fmt.Errorf("expected an absolute HTTP(S) URL")
+	}
+	if parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" || (parsed.Path != "" && parsed.Path != "/") {
+		return "", fmt.Errorf("credentials, paths, queries, and fragments are not allowed")
+	}
+	if !isLoopbackURL(trimmed) {
+		return "", fmt.Errorf("OpenClaw's native plugin accepts only a loopback Rampart service")
+	}
+	return trimmed, nil
 }
 
 func atomicWritePrivateFile(path string, data []byte) error {

--- a/cmd/rampart/cli/protect_test.go
+++ b/cmd/rampart/cli/protect_test.go
@@ -7,6 +7,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -106,7 +108,7 @@ cat > "$RAMPART_TEST_STDIN"
 	}
 	prepareOpenClawGuardTest(t, dir, bin)
 
-	if err := configureOpenClawGuardMode(bin, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+	if err := configureOpenClawGuardMode(bin, "http://127.0.0.1:19090", &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
 		t.Fatal(err)
 	}
 	args, err := os.ReadFile(argsPath)
@@ -131,7 +133,7 @@ cat > "$RAMPART_TEST_STDIN"
 	}
 	entry := patch["plugins"].(map[string]any)["entries"].(map[string]any)["rampart"].(map[string]any)
 	pluginConfig := entry["config"].(map[string]any)
-	if entry["enabled"] != true || pluginConfig["failOpen"] != false || pluginConfig["failOpenTools"] != nil || pluginConfig["serveUrl"] != "http://localhost:9090" {
+	if entry["enabled"] != true || pluginConfig["failOpen"] != false || pluginConfig["failOpenTools"] != nil || pluginConfig["serveUrl"] != "http://127.0.0.1:19090" {
 		t.Fatalf("unexpected managed guard patch: %#v", entry)
 	}
 }
@@ -156,7 +158,7 @@ printf '\n' >> "$RAMPART_TEST_ARGS"
 	}
 	prepareOpenClawGuardTest(t, dir, bin)
 
-	if err := configureOpenClawGuardMode(bin, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+	if err := configureOpenClawGuardMode(bin, "http://localhost:9090", &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
 		t.Fatal(err)
 	}
 	args, err := os.ReadFile(argsPath)
@@ -206,12 +208,70 @@ touch "$RAMPART_TEST_MARKER"
 	}
 	prepareOpenClawGuardTest(t, dir, bin)
 
-	err := configureOpenClawGuardMode(bin, &bytes.Buffer{}, &bytes.Buffer{})
+	err := configureOpenClawGuardMode(bin, "http://localhost:9090", &bytes.Buffer{}, &bytes.Buffer{})
 	if err == nil || !strings.Contains(err.Error(), "config patch") {
 		t.Fatalf("expected supported host rejection, got %v", err)
 	}
 	if _, err := os.Stat(marker); !os.IsNotExist(err) {
 		t.Fatalf("fallback bypassed a supported host rejection: %v", err)
+	}
+}
+
+func TestNormalizeOpenClawServeURLRequiresLoopbackRoot(t *testing.T) {
+	for _, test := range []struct {
+		raw  string
+		want string
+		ok   bool
+	}{
+		{raw: "http://localhost:9090/", want: "http://localhost:9090", ok: true},
+		{raw: "https://127.0.0.1:19090", want: "https://127.0.0.1:19090", ok: true},
+		{raw: "http://[::1]:9090", want: "http://[::1]:9090", ok: true},
+		{raw: "https://rampart.example.com", ok: false},
+		{raw: "http://localhost:9090/path", ok: false},
+		{raw: "http://user:secret@localhost:9090", ok: false},
+	} {
+		t.Run(test.raw, func(t *testing.T) {
+			got, err := normalizeOpenClawServeURL(test.raw)
+			if test.ok {
+				if err != nil || got != test.want {
+					t.Fatalf("normalizeOpenClawServeURL(%q) = %q, %v; want %q", test.raw, got, err, test.want)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("normalizeOpenClawServeURL(%q) unexpectedly returned %q", test.raw, got)
+			}
+		})
+	}
+}
+
+func TestEnsureServeRunningHonorsReachableExplicitEndpoint(t *testing.T) {
+	uptime := 1.0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/healthz" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"service": "rampart", "status": "ok", "mode": "enforce",
+			"version": "test", "uptime_seconds": uptime,
+		})
+	}))
+	defer srv.Close()
+
+	var out bytes.Buffer
+	if err := ensureServeRunningForURL(&out, &bytes.Buffer{}, srv.URL); err != nil {
+		t.Fatalf("ensureServeRunningForURL: %v", err)
+	}
+	if !strings.Contains(out.String(), srv.URL) {
+		t.Fatalf("output does not identify explicit endpoint: %q", out.String())
+	}
+}
+
+func TestEnsureServeRunningDoesNotReplaceUnreachableExplicitEndpoint(t *testing.T) {
+	err := ensureServeRunningForURL(&bytes.Buffer{}, &bytes.Buffer{}, "http://127.0.0.1:1")
+	if err == nil || !strings.Contains(err.Error(), "configured Rampart policy service") {
+		t.Fatalf("error = %v, want explicit-endpoint failure", err)
 	}
 }
 

--- a/cmd/rampart/cli/serve.go
+++ b/cmd/rampart/cli/serve.go
@@ -850,13 +850,23 @@ func waitForBackgroundReady(path string, pid int, timeout time.Duration) error {
 }
 
 func isRampartServeCommand(comm, args string) bool {
-	name := strings.ToLower(filepath.Base(strings.TrimSpace(comm)))
-	if name != "rampart" && name != "rampart.exe" {
-		return false
-	}
-	remaining, ok := commandLineAfterExecutable(args)
+	return isRampartServeCommandForExecutable(comm, args, "")
+}
+
+func isRampartServeCommandForExecutable(comm, args, expectedExecutable string) bool {
+	executable, remaining, ok := splitCommandLineExecutable(args)
 	if !ok {
 		return false
+	}
+	if expectedExecutable != "" {
+		if !samePath(executable, expectedExecutable) {
+			return false
+		}
+	} else {
+		name := strings.ToLower(filepath.Base(strings.TrimSpace(comm)))
+		if name != "rampart" && name != "rampart.exe" {
+			return false
+		}
 	}
 	fields := strings.Fields(remaining)
 	for i := 0; i < len(fields); i++ {
@@ -888,9 +898,14 @@ func isRampartServeCommand(comm, args string) bool {
 }
 
 func commandLineAfterExecutable(commandLine string) (string, bool) {
+	_, remaining, ok := splitCommandLineExecutable(commandLine)
+	return remaining, ok
+}
+
+func splitCommandLineExecutable(commandLine string) (string, string, bool) {
 	commandLine = strings.TrimSpace(commandLine)
 	if commandLine == "" {
-		return "", false
+		return "", "", false
 	}
 	if commandLine[0] == '"' || commandLine[0] == '\'' {
 		quote := commandLine[0]
@@ -905,15 +920,15 @@ func commandLineAfterExecutable(commandLine string) (string, bool) {
 				continue
 			}
 			if commandLine[i] == quote {
-				return strings.TrimSpace(commandLine[i+1:]), true
+				return commandLine[1:i], strings.TrimSpace(commandLine[i+1:]), true
 			}
 		}
-		return "", false
+		return "", "", false
 	}
 	if index := strings.IndexAny(commandLine, " \t\r\n"); index >= 0 {
-		return strings.TrimSpace(commandLine[index:]), true
+		return commandLine[:index], strings.TrimSpace(commandLine[index:]), true
 	}
-	return "", false
+	return "", "", false
 }
 
 func isWriteEvent(event fsnotify.Event) bool {

--- a/cmd/rampart/cli/serve.go
+++ b/cmd/rampart/cli/serve.go
@@ -897,11 +897,6 @@ func isRampartServeCommandForExecutable(comm, args, expectedExecutable string) b
 	return false
 }
 
-func commandLineAfterExecutable(commandLine string) (string, bool) {
-	_, remaining, ok := splitCommandLineExecutable(commandLine)
-	return remaining, ok
-}
-
 func splitCommandLineExecutable(commandLine string) (string, string, bool) {
 	commandLine = strings.TrimSpace(commandLine)
 	if commandLine == "" {

--- a/cmd/rampart/cli/serve_background_unix.go
+++ b/cmd/rampart/cli/serve_background_unix.go
@@ -55,7 +55,7 @@ func isRampartServeProcess(pid int) (bool, string, error) {
 
 	comm := strings.TrimSpace(string(commOut))
 	args := strings.TrimSpace(string(argsOut))
-	return isRampartServeCommand(filepath.Base(comm), args), strings.TrimSpace(comm + " " + args), nil
+	return isRampartServeCommandForExecutable(filepath.Base(comm), args, serveExecutableForPID(pid)), strings.TrimSpace(comm + " " + args), nil
 }
 
 func terminateRampartServeProcess(proc *os.Process) error {

--- a/cmd/rampart/cli/serve_background_windows.go
+++ b/cmd/rampart/cli/serve_background_windows.go
@@ -70,7 +70,7 @@ func isRampartServeProcess(pid int) (bool, string, error) {
 		return false, "", fmt.Errorf("decode Windows process %d: %w", pid, err)
 	}
 	description := strings.TrimSpace(identity.Name + " " + identity.CommandLine)
-	return isRampartServeCommand(identity.Name, identity.CommandLine), description, nil
+	return isRampartServeCommandForExecutable(identity.Name, identity.CommandLine, serveExecutableForPID(pid)), description, nil
 }
 
 func terminateRampartServeProcess(proc *os.Process) error {

--- a/cmd/rampart/cli/serve_state.go
+++ b/cmd/rampart/cli/serve_state.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 )
@@ -15,13 +16,17 @@ import (
 // serveState is written by `rampart serve` so other commands (doctor, watch, log)
 // can discover the serve URL and port without requiring flags or env vars.
 type serveState struct {
-	URL     string `json:"url"`
-	Port    int    `json:"port"`
-	PID     int    `json:"pid"`
-	Started string `json:"started"`
+	URL        string `json:"url"`
+	Port       int    `json:"port"`
+	PID        int    `json:"pid"`
+	Started    string `json:"started"`
+	Executable string `json:"executable,omitempty"`
 }
 
-const serveStateFile = "serve.state"
+const (
+	serveStateFile         = "serve.state"
+	maxServeStateFileBytes = 64 << 10
+)
 
 // writeServeState writes the serve state to ~/.rampart/serve.state.
 func writeServeState(dir string, port, pid int, tls bool) error {
@@ -29,17 +34,54 @@ func writeServeState(dir string, port, pid int, tls bool) error {
 	if tls {
 		scheme = "https"
 	}
+	executable, _ := os.Executable()
+	if executable != "" {
+		executable, _ = filepath.Abs(executable)
+	}
 	state := serveState{
-		URL:     fmt.Sprintf("%s://localhost:%d", scheme, port),
-		Port:    port,
-		PID:     pid,
-		Started: time.Now().UTC().Format(time.RFC3339),
+		URL:        fmt.Sprintf("%s://localhost:%d", scheme, port),
+		Port:       port,
+		PID:        pid,
+		Started:    time.Now().UTC().Format(time.RFC3339),
+		Executable: executable,
 	}
 	data, err := json.Marshal(state)
 	if err != nil {
 		return err
 	}
 	return atomicWriteRecoverablePrivateFile(filepath.Join(dir, serveStateFile), data)
+}
+
+// serveExecutableForPID returns the executable identity published by the
+// running service. It is used only to make process authentication stricter:
+// malformed, stale, permissive, or symlinked state falls back to the legacy
+// exact `rampart serve` process-name check.
+func serveExecutableForPID(pid int) string {
+	dir, err := rampartDir()
+	if err != nil {
+		return ""
+	}
+	path := filepath.Join(dir, serveStateFile)
+	info, err := os.Lstat(path)
+	if err != nil || info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() || info.Size() > maxServeStateFileBytes {
+		return ""
+	}
+	if runtime.GOOS != "windows" && info.Mode().Perm()&0o077 != 0 {
+		return ""
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	var state serveState
+	if json.Unmarshal(data, &state) != nil || state.PID != pid || strings.TrimSpace(state.Executable) == "" {
+		return ""
+	}
+	executable, err := filepath.Abs(state.Executable)
+	if err != nil {
+		return ""
+	}
+	return filepath.Clean(executable)
 }
 
 // removeServeState removes the state file on shutdown.

--- a/cmd/rampart/cli/serve_test.go
+++ b/cmd/rampart/cli/serve_test.go
@@ -279,6 +279,47 @@ func TestIsRampartServeCommand(t *testing.T) {
 	}
 }
 
+func TestIsRampartServeCommandAuthenticatesPublishedExecutable(t *testing.T) {
+	executable := filepath.Join(t.TempDir(), "rampart-openclaw-candidate")
+	args := executable + " serve --port 19090"
+	if !isRampartServeCommandForExecutable("rampart-o", args, executable) {
+		t.Fatal("published executable identity did not authenticate a renamed Rampart server")
+	}
+	if isRampartServeCommandForExecutable("rampart-o", args, filepath.Join(t.TempDir(), "rampart-openclaw-candidate")) {
+		t.Fatal("mismatched executable identity authenticated")
+	}
+	if isRampartServeCommand("rampart-o", args) {
+		t.Fatal("renamed binary authenticated without published executable identity")
+	}
+}
+
+func TestServeStatePublishesPrivateExecutableIdentity(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+	dir := filepath.Join(home, ".rampart")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	const pid = 4242
+	if err := writeServeState(dir, 19090, pid, false); err != nil {
+		t.Fatal(err)
+	}
+	want, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err = filepath.Abs(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := serveExecutableForPID(pid); !samePath(got, want) {
+		t.Fatalf("serveExecutableForPID() = %q, want %q", got, want)
+	}
+	if got := serveExecutableForPID(pid + 1); got != "" {
+		t.Fatalf("mismatched PID returned executable %q", got)
+	}
+}
+
 func TestSamePath(t *testing.T) {
 	tests := []struct {
 		a, b string

--- a/cmd/rampart/cli/setup_openclaw_plugin.go
+++ b/cmd/rampart/cli/setup_openclaw_plugin.go
@@ -1510,7 +1510,7 @@ func ensureServeRunning(w io.Writer, errW io.Writer) error {
 func ensureServeRunningForURL(w io.Writer, errW io.Writer, serveURL string) error {
 	serveURL = strings.TrimRight(strings.TrimSpace(serveURL), "/")
 	if serveURL == "" {
-		return fmt.Errorf("Rampart policy service URL is empty")
+		return fmt.Errorf("rampart policy service URL is empty")
 	}
 	if isSetupServeReachableAt(serveURL) {
 		fmt.Fprintf(w, "✓ Rampart serve is running at %s\n", serveURL)
@@ -1569,11 +1569,6 @@ func startServeBackgroundFallback(rampartBin, serveURL string, w io.Writer, errW
 		}
 	}
 	return fmt.Errorf("rampart serve --background did not become reachable after 5s")
-}
-
-// isSetupServeReachable does a quick healthz check against the default serve port.
-func isSetupServeReachable() bool {
-	return isSetupServeReachableAt(fmt.Sprintf("http://localhost:%d", defaultServePort))
 }
 
 func isSetupServeReachableAt(serveURL string) bool {

--- a/cmd/rampart/cli/setup_openclaw_plugin.go
+++ b/cmd/rampart/cli/setup_openclaw_plugin.go
@@ -55,6 +55,10 @@ const openclawMinVersion = "2026.3.28"
 //  6. Run rampart doctor for a health summary.
 //  7. Print success and next steps.
 func runSetupOpenClawPlugin(w io.Writer, errW io.Writer) error {
+	return runSetupOpenClawPluginForServeURL(w, errW, "")
+}
+
+func runSetupOpenClawPluginForServeURL(w io.Writer, errW io.Writer, requestedServeURL string) error {
 	// 1. Locate openclaw.
 	openclawBin, err := findOpenClawBinary()
 	if err != nil {
@@ -80,11 +84,15 @@ func runSetupOpenClawPlugin(w io.Writer, errW io.Writer) error {
 		return fmt.Errorf("OpenClaw version %s is too old — need >= %s for before_tool_call hook\n  Upgrade: npm install -g openclaw@latest", version, openclawMinVersion)
 	}
 	fmt.Fprintf(w, "✓ OpenClaw version: %s (>= %s required)\n", version, openclawMinVersion)
+	serveURL, err := resolveServeURLStrict(requestedServeURL, fmt.Sprintf("http://localhost:%d", defaultServePort))
+	if err != nil {
+		return fmt.Errorf("resolve Rampart policy service URL: %w", err)
+	}
 
 	// Start the policy service only after proving that the requested host exists
 	// and supports the native security hook. A missing, malformed, or outdated
 	// OpenClaw install must not mutate Rampart's background-service state.
-	if err := ensureServeRunning(w, errW); err != nil {
+	if err := ensureServeRunningForURL(w, errW, serveURL); err != nil {
 		return fmt.Errorf("start Rampart policy service: %w", err)
 	}
 
@@ -141,8 +149,8 @@ func runSetupOpenClawPlugin(w io.Writer, errW io.Writer) error {
 	fmt.Fprintln(w, "✅ Rampart is protecting your OpenClaw agent")
 	fmt.Fprintln(w, "")
 	fmt.Fprintln(w, "  Protected tools: exec, read, write, edit, web_fetch, browser, message")
-	serveStatus := "http://localhost:9090"
-	if isSetupServeReachable() {
+	serveStatus := serveURL
+	if isSetupServeReachableAt(serveURL) {
 		serveStatus += " (running)"
 	} else {
 		serveStatus += " (not running — start with: rampart serve --background)"
@@ -1492,9 +1500,25 @@ func modernOpenClawVersion() (string, bool) {
 // ensureServeRunning checks whether rampart serve is reachable, and if not,
 // installs and starts it as a systemd/launchd service via `rampart serve install`.
 func ensureServeRunning(w io.Writer, errW io.Writer) error {
-	if isSetupServeReachable() {
-		fmt.Fprintln(w, "✓ Rampart serve is running")
+	serveURL, err := resolveServeURLStrict("", fmt.Sprintf("http://localhost:%d", defaultServePort))
+	if err != nil {
+		return fmt.Errorf("resolve Rampart policy service URL: %w", err)
+	}
+	return ensureServeRunningForURL(w, errW, serveURL)
+}
+
+func ensureServeRunningForURL(w io.Writer, errW io.Writer, serveURL string) error {
+	serveURL = strings.TrimRight(strings.TrimSpace(serveURL), "/")
+	if serveURL == "" {
+		return fmt.Errorf("Rampart policy service URL is empty")
+	}
+	if isSetupServeReachableAt(serveURL) {
+		fmt.Fprintf(w, "✓ Rampart serve is running at %s\n", serveURL)
 		return nil
+	}
+	defaultURL := fmt.Sprintf("http://localhost:%d", defaultServePort)
+	if serveURL != defaultURL {
+		return fmt.Errorf("configured Rampart policy service %s is unreachable; start that service or remove the endpoint override before retrying", serveURL)
 	}
 
 	fmt.Fprintln(w, "Starting rampart serve...")
@@ -1511,7 +1535,7 @@ func ensureServeRunning(w io.Writer, errW io.Writer) error {
 		// Wait up to 3 seconds for serve to come up.
 		for i := 0; i < 6; i++ {
 			time.Sleep(500 * time.Millisecond)
-			if isSetupServeReachable() {
+			if isSetupServeReachableAt(serveURL) {
 				fmt.Fprintln(w, "✓ Rampart serve started (system service)")
 				return nil
 			}
@@ -1521,7 +1545,7 @@ func ensureServeRunning(w io.Writer, errW io.Writer) error {
 		fmt.Fprintf(errW, "⚠ rampart serve service install failed (%v); trying background fallback\n", installErr)
 	}
 
-	if err := startServeBackgroundFallback(rampartBin, w, errW); err != nil {
+	if err := startServeBackgroundFallback(rampartBin, serveURL, w, errW); err != nil {
 		if installErr != nil {
 			return fmt.Errorf("rampart serve service install failed (%v) and background fallback failed: %w", installErr, err)
 		}
@@ -1530,7 +1554,7 @@ func ensureServeRunning(w io.Writer, errW io.Writer) error {
 	return nil
 }
 
-func startServeBackgroundFallback(rampartBin string, w io.Writer, errW io.Writer) error {
+func startServeBackgroundFallback(rampartBin, serveURL string, w io.Writer, errW io.Writer) error {
 	cmd := osexec.Command(rampartBin, "serve", "--background")
 	cmd.Stdout = w
 	cmd.Stderr = errW
@@ -1539,7 +1563,7 @@ func startServeBackgroundFallback(rampartBin string, w io.Writer, errW io.Writer
 	}
 	for i := 0; i < 10; i++ {
 		time.Sleep(500 * time.Millisecond)
-		if isSetupServeReachable() {
+		if isSetupServeReachableAt(serveURL) {
 			fmt.Fprintln(w, "✓ Rampart serve started (background fallback)")
 			return nil
 		}
@@ -1549,7 +1573,12 @@ func startServeBackgroundFallback(rampartBin string, w io.Writer, errW io.Writer
 
 // isSetupServeReachable does a quick healthz check against the default serve port.
 func isSetupServeReachable() bool {
+	return isSetupServeReachableAt(fmt.Sprintf("http://localhost:%d", defaultServePort))
+}
+
+func isSetupServeReachableAt(serveURL string) bool {
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	defer cancel()
-	return isRampartHealthReady(ctx, newRampartHTTPClient(2*time.Second), "http://localhost:9090/healthz")
+	healthURL := strings.TrimRight(serveURL, "/") + "/healthz"
+	return isRampartHealthReady(ctx, newRampartHTTPClient(2*time.Second), healthURL)
 }

--- a/cmd/rampart/cli/verify.go
+++ b/cmd/rampart/cli/verify.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -22,7 +23,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const verifyJSONSchemaVersion = "rampart.verify.v1"
+const (
+	verifyJSONSchemaVersion    = "rampart.verify.v1"
+	verifyAllJSONSchemaVersion = "rampart.verify-all.v1"
+)
 
 type verificationStatus string
 
@@ -78,6 +82,25 @@ type verificationReport struct {
 	policyEndpoint string
 }
 
+type verificationBatchSummary struct {
+	Targets           int `json:"targets"`
+	PassedTargets     int `json:"passed_targets"`
+	FailedTargets     int `json:"failed_targets"`
+	UnverifiedTargets int `json:"unverified_targets"`
+	Checks            int `json:"checks"`
+	PassedChecks      int `json:"passed_checks"`
+	FailedChecks      int `json:"failed_checks"`
+	UnverifiedChecks  int `json:"unverified_checks"`
+}
+
+type verificationBatchReport struct {
+	SchemaVersion string                   `json:"schema_version"`
+	GeneratedAt   string                   `json:"generated_at"`
+	SafeCanaries  bool                     `json:"safe_canaries"`
+	Summary       verificationBatchSummary `json:"summary"`
+	Results       []verificationReport     `json:"results"`
+}
+
 type behavioralCanary struct {
 	ID       string
 	Name     string
@@ -94,6 +117,7 @@ type preflightResponse struct {
 }
 
 func newVerifyCmd() *cobra.Command {
+	var all bool
 	var jsonOut bool
 	var serveURL string
 	var timeout time.Duration
@@ -110,6 +134,33 @@ verification also runs fixed canaries through the live before_tool_call
 implementation.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if all {
+				if len(args) > 0 {
+					return fmt.Errorf("verify: --all cannot be combined with target %q", args[0])
+				}
+				resolvedURL, err := resolveServeURLStrict(serveURL, fmt.Sprintf("http://localhost:%d", defaultServePort))
+				if err != nil {
+					return fmt.Errorf("verify: resolve serve URL: %w", err)
+				}
+				report, receiptErr := runAllBehavioralVerifications(cmd.Context(), resolvedURL, timeout)
+				if jsonOut {
+					if err := json.NewEncoder(cmd.OutOrStdout()).Encode(report); err != nil {
+						return fmt.Errorf("verify: encode aggregate report: %w", err)
+					}
+				} else {
+					printVerificationBatchReport(cmd.OutOrStdout(), report)
+				}
+				if report.Summary.FailedTargets > 0 {
+					return exitCodeError{code: 1}
+				}
+				if report.Summary.UnverifiedTargets > 0 {
+					return exitCodeError{code: 2}
+				}
+				if receiptErr != nil {
+					return fmt.Errorf("verify: persist aggregate assurance evidence: %w", receiptErr)
+				}
+				return nil
+			}
 			target := ""
 			if len(args) == 1 {
 				target = strings.ToLower(strings.TrimSpace(args[0]))
@@ -155,10 +206,69 @@ implementation.`,
 		},
 	}
 
+	cmd.Flags().BoolVar(&all, "all", false, "Verify policy and every configured integration without invoking a model")
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output a machine-readable verification report")
 	cmd.Flags().StringVar(&serveURL, "serve-url", "", "Rampart service URL override (default: auto-discover)")
 	cmd.Flags().DurationVar(&timeout, "timeout", 5*time.Second, "Timeout for each active verification check")
 	return cmd
+}
+
+func configuredVerificationTargets(home string) []string {
+	targets := []string{"policy"}
+	seen := map[string]struct{}{"policy": {}}
+	for _, driver := range supportedIntegrationDrivers() {
+		if !integrationDriverSupportsPlatform(driver, runtime.GOOS) || driver.Configured == nil || !driver.Configured(home) {
+			continue
+		}
+		target := strings.TrimSpace(driver.VerifyTarget)
+		if target == "" {
+			target = driver.ID
+		}
+		if _, exists := seen[target]; exists {
+			continue
+		}
+		seen[target] = struct{}{}
+		targets = append(targets, target)
+	}
+	return targets
+}
+
+func runAllBehavioralVerifications(ctx context.Context, serveURL string, timeout time.Duration) (verificationBatchReport, error) {
+	report := verificationBatchReport{
+		SchemaVersion: verifyAllJSONSchemaVersion,
+		GeneratedAt:   time.Now().UTC().Format(time.RFC3339),
+		SafeCanaries:  true,
+		Results:       make([]verificationReport, 0),
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return report, fmt.Errorf("verify all: resolve home: %w", err)
+	}
+	var receiptErrors []error
+	for _, target := range configuredVerificationTargets(home) {
+		result := runBehavioralVerification(ctx, target, serveURL, timeout)
+		report.Results = append(report.Results, result)
+		report.Summary.Targets++
+		report.Summary.Checks += result.Summary.Checks
+		report.Summary.PassedChecks += result.Summary.Passed
+		report.Summary.FailedChecks += result.Summary.Failed
+		report.Summary.UnverifiedChecks += result.Summary.Unverified
+		if !result.SafeCanaries {
+			report.SafeCanaries = false
+		}
+		switch {
+		case result.Summary.Failed > 0:
+			report.Summary.FailedTargets++
+		case result.Summary.Unverified > 0:
+			report.Summary.UnverifiedTargets++
+		default:
+			report.Summary.PassedTargets++
+		}
+		if err := writeVerificationReceipt(result); err != nil {
+			receiptErrors = append(receiptErrors, fmt.Errorf("%s: %w", target, err))
+		}
+	}
+	return report, errors.Join(receiptErrors...)
 }
 
 func behavioralCanaries(target string) []behavioralCanary {
@@ -1106,6 +1216,30 @@ func printVerificationReport(w io.Writer, report verificationReport) {
 	fmt.Fprintln(w, "Safe canaries only: no commands, file reads, messages, or external network requests are executed.")
 	fmt.Fprintln(w, "Verification uses the local admin path and does not add events to Rampart's audit log.")
 	fmt.Fprintln(w)
+	printVerificationResult(w, report)
+}
+
+func printVerificationBatchReport(w io.Writer, report verificationBatchReport) {
+	fmt.Fprintf(w, "Rampart behavioral verification — all configured integrations (%d targets)\n\n", report.Summary.Targets)
+	fmt.Fprintln(w, "Safe canaries only: no models, commands, file reads, messages, or external network requests are invoked.")
+	fmt.Fprintln(w, "Verification uses the local admin path and does not add events to Rampart's audit log.")
+	for index, result := range report.Results {
+		if index > 0 {
+			fmt.Fprintln(w)
+		}
+		fmt.Fprintf(w, "\n[%s]\n", result.Target)
+		printVerificationResult(w, result)
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "Aggregate: %d targets passed, %d failed, %d unverified; %d checks total\n",
+		report.Summary.PassedTargets,
+		report.Summary.FailedTargets,
+		report.Summary.UnverifiedTargets,
+		report.Summary.Checks,
+	)
+}
+
+func printVerificationResult(w io.Writer, report verificationReport) {
 	for _, check := range report.Checks {
 		icon := "?"
 		switch check.Status {

--- a/cmd/rampart/cli/verify.go
+++ b/cmd/rampart/cli/verify.go
@@ -206,7 +206,7 @@ implementation.`,
 		},
 	}
 
-	cmd.Flags().BoolVar(&all, "all", false, "Verify policy and every configured integration without invoking a model")
+	cmd.Flags().BoolVar(&all, "all", false, "Verify policy and every behaviorally verifiable configured integration without invoking a model")
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output a machine-readable verification report")
 	cmd.Flags().StringVar(&serveURL, "serve-url", "", "Rampart service URL override (default: auto-discover)")
 	cmd.Flags().DurationVar(&timeout, "timeout", 5*time.Second, "Timeout for each active verification check")
@@ -1220,9 +1220,10 @@ func printVerificationReport(w io.Writer, report verificationReport) {
 }
 
 func printVerificationBatchReport(w io.Writer, report verificationBatchReport) {
-	fmt.Fprintf(w, "Rampart behavioral verification — all configured integrations (%d targets)\n\n", report.Summary.Targets)
+	fmt.Fprintf(w, "Rampart behavioral verification — configured integrations with safe verifiers (%d targets)\n\n", report.Summary.Targets)
 	fmt.Fprintln(w, "Safe canaries only: no models, commands, file reads, messages, or external network requests are invoked.")
 	fmt.Fprintln(w, "Verification uses the local admin path and does not add events to Rampart's audit log.")
+	fmt.Fprintln(w, "Static-only integrations are not included; use `rampart doctor` for their installation status.")
 	for index, result := range report.Results {
 		if index > 0 {
 			fmt.Fprintln(w)

--- a/cmd/rampart/cli/verify_test.go
+++ b/cmd/rampart/cli/verify_test.go
@@ -4,6 +4,7 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
@@ -16,6 +17,79 @@ import (
 
 	ocplugin "github.com/peg/rampart/internal/plugin/openclaw"
 )
+
+func TestConfiguredVerificationTargetsIncludesPolicyAndConfiguredHooks(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+	t.Setenv("PATH", t.TempDir())
+	hooksPath := filepath.Join(home, ".codex", "hooks.json")
+	command, commandWindows := currentCodexHookCommands()
+	if err := installCodexHooks(hooksPath, command, commandWindows, false); err != nil {
+		t.Fatal(err)
+	}
+
+	targets := configuredVerificationTargets(home)
+	if got := strings.Join(targets, ","); got != "policy,codex" {
+		t.Fatalf("configured verification targets = %q, want policy,codex", got)
+	}
+}
+
+func TestRunAllBehavioralVerificationsWritesAggregateEvidence(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("RAMPART_TOKEN", "verification-token")
+	command, commandWindows := currentCodexHookCommands()
+	if err := installCodexHooks(filepath.Join(home, ".codex", "hooks.json"), command, commandWindows, false); err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer verification-token" {
+			t.Fatalf("authorization = %q", r.Header.Get("Authorization"))
+		}
+		var body struct {
+			Params map[string]any `json:"params"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		decision := "deny"
+		if body.Params["command"] == "pwd" {
+			decision = "allow"
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"allowed": decision == "allow", "decision": decision, "message": "safe test decision",
+		})
+	}))
+	defer server.Close()
+
+	report, err := runAllBehavioralVerifications(context.Background(), server.URL, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.SchemaVersion != verifyAllJSONSchemaVersion || !report.SafeCanaries {
+		t.Fatalf("unexpected aggregate metadata: %#v", report)
+	}
+	if report.Summary.Targets != 2 || report.Summary.PassedTargets != 2 || report.Summary.Checks != 12 {
+		t.Fatalf("unexpected aggregate summary: %#v", report.Summary)
+	}
+	if len(report.Results) != 2 || report.Results[0].Target != "policy" || report.Results[1].Target != "codex" {
+		t.Fatalf("unexpected aggregate results: %#v", report.Results)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".rampart", "verification", "codex.json")); err != nil {
+		t.Fatalf("aggregate verification receipt missing: %v", err)
+	}
+}
+
+func TestVerifyAllRejectsExplicitTarget(t *testing.T) {
+	var out, errOut bytes.Buffer
+	cmd := NewRootCmd(context.Background(), &out, &errOut)
+	cmd.SetArgs([]string{"verify", "codex", "--all"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--all cannot be combined") {
+		t.Fatalf("error = %v, want --all target conflict", err)
+	}
+}
 
 func TestBehavioralVerificationSafeCanariesPass(t *testing.T) {
 	installVerificationToken(t, "verification-token")

--- a/internal/plugin/openclaw/approval-regression.mjs
+++ b/internal/plugin/openclaw/approval-regression.mjs
@@ -66,6 +66,13 @@ const ask = await runScenario({
 assert(ask.result?.requireApproval, 'ask-exec: requireApproval missing');
 assert(!ask.result?.params?.ask, 'ask-exec: legacy ask param mutation still present');
 assert(ask.result.requireApproval.title.includes('exec approval required'), 'ask-exec: wrong title');
+assert(ask.result.requireApproval.pluginId === 'rampart', 'ask-exec: approval plugin ownership missing');
+assert(
+  JSON.stringify(ask.result.requireApproval.allowedDecisions) === JSON.stringify(['allow-once', 'allow-always', 'deny']),
+  'ask-exec: allowed approval decisions drifted',
+);
+assert(ask.result.requireApproval.timeoutReason.includes('denied'), 'ask-exec: explicit timeout reason missing');
+assert(ask.result.requireApproval.timeoutBehavior === 'deny', 'ask-exec: stable timeout fallback missing');
 assert(ask.hookOpts.before_tool_call?.priority < 0, 'ask-exec: Rampart should run as a late before_tool_call hook');
 
 const deny = await runScenario({
@@ -79,13 +86,26 @@ const allowAlways = await runScenario({
   toolResult: { decision: 'ask', allowed: false, policy: 'test-policy', message: 'needs approval', severity: 'warning' },
   resolution: 'allow-always',
 });
+const nonPersistentResolutions = [];
+for (const resolution of ['allow-once', 'deny', 'timeout', 'cancelled']) {
+  const scenario = await runScenario({
+    name: `resolution-${resolution}`,
+    toolResult: { decision: 'ask', allowed: false, policy: 'test-policy', message: 'needs approval', severity: 'warning' },
+    resolution,
+  });
+  assert(
+    !scenario.fetchCalls.some((call) => call.url.includes('/v1/rules/learn')),
+    `${scenario.name}: non-persistent resolution unexpectedly created a durable rule`,
+  );
+  nonPersistentResolutions.push(scenario);
+}
 assert(
   !JSON.stringify(allowAlways.logs).includes('sudo true'),
   'allow-always: raw command leaked into plugin logs',
 );
 const learnCall = allowAlways.fetchCalls.find((call) => call.url.includes('/v1/rules/learn'));
 assert(learnCall, 'allow-always: learn endpoint not called');
-for (const scenario of [ask, deny, allowAlways]) {
+for (const scenario of [ask, deny, allowAlways, ...nonPersistentResolutions]) {
   assert(
     scenario.fetchCalls.every((call) => call.opts.redirect === 'error'),
     `${scenario.name}: control request allowed redirects`,
@@ -117,5 +137,6 @@ console.log(JSON.stringify({
     { name: ask.name, result: ask.result },
     { name: deny.name, result: deny.result },
     { name: allowAlways.name, learnPersisted: true },
+    ...nonPersistentResolutions.map((scenario) => ({ name: scenario.name, learnPersisted: false })),
   ],
 }, null, 2));

--- a/internal/plugin/openclaw/index.js
+++ b/internal/plugin/openclaw/index.js
@@ -147,6 +147,10 @@ const OPENCLAW_TOOL_CLASS = new Map([
   ["web_search", "web_search"],
   ["browser", "browser"],
   ["message", "message"],
+  // OpenClaw 2026.7.2's ask_user tool only presents structured questions to
+  // the originating user. Route it through the existing message policy class
+  // while preserving a distinct host name for audit and approval display.
+  ["ask_user", "message"],
   ["canvas", "canvas"],
   ["process", "process"],
   ["nodes", "nodes"],
@@ -445,7 +449,7 @@ function addBrowserURLFacts(policyParams) {
 
 // Add host-derived facts used only for policy evaluation. These fields are
 // never returned to OpenClaw as executable tool parameters.
-function policyParamsForTool(toolName, params, ctx) {
+function policyParamsForTool(toolName, params, ctx, originalToolName = toolName) {
   const policyParams = { ...(params ?? {}) };
 
   // Scope the managed Guard layer to calls that actually crossed the native
@@ -463,7 +467,14 @@ function policyParamsForTool(toolName, params, ctx) {
   }
   if (toolName !== "message") return policyParams;
 
-  policyParams.rampart_consequence = `openclaw:${classifyMessageConsequence(policyParams, ctx)}`;
+  // ask_user is a local interaction with the user who initiated the current
+  // turn. It neither sends to another recipient nor mutates external state.
+  // Classify it explicitly instead of inferring from message-style fields that
+  // this newer tool does not carry.
+  const messageConsequence = String(originalToolName).trim().toLowerCase() === "ask_user"
+    ? "routine-reply"
+    : classifyMessageConsequence(policyParams, ctx);
+  policyParams.rampart_consequence = `openclaw:${messageConsequence}`;
   const originChannel = ctx?.channelId ?? ctx?.chatId ?? ctx?.channelContext?.chat?.id;
   if (originChannel !== undefined && originChannel !== null) {
     policyParams.rampart_origin_channel = String(originChannel);
@@ -744,7 +755,7 @@ export function register(api) {
       );
     }
 
-    const basePolicyParams = policyParamsForTool(toolName, params, ctx);
+    const basePolicyParams = policyParamsForTool(toolName, params, ctx, originalToolName);
     const policyVariants = policyPaths.length > 0
       ? policyPaths.map((path) => ({ ...basePolicyParams, path }))
       : [basePolicyParams];
@@ -856,6 +867,7 @@ export function register(api) {
         api.logger.info(`[rampart] returning requireApproval for ${displayToolName}`);
         return {
           requireApproval: {
+            pluginId: id,
             title: `🛡️ Rampart — ${displayToolName} approval required`,
             description: [
               `**Command:** ${markdownInlineCode(subjectPreview)}`,
@@ -864,6 +876,10 @@ export function register(api) {
             ].filter(Boolean).join("\n"),
             severity,
             timeoutMs: pluginConfig.approvalTimeoutMs ?? 120_000,
+            allowedDecisions: ["allow-once", "allow-always", "deny"],
+            timeoutReason: "rampart: approval timed out — tool call denied",
+            // Retained for the stable OpenClaw train while 2026.7.2 migrates
+            // to unconditional deny-on-timeout behavior.
             timeoutBehavior: "deny",
             onResolution: async (resolution) => {
               api.logger.info(`[rampart] plugin approval resolved: ${displayToolName} → ${safeLogLabel(resolution)}`);

--- a/internal/plugin/openclaw/provider-surface-replay.mjs
+++ b/internal/plugin/openclaw/provider-surface-replay.mjs
@@ -310,6 +310,24 @@ for (const [name, params, context, expectedConsequence] of [
   scenarios.push(name);
 }
 
+await runPolicyScenario({
+  name: 'ask-user-is-local-user-interaction',
+  event: {
+    toolName: 'ask_user',
+    params: {
+      questions: [{ header: 'Confirm', question: 'Continue?', options: [{ label: 'Yes' }, { label: 'No' }] }],
+    },
+  },
+  expectedTool: 'message',
+  assertResult: (_result, body) => {
+    assert(
+      body.params.rampart_consequence === 'openclaw:routine-reply',
+      `ask_user should stay scoped to the originating user: ${JSON.stringify(body.params)}`,
+    );
+  },
+});
+scenarios.push('ask-user-is-local-user-interaction');
+
 for (const [name, params, expectedConsequence, expectedDomain] of [
   [
     'browser-status-is-read-only',
@@ -398,6 +416,12 @@ const ask = await runPolicyScenario({
   },
 });
 assert(ask.result.requireApproval.timeoutBehavior === 'deny', 'approval should deny on timeout');
+assert(ask.result.requireApproval.pluginId === 'rampart', 'approval should identify its owning plugin');
+assert(
+  JSON.stringify(ask.result.requireApproval.allowedDecisions) === JSON.stringify(['allow-once', 'allow-always', 'deny']),
+  `unexpected approval decisions: ${JSON.stringify(ask.result.requireApproval.allowedDecisions)}`,
+);
+assert(ask.result.requireApproval.timeoutReason.includes('denied'), 'approval should explain timeout denial');
 scenarios.push('write-tool-hosted-approval');
 
 const authError = await withPlugin({

--- a/scripts/compat-openclaw-latest.mjs
+++ b/scripts/compat-openclaw-latest.mjs
@@ -108,7 +108,10 @@ function main() {
   const pluginDir = join(repoRoot, 'internal', 'plugin', 'openclaw');
 
   const version = runOpenClaw(['--version'], { env });
-  const install = runOpenClaw(['plugins', 'install', pluginDir], { env });
+  // OpenClaw 2026.7.2 requires explicit confirmation for local, non-ClawHub
+  // plugin sources. --force is also supported by the current stable train, so
+  // use the same non-interactive installation path users receive from Rampart.
+  const install = runOpenClaw(['plugins', 'install', pluginDir, '--force'], { env });
   const validate = runOpenClaw(['config', 'validate'], { env });
   const configFile = runOpenClaw(['config', 'file'], { env });
   const configFilePath = reportedConfigPath(commandOutput(configFile));
@@ -142,6 +145,7 @@ function main() {
     openclaw_version: commandOutput(version).split('\n')[0],
     openclaw_source: useNpmLatest ? openclawPackage : 'PATH',
     plugin_install_checked: true,
+    plugin_install_force_checked: true,
     config_validate_checked: validate.status === 0,
     config_file_checked: configFileMatches,
     plugin_inspect_checked: inspect.status === 0,


### PR DESCRIPTION
## What changed

- make `protect --serve-url` authoritative for service startup, host configuration, and verification
- authenticate background services launched from renamed Rampart binaries using the private service-state executable identity
- add `rampart verify --all` with additive JSON output, aggregate exit semantics, and per-integration receipts
- update the OpenClaw adapter for the 2026.7.2 approval contract and `ask_user` tool
- keep current OpenClaw stable compatibility blocking while adding an advisory beta package gate
- update the isolated OpenClaw installer check to use the explicit non-ClawHub `--force` contract

## Why

The v1.6 cycle needs one reliable lifecycle path and one safe command that can prove policy plus every configured integration that exposes a behavioral verifier, without model calls. OpenClaw's next release also changes local-plugin installation and approval metadata, so detecting that drift before it reaches stable reduces emergency compatibility patches.

## Impact

Existing default installs continue to auto-start the local service. Explicit loopback endpoints are now honored end to end and fail clearly when unreachable instead of silently starting a different default service. Verification remains side-effect-free and the existing single-target JSON schema is unchanged.

Hermes remains a static/host-evidence integration and is intentionally not implied by `verify --all`; the command directs users to `rampart doctor` for static-only integrations.

Only `allow-always` persists an OpenClaw approval. Allow-once, deny, timeout, and cancellation do not create durable rules. Unknown OpenClaw tools still fail closed.

## Root causes addressed

- endpoint overrides previously affected verification but not startup or OpenClaw configuration
- renamed release-candidate binaries could not be authenticated as Rampart background services
- maintainers lacked one aggregate behavioral-verification entry point
- the OpenClaw compatibility harness used an installation form rejected by 2026.7.2 beta
- the newer approval ownership/decision contract and `ask_user` surface were not represented explicitly

## Validation

- `go test ./... -count=1`
- `go vet ./...`
- Windows amd64 CLI test compilation
- all bundled OpenClaw Node harnesses
- isolated OpenClaw stable `2026.7.1-2` compatibility
- isolated OpenClaw beta `2026.7.2-beta.7` compatibility
- isolated candidate `rampart verify --all`: expected failure without Guard, 5/5 pass after Guard installation

No model invocation or live user-agent state was used in these checks.