### PR TITLE
Document v1.6 verification and release claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **One safe verification command for configured boundaries** —
+  `rampart verify --all` runs the policy canaries plus every configured
+  integration with an active behavioral verifier, without invoking a model or
+  executing the represented actions. Machine-readable output uses
+  `rampart.verify-all.v1`, retains per-target reports, and distinguishes failed
+  targets from incomplete or unreachable checks.
+- **OpenClaw prerelease warning gate** — Scheduled compatibility CI keeps the
+  latest stable OpenClaw path blocking while checking the beta package as a
+  non-blocking advisory, so upstream contract changes are visible before they
+  reach stable without overstating prerelease support.
+
+### Changed
+
+- **Explicit service endpoints are lifecycle-wide** —
+  `rampart protect --serve-url` now selects the endpoint used for service health, host
+  configuration, and behavioral verification. Non-default endpoints must
+  already be reachable, and OpenClaw accepts only a local loopback service
+  without credentials or URL suffixes.
+- **OpenClaw approvals use the current ownership contract** — Approval cards
+  identify Rampart as their owner, advertise `allow-once`, `allow-always`, and
+  `deny`, explain timeout denial, and persist policy only for `allow-always`.
+  OpenClaw's local `ask_user` interaction is classified separately from an
+  outbound or cross-conversation message.
+
+### Security
+
+- **Background service identity survives legitimate binary names safely** — A
+  private, bounded `serve.state` records the executable that launched the
+  service, allowing renamed Rampart binaries to be authenticated by exact path
+  while malformed, permissive, stale, or symlinked state falls back to the
+  stricter legacy process-name check.
+
 ## [1.5.0] - 2026-07-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -48,7 +48,14 @@ To detect and protect every installed supported agent with managed defaults:
 
 ```bash
 rampart protect
+rampart verify --all
 ```
+
+The second command reruns fixed, non-executing canaries for the policy engine
+and every configured integration that has an active behavioral verifier. It
+does not invoke a model or perform the represented actions. Static-only paths,
+including the experimental Hermes plugin, are reported by `rampart doctor`
+instead of being overstated as behaviorally verified.
 
 ---
 
@@ -271,6 +278,17 @@ message, contacting an external host, or adding verification noise to the audit
 log. Verification requires Rampart's local admin token and rejects incomplete or
 stale plugin self-reports.
 
+For a non-default local service, pass the endpoint explicitly:
+
+```bash
+rampart protect openclaw --serve-url http://127.0.0.1:19090
+```
+
+That endpoint is authoritative for service startup checks, OpenClaw plugin
+configuration, and verification. OpenClaw accepts only a loopback Rampart URL;
+an explicitly selected non-default service must already be reachable, and
+Rampart will not silently start or verify against port 9090 instead.
+
 `rampart serve` is part of this path. The plugin calls the local Rampart service for policy evaluation, approvals, and audit flow.
 
 ### How exec approvals work
@@ -282,6 +300,9 @@ In practice, that means:
 - safe commands run normally, with no prompt
 - denied commands are blocked immediately
 - only commands that match a Rampart `ask` rule show an OpenClaw approval card
+- the card offers `allow-once`, `allow-always`, and `deny`; timeout denies
+- only `allow-always` writes a durable rule, while one-time, denied, timed-out,
+  and cancelled resolutions do not change policy
 
 ### What the plugin protects
 
@@ -334,6 +355,11 @@ hermes plugins enable rampart
 ```
 
 The plugin registers a Hermes `pre_tool_call` hook and sends sanitized tool metadata to Rampart before execution. It defaults to `/v1/preflight/{tool}` with execution intent, so one-time grants and call counters are enforced without creating hidden approvals that Hermes cannot resume. `ask` decisions block with an approval-required message until Hermes has a first-class plugin approval/resume flow. Service outages deny every Hermes tool by default.
+
+Hermes currently has a static installation check rather than a safe built-in
+host verifier. Use `rampart doctor` for local status, then the isolated Hermes
+compatibility harness for release evidence. `rampart verify --all` intentionally
+does not count Hermes as behaviorally verified.
 
 ---
 
@@ -674,6 +700,7 @@ Rampart maps to the [OWASP Top 10 for Agentic Applications](https://genai.owasp.
 ```bash
 # Setup
 rampart protect                             # Detect, configure, and verify supported installed agents
+rampart verify --all                        # Safely verify policy + configured active-verifier integrations
 rampart protect openclaw                    # Zero-config guard + live behavioral verification
 rampart verify openclaw                     # Re-run safe canaries through the live plugin
 rampart quickstart                           # Auto-detect, install, configure, health check

--- a/assurance/README.md
+++ b/assurance/README.md
@@ -33,6 +33,19 @@ Support tiers are intentionally separate from feature breadth:
 
 ## Running the gate
 
+To check an installed environment without invoking a model or executing the
+represented actions:
+
+```bash
+rampart verify --all
+rampart verify --all --json
+```
+
+The aggregate includes the policy path and configured integrations with active
+safe verifiers. Static-only integrations such as Hermes are intentionally
+excluded; inspect them with `rampart doctor` and use the isolated host harness
+when runtime evidence is required.
+
 ```bash
 make security-assurance
 ```

--- a/docs-site/getting-started/configuration.md
+++ b/docs-site/getting-started/configuration.md
@@ -46,6 +46,12 @@ That means:
 - `~/.rampart/config.yaml` is the persistent local default
 - if nothing is configured, Rampart falls back to discovered local state and then localhost defaults
 
+For `rampart protect`, the resolved service URL is used consistently for
+startup checks, host configuration, and behavioral verification. An explicit
+non-default endpoint must already be reachable; Rampart will not silently start
+the default service instead. OpenClaw's native plugin further requires a
+loopback HTTP(S) URL and rejects credentials, paths, queries, and fragments.
+
 ### Which setting should I use?
 
 Use **`url`** unless you have a specific reason not to.

--- a/docs-site/getting-started/quickstart.md
+++ b/docs-site/getting-started/quickstart.md
@@ -39,11 +39,20 @@ Before you dive in, skim the [integration support matrix](support-matrix.md) if 
 
 ```bash
 rampart quickstart
+rampart verify --all
 ```
 
 This discovers integrations in Rampart's current auto-protect registry, installs
 the service when the selected path needs it, wires up the appropriate boundary,
-and verifies the result. Done.
+and verifies the result. The second command gives you one aggregate re-check of
+the policy engine and every configured integration with an active behavioral
+verifier.
+
+`rampart verify --all` uses fixed safe canaries. It does not invoke a model,
+execute commands, read files, send messages, or contact external hosts. Static-only
+integrations such as the experimental Hermes plugin are intentionally excluded;
+use `rampart doctor` for their installation status and their isolated
+compatibility harness for release evidence.
 
 Then use your agent normally. Rampart is invisible until something needs to be blocked or approved.
 
@@ -131,10 +140,15 @@ See [Configuration](configuration.md) for the full `url` / `serve_url` / `api` s
 ## Verify It's Working
 
 ```bash
+rampart verify --all
 rampart doctor
 ```
 
-Doctor should tell you which integration path is active, whether `serve` is optional or required for that path, and what coverage gaps remain. If something's off, it should tell you exactly what to fix.
+The aggregate verifier proves expected policy and adapter/plugin behavior for
+configured integrations with safe verifiers. It exits 1 for a failed
+expectation and 2 when a check is incomplete or unreachable. Doctor then tells
+you which integration paths are installed—including static-only paths—whether
+`serve` is optional or required, and what coverage gaps remain.
 
 ## Test the Policy Engine
 

--- a/docs-site/getting-started/release-compatibility-gate.md
+++ b/docs-site/getting-started/release-compatibility-gate.md
@@ -11,7 +11,9 @@ Use this checklist before publishing a Rampart release that advertises agent int
 
 Rampart uses these tiers in the support matrix:
 
-- **Recommended**: actively tested against the current stable runtime, polished approval UX, and clear `rampart doctor` checks.
+- **Verified**: the installed boundary has an active safe host verifier or fresh
+  completed host evidence against the current stable runtime, with limitations
+  documented separately.
 - **Supported**: documented and regression-covered, with narrower UX or less frequent runtime smoke coverage.
 - **Experimental**: installable and useful, but with known limits that are still part of the public contract.
 - **Legacy compatibility**: maintained where practical for older clients, but not the preferred path.
@@ -38,6 +40,8 @@ Gemini CLI remains **experimental** because consumer Google sign-in is retired, 
    - Record latest stable OpenClaw from npm.
    - Record latest stable Hermes Agent from PyPI.
    - Treat upstream release notes touching plugin discovery, hook dispatch, approval behavior, native tool relay, model/tool execution, or security boundaries as compatibility-relevant.
+   - Install and record released stable versions for the candidate baseline.
+     Prerelease checks are advisory and never substitute for the stable gate.
 
 3. **Validate current Claude Code**
    - Review Anthropic's current tool and hook references for newly hook-visible
@@ -59,6 +63,8 @@ Gemini CLI remains **experimental** because consumer Google sign-in is retired, 
    - Exercise allow, ask, and deny with a unique marker.
    - For command execution paths, require OpenClaw runtime evidence plus a correlated Rampart audit event for canonical `exec`.
    - Check for stale shim, dist patch, or duplicate enforcement paths before calling the result clean.
+   - Keep the stable compatibility job blocking. Treat the OpenClaw beta job as
+     non-blocking early warning; a green beta run is not a support claim.
 
 5. **Validate current Codex**
    - Run `rampart verify codex` against the installed candidate hook definition.
@@ -124,13 +130,25 @@ Gemini CLI remains **experimental** because consumer Google sign-in is retired, 
    - Exercise the real Hermes plugin dispatcher, including plugin discovery and `pre_tool_call` hook registration.
    - Prove deny blocks before execution, allow continues, `ask` blocks with an approval-required/no-resume message, Rampart auth failures fail closed for mutating tools, and mutating tools fail closed when Rampart is unavailable.
    - Do not restart or mutate a live Discord, Telegram, or other long-running Hermes gateway for this gate.
+   - Run `rampart doctor` for local installation status. Do not count Hermes in
+     `rampart verify --all`: its built-in verification level remains static.
 
-10. **Run `rampart doctor` as a support-contract check**
+10. **Run the aggregate safe verifier**
+   - Run `rampart verify --all --json` from the exact candidate build.
+   - Require the policy target and every configured active-verifier integration
+     to pass. Exit 1 is a failed expectation; exit 2 is an incomplete or
+     unreachable target.
+   - Archive the `rampart.verify-all.v1` report with the candidate evidence.
+     It invokes no model and does not replace the real-host checks above.
+   - Confirm static-only paths are absent rather than misleadingly reported as
+     passing.
+
+11. **Run `rampart doctor` as a support-contract check**
    - Group findings by integration surface.
    - Classify each finding as blocker, expected optional local gap, or follow-up diagnostic improvement.
    - Do not collapse OpenClaw, Hermes, Claude Code, Codex, and Cline findings into one global yes/no.
 
-11. **Publish claims that match the evidence**
+12. **Publish claims that match the evidence**
    - Coverage means tool calls delivered through the named integration
      boundary, not all syscalls, packets, or behavior inside allowed processes.
    - A harness proves a live check is available; only a completed sanitized run
@@ -138,7 +156,7 @@ Gemini CLI remains **experimental** because consumer Google sign-in is retired, 
    - A completed Claude Code shell host proof supports only the shell claim;
      file, network, MCP, subagent, crash, and timeout behavior keep their own
      evidence levels until separately exercised.
-   - OpenClaw can be called recommended only when the latest stable path has fresh runtime/audit proof.
+   - OpenClaw can be called verified only when the latest stable path has fresh runtime/audit proof.
    - Hermes can be called an experimental policy gate when isolated latest-Hermes plugin dispatch has deny, allow, ask-block, and fail-closed proof.
    - First-class Hermes support requires Hermes-owned approval/resume APIs plus live or staging end-to-end validation.
 
@@ -157,7 +175,7 @@ scripts/compat-codex-host.sh --yes
 
 The Hermes harness installs or uses an isolated Hermes runtime and never touches the active gateway. The OpenClaw harness can run either the `openclaw` on `PATH` or `--npm-latest` for the latest npm package, uses a temporary home/state directory, and validates plugin installation plus the bundled plugin behavior checks. The Gemini and Copilot gates use disposable homes and start the latest published packages, then separately validate candidate-generated configuration shapes and exercise their adapters without credentials or model calls. Their version commands do not prove that either host ingested or dispatched the hooks. Harnesses propagate only an allowlist of runtime variables and standard credential-free registry/proxy URLs; URLs containing userinfo, query strings, or fragments are dropped.
 
-For OpenClaw's recommended support tier, also run the opt-in runtime audit regression before a release promotion:
+For OpenClaw's verified support tier, also run the opt-in runtime audit regression before a release promotion:
 
 ```bash
 export RAMPART_OPENCLAW_ISOLATION_ROOT=/path/to/disposable/root

--- a/docs-site/getting-started/security-assurance.md
+++ b/docs-site/getting-started/security-assurance.md
@@ -50,6 +50,22 @@ they are not cryptographic signatures or substitutes for rerunning the harness.
 
 ## Run the local gate
 
+For an installed Rampart environment, first run the safe behavioral aggregate:
+
+```bash
+rampart verify --all
+rampart verify --all --json
+```
+
+It always checks the policy path and adds each configured integration that has
+an active safe verifier. No model or represented action is invoked. Exit status
+1 means at least one target failed; status 2 means no target failed but at least
+one remained unverified. The JSON form uses `rampart.verify-all.v1` and contains
+the complete per-target `rampart.verify.v1` reports.
+
+Static-only integrations are deliberately absent. Use `rampart doctor` to
+inspect them; for Hermes runtime proof, use the isolated harness below.
+
 From a Rampart source checkout:
 
 ```bash

--- a/docs-site/getting-started/support-matrix.md
+++ b/docs-site/getting-started/support-matrix.md
@@ -11,6 +11,23 @@ Rampart is policy, approval, audit, and proof infrastructure for agents that nee
 
 For release-candidate validation and latest-agent checks, use the [Release Compatibility Gate](release-compatibility-gate.md). The support tier below should match the most recent evidence from the exact Rampart candidate build and bundled plugin metadata.
 
+## Verify configured boundaries safely
+
+```bash
+rampart verify --all
+```
+
+This runs the policy canaries plus every configured integration on the current
+platform that has an active behavioral verifier. It does not invoke a model or
+execute the represented actions. A target is not promoted merely because its
+configuration exists: OpenClaw's live plugin can earn `host_verified`, while
+ordinary native-hook checks earn `adapter_verified` unless a separate real-host
+run is recorded.
+
+Static-only integrations are excluded from the aggregate rather than reported
+as passing. In particular, use `rampart doctor` for Hermes installation status
+and the isolated Hermes harness for runtime evidence.
+
 ## At a glance
 
 <table class="support-matrix-table">
@@ -149,7 +166,10 @@ For release-candidate validation and latest-agent checks, use the [Release Compa
   administrator-owned machine policy hook, while VS Code hooks remain an
   upstream Preview surface covered by contract and adapter tests
 - **OpenClaw >= 2026.5.2** → `rampart protect openclaw` installs and verifies
-  the managed native guard with fail-closed service behavior and native approval UI
+  the managed native guard with fail-closed service behavior and native approval
+  UI. An explicit `--serve-url` is used consistently for startup, plugin
+  configuration, and verification; it must be loopback, and a non-default
+  endpoint must already be reachable
 - **Cline** → current editor and CLI payloads plus POSIX and Windows discovery
   artifacts are covered by adapter/setup tests; physical Windows and rolling
   latest-Cline host proof remain pending. Legacy CLI `--yolo` disables hooks,
@@ -164,7 +184,8 @@ For release-candidate validation and latest-agent checks, use the [Release Compa
   pending, and this does not cover Antigravity
 - **Hermes Agent** → experimental plugin path with a completed isolated
   Hermes 0.19.0 shell deny/allow host run; `ask` decisions block rather than
-  resume until Hermes exposes a first-class plugin approval flow
+  resume until Hermes exposes a first-class plugin approval flow. Its built-in
+  status check remains static, so it is not included in `rampart verify --all`
 
 ## Degraded behavior notes
 

--- a/docs-site/getting-started/upgrade.md
+++ b/docs-site/getting-started/upgrade.md
@@ -73,13 +73,17 @@ sudo mv rampart /usr/local/bin/
 rampart version
 rampart upgrade --no-binary
 rampart protect
+rampart verify --all
 ```
 
 Run `rampart protect` once after replacing the binary. It preserves user-owned
 configuration, refreshes Rampart-managed hooks and plugins for detected agents,
 migrates recognized legacy integrations, and runs the matching behavioral
 verification. This is especially important when a release adds a newer native
-host boundary.
+host boundary. The aggregate verifier then re-checks the policy path and each
+configured integration with an active safe verifier without invoking a model.
+Use `rampart doctor` as well when you have a static-only integration such as
+Hermes.
 
 ## What Upgrades Preserve
 

--- a/docs-site/index.html
+++ b/docs-site/index.html
@@ -1371,6 +1371,7 @@
         <div class="setup-box panel">
             <p style="color:var(--heading);font-weight:700;margin-bottom:12px;text-align:center;">Then do the part that actually wires protection:</p>
             <pre><span style="color:var(--accent)">$</span> rampart quickstart     <span style="color:var(--text-dim)"># detect agent, install service, wire integration, verify setup</span>
+<span style="color:var(--accent)">$</span> rampart verify --all   <span style="color:var(--text-dim)"># safe aggregate check; no model calls</span>
 
 <span style="color:var(--accent)">$</span> rampart protect openclaw <span style="color:var(--text-dim)"># managed fail-closed guard + verification</span>
 

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -97,6 +97,9 @@ rampart protect openclaw
 
 # Codex CLI, IDE, and desktop
 rampart setup codex
+
+# Re-check policy and every configured active-verifier integration
+rampart verify --all
 ```
 
 That's it. Pick the integration that matches your agent. [Full setup guide →](getting-started/quickstart.md) · [Support matrix →](getting-started/support-matrix.md)

--- a/docs-site/integrations/hermes.md
+++ b/docs-site/integrations/hermes.md
@@ -113,6 +113,12 @@ Use this only when you understand the approval ownership tradeoff. If a policy r
 
 ## Verification
 
+Hermes does not yet expose a safe built-in host verifier, so there is no
+`rampart verify hermes` command. `rampart verify --all` intentionally skips the
+Hermes plugin instead of treating its static configuration as behavioral proof.
+Use `rampart doctor` to confirm local installation and service requirements,
+then use the isolated compatibility harness for runtime evidence.
+
 Use the isolated latest-Hermes compatibility harness before enabling the plugin on a live gateway:
 
 ```bash

--- a/docs-site/integrations/index.md
+++ b/docs-site/integrations/index.md
@@ -10,6 +10,12 @@ methods, with different assurance levels and boundaries. Choose the guide for
 your agent below, then check the [support matrix](../getting-started/support-matrix.md)
 for the evidence and known limitations of that path.
 
+After setup, `rampart verify --all` safely checks the policy engine and every
+configured integration with an active behavioral verifier without invoking a
+model. Static-only integrations such as Hermes remain visible in
+`rampart doctor` and require their isolated compatibility harness for runtime
+evidence.
+
 ## Integration Methods
 
 | Method | How It Works | Best For |

--- a/docs-site/integrations/openclaw.md
+++ b/docs-site/integrations/openclaw.md
@@ -46,6 +46,20 @@ Both should return `active`.
 
 No external downloads, no npm install — the plugin is bundled inside the `rampart` binary.
 
+To use a different local port, start that service first and make the endpoint
+explicit:
+
+```bash
+rampart serve --addr 127.0.0.1 --port 19090 --background
+rampart protect openclaw --serve-url http://127.0.0.1:19090
+```
+
+The explicit URL is authoritative for startup checks, plugin configuration,
+and verification. The managed OpenClaw path accepts only loopback HTTP(S) URLs
+without embedded credentials, paths, queries, or fragments. Rampart will not
+silently fall back to port 9090 when an explicit non-default endpoint is
+unreachable.
+
 For advanced setups that manage their own policies or require the legacy compatibility path, use `rampart setup openclaw` and configure degraded behavior explicitly.
 
 ### Security scanner note
@@ -94,6 +108,7 @@ With the native plugin, **supported OpenClaw tool calls are intercepted**. Polic
 | `web_search` | ✅ Native plugin | Always allowed by default |
 | `browser` | ✅ Native plugin | Read-only inspection is allowed; navigation uses domain rules; clicks, typing, uploads, and other mutations require approval |
 | `message` | ✅ Native plugin | Read actions always allowed; sends to unknown channels require approval |
+| `ask_user` | ✅ Native plugin | Structured questions to the originating user are classified as local interaction, not cross-conversation messaging |
 | `canvas` | ✅ Native plugin | Always allowed (UI only) |
 | `sessions_spawn` | ✅ Native plugin | Subagents cannot spawn further agents |
 | `process` / `nodes` / `gateway` / `subagents` | ✅ Native plugin | Known read-only status operations are allowed; mutations require approval |
@@ -147,6 +162,10 @@ rampart init --profile openclaw
 
 When you click "Always Allow" in the OpenClaw approval UI, Rampart writes a durable rule to `~/.rampart/policies/user-overrides.yaml` via `POST /v1/rules/learn`. The rule takes effect immediately without restarting serve.
 
+The Rampart-owned approval card explicitly offers `allow-once`, `allow-always`,
+and `deny`, and denies on timeout. Only `allow-always` creates a durable rule.
+One-time approvals, denials, timeouts, and cancellations never change policy.
+
 Automatic approvals are exact by default. Rampart never inserts a wildcard or
 strips arguments, pipes, or redirects when persisting an approved command.
 Literal wildcard characters are escaped as policy literals. Exact automatic
@@ -192,7 +211,11 @@ For release-candidate validation, run the latest-OpenClaw compatibility harness 
 node scripts/compat-openclaw-latest.mjs --npm-latest
 ```
 
-That isolated harness validates plugin install/config and bundled plugin behavior. Before promoting a release that claims OpenClaw as recommended, also run the opt-in live runtime audit regression:
+That isolated harness validates plugin install/config and bundled plugin behavior. Before promoting a release that claims OpenClaw as verified, also run the opt-in live runtime audit regression:
+
+Scheduled CI also checks the current OpenClaw beta package as a non-blocking
+advisory. A green beta job is early compatibility evidence only; it does not
+make an unreleased OpenClaw version part of Rampart's supported stable baseline.
 
 ```bash
 export RAMPART_OPENCLAW_ISOLATION_ROOT=/path/to/disposable/root

--- a/docs-site/reference/cli-commands.md
+++ b/docs-site/reference/cli-commands.md
@@ -33,6 +33,7 @@ real Rampart adapter without invoking a model. No policy authoring is required.
 rampart protect                       # Detect and protect supported installed agents
 rampart protect copilot               # Protect Copilot CLI and VS Code agent sessions
 rampart protect openclaw              # Install, activate, restart, and verify
+rampart protect openclaw --serve-url http://127.0.0.1:19090
 rampart protect openclaw --reinstall  # Replace the plugin even when versions match
 rampart protect openclaw --no-restart # Configure without restarting the gateway
 rampart protect openclaw --no-verify  # Configure without running behavioral canaries
@@ -40,11 +41,18 @@ rampart protect openclaw --no-verify  # Configure without running behavioral can
 
 The command installs managed Guard and OpenClaw policies, enables the bundled native plugin, starts the local policy service, configures every OpenClaw tool to fail closed when Rampart is unavailable, restarts the gateway, and runs safe behavioral verification. Existing unrelated OpenClaw settings and custom Rampart policy files are preserved.
 
+An explicit `--serve-url` is authoritative for startup checks, host
+configuration, and verification. OpenClaw's native plugin accepts only a
+loopback HTTP(S) service. A non-default explicit endpoint must already be
+reachable; Rampart does not silently start or verify against the default port.
+
 ### `rampart verify`
 
 Actively test expected policy decisions with fixed, non-executing canaries.
 
 ```bash
+rampart verify --all            # Verify policy + every configured active-verifier integration
+rampart verify --all --json     # Emit aggregate schema rampart.verify-all.v1
 rampart verify openclaw        # Verify policy plus the live OpenClaw plugin path
 rampart verify claude-code     # Verify Claude hook installation and adapter denial
 rampart verify cline           # Verify Cline hook installation and adapter denial
@@ -57,6 +65,14 @@ rampart verify openclaw --json # Emit schema rampart.verify.v1
 ```
 
 Verification does not execute commands, read files, send messages, contact external hosts, or add canary events to the audit log. A failed expectation exits with status 1; an incomplete or unreachable check exits with status 2. Human and JSON reports identify the resulting `policy_verified`, `adapter_verified`, `host_verified`, `unverified`, or `degraded` assurance level.
+
+`--all` always checks the policy path, then every configured integration on the
+current platform that exposes an active safe verifier. It does not invoke a
+model. Static-only integrations are excluded rather than counted as passing;
+use `rampart doctor` for their installation status. The aggregate JSON report
+uses `rampart.verify-all.v1`, retains the per-target `rampart.verify.v1`
+reports, and exits 1 if any target fails or 2 if none fail but at least one is
+unverified.
 
 For integration targets, a completed run also records a minimal verification
 receipt under `~/.rampart/verification/`. The receipt contains check IDs and

--- a/docs/index.html
+++ b/docs/index.html
@@ -1371,6 +1371,7 @@
         <div class="setup-box panel">
             <p style="color:var(--heading);font-weight:700;margin-bottom:12px;text-align:center;">Then do the part that actually wires protection:</p>
             <pre><span style="color:var(--accent)">$</span> rampart quickstart     <span style="color:var(--text-dim)"># detect agent, install service, wire integration, verify setup</span>
+<span style="color:var(--accent)">$</span> rampart verify --all   <span style="color:var(--text-dim)"># safe aggregate check; no model calls</span>
 
 <span style="color:var(--accent)">$</span> rampart protect openclaw <span style="color:var(--text-dim)"># managed fail-closed guard + verification</span>
 


### PR DESCRIPTION
## What changed

- documents `rampart verify --all` across the README, quickstart, CLI reference, assurance guidance, upgrade path, support matrix, and landing page
- distinguishes active behavioral verification from static installation checks; Hermes remains experimental and is deliberately excluded from aggregate behavioral claims
- documents authoritative `--serve-url` lifecycle behavior and OpenClaw's loopback-only endpoint requirement
- documents the current OpenClaw approval decisions, allow-always persistence rule, `ask_user` classification, and stable-versus-beta compatibility gates
- records the merged v1.6 groundwork accurately under the unreleased changelog

## Why

PR #358 added lifecycle hardening, aggregate safe verification, and current OpenClaw compatibility behavior. Public guidance still described the older per-target workflow and could imply that static configuration was behavioral proof. This aligns public claims with the code and evidence model before release-grade host testing.

Recorded OpenClaw and Hermes host-version evidence is intentionally unchanged. Those versions will be refreshed only after isolated runs against the exact release candidate.

## Validation

- `go test ./cmd/rampart/cli ./internal/assurance`
- `make security-assurance`
- `mkdocs build --strict` with the repository-pinned Python 3.12 dependencies
- `sh scripts/check-api-reference.sh`
- `git diff --check`
- confirmed `docs-site/index.html` and `docs/index.html` remain byte-for-byte synchronized
