### PR TITLE
Fix Claude Code string tool responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   while malformed, permissive, stale, or symlinked state falls back to the
   stricter legacy process-name check.
 
+### Fixed
+
+- **Claude Code string tool responses remain visible** — `PostToolUse` and
+  `PostToolUseFailure` now accept plain-string, object, and array response
+  payloads while preserving response-policy scanning and fail-closed handling
+  for genuinely malformed hook input.
+
 ## [1.5.0] - 2026-07-29
 
 ### Added

--- a/cmd/rampart/cli/cli_unit_test.go
+++ b/cmd/rampart/cli/cli_unit_test.go
@@ -63,9 +63,10 @@ func TestExitCode(t *testing.T) {
 func TestExtractToolResponse(t *testing.T) {
 	tests := []struct {
 		name string
-		resp map[string]any
+		resp any
 		want string
 	}{
+		{"plain string", "hello", "hello"},
 		{"stdout only", map[string]any{"stdout": "hello"}, "hello"},
 		{"stdout+stderr", map[string]any{"stdout": "out", "stderr": "err"}, "out\nerr"},
 		{"content", map[string]any{"content": "body"}, "body"},
@@ -75,6 +76,7 @@ func TestExtractToolResponse(t *testing.T) {
 		{"non-string ignored", map[string]any{"count": 42}, ""},
 		{"empty map", map[string]any{}, ""},
 		{"priority order", map[string]any{"stdout": "a", "content": "b"}, "a\nb"},
+		{"top-level array", []any{"first", map[string]any{"text": "second"}}, "first\nsecond"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/rampart/cli/hook.go
+++ b/cmd/rampart/cli/hook.go
@@ -47,7 +47,7 @@ type hookInput struct {
 	// Tool-specific fields
 	ToolName     string         `json:"tool_name"`
 	ToolInput    map[string]any `json:"tool_input"`
-	ToolResponse map[string]any `json:"tool_response,omitempty"`
+	ToolResponse any            `json:"tool_response,omitempty"`
 }
 
 // hookOutput is the JSON response for Claude Code hooks.
@@ -114,7 +114,7 @@ type hookParseResult struct {
 	WorkDir       string   // host-reported working directory for project policy discovery
 	Agent         string
 	Response      string // non-empty for PostToolUse events
-	RawResponse   map[string]any
+	RawResponse   any
 	RunID         string // run ID derived from session_id (or env overrides)
 	HookEventName string // e.g. "PreToolUse", "PostToolUse", "PostToolUseFailure"
 	SessionID     string // raw session_id from Claude Code input (for session state)
@@ -1110,7 +1110,7 @@ func parseClaudeCodeInput(reader interface{ Read([]byte) (int, error) }, logger 
 	}
 
 	// Extract response text from PostToolUse tool_response.
-	if len(input.ToolResponse) > 0 {
+	if input.ToolResponse != nil {
 		result.Response = extractToolResponse(input.ToolResponse)
 		result.RawResponse = input.ToolResponse
 	}
@@ -1186,11 +1186,12 @@ func validateClaudePreToolParams(toolName string, params map[string]any) error {
 	}
 }
 
-// extractToolResponse extracts every string leaf from the tool_response map.
+// extractToolResponse extracts every string leaf from a tool response.
 // Host response schemas vary and frequently nest model-visible content inside
-// arrays and result objects. Traversing the complete value prevents a nested
-// credential or prompt-injection marker from bypassing response policies.
-func extractToolResponse(resp map[string]any) string {
+// arrays and result objects; some hosts also return a plain string. Traversing
+// the complete value prevents a nested credential or prompt-injection marker
+// from bypassing response policies.
+func extractToolResponse(resp any) string {
 	parts := make([]string, 0, 4)
 	stack := []any{resp}
 	for len(stack) > 0 {

--- a/cmd/rampart/cli/hook_security_test.go
+++ b/cmd/rampart/cli/hook_security_test.go
@@ -244,6 +244,48 @@ func TestClaudeUnknownPostToolBlocksAndRedactsResponse(t *testing.T) {
 	}
 }
 
+func TestClaudeStringPostToolResponsePolicyBlocksAndRedacts(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+	policyPath := filepath.Join(home, "response-policy.yaml")
+	policy := `version: "1"
+default_action: allow
+policies:
+  - name: block-response-secret
+    match:
+      tool: exec
+    rules:
+      - action: deny
+        when:
+          response_matches: ["secret-[0-9]+"]
+        message: "protected response"
+`
+	if err := os.WriteFile(policyPath, []byte(policy), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	payload := `{"hook_event_name":"PostToolUse","session_id":"s","tool_use_id":"tool-1","tool_name":"Bash","tool_input":{"command":"printf secret"},"tool_response":"output contains secret-42"}`
+	stdout, stderr, err := runHookWithStdin(
+		t,
+		&rootOptions{configPath: policyPath},
+		payload,
+		"--mode", "enforce",
+		"--audit-dir", filepath.Join(home, "audit"),
+	)
+	if err != nil {
+		t.Fatalf("hook returned an ordinary host error: %v (stderr=%q)", err, stderr)
+	}
+	var output hookOutput
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatalf("output = %q: %v", stdout, err)
+	}
+	if output.Decision != "block" || !strings.Contains(output.Reason, "protected response") {
+		t.Fatalf("output = %#v, want response-policy block", output)
+	}
+	if output.HookSpecificOutput == nil || output.HookSpecificOutput.UpdatedToolOutput != redactedToolOutput {
+		t.Fatalf("updated tool output = %#v, want scalar redaction", output.HookSpecificOutput)
+	}
+}
+
 func TestHookLoadsProjectPolicyFromHostWorkingDirectory(t *testing.T) {
 	home := t.TempDir()
 	testSetHome(t, home)

--- a/cmd/rampart/cli/hook_test.go
+++ b/cmd/rampart/cli/hook_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log/slog"
 	"os"
@@ -248,6 +249,83 @@ func TestParseClaudeCodeInputPostToolKeepsScanningMalformedKnownInput(t *testing
 	}
 	if result.Response != "scan me" {
 		t.Fatalf("response = %q, want scan me", result.Response)
+	}
+}
+
+func TestParseClaudeCodeInputAcceptsPostToolResponseShapes(t *testing.T) {
+	tests := []struct {
+		name     string
+		event    string
+		response string
+		want     string
+	}{
+		{
+			name:     "PostToolUse plain string",
+			event:    "PostToolUse",
+			response: `"On branch master\nnothing to commit"`,
+			want:     "On branch master\nnothing to commit",
+		},
+		{
+			name:     "PostToolUseFailure plain string",
+			event:    "PostToolUseFailure",
+			response: `"command exited with status 1"`,
+			want:     "command exited with status 1",
+		},
+		{
+			name:     "PostToolUse nested array",
+			event:    "PostToolUse",
+			response: `[{"text":"first"},"second"]`,
+			want:     "first\nsecond",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			payload := fmt.Sprintf(
+				`{"hook_event_name":%q,"tool_name":"Bash","tool_input":{"command":"git status"},"tool_response":%s}`,
+				testCase.event,
+				testCase.response,
+			)
+			result, err := parseClaudeCodeInput(strings.NewReader(payload), testLogger())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if result.Response != testCase.want {
+				t.Fatalf("response = %q, want %q", result.Response, testCase.want)
+			}
+			if result.RawResponse == nil {
+				t.Fatal("raw response was discarded")
+			}
+		})
+	}
+}
+
+func TestClaudeCodeStringPostToolResponseDoesNotFailClosed(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+	configPath := filepath.Join(home, "policy.yaml")
+	if err := os.WriteFile(configPath, []byte("version: \"1\"\ndefault_action: allow\npolicies: []\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, event := range []string{"PostToolUse", "PostToolUseFailure"} {
+		t.Run(event, func(t *testing.T) {
+			payload := fmt.Sprintf(
+				`{"hook_event_name":%q,"tool_name":"Bash","tool_input":{"command":"git status"},"tool_response":"On branch master\nnothing to commit"}`,
+				event,
+			)
+			stdout, _, err := runHookWithStdin(t, &rootOptions{configPath: configPath}, payload)
+			if err != nil {
+				t.Fatalf("hook failed: %v", err)
+			}
+			var output hookOutput
+			if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+				t.Fatalf("unmarshal hook output: %v (stdout=%q)", err, stdout)
+			}
+			if output.Decision == "block" {
+				t.Fatalf("valid string response failed closed: %s", stdout)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- accept Claude Code `tool_response` values as plain strings, objects, or arrays
- scan every string leaf deterministically while preserving the original response shape for redaction
- cover the exact #359 `PostToolUse` payload and the equivalent `PostToolUseFailure` path
- prove that string responses still trigger response-policy blocking and scalar redaction

## Root cause

Rampart decoded Claude Code's `tool_response` directly into `map[string]any`. Current Claude Code can emit a plain string for Bash and other tool results, so otherwise-valid post-tool events failed during JSON decoding and were converted into Rampart's fail-closed block response.

The response is now represented as an arbitrary JSON value at the host boundary. Existing object handling remains intact, arrays are traversed, and plain strings are passed directly to response-policy evaluation.

## Security behavior

- genuinely malformed JSON and invalid hook metadata still fail closed
- unknown post-tool surfaces still block and redact
- response-policy evaluation remains active for string payloads
- blocked scalar output is replaced with Rampart's redaction marker
- managed-hook verification remains intentionally strict; unreviewed wrapper commands are not claimed as Rampart-managed verified hooks

## User impact

Claude Code users no longer lose Bash output when `PostToolUse` or `PostToolUseFailure` sends a string response. The workaround wrapper described in #359 is no longer required after upgrading to a release containing this patch.

Addresses #359.

## Validation

- `go test ./...`
- `go test -race ./...`
- focused new regression/security tests under the race detector
- `go vet ./...`
- `make security-assurance`
- `git diff --check`
