### PR TITLE
fix: preserve OpenClaw policy upgrades

### DIFF
--- a/cmd/rampart/cli/policy_profiles.go
+++ b/cmd/rampart/cli/policy_profiles.go
@@ -52,8 +52,14 @@ func parseManagedPolicyHeaders(data []byte) (version, contentHash string, conten
 		line := string(content[:idx])
 		switch {
 		case strings.HasPrefix(line, managedPolicyVersionPrefix):
+			if version != "" {
+				return version, contentHash, content
+			}
 			version = strings.TrimSpace(strings.TrimPrefix(line, managedPolicyVersionPrefix))
 		case strings.HasPrefix(line, managedPolicyHashPrefix):
+			if contentHash != "" {
+				return version, contentHash, content
+			}
 			contentHash = strings.ToLower(strings.TrimSpace(strings.TrimPrefix(line, managedPolicyHashPrefix)))
 		default:
 			return version, contentHash, content

--- a/cmd/rampart/cli/setup_extra_test.go
+++ b/cmd/rampart/cli/setup_extra_test.go
@@ -9,6 +9,9 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/peg/rampart/internal/build"
+	"github.com/peg/rampart/policies"
 )
 
 func TestHasRampartHook(t *testing.T) {
@@ -591,5 +594,29 @@ func TestInstallOpenClawPolicyVersionStamped(t *testing.T) {
 			snippet = snippet[:40]
 		}
 		t.Fatalf("expected installed OpenClaw policy to be version stamped, got: %q", snippet)
+	}
+	version, hash, installedContent := parseManagedPolicyHeaders(content)
+	if version != build.Version || hash == "" {
+		t.Fatalf("managed headers = version %q hash %q, want version %q and a content hash", version, hash, build.Version)
+	}
+	embedded, err := policies.Profile("openclaw")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(installedContent, embedded) {
+		t.Fatal("installed OpenClaw policy payload does not match the embedded profile")
+	}
+}
+
+func TestManagedPolicyHeadersPreserveEmbeddedReleaseMetadata(t *testing.T) {
+	payload := []byte("# rampart-policy-version: 1.5.0\n# Rampart built-in profile: openclaw\nversion: \"1\"\npolicies: []\n")
+	installed := versionStampedPolicyContentForVersion(payload, "1.6.0")
+
+	version, hash, content := parseManagedPolicyHeaders(installed)
+	if version != "1.6.0" || hash == "" {
+		t.Fatalf("managed headers = version %q hash %q, want outer version and hash", version, hash)
+	}
+	if !bytes.Equal(content, payload) {
+		t.Fatalf("managed payload was truncated at embedded release metadata:\n%s", content)
 	}
 }

--- a/internal/audit/jsonl_test.go
+++ b/internal/audit/jsonl_test.go
@@ -642,6 +642,121 @@ func TestJSONLSink_RecoverySupportsLegacyReopenAfterRotation(t *testing.T) {
 	assert.EqualValues(t, 4, state.eventCount)
 }
 
+func TestJSONLSink_RecoverySupportsLegacyRestartEpochs(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, time.Now().UTC().Format("2006-01-02")+".jsonl")
+	started := time.Now().UTC().Add(-4 * time.Hour)
+
+	firstRoot := sampleEvent("exec")
+	firstRoot.ID = NewEventID()
+	firstRoot.Timestamp = started
+	firstRoot.PrevHash = ""
+	require.NoError(t, firstRoot.ComputeHash())
+	firstTail := sampleEvent("read")
+	firstTail.ID = NewEventID()
+	firstTail.Timestamp = started.Add(time.Hour)
+	firstTail.PrevHash = firstRoot.Hash
+	require.NoError(t, firstTail.ComputeHash())
+	secondRoot := sampleEvent("write")
+	secondRoot.ID = NewEventID()
+	secondRoot.Timestamp = started.Add(2 * time.Hour)
+	secondRoot.PrevHash = ""
+	require.NoError(t, secondRoot.ComputeHash())
+	secondTail := sampleEvent("exec")
+	secondTail.ID = NewEventID()
+	secondTail.Timestamp = started.Add(3 * time.Hour)
+	secondTail.PrevHash = secondRoot.Hash
+	require.NoError(t, secondTail.ComputeHash())
+
+	lines := make([][]byte, 0, 5)
+	for _, event := range []Event{firstRoot, firstTail, secondRoot, secondTail} {
+		encoded, err := json.Marshal(event)
+		require.NoError(t, err)
+		lines = append(lines, encoded)
+	}
+	lines = append(lines, nil)
+	require.NoError(t, os.WriteFile(path, bytes.Join(lines, []byte{'\n'}), 0o600))
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	state, err := recoverChainStateFromDir(dir, logger)
+	require.NoError(t, err)
+	assert.EqualValues(t, 4, state.eventCount)
+	assert.Equal(t, secondTail.Hash, state.lastHash)
+
+	sink, err := NewJSONLSink(dir, WithFsync(false), WithLogger(logger))
+	require.NoError(t, err)
+	require.NoError(t, sink.Write(sampleEvent("exec")))
+	require.NoError(t, sink.Close())
+	assertLastEventPrevHash(t, path, secondTail.Hash)
+}
+
+func TestJSONLSink_RecoverySupportsLegacyEmptyContinuationAtNewEpoch(t *testing.T) {
+	dir := t.TempDir()
+	firstName := "2026-05-25.jsonl"
+	secondName := "2026-05-26.jsonl"
+	started := time.Date(2026, 5, 25, 20, 0, 0, 0, time.UTC)
+
+	first := sampleEvent("exec")
+	first.ID = NewEventID()
+	first.Timestamp = started
+	first.PrevHash = ""
+	require.NoError(t, first.ComputeHash())
+	second := sampleEvent("write")
+	second.ID = NewEventID()
+	second.Timestamp = started.Add(6 * time.Hour)
+	second.PrevHash = ""
+	require.NoError(t, second.ComputeHash())
+
+	firstLine, err := json.Marshal(first)
+	require.NoError(t, err)
+	headerLine, err := json.Marshal(chainHeader{ChainContinue: "", PrevFile: firstName})
+	require.NoError(t, err)
+	secondLine, err := json.Marshal(second)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, firstName), append(firstLine, '\n'), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, secondName),
+		bytes.Join([][]byte{headerLine, secondLine, nil}, []byte{'\n'}), 0o600))
+
+	state, err := recoverChainStateFromDir(dir, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	require.NoError(t, err)
+	assert.EqualValues(t, 2, state.eventCount)
+	assert.Equal(t, second.Hash, state.lastHash)
+}
+
+func TestJSONLSink_RecoveryRejectsOverlappingLegacyEpochs(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "2026-05-23.jsonl")
+	started := time.Date(2026, 5, 23, 4, 0, 0, 0, time.UTC)
+
+	firstRoot := sampleEvent("exec")
+	firstRoot.ID = NewEventID()
+	firstRoot.Timestamp = started
+	firstRoot.PrevHash = ""
+	require.NoError(t, firstRoot.ComputeHash())
+	firstTail := sampleEvent("read")
+	firstTail.ID = NewEventID()
+	firstTail.Timestamp = started.Add(3 * time.Hour)
+	firstTail.PrevHash = firstRoot.Hash
+	require.NoError(t, firstTail.ComputeHash())
+	overlappingRoot := sampleEvent("write")
+	overlappingRoot.ID = NewEventID()
+	overlappingRoot.Timestamp = started.Add(2 * time.Hour)
+	overlappingRoot.PrevHash = ""
+	require.NoError(t, overlappingRoot.ComputeHash())
+
+	lines := make([][]byte, 0, 4)
+	for _, event := range []Event{firstRoot, firstTail, overlappingRoot} {
+		encoded, err := json.Marshal(event)
+		require.NoError(t, err)
+		lines = append(lines, encoded)
+	}
+	lines = append(lines, nil)
+	require.NoError(t, os.WriteFile(path, bytes.Join(lines, []byte{'\n'}), 0o600))
+
+	_, err := recoverChainStateFromDir(dir, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	require.ErrorContains(t, err, "overlaps or precedes")
+}
+
 func TestJSONLSink_TamperedAnchorFallsBack(t *testing.T) {
 	dir := t.TempDir()
 

--- a/internal/audit/recovery_links.go
+++ b/internal/audit/recovery_links.go
@@ -12,12 +12,14 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"time"
 )
 
 type linkedAuditEvent struct {
 	id        string
 	hash      string
 	prevHash  string
+	timestamp time.Time
 	file      string
 	start     int64
 	recordLen int64
@@ -126,6 +128,7 @@ func recoverChainStateByLinks(dir string, files []string) (recoveredChainState, 
 				id:        event.ID,
 				hash:      event.Hash,
 				prevHash:  event.PrevHash,
+				timestamp: event.Timestamp,
 				file:      name,
 				start:     recordStart,
 				recordLen: int64(len(record) + 1),
@@ -166,22 +169,40 @@ func recoverChainStateByLinks(dir string, files []string) (recoveredChainState, 
 		}
 	}
 	roots := children[""]
-	if len(roots) != 1 {
-		return recoveredChainState{}, fmt.Errorf("verify audit chain: expected one root event, found %d", len(roots))
+	if len(roots) == 0 {
+		return recoveredChainState{}, fmt.Errorf("verify audit chain: no root event found")
 	}
 
 	visited := 0
-	tail := roots[0]
-	for {
-		visited++
-		next := children[tail.hash]
-		if len(next) == 0 {
-			break
+	var tail *linkedAuditEvent
+	var previousEpochLatest time.Time
+	rootHashes := make(map[string]struct{}, len(roots))
+	for index, root := range roots {
+		rootHashes[root.hash] = struct{}{}
+		if root.timestamp.IsZero() {
+			return recoveredChainState{}, fmt.Errorf("verify %s event %s: legacy chain root has no timestamp", root.file, root.id)
 		}
-		tail = next[0]
-		if visited > len(eventsByHash) {
-			return recoveredChainState{}, fmt.Errorf("verify audit chain: cycle detected")
+		if index > 0 && !root.timestamp.After(previousEpochLatest) {
+			return recoveredChainState{}, fmt.Errorf("verify %s event %s: legacy chain epoch overlaps or precedes the prior epoch", root.file, root.id)
 		}
+
+		epochLatest := root.timestamp
+		tail = root
+		for {
+			visited++
+			if tail.timestamp.After(epochLatest) {
+				epochLatest = tail.timestamp
+			}
+			next := children[tail.hash]
+			if len(next) == 0 {
+				break
+			}
+			tail = next[0]
+			if visited > len(eventsByHash) {
+				return recoveredChainState{}, fmt.Errorf("verify audit chain: cycle detected")
+			}
+		}
+		previousEpochLatest = epochLatest
 	}
 	if visited != len(eventsByHash) {
 		return recoveredChainState{}, fmt.Errorf("verify audit chain: %d events are disconnected", len(eventsByHash)-visited)
@@ -193,7 +214,14 @@ func recoverChainStateByLinks(dir string, files []string) (recoveredChainState, 
 		}
 		if header.chainContinue == "" {
 			if header.prevFile != "" {
-				return recoveredChainState{}, fmt.Errorf("verify %s line %d: empty chain continuation references prev_file %q", header.file, header.line, header.prevFile)
+				first := firstEventByFile[header.file]
+				legacyEpochRoot := false
+				if first != nil {
+					_, legacyEpochRoot = rootHashes[first.hash]
+				}
+				if len(roots) == 1 || first == nil || first.prevHash != "" || !legacyEpochRoot {
+					return recoveredChainState{}, fmt.Errorf("verify %s line %d: empty chain continuation references prev_file %q", header.file, header.line, header.prevFile)
+				}
 			}
 		} else {
 			previous, ok := eventsByHash[header.chainContinue]

--- a/internal/engine/dirstore.go
+++ b/internal/engine/dirstore.go
@@ -146,18 +146,19 @@ func NewMultiStore(file, dir string, logger *slog.Logger) *MultiStore {
 
 // Load reads the primary file (if set) and all directory files, merging them.
 func (s *MultiStore) Load() (*Config, error) {
-	var allFiles []string
-
-	// Primary config file first.
+	var primary *Config
 	if s.file != "" {
 		absFile, err := filepath.Abs(s.file)
 		if err != nil {
 			return nil, fmt.Errorf("engine: resolve file %q: %w", s.file, err)
 		}
-		allFiles = append(allFiles, absFile)
+		primary, err = NewFileStore(absFile).Load()
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	// Then directory files in sorted order.
+	var dirFiles []string
 	if s.dir != "" {
 		absDir, err := filepath.Abs(s.dir)
 		if err != nil {
@@ -169,7 +170,6 @@ func (s *MultiStore) Load() (*Config, error) {
 			return nil, fmt.Errorf("engine: read dir %q: %w", absDir, err)
 		}
 		if err == nil {
-			var dirFiles []string
 			for _, e := range entries {
 				if e.IsDir() {
 					continue
@@ -188,17 +188,55 @@ func (s *MultiStore) Load() (*Config, error) {
 				}
 			}
 			sort.Strings(dirFiles)
-			allFiles = append(allFiles, dirFiles...)
 		} else {
 			s.logger.Debug("engine: config dir does not exist, skipping", "dir", absDir)
 		}
 	}
 
-	if len(allFiles) == 0 {
+	if primary == nil && len(dirFiles) == 0 {
 		return nil, fmt.Errorf("engine: no config file or directory specified")
 	}
+	if len(dirFiles) == 0 {
+		return primary, nil
+	}
 
-	return mergeYAMLFiles(allFiles, s.logger)
+	directory, err := mergeYAMLFiles(dirFiles, s.logger)
+	if err != nil {
+		return nil, err
+	}
+	if primary == nil {
+		return directory, nil
+	}
+
+	// MultiStore is an explicit layering construct: the primary file wins on
+	// name collisions, matching Rampart's historical behavior. Directory files
+	// are still merged and validated together first, so duplicates within the
+	// policy directory remain hard errors instead of becoming order-dependent.
+	seen := make(map[string]struct{}, len(primary.Policies))
+	for _, policy := range primary.Policies {
+		seen[policy.Name] = struct{}{}
+	}
+	for _, policy := range directory.Policies {
+		if _, duplicate := seen[policy.Name]; duplicate {
+			s.logger.Debug("engine: primary policy overrides directory policy", "name", policy.Name, "primary", s.file, "directory", policy.FilePath)
+			continue
+		}
+		seen[policy.Name] = struct{}{}
+		primary.Policies = append(primary.Policies, policy)
+	}
+	if primary.DefaultAction == "" {
+		primary.DefaultAction = directory.DefaultAction
+	}
+	if primary.Notify == nil {
+		primary.Notify = directory.Notify
+	}
+	if primary.responseRegexCache == nil {
+		primary.responseRegexCache = make(map[string]*regexp.Regexp)
+	}
+	for pattern, compiled := range directory.responseRegexCache {
+		primary.responseRegexCache[pattern] = compiled
+	}
+	return primary, nil
 }
 
 // Path returns a description of the sources.
@@ -344,7 +382,7 @@ func mergeYAMLFiles(files []string, logger *slog.Logger) (*Config, error) {
 		Version:            "1",
 		responseRegexCache: make(map[string]*regexp.Regexp),
 	}
-	seen := make(map[string]bool) // track policy names for dedup
+	seen := make(map[string]string) // policy name -> first source path
 	var loadedFiles []string
 
 	for _, f := range files {
@@ -375,16 +413,27 @@ func mergeYAMLFiles(files []string, logger *slog.Logger) (*Config, error) {
 			merged.Notify = cfg.Notify
 		}
 
-		// Merge policies, skipping duplicates.
+		// Merge policies. Unexpected duplicate names fail closed; the one
+		// explicitly recognized legacy managed-profile collision is retired by
+		// the next OpenClaw policy refresh.
 		for _, p := range cfg.Policies {
 			if p.Name == "" {
 				return nil, fmt.Errorf("engine: policy in %q has no name", f)
 			}
-			if seen[p.Name] {
+			if firstPath, duplicate := seen[p.Name]; duplicate {
+				if isLegacyManagedProfileCollision(p.Name, firstPath, f) {
+					// Rampart <=1.5 shipped block-self-modification in both the
+					// OpenClaw and standard managed profiles. Directory ordering
+					// historically made the OpenClaw rule authoritative. Preserve
+					// exactly that narrow upgrade path while continuing to fail
+					// closed on every other duplicate.
+					logger.Warn("engine: skipped legacy managed profile duplicate", "name", p.Name, "first", firstPath, "duplicate", f)
+					continue
+				}
 				return nil, fmt.Errorf("engine: duplicate policy name %q in %q", p.Name, f)
 			}
 			p.FilePath = f
-			seen[p.Name] = true
+			seen[p.Name] = f
 			merged.Policies = append(merged.Policies, p)
 		}
 		for pattern, compiled := range cfg.responseRegexCache {
@@ -400,6 +449,16 @@ func mergeYAMLFiles(files []string, logger *slog.Logger) (*Config, error) {
 
 	logger.Info("engine: loaded policy files", "files", loadedFiles, "policies", len(merged.Policies))
 	return merged, nil
+}
+
+func isLegacyManagedProfileCollision(name, firstPath, duplicatePath string) bool {
+	if name != "block-self-modification" {
+		return false
+	}
+	first := filepath.Base(firstPath)
+	duplicate := filepath.Base(duplicatePath)
+	return (first == "openclaw.yaml" && duplicate == "standard.yaml") ||
+		(first == "standard.yaml" && duplicate == "openclaw.yaml")
 }
 
 // LayeredStore wraps a base PolicyStore and layers an optional extra policy file on top.

--- a/internal/engine/dirstore_test.go
+++ b/internal/engine/dirstore_test.go
@@ -238,6 +238,48 @@ policies:
 	assert.Contains(t, err.Error(), "duplicate policy name")
 }
 
+func TestDirStore_AllowsOnlyLegacyManagedOpenClawCollision(t *testing.T) {
+	dir := t.TempDir()
+
+	writeTestFile(t, filepath.Join(dir, "openclaw.yaml"), `
+version: "1"
+policies:
+  - name: block-self-modification
+    match: {tool: exec}
+    rules: [{action: deny, when: {command_matches: ["rampart *"]}}]
+`)
+	writeTestFile(t, filepath.Join(dir, "standard.yaml"), `
+version: "1"
+policies:
+  - name: block-self-modification
+    match: {tool: exec}
+    rules: [{action: deny, when: {default: true}}]
+`)
+
+	cfg, err := NewDirStore(dir, nil).Load()
+	require.NoError(t, err)
+	require.Len(t, cfg.Policies, 1)
+	assert.Equal(t, filepath.Join(dir, "openclaw.yaml"), cfg.Policies[0].FilePath)
+}
+
+func TestDirStore_LegacyProfileNamesDoNotExcuseOtherDuplicates(t *testing.T) {
+	dir := t.TempDir()
+
+	for _, name := range []string{"openclaw.yaml", "standard.yaml"} {
+		writeTestFile(t, filepath.Join(dir, name), `
+version: "1"
+policies:
+  - name: unexpected-duplicate
+    match: {tool: exec}
+    rules: [{action: deny, when: {default: true}}]
+`)
+	}
+
+	_, err := NewDirStore(dir, nil).Load()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate policy name")
+}
+
 func TestMultiStore_FileAndDir(t *testing.T) {
 	dir := t.TempDir()
 	policyDir := filepath.Join(dir, "policies")
@@ -272,6 +314,65 @@ policies:
 	assert.Len(t, cfg.Policies, 2)
 	assert.Equal(t, "main-policy", cfg.Policies[0].Name)
 	assert.Equal(t, "auto-allow-git", cfg.Policies[1].Name)
+}
+
+func TestMultiStore_PrimaryPolicyWinsCrossLayerDuplicate(t *testing.T) {
+	dir := t.TempDir()
+	policyDir := filepath.Join(dir, "policies")
+	require.NoError(t, os.MkdirAll(policyDir, 0o755))
+
+	primaryPath := filepath.Join(dir, "rampart.yaml")
+	writeTestFile(t, primaryPath, `
+version: "1"
+default_action: deny
+policies:
+  - name: shared-policy
+    match: {tool: exec}
+    rules: [{action: deny, when: {default: true}}]
+`)
+	writeTestFile(t, filepath.Join(policyDir, "openclaw.yaml"), `
+version: "1"
+default_action: ask
+policies:
+  - name: shared-policy
+    match: {tool: exec}
+    rules: [{action: allow, when: {default: true}}]
+  - name: directory-only
+    match: {tool: read}
+    rules: [{action: ask, when: {default: true}}]
+`)
+
+	cfg, err := NewMultiStore(primaryPath, policyDir, nil).Load()
+	require.NoError(t, err)
+	assert.Equal(t, "deny", cfg.DefaultAction)
+	require.Len(t, cfg.Policies, 2)
+	assert.Equal(t, "shared-policy", cfg.Policies[0].Name)
+	assert.Equal(t, primaryPath, cfg.Policies[0].FilePath)
+	assert.Equal(t, "directory-only", cfg.Policies[1].Name)
+}
+
+func TestMultiStore_DirectoryDuplicatesStillFailClosed(t *testing.T) {
+	dir := t.TempDir()
+	policyDir := filepath.Join(dir, "policies")
+	require.NoError(t, os.MkdirAll(policyDir, 0o755))
+
+	primaryPath := filepath.Join(dir, "rampart.yaml")
+	writeTestFile(t, primaryPath, `version: "1"
+policies: []
+`)
+	for _, name := range []string{"a.yaml", "b.yaml"} {
+		writeTestFile(t, filepath.Join(policyDir, name), `
+version: "1"
+policies:
+  - name: directory-duplicate
+    match: {tool: exec}
+    rules: [{action: deny, when: {default: true}}]
+`)
+	}
+
+	_, err := NewMultiStore(primaryPath, policyDir, nil).Load()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate policy name")
 }
 
 func TestMultiStore_DirOnly(t *testing.T) {

--- a/internal/engine/shipped_policy_test.go
+++ b/internal/engine/shipped_policy_test.go
@@ -51,6 +51,27 @@ func TestShippedPolicyFilesPassStrictValidation(t *testing.T) {
 	}
 }
 
+func TestStandardAndOpenClawProfilesHaveUniquePolicyNames(t *testing.T) {
+	standard, err := NewFileStore(filepath.Join("..", "..", "policies", "standard.yaml")).Load()
+	if err != nil {
+		t.Fatalf("load standard policy: %v", err)
+	}
+	openclaw, err := NewFileStore(filepath.Join("..", "..", "policies", "openclaw.yaml")).Load()
+	if err != nil {
+		t.Fatalf("load OpenClaw policy: %v", err)
+	}
+
+	standardNames := make(map[string]struct{}, len(standard.Policies))
+	for _, policy := range standard.Policies {
+		standardNames[policy.Name] = struct{}{}
+	}
+	for _, policy := range openclaw.Policies {
+		if _, duplicate := standardNames[policy.Name]; duplicate {
+			t.Fatalf("standard.yaml and openclaw.yaml both define policy %q", policy.Name)
+		}
+	}
+}
+
 func TestStandardPolicyBlocksMixedCaseDestructiveCommandOnCaseInsensitiveHosts(t *testing.T) {
 	if !platformUsesCaseInsensitiveNames(runtime.GOOS) {
 		t.Skip("case-insensitive host behavior is covered on macOS and Windows CI")

--- a/policies/openclaw.yaml
+++ b/policies/openclaw.yaml
@@ -19,7 +19,7 @@ default_action: ask
 policies:
   # ── Self-modification protection ──────────────────────────────────────
   # Agents cannot modify their own Rampart policy or disable enforcement.
-  - name: block-self-modification
+  - name: openclaw-block-self-modification
     description: "Prevent AI agents from modifying their own Rampart policy"
     match:
       tool: ["exec"]


### PR DESCRIPTION
## What changed

- gives the current OpenClaw profile a unique self-protection rule name while retaining a narrowly scoped compatibility exception for the duplicate shipped by Rampart <=1.5
- restores historical primary-policy precedence across the primary config and managed policy directory, while continuing to reject duplicates within either layer
- preserves the outer managed-policy version/hash when an embedded profile already contains release metadata
- accepts old Rampart restart-created audit chain epochs only when every event hash/link is valid and the epochs are chronologically non-overlapping; recovery continues from the newest valid tail
- adds regression coverage for all upgrade paths and fail-closed cases

## Root cause

The v1.6 hardening work made directory duplicate detection and audit-chain recovery stricter than the layouts produced by older Rampart releases. On a real 1.3 installation this caused startup failures from:

1. the historical `block-self-modification` collision between stock Standard and OpenClaw profiles;
2. intentional same-name rules in a user's primary policy overriding managed directory rules; and
3. multiple internally valid audit roots created by legacy service restarts.

The managed OpenClaw policy was also double-stamped, allowing the embedded release header to obscure installed provenance.

## User impact

Existing users can upgrade without deleting their custom policy or rewriting/discarding old audit logs. New installations use unique shipped rule names. Unexpected duplicates, missing links, forks, altered hashes, disconnected events, and overlapping legacy epochs still fail closed.

## Validation

- `go test ./...`
- OpenClaw compatibility environment, smoke, alias, provider-surface, approval-regression, and degraded-mode suites
- exact commit `c2f35d3f0bc2257a26fd3b53ba1485441aef30bc` deployed transactionally on agent01
- OpenClaw installed/current: `2026.7.1-2`
- 4,815 existing audit events verified across 34 managed files with no modification detected
- Rampart and OpenClaw services active after restart
- live OpenClaw behavioral verification: 12 passed, 0 failed, 0 unverified (`HOST VERIFIED`)
- native approval ownership confirmed: `tools.exec.ask=off`, Rampart plugin enabled, no Rampart pending approvals, and no dual-queue warning after restart

No model turn was invoked, and no agent memory or credential content was read or changed.