### PR TITLE
Prepare Rampart 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0] - 2026-08-07
+
 ### Added
 
 - **One safe verification command for configured boundaries** —
@@ -36,6 +38,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   gate resolves and records the exact `openclaw@latest` npm release before
   exercising zero-configuration protection, so a lagging container tag cannot
   silently test an older version than users install.
+- **Hermes host assurance follows the current release** — An isolated Linux
+  gateway run now proves deny, allow, and correlated pre-tool auditing through
+  Hermes Agent 0.20.0 using only model, provider, toolset, and authentication
+  state. Hermes remains experimental until it exposes a dependable native
+  approval/resume contract and fail-closed plugin execution.
 
 ### Security
 
@@ -55,6 +62,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `PostToolUseFailure` now accept plain-string, object, and array response
   payloads while preserving response-policy scanning and fail-closed handling
   for genuinely malformed hook input.
+- **Existing OpenClaw policy upgrades preserve operator intent** — Managed
+  installs keep the primary configured policy authoritative, migrate only the
+  narrowly recognized legacy stock duplicate, and retain correct release and
+  content-hash metadata around the embedded policy payload.
+- **Historical audit service restarts verify without weakening integrity** —
+  Chronological legacy epochs can be validated and recovered without rewriting
+  existing logs, while altered hashes, missing links, forks, overlaps, and
+  disconnected epochs still fail closed.
 
 ## [1.5.0] - 2026-07-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Chronological legacy epochs can be validated and recovered without rewriting
   existing logs, while altered hashes, missing links, forks, overlaps, and
   disconnected epochs still fail closed.
+- **Linux lab teardown stops the process it started** — The isolated preload
+  check now tracks the actual Rampart server rather than a background shell
+  wrapper, so successful and interrupted runs cannot leave a test service
+  behind after their disposable state is removed.
 
 ## [1.5.0] - 2026-07-29
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ configured Rampart boundary are written to a hash-chained audit trail.
 |-------|--------------|-------------|
 | **Claude Code** | `rampart setup claude-code` | Native pre/post tool hooks via `~/.claude/settings.json` |
 | **OpenClaw** | `rampart protect openclaw` | Zero-config native guard + active verification |
-| **Hermes Agent** | `rampart setup hermes` | Experimental `pre_tool_call` user plugin |
+| **Hermes Agent** | `rampart setup hermes` | Experimental `pre_tool_call` user plugin; Hermes 0.20 gateway host proof, native approval/resume pending |
 | **Cline** | `rampart setup cline` | Platform-native editor/CLI hook files |
 | **Codex** | `rampart setup codex` | Native user-level lifecycle hooks for CLI, IDE, and desktop |
 | **Gemini CLI** | `rampart setup gemini` | Experimental enterprise/API-key `BeforeTool`/`AfterTool` hooks |

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ configured Rampart boundary are written to a hash-chained audit trail.
 |-------|--------------|-------------|
 | **Claude Code** | `rampart setup claude-code` | Native pre/post tool hooks via `~/.claude/settings.json` |
 | **OpenClaw** | `rampart protect openclaw` | Zero-config native guard + active verification |
-| **Hermes Agent** | `rampart setup hermes` | Experimental `pre_tool_call` user plugin; Hermes 0.20 gateway host proof, native approval/resume pending |
+| **Hermes Agent** | `rampart setup hermes` | Experimental `pre_tool_call` user plugin |
 | **Cline** | `rampart setup cline` | Platform-native editor/CLI hook files |
 | **Codex** | `rampart setup codex` | Native user-level lifecycle hooks for CLI, IDE, and desktop |
 | **Gemini CLI** | `rampart setup gemini` | Experimental enterprise/API-key `BeforeTool`/`AfterTool` hooks |

--- a/assurance/evidence/hermes-gateway-2026-08-07.json
+++ b/assurance/evidence/hermes-gateway-2026-08-07.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": "rampart.hermes-host-e2e.v1",
+  "result": "pass",
+  "recorded_at": "2026-08-07",
+  "candidate_commit": "e46102b7fae0bcd1ed18d3ec02e04ae78f833982",
+  "platform": "linux/amd64",
+  "checks": {
+    "allow_command_executed": true,
+    "allow_pretoolcall_audited": true,
+    "deny_command_not_executed": true,
+    "deny_pretoolcall_blocked": true,
+    "isolated_gateway_healthy": true,
+    "isolated_plugin_installed": true,
+    "tool_call_identity_recorded": true
+  },
+  "exit_status": {
+    "allow": 0,
+    "deny": 0
+  },
+  "gateway_loaded": true,
+  "hermes_version": "Hermes Agent v0.20.0 (2026.8.3)",
+  "mcp_servers_loaded": false,
+  "model_invocations": 2,
+  "rampart_version": "rampart v1.5.1-0.20260807221127-e46102b7fae0 (unknown) built unknown",
+  "source_hermes_state_loaded": [
+    "config.model",
+    "config.provider",
+    "config.toolsets",
+    "auth.json"
+  ],
+  "source_memories_sessions_rules_loaded": false,
+  "notes": [
+    "The candidate binary was built from the exact merged staging baseline in candidate_commit.",
+    "The disposable gateway ran on loopback with no messaging, memory, session, rule, workspace, or MCP state loaded.",
+    "Credentials, temporary paths, audit identifiers, hostnames, logs, and raw model output are intentionally omitted."
+  ]
+}

--- a/assurance/integrations.yaml
+++ b/assurance/integrations.yaml
@@ -1,6 +1,6 @@
 schema_version: rampart.assurance.v2
-baseline_release: v1.5.0
-reviewed_at: "2026-07-29"
+baseline_release: v1.6.0
+reviewed_at: "2026-08-07"
 
 # Version 2 uses the canonical Rampart command target as each integration id
 # and requires an explicit declaration of bare `rampart protect` eligibility.
@@ -248,6 +248,9 @@ integrations:
       - path: assurance/evidence/hermes-gateway-2026-07-27.json
         kind: live
         proves: A completed Linux run sends deny and allow turns through an isolated localhost Hermes API gateway, records correlated audits, and loads no source memories, sessions, rules, workspaces, MCP servers, or messaging gateways.
+      - path: assurance/evidence/hermes-gateway-2026-08-07.json
+        kind: live
+        proves: A completed Linux Hermes Agent 0.20.0 gateway run repeats deny, allow, and correlated pre-tool audit proof from the exact merged staging baseline while loading only isolated model, provider, toolset, and authentication state.
     limitations:
       - Hermes documents that a crashing plugin callback is skipped and the agent continues.
       - Hermes approval observer hooks cannot answer or resume an approval.

--- a/cmd/rampart/cli/setup_openclaw_plugin_test.go
+++ b/cmd/rampart/cli/setup_openclaw_plugin_test.go
@@ -1035,7 +1035,7 @@ func TestGetOpenClawPluginStateWithMigrationNotice(t *testing.T) {
 	if err := os.MkdirAll(pluginDir, 0o700); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(pluginDir, "openclaw.plugin.json"), []byte(`{"version":"1.6.0","activation":{"onStartup":true}}`), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(pluginDir, "openclaw.plugin.json"), []byte(`{"version":"1.5.0","activation":{"onStartup":true}}`), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(stateDir, "openclaw.json"), []byte(`{"plugins":{"allow":["rampart"],"entries":{"rampart":{"enabled":true}}}}`), 0o600); err != nil {

--- a/cmd/rampart/cli/setup_openclaw_plugin_test.go
+++ b/cmd/rampart/cli/setup_openclaw_plugin_test.go
@@ -1035,7 +1035,7 @@ func TestGetOpenClawPluginStateWithMigrationNotice(t *testing.T) {
 	if err := os.MkdirAll(pluginDir, 0o700); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(pluginDir, "openclaw.plugin.json"), []byte(`{"version":"1.5.0","activation":{"onStartup":true}}`), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(pluginDir, "openclaw.plugin.json"), []byte(`{"version":"1.6.0","activation":{"onStartup":true}}`), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(stateDir, "openclaw.json"), []byte(`{"plugins":{"allow":["rampart"],"entries":{"rampart":{"enabled":true}}}}`), 0o600); err != nil {

--- a/docs-site/getting-started/installation.md
+++ b/docs-site/getting-started/installation.md
@@ -114,7 +114,7 @@ volumes:
 
 The loopback bind keeps the bearer-token control API off your LAN. For remote administration, put Rampart behind a trusted HTTPS reverse proxy and supply `RAMPART_TOKEN` explicitly; do not publish port 9090 directly over plaintext HTTP.
 
-Available tags include full versions such as `1.5.0`, minor versions such as `1.5`, and `latest` for the current stable release. Prereleases use their full tag, for example `1.5.0-rc.1`, and do not move `latest`. Pin to a specific version tag for reproducibility. Images are published on [GitHub Container Registry](https://github.com/peg/rampart/pkgs/container/rampart).
+Available tags include full versions such as `1.6.0`, minor versions such as `1.6`, and `latest` for the current stable release. Prereleases use their full tag, for example `1.6.0-rc.1`, and do not move `latest`. Pin to a specific version tag for reproducibility. Images are published on [GitHub Container Registry](https://github.com/peg/rampart/pkgs/container/rampart).
 
 ## Build from Source
 

--- a/docs-site/getting-started/security-assurance.md
+++ b/docs-site/getting-started/security-assurance.md
@@ -38,7 +38,7 @@ support.
 | **Antigravity CLI / IDE** | Antigravity CLI 1.1.7 loaded the generated plugin; an allowed command was audited and a disposable sensitive-path write was denied before modification. | PostToolUse omits tool results; rolling-latest and physical Windows host proof are pending. |
 | **GitHub Copilot CLI / VS Code** | Latest-package isolated startup plus separate shared-schema and dual-schema destructive-call adapter checks. | Package startup does not prove hook ingestion; authenticated CLI and VS Code host proof remain pending, VS Code hooks remain Preview, and CLI timeouts fail open. |
 | **Cline** | Current editor/CLI payload and tool mapping tests; direct POSIX and Windows setup, ownership, and migration tests; cross-build coverage. | A rolling latest-Cline job, completed current-host proof, and physical Windows E2E. Current CLI hook errors/timeouts fail open and post-tool control is ignored. |
-| **Hermes Agent** | Isolated Hermes 0.19.0 Linux direct and localhost API-gateway proofs: deny did not execute, allow executed, and pre-tool audit identity correlated. | Hermes can skip crashing plugin callbacks, delegated-agent proof is pending, and it does not expose a stable plugin approval/resume primitive. |
+| **Hermes Agent** | Isolated Hermes 0.20.0 Linux gateway proof, plus earlier 0.19.0 direct and gateway runs: deny did not execute, allow executed, and pre-tool audit identity correlated. | Hermes can skip crashing plugin callbacks, delegated-agent proof is pending, and it does not expose a stable plugin approval/resume primitive. |
 
 The canonical source is
 [`assurance/integrations.yaml`](https://github.com/peg/rampart/blob/main/assurance/integrations.yaml).

--- a/docs-site/getting-started/support-matrix.md
+++ b/docs-site/getting-started/support-matrix.md
@@ -106,7 +106,7 @@ and the isolated Hermes harness for runtime evidence.
       <td data-label="Bare protect">No</td>
       <td data-label="rampart serve">Required</td>
       <td data-label="Approval UX"><code>ask</code> blocks until plugin approval/resume support exists</td>
-      <td data-label="Support tier"><strong>Experimental</strong><br>0.19.0 shell deny/allow host proof; native approval/resume pending</td>
+      <td data-label="Support tier"><strong>Experimental</strong><br>0.20.0 gateway deny/allow host proof; native approval/resume pending</td>
     </tr>
     <tr class="tier-supported">
       <td data-label="Surface"><strong>OpenClaw 2026.4.29 - 2026.5.1</strong></td>
@@ -185,7 +185,7 @@ and the isolated Hermes harness for runtime evidence.
   memory, and delegated-agent calls; a real authenticated host proof is still
   pending, and this does not cover Antigravity
 - **Hermes Agent** → experimental plugin path with a completed isolated
-  Hermes 0.19.0 shell deny/allow host run; `ask` decisions block rather than
+  Hermes 0.20.0 gateway deny/allow host run; `ask` decisions block rather than
   resume until Hermes exposes a first-class plugin approval flow. Its built-in
   status check remains static, so it is not included in `rampart verify --all`
 

--- a/docs-site/getting-started/troubleshooting.md
+++ b/docs-site/getting-started/troubleshooting.md
@@ -165,7 +165,7 @@ rampart test --tool read "/etc/shadow"
 
 ```bash
 openclaw plugins list
-# Should show: rampart  1.5.0  ✓ active
+# Should show: rampart  1.6.0  ✓ active
 
 rampart doctor
 # Should show: ✓ OpenClaw plugin: installed (before_tool_call hook active)

--- a/docs-site/index.html
+++ b/docs-site/index.html
@@ -27,7 +27,7 @@
       "url": "https://rampart.sh",
       "applicationCategory": "SecurityApplication",
       "operatingSystem": "Linux, macOS, Windows",
-      "softwareVersion": "1.5.0",
+      "softwareVersion": "1.6.0",
       "offers": {
         "@type": "Offer",
         "price": "0",
@@ -1114,7 +1114,7 @@
 <section class="hero">
     <div class="container hero-grid">
         <div>
-            <div class="eyebrow"><span class="eyebrow-dot"></span>v1.5.0 · hardened multi-agent enforcement</div>
+            <div class="eyebrow"><span class="eyebrow-dot"></span>v1.6.0 · verified agent boundaries</div>
             <h1>Your agent has root.<br><span class="accent">That’s the problem.</span></h1>
             <p class="hero-sub">Rampart sits in the execution path. Run <code>rampart protect openclaw</code> for a managed, fail-closed OpenClaw guard that verifies itself, or use <code>rampart quickstart</code> for other supported agents.</p>
             <div class="install-cluster">

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -238,10 +238,10 @@ verify -> outcomes.approval
 
 ## Current release
 
-Rampart v1.5.0 introduced zero-configuration protection across supported local
-agents, native Codex and Claude Code improvements, Antigravity and GitHub
-Copilot integration paths, stronger exact-context approvals, and executable
-security assurance. See the
+Rampart v1.6.0 adds one-command behavioral verification across configured
+boundaries, current OpenClaw approval ownership and stable-package gating,
+safer service lifecycle identity, seamless policy and historical-audit
+upgrades, and isolated Hermes 0.20 host evidence. See the
 [release notes](https://github.com/peg/rampart/releases/latest) for the concise
 upgrade summary or the repository
 [changelog](https://github.com/peg/rampart/blob/main/CHANGELOG.md) for history.

--- a/docs-site/integrations/hermes.md
+++ b/docs-site/integrations/hermes.md
@@ -141,8 +141,8 @@ cannot accidentally load source messaging-platform credentials:
 scripts/compat-hermes-host.sh --yes --gateway --rampart-bin ./rampart
 ```
 
-A completed isolated Hermes 0.19.0 Linux run proved those properties through
-both the direct CLI and a disposable localhost API gateway. The gateway run
+A completed isolated Hermes 0.20.0 Linux gateway run, plus earlier 0.19.0
+direct and gateway runs, proved those properties. The current gateway run
 loaded only isolated model, provider, toolset, and authentication state; it did
 not load normal memories, sessions, rules, workspaces, messaging gateways, or
 MCP configuration. See

--- a/docs-site/integrations/openclaw.md
+++ b/docs-site/integrations/openclaw.md
@@ -213,7 +213,7 @@ Or check plugin status directly:
 
 ```bash
 openclaw plugins list
-# rampart  v1.5.0  active
+# rampart  v1.6.0  active
 ```
 
 ## Troubleshooting

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -1,6 +1,6 @@
 # Threat Model
 
-> Last reviewed: 2026-07-29 | Applies to: v1.5.0+
+> Last reviewed: 2026-08-07 | Applies to: v1.6.0+
 
 Rampart is a policy engine for AI agents — not a sandbox, not a hypervisor, not a full isolation boundary. This document describes what Rampart protects against, what it doesn't, and why.
 

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -73,6 +73,12 @@ Rampart evaluates the command string passed to the shell. This applies to **all 
 
 The hash-chained audit trail detects **partial tampering** — editing, inserting, or deleting individual records breaks the chain. However, a complete rewrite from scratch with a new valid chain is not detectable from the log file alone.
 
+Rampart v1.6 also validates older logs containing chronological chain epochs
+created by legacy service restarts. Recovery verifies every event hash,
+internal link, continuation header, epoch order, and whole-graph connectivity
+without rewriting the existing records. Forks, missing references,
+disconnected events, and overlapping epochs fail verification.
+
 Audit records are capped at 2 MiB. If JSON escaping or decision guidance would exceed that limit, Rampart replaces large fields with their original encoded size and SHA-256 digest, then computes the event hash over the compacted record. This preserves a bounded, correlatable decision record instead of silently dropping the audit event.
 
 **Mitigations:**

--- a/docs/index.html
+++ b/docs/index.html
@@ -27,7 +27,7 @@
       "url": "https://rampart.sh",
       "applicationCategory": "SecurityApplication",
       "operatingSystem": "Linux, macOS, Windows",
-      "softwareVersion": "1.5.0",
+      "softwareVersion": "1.6.0",
       "offers": {
         "@type": "Offer",
         "price": "0",
@@ -1114,7 +1114,7 @@
 <section class="hero">
     <div class="container hero-grid">
         <div>
-            <div class="eyebrow"><span class="eyebrow-dot"></span>v1.5.0 · hardened multi-agent enforcement</div>
+            <div class="eyebrow"><span class="eyebrow-dot"></span>v1.6.0 · verified agent boundaries</div>
             <h1>Your agent has root.<br><span class="accent">That’s the problem.</span></h1>
             <p class="hero-sub">Rampart sits in the execution path. Run <code>rampart protect openclaw</code> for a managed, fail-closed OpenClaw guard that verifies itself, or use <code>rampart quickstart</code> for other supported agents.</p>
             <div class="install-cluster">

--- a/docs/install
+++ b/docs/install
@@ -7,8 +7,8 @@
 # Usage: curl -fsSL https://rampart.sh/install | sh
 #        curl -fsSL https://rampart.sh/install | sh -s -- --version v0.1.0
 #        curl -fsSL https://rampart.sh/install | sh -s -- --auto-setup
-#        RAMPART_INSTALL_DRY_RUN=1 sh install.sh --version v1.5.0
-#        RAMPART_VERSION=v1.5.0 RAMPART_INSTALL_DIR=$HOME/.local/bin sh install.sh
+#        RAMPART_INSTALL_DRY_RUN=1 sh install.sh --version v1.6.0
+#        RAMPART_VERSION=v1.6.0 RAMPART_INSTALL_DIR=$HOME/.local/bin sh install.sh
 set -e
 
 REPO="peg/rampart"
@@ -107,7 +107,7 @@ esac
 # caller-controlled value cannot introduce path separators or option syntax.
 SEMVER_RE='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*))?(\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?$'
 if ! printf '%s\n' "$VERSION" | grep -Eq "$SEMVER_RE"; then
-    error "Invalid release version: ${VERSION}. Expected a tag such as v1.5.0 or v1.5.0-rc.1."
+    error "Invalid release version: ${VERSION}. Expected a tag such as v1.6.0 or v1.6.0-rc.1."
 fi
 
 info "Installing ${BOLD}rampart ${VERSION}${RESET}"

--- a/docs/install.ps1
+++ b/docs/install.ps1
@@ -420,7 +420,7 @@ if ($TestMode) {
     $version = "installer-test"
     $expectedCandidateVersion = $TestExpectedVersion
     if (-not (Test-StrictReleaseVersion $expectedCandidateVersion)) {
-        Write-Err "Invalid release version: $expectedCandidateVersion. Expected a tag such as v1.5.0 or v1.5.0-rc.1."
+        Write-Err "Invalid release version: $expectedCandidateVersion. Expected a tag such as v1.6.0 or v1.6.0-rc.1."
         exit 1
     }
     $tempZip = [System.IO.Path]::GetFullPath($TestArchivePath)
@@ -449,7 +449,7 @@ if ($TestMode) {
         exit 1
     }
     if (-not (Test-StrictReleaseVersion $version)) {
-        Write-Err "Invalid release version: $version. Expected a tag such as v1.5.0 or v1.5.0-rc.1."
+        Write-Err "Invalid release version: $version. Expected a tag such as v1.6.0 or v1.6.0-rc.1."
         exit 1
     }
     Write-Status "Latest version: $version"

--- a/docs/install.sh
+++ b/docs/install.sh
@@ -7,8 +7,8 @@
 # Usage: curl -fsSL https://rampart.sh/install | sh
 #        curl -fsSL https://rampart.sh/install | sh -s -- --version v0.1.0
 #        curl -fsSL https://rampart.sh/install | sh -s -- --auto-setup
-#        RAMPART_INSTALL_DRY_RUN=1 sh install.sh --version v1.5.0
-#        RAMPART_VERSION=v1.5.0 RAMPART_INSTALL_DIR=$HOME/.local/bin sh install.sh
+#        RAMPART_INSTALL_DRY_RUN=1 sh install.sh --version v1.6.0
+#        RAMPART_VERSION=v1.6.0 RAMPART_INSTALL_DIR=$HOME/.local/bin sh install.sh
 set -e
 
 REPO="peg/rampart"
@@ -107,7 +107,7 @@ esac
 # caller-controlled value cannot introduce path separators or option syntax.
 SEMVER_RE='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*))?(\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?$'
 if ! printf '%s\n' "$VERSION" | grep -Eq "$SEMVER_RE"; then
-    error "Invalid release version: ${VERSION}. Expected a tag such as v1.5.0 or v1.5.0-rc.1."
+    error "Invalid release version: ${VERSION}. Expected a tag such as v1.6.0 or v1.6.0-rc.1."
 fi
 
 info "Installing ${BOLD}rampart ${VERSION}${RESET}"

--- a/install.ps1
+++ b/install.ps1
@@ -420,7 +420,7 @@ if ($TestMode) {
     $version = "installer-test"
     $expectedCandidateVersion = $TestExpectedVersion
     if (-not (Test-StrictReleaseVersion $expectedCandidateVersion)) {
-        Write-Err "Invalid release version: $expectedCandidateVersion. Expected a tag such as v1.5.0 or v1.5.0-rc.1."
+        Write-Err "Invalid release version: $expectedCandidateVersion. Expected a tag such as v1.6.0 or v1.6.0-rc.1."
         exit 1
     }
     $tempZip = [System.IO.Path]::GetFullPath($TestArchivePath)
@@ -449,7 +449,7 @@ if ($TestMode) {
         exit 1
     }
     if (-not (Test-StrictReleaseVersion $version)) {
-        Write-Err "Invalid release version: $version. Expected a tag such as v1.5.0 or v1.5.0-rc.1."
+        Write-Err "Invalid release version: $version. Expected a tag such as v1.6.0 or v1.6.0-rc.1."
         exit 1
     }
     Write-Status "Latest version: $version"

--- a/install.sh
+++ b/install.sh
@@ -7,8 +7,8 @@
 # Usage: curl -fsSL https://rampart.sh/install | sh
 #        curl -fsSL https://rampart.sh/install | sh -s -- --version v0.1.0
 #        curl -fsSL https://rampart.sh/install | sh -s -- --auto-setup
-#        RAMPART_INSTALL_DRY_RUN=1 sh install.sh --version v1.5.0
-#        RAMPART_VERSION=v1.5.0 RAMPART_INSTALL_DIR=$HOME/.local/bin sh install.sh
+#        RAMPART_INSTALL_DRY_RUN=1 sh install.sh --version v1.6.0
+#        RAMPART_VERSION=v1.6.0 RAMPART_INSTALL_DIR=$HOME/.local/bin sh install.sh
 set -e
 
 REPO="peg/rampart"
@@ -107,7 +107,7 @@ esac
 # caller-controlled value cannot introduce path separators or option syntax.
 SEMVER_RE='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*))?(\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?$'
 if ! printf '%s\n' "$VERSION" | grep -Eq "$SEMVER_RE"; then
-    error "Invalid release version: ${VERSION}. Expected a tag such as v1.5.0 or v1.5.0-rc.1."
+    error "Invalid release version: ${VERSION}. Expected a tag such as v1.6.0 or v1.6.0-rc.1."
 fi
 
 info "Installing ${BOLD}rampart ${VERSION}${RESET}"

--- a/internal/plugin/hermes/__init__.py
+++ b/internal/plugin/hermes/__init__.py
@@ -30,7 +30,7 @@ from pathlib import Path
 from typing import Any, Callable, Mapping
 from urllib.parse import quote, urlsplit
 
-VERSION = "1.5.0"
+VERSION = "1.6.0"
 
 DEFAULT_SERVE_URL = "http://127.0.0.1:9090"
 DEFAULT_TIMEOUT_MS = 3000

--- a/internal/plugin/hermes/embed_test.go
+++ b/internal/plugin/hermes/embed_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestVersionReadsManifest(t *testing.T) {
-	if got, want := Version(), "1.5.0"; got != want {
+	if got, want := Version(), "1.6.0"; got != want {
 		t.Fatalf("Version() = %q, want %q", got, want)
 	}
 }
@@ -97,7 +97,7 @@ func TestExtractRollsBackManagedPluginOnActivationFailure(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	oldManifest = bytes.Replace(oldManifest, []byte("version: 1.5.0"), []byte("version: 1.4.0"), 1)
+	oldManifest = bytes.Replace(oldManifest, []byte("version: 1.6.0"), []byte("version: 1.5.0"), 1)
 	if err := os.WriteFile(manifestPath, oldManifest, 0o600); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/plugin/hermes/plugin.yaml
+++ b/internal/plugin/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: rampart
-version: 1.5.0
+version: 1.6.0
 description: Experimental Rampart policy gate for Hermes Agent pre_tool_call hooks
 author: peg
 provides_hooks:

--- a/internal/plugin/openclaw/index.js
+++ b/internal/plugin/openclaw/index.js
@@ -5,7 +5,7 @@
  * Replaces brittle dist-file patching with the official OpenClaw plugin API.
  *
  * @see https://github.com/peg/rampart
- * @version 1.5.0
+ * @version 1.6.0
  */
 
 import { readFile } from "fs/promises";
@@ -712,7 +712,7 @@ async function checkWithRampart(toolName, params, ctx, config, { verification = 
 export const id = "rampart";
 export const name = "Rampart";
 export const description = "Independent safety guard for unattended AI agent actions";
-export const version = "1.5.0";
+export const version = "1.6.0";
 
 // OpenClaw runs higher-priority before_tool_call hooks first, so place Rampart
 // late among normal plugins as defense in depth. Priority alone is not an

--- a/internal/plugin/openclaw/openclaw.plugin.json
+++ b/internal/plugin/openclaw/openclaw.plugin.json
@@ -8,7 +8,7 @@
       "hook"
     ]
   },
-  "version": "1.5.0",
+  "version": "1.6.0",
   "author": "peg",
   "homepage": "https://rampart.sh",
   "repository": "https://github.com/peg/rampart",

--- a/internal/plugin/openclaw/package.json
+++ b/internal/plugin/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rampart",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Rampart AI agent firewall — OpenClaw native plugin (before_tool_call hook)",
   "type": "module",
   "main": "index.js",

--- a/policies/openclaw.yaml
+++ b/policies/openclaw.yaml
@@ -1,4 +1,4 @@
-# rampart-policy-version: 1.5.0
+# rampart-policy-version: 1.6.0
 # Rampart built-in profile: openclaw
 # Use with: rampart init --profile openclaw
 #

--- a/scripts/lab/run-e2e.sh
+++ b/scripts/lab/run-e2e.sh
@@ -363,10 +363,20 @@ run_preload() {
   mkdir -p "${preload_home}/.ssh"
   printf '%s\n' 'rampart-lab-private-credential-canary' >"${preload_home}/.ssh/id_rsa"
   chmod 600 "${preload_home}/.ssh/id_rsa"
-  isolated env HOME="$preload_home" \
+  # Launch the external env process directly. Backgrounding the isolated shell
+  # function would make $! identify its wrapper instead of the Rampart server,
+  # leaving the real server alive after the wrapper is terminated.
+  env -i \
+    HOME="$preload_home" \
     XDG_CONFIG_HOME="$preload_home/.config" \
     XDG_CACHE_HOME="$preload_home/.cache" \
     XDG_STATE_HOME="$preload_home/.local/state" \
+    TMPDIR="$tmp_dir" \
+    GOCACHE="$run_root/go-build" \
+    GOMODCACHE="${RAMPART_LAB_GOMODCACHE:-$lab_root/go-mod}" \
+    PATH="$isolated_path" \
+    LANG="${LANG:-C.UTF-8}" \
+    CI=1 \
     RAMPART_TOKEN="rampart-lab-token" \
     "${bin_dir}/rampart" --config "${worktree}/policies/standard.yaml" \
     serve --no-openclaw-bridge --mode enforce --port "$port" \

--- a/scripts/lab/test-run-e2e.sh
+++ b/scripts/lab/test-run-e2e.sh
@@ -135,6 +135,19 @@ grep -q 'exact 40-character hexadecimal commit SHA' "${tmp}/invalid.err"
 grep -q 'openclaw-container-acceptance.sh' "$runner"
 grep -q 'CGO_ENABLED=0 GOOS=linux GOARCH=' "$runner"
 grep -q 'run_step go-test isolated env RAMPART_OPENCLAW_BIN=' "$runner"
+python3 - "$runner" <<'PY'
+from pathlib import Path
+import sys
+
+text = Path(sys.argv[1]).read_text(encoding="utf-8")
+run_preload = text.split("run_preload() {", 1)[1].split("\n}\n\nrun_e2e()", 1)[0]
+if 'isolated env HOME="$preload_home"' in run_preload:
+    raise SystemExit("preload server must not background the isolated shell wrapper")
+if 'env -i \\\n    HOME="$preload_home"' not in run_preload:
+    raise SystemExit("preload server must directly background an isolated external process")
+if "preload_server_pid=$!" not in run_preload:
+    raise SystemExit("preload server PID is not tracked for cleanup")
+PY
 if grep -Eq '\$\{controller_repo\}/(preload/test_preload\.sh|scripts/test-approval-flow\.sh|scripts/compat-hermes-latest\.py)' "$runner"; then
   echo "test-run-e2e: candidate harnesses must run from the detached worktree" >&2
   exit 1


### PR DESCRIPTION
## Summary

- finalize Rampart 1.6.0 version metadata, changelog, installer examples, website copy, threat-model review, and OpenClaw/Hermes plugin versions
- record a sanitized, authenticated Hermes Agent 0.20.0 isolated gateway proof while retaining the integration's experimental support tier and documented limitations
- fix the Linux E2E runner so it tracks and stops the actual disposable Rampart preload server instead of a background shell wrapper
- keep the README support table version-neutral, preserve a real 1.5 OpenClaw upgrade fixture, and document the 1.6 legacy audit-epoch integrity boundary in the reviewed threat model

## Release delta

Compared with v1.5.0, current staging spans 112 files with 3,220 additions and 4,633 deletions: a net reduction of 1,413 lines. The release combines aggregate behavioral verification, current OpenClaw approval ownership and stable-package gating, safer service lifecycle identity, seamless policy and historical-audit upgrades, and refreshed integration assurance.

## Verification

- local: all Go packages, race detector, vet/build, formatting/tidy checks, installer transaction tests, policy checks, OpenClaw and Hermes regressions, docs synchronization, lab-runner contract, actionlint, staticcheck, and govulncheck; no vulnerabilities found
- agent01 runtime candidate `1efbc2c966747df3315f614f3e23fc348ffa69fb`: full isolated Linux suite passed with controller and worktree pinned to the same clean SHA; the later head commit changes only release documentation and a non-behavioral upgrade fixture
- OpenClaw 2026.7.1-2: zero-configuration install, idempotent second protect run, and 12/12 safe behavioral canaries passed twice
- Hermes: rolling public-package compatibility passed; separately recorded installed-host 0.20.0 gateway proof completed two real deny/allow model turns without source memories, sessions, rules, workspaces, messaging gateways, or MCP configuration
- retained-evidence scanner: 37 files and 50,707 bytes checked, zero credential findings
- cleanup: no disposable process or temporary tree remained; live Rampart, OpenClaw, and Hermes services stayed active
- final cleanup: assurance, audit, CLI, OpenClaw migration-notice, Hermes/OpenClaw security, and canonical-document checks passed

## Release guidance

Ready to merge into `staging` once the refreshed CI run is green. Keep Hermes experimental for 1.6.0 because native approval/resume and guaranteed fail-closed plugin execution remain upstream gaps. After this PR merges, open the final `staging` to `main` release PR and tag only the exact green merge commit.
