### PR TITLE
Close integration assurance gaps and correct Hermes release tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Bundled plugin freshness is component-aware** — Doctor compares installed
+  OpenClaw and Hermes files with the exact plugin payload embedded in the
+  running binary, so core-only patch releases do not create false version
+  warnings and same-version file drift is still detected.
+- **Hermes latest compatibility follows the supported release channel** — The
+  isolated gate resolves Hermes' official stable GitHub release and uses its
+  permitted editable checkout path instead of treating lagging PyPI metadata
+  as the current Hermes release.
+
+### Changed
+
+- **Integration assurance has no indefinite unknown state** — Every declared
+  surface is now proven, partial, or explicitly not covered; host-owned failure
+  behavior is labeled as such, and schema validation rejects new `unknown`
+  claims.
+- **Hermes participates in the common status model** — Configured Hermes
+  plugins appear with explicit static assurance and `rampart doctor` guidance,
+  while remaining excluded from behavioral `rampart verify --all`.
+- **Release metadata and bundled component versions are independent** — Public
+  release metadata now identifies v1.6.1, while unchanged embedded plugins keep
+  their own internally synchronized component versions.
+
+## [1.6.1] - 2026-08-10
+
 ### Security
 
 - **MCP response handling now fails closed on ambiguous child output** — Enforce

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -277,9 +277,9 @@ policies/            Built-in policy presets
 
 We track these so contributors know where improvement is welcome:
 
-- `internal/proxy/server.go` is 1,600+ lines — approval handlers and webhook logic should be extracted into separate files
-- `cmd/rampart/cli/hook.go` mixes CLI wiring with business logic
-- `internal/engine/matcher.go` is approaching 700 lines
+- `cmd/rampart/cli` still owns too much integration lifecycle and presentation logic
+- `cmd/rampart/cli/hook.go` mixes CLI wiring with host-adapter business logic
+- `internal/engine/matcher.go` combines enforcement matching with explanation tracing
 - Some cobra RunE functions exceed 200 lines of wiring
 
 If you want to tackle any of these, open an issue first to discuss the approach.

--- a/assurance/README.md
+++ b/assurance/README.md
@@ -22,7 +22,10 @@ executable evidence.
 - **live evidence** — a reviewed JSON summary records a completed host run.
 - **partial** — some routes are covered, but the surface has known exclusions.
 - **not_covered** — the integration does not intercept the surface.
-- **unknown** — no reliable claim is made until evidence is added.
+
+The public manifest does not allow an indefinite `unknown` state. A surface
+must be evidenced, narrowed to `partial`, or explicitly marked `not_covered`.
+Host-owned error and timeout behavior is recorded as `host_defined`.
 
 Support tiers are intentionally separate from feature breadth:
 

--- a/assurance/integrations.yaml
+++ b/assurance/integrations.yaml
@@ -1,6 +1,6 @@
 schema_version: rampart.assurance.v2
-baseline_release: v1.6.0
-reviewed_at: "2026-08-07"
+baseline_release: v1.6.1
+reviewed_at: "2026-08-10"
 
 # Version 2 uses the canonical Rampart command target as each integration id
 # and requires an explicit declaration of bare `rampart protect` eligibility.
@@ -23,11 +23,11 @@ integrations:
       file_read: verified
       file_write: verified
       network: partial
-      mcp: unknown
+      mcp: not_covered
       subagents: partial
     degraded:
       policy_unavailable: deny
-      adapter_error: unknown
+      adapter_error: host_defined
       timeout: deny
     approval: native
     verification:
@@ -74,7 +74,7 @@ integrations:
       file_read: tested
       file_write: tested
       network: tested
-      mcp: unknown
+      mcp: tested
       subagents: partial
     degraded:
       policy_unavailable: local
@@ -90,6 +90,9 @@ integrations:
       - path: cmd/rampart/cli/hook_test.go
         kind: unit
         proves: Claude hook payloads map to structured allow, ask, and deny responses.
+      - path: cmd/rampart/cli/hook_mcp_test.go
+        kind: unit
+        proves: Claude MCP tool names pass through the shared native-hook classifier, including conservative destructive-tool classification.
       - path: cmd/rampart/cli/hook_ask_test.go
         kind: integration
         proves: Invalid policy and malformed input fail closed through the hook protocol.
@@ -220,8 +223,8 @@ integrations:
       file_read: tested
       file_write: tested
       network: tested
-      mcp: unknown
-      subagents: unknown
+      mcp: not_covered
+      subagents: not_covered
     degraded:
       policy_unavailable: deny
       adapter_error: deny
@@ -238,7 +241,7 @@ integrations:
         proves: Tool normalization, redaction, allow, deny, ask, malformed responses, unknown-tool fail-closed behavior, adapter exceptions, and service failure are tested.
       - path: scripts/compat-hermes-latest.py
         kind: upstream_latest
-        proves: Latest Hermes discovery, dispatcher decisions, degraded mode, and multi-path deny-wins behavior are checked in isolation.
+        proves: Hermes' official latest stable GitHub release is resolved independently of PyPI, then discovery, dispatcher decisions, degraded mode, and multi-path deny-wins behavior are checked in isolation.
       - path: scripts/compat-hermes-host.sh
         kind: live_harness
         proves: An opt-in auth-minimized harness proves deny and allowed execution through a real isolated Hermes model/tool loop.
@@ -255,8 +258,8 @@ integrations:
       - Hermes documents that a crashing plugin callback is skipped and the agent continues.
       - Hermes approval observer hooks cannot answer or resume an approval.
       - Operators may explicitly weaken degraded behavior by configuring selected tools to fail open; the default denies every tool.
-      - Unknown plugin and MCP tool names deny until Rampart has an explicit typed mapping for them.
-      - Delegated-agent and approved-execution E2E are not yet present.
+      - Hermes tools outside the plugin's typed map, including MCP and delegated-agent tools, fail closed but are not claimed as covered policy surfaces.
+      - Delegated-agent and approved-execution E2E are not present.
 
   - id: gemini
     display_name: Gemini CLI
@@ -319,7 +322,7 @@ integrations:
       file_read: tested
       file_write: verified
       network: tested
-      mcp: unknown
+      mcp: tested
       subagents: tested
     degraded:
       policy_unavailable: local
@@ -334,7 +337,7 @@ integrations:
     evidence:
       - path: cmd/rampart/cli/hook_antigravity_test.go
         kind: unit
-        proves: The documented tool surface maps to Rampart policy classes, unknown future tools deny, and approval decisions use Antigravity force_ask.
+        proves: The documented tool and MCP surfaces map to Rampart policy classes, destructive MCP operations are classified conservatively, unknown future tools deny, and approval decisions use Antigravity force_ask.
       - path: cmd/rampart/cli/setup_antigravity_test.go
         kind: unit
         proves: Setup creates the documented shared CLI/IDE plugin idempotently, validates ownership structurally, removes only Rampart-owned state, and refuses foreign plugin replacement by default.

--- a/cmd/rampart/cli/assurance_status.go
+++ b/cmd/rampart/cli/assurance_status.go
@@ -383,7 +383,7 @@ func collectIntegrationAssuranceStatuses(now time.Time, serverRunning bool) []in
 			ID: driver.ID, DisplayName: driver.DisplayName, Boundary: driver.Boundary,
 			Installed: installed, Configured: configured, ServiceRequired: driver.ServiceRequired,
 			AssuranceLevel:      assuranceDetected,
-			VerificationCommand: "rampart verify " + driver.VerifyTarget,
+			VerificationCommand: integrationDriverVerificationCommand(driver),
 		}
 		if driver.AutoProtect {
 			status.RecommendedCommand = "rampart protect " + driver.ID

--- a/cmd/rampart/cli/assurance_status_test.go
+++ b/cmd/rampart/cli/assurance_status_test.go
@@ -9,7 +9,33 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	hermesplugin "github.com/peg/rampart/internal/plugin/hermes"
 )
+
+func TestHermesUsesCommonStaticAssuranceStatus(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+	t.Setenv("PATH", t.TempDir())
+	hermesHome := filepath.Join(home, ".hermes")
+	if err := hermesplugin.Extract(filepath.Join(hermesHome, "plugins", "rampart")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(hermesHome, "config.yaml"), []byte("plugins:\n  enabled: [rampart]\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	status, ok := findAssuranceStatus(collectIntegrationAssuranceStatuses(time.Now().UTC(), false), "hermes")
+	if !ok {
+		t.Fatal("Hermes assurance status missing")
+	}
+	if !status.Installed || !status.Configured || status.AssuranceLevel != assuranceConfigured {
+		t.Fatalf("Hermes assurance status = %#v", status)
+	}
+	if status.VerificationCommand != "rampart doctor" || status.RecommendedCommand != "rampart doctor" {
+		t.Fatalf("Hermes static verification guidance = %#v", status)
+	}
+}
 
 func TestVerificationReceiptPromotesConfiguredIntegration(t *testing.T) {
 	home := t.TempDir()

--- a/cmd/rampart/cli/doctor.go
+++ b/cmd/rampart/cli/doctor.go
@@ -32,6 +32,7 @@ import (
 	"github.com/peg/rampart/internal/detect"
 	"github.com/peg/rampart/internal/engine"
 	ochardening "github.com/peg/rampart/internal/openclaw/hardening"
+	hermesplugin "github.com/peg/rampart/internal/plugin/hermes"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
@@ -1614,9 +1615,9 @@ func doctorOpenClawPlugin(emit emitFn) (warnings int) {
 				"Add \"rampart\" to plugins.allow or rerun: rampart setup openclaw")
 		return 1
 	}
-	if state.ManifestVersion != "" && !pluginVersionMatchesBuildVersion(state.ManifestVersion, build.Version) {
+	if !openClawPluginCurrent(state) {
 		emit("OpenClaw plugin", "warn",
-			fmt.Sprintf("installed manifest version %s does not match rampart binary %s", state.ManifestVersion, build.Version)+hintSep+
+			"installed plugin files do not match the plugin bundled with this Rampart binary"+hintSep+
 				"Rerun `rampart setup openclaw` using the same OpenClaw profile/state dir, then restart OpenClaw")
 		return 1
 	}
@@ -1676,18 +1677,6 @@ func doctorOpenClawProviderDiscovery(emit emitFn) (warnings int) {
 		"plugins.allow is restrictive, but bundled provider discovery is still in compatibility mode"+hintSep+
 			"After confirming plugins.allow includes every bundled provider you intend to keep, run: openclaw config set plugins.bundledDiscovery allowlist")
 	return 1
-}
-
-func pluginVersionMatchesBuildVersion(manifestVersion, buildVersion string) bool {
-	buildRelease, ok := normalizedReleaseVersion(buildVersion)
-	if !ok {
-		return true
-	}
-	manifestRelease, ok := normalizedReleaseVersion(manifestVersion)
-	if !ok {
-		manifestRelease = strings.TrimPrefix(strings.TrimSpace(manifestVersion), "v")
-	}
-	return manifestRelease == buildRelease
 }
 
 func normalizedReleaseVersion(version string) (string, bool) {
@@ -2063,8 +2052,8 @@ func doctorHermesIntegration(emit emitFn, serveURL, token string) (warnings int)
 				"Reinstall the plugin from a current Rampart build: rampart setup hermes")
 			warnings++
 		}
-		if manifest.Version != "" && !pluginVersionMatchesBuildVersion(manifest.Version, build.Version) {
-			emit("Hermes plugin", "warn", fmt.Sprintf("installed manifest version %s does not match rampart binary %s", manifest.Version, build.Version)+hintSep+
+		if !hermesplugin.Current(pluginDir) {
+			emit("Hermes plugin", "warn", "installed plugin files do not match the plugin bundled with this Rampart binary"+hintSep+
 				"Rerun `rampart setup hermes` from the same Rampart build, then restart long-running Hermes gateways")
 			warnings++
 		} else {

--- a/cmd/rampart/cli/doctor_test.go
+++ b/cmd/rampart/cli/doctor_test.go
@@ -25,6 +25,8 @@ import (
 	"time"
 
 	"github.com/peg/rampart/internal/build"
+	hermesplugin "github.com/peg/rampart/internal/plugin/hermes"
+	openclawplugin "github.com/peg/rampart/internal/plugin/openclaw"
 	"github.com/peg/rampart/policies"
 )
 
@@ -722,8 +724,7 @@ func TestDoctorOpenClawPlugin(t *testing.T) {
 		t.Setenv("RAMPART_OPENCLAW_BIN", openclawBin)
 		requireNoErr(t, os.MkdirAll(filepath.Join(home, ".openclaw", "extensions", "rampart"), 0o755))
 		pluginDir := filepath.Join(home, ".openclaw", "extensions", "rampart")
-		requireNoErr(t, os.WriteFile(filepath.Join(pluginDir, "openclaw.plugin.json"), []byte(`{"version":"1.0.0","activation":{"onStartup":true}}`), 0o600))
-		requireNoErr(t, os.WriteFile(filepath.Join(pluginDir, "index.js"), []byte(`export const version = "1.0.0";`), 0o600))
+		requireNoErr(t, openclawplugin.Extract(pluginDir))
 		return home
 	}
 
@@ -745,6 +746,19 @@ func TestDoctorOpenClawPlugin(t *testing.T) {
 		warnings, results := run(t)
 		if warnings != 0 || len(results) != 1 || results[0].Status != "ok" {
 			t.Fatalf("expected ok, got warnings=%d results=%+v", warnings, results)
+		}
+	})
+
+	t.Run("warns when same-version plugin payload differs", func(t *testing.T) {
+		home := setup(t)
+		requireNoErr(t, os.MkdirAll(filepath.Join(home, ".openclaw"), 0o755))
+		requireNoErr(t, os.WriteFile(filepath.Join(home, ".openclaw", "openclaw.json"), []byte(`{"plugins":{"entries":{"rampart":{"enabled":true}}}}`), 0o600))
+		hookPath := filepath.Join(home, ".openclaw", "extensions", "rampart", "hooks", "rampart", "index.js")
+		requireNoErr(t, os.WriteFile(hookPath, []byte("// same-version drift\n"), 0o600))
+
+		warnings, results := run(t)
+		if warnings != 1 || len(results) != 1 || !strings.Contains(results[0].Message, "do not match the plugin bundled") {
+			t.Fatalf("expected bundled-payload warning, got warnings=%d results=%+v", warnings, results)
 		}
 	})
 
@@ -995,6 +1009,23 @@ func TestDoctorHermesIntegrationReportsReadyExperimentalGate(t *testing.T) {
 	}
 }
 
+func TestDoctorHermesIntegrationDetectsSameVersionPayloadDrift(t *testing.T) {
+	home, hermesHome := setupHermesDoctorFixture(t, `plugins:
+  enabled:
+    - rampart
+`)
+	t.Setenv("PATH", filepath.Join(home, "empty-bin"))
+	requireNoErr(t, os.WriteFile(filepath.Join(hermesHome, "plugins", "rampart", "__init__.py"), []byte("# same-version drift\n"), 0o644))
+
+	var results []checkResult
+	warnings := doctorHermesIntegration(func(name, status, msg string) {
+		results = append(results, checkResult{Name: name, Status: status, Message: msg})
+	}, "http://127.0.0.1:9090", "test-token")
+	if warnings != 2 || !strings.Contains(doctorResultText(results), "do not match the plugin bundled") {
+		t.Fatalf("expected missing-binary plus bundled-payload warnings, got warnings=%d results=%+v", warnings, results)
+	}
+}
+
 func TestDoctorHermesIntegrationWarnsOnToolModeAndRiskyFailOpen(t *testing.T) {
 	home, _ := setupHermesDoctorFixture(t, `plugins:
   enabled:
@@ -1032,13 +1063,7 @@ func setupHermesDoctorFixture(t *testing.T, config string) (home string, hermesH
 	hermesHome = filepath.Join(home, "hermes")
 	t.Setenv("HERMES_HOME", hermesHome)
 	pluginDir := filepath.Join(hermesHome, "plugins", "rampart")
-	requireNoErr(t, os.MkdirAll(pluginDir, 0o755))
-	requireNoErr(t, os.WriteFile(filepath.Join(pluginDir, "plugin.yaml"), []byte(`name: rampart
-version: 1.2.0
-provides_hooks:
-  - pre_tool_call
-`), 0o644))
-	requireNoErr(t, os.WriteFile(filepath.Join(pluginDir, "__init__.py"), []byte("def register(ctx):\n    pass\n"), 0o644))
+	requireNoErr(t, hermesplugin.Extract(pluginDir))
 	requireNoErr(t, os.WriteFile(filepath.Join(hermesHome, "config.yaml"), []byte(config), 0o644))
 	return home, hermesHome
 }
@@ -1077,32 +1102,6 @@ func TestNormalizedReleaseVersionAcceptance(t *testing.T) {
 		_, got := normalizedReleaseVersion(tt.version)
 		if got != tt.want {
 			t.Fatalf("normalizedReleaseVersion(%q) accepted = %v, want %v", tt.version, got, tt.want)
-		}
-	}
-}
-
-func TestPluginVersionMatchesBuildVersion(t *testing.T) {
-	tests := []struct {
-		manifest string
-		build    string
-		want     bool
-	}{
-		{"0.9.22", "v0.9.22", true},
-		{"0.9.22", "0.9.22", true},
-		{"0.9.22", "v0.9.23", false},
-		{"1.0.0-rc.1", "v1.0.0-rc.1", true},
-		{"1.0.0-rc.2", "v1.0.0-rc.3", false},
-		{"1.0.0-rc.2", "v1.0.0", false},
-		{"1.0.0", "v1.0.0-rc.2", false},
-		{"0.9.22", "v1.0.0-rc.1", false},
-		{"0.9.22", "v0.9.22-staging-47fa0cf", true},
-		{"0.9.22", "v0.9.22-33-g47fa0cf", true},
-		{"0.9.22", "v0.9.22-0.20260503052103-a72c3452fe38", true},
-		{"0.9.22", "dev", true},
-	}
-	for _, tt := range tests {
-		if got := pluginVersionMatchesBuildVersion(tt.manifest, tt.build); got != tt.want {
-			t.Fatalf("pluginVersionMatchesBuildVersion(%q, %q) = %v, want %v", tt.manifest, tt.build, got, tt.want)
 		}
 	}
 }

--- a/cmd/rampart/cli/integration_driver.go
+++ b/cmd/rampart/cli/integration_driver.go
@@ -20,21 +20,24 @@ import (
 // deliberately contains only lifecycle operations shared by the CLI. Tool
 // payload normalization remains in the adapter that owns the host protocol.
 type integrationDriver struct {
-	ID              string
-	Aliases         []string
-	DisplayName     string
-	Boundary        string
-	VerifyTarget    string
-	ProofLevel      assuranceLevel
-	Executables     []string
-	Installed       func(home string) bool
-	SetupCommand    func(opts *rootOptions) *cobra.Command
-	VerifyChecks    func(ctx context.Context, timeout time.Duration) []verificationCheck
-	OpenClaw        bool
-	AutoProtect     bool
-	ServiceRequired bool
-	Platforms       []string
-	Configured      func(home string) bool
+	ID           string
+	Aliases      []string
+	DisplayName  string
+	Boundary     string
+	VerifyTarget string
+	// VerificationCommand names the non-behavioral proof command for drivers
+	// that cannot safely participate in `rampart verify --all`.
+	VerificationCommand string
+	ProofLevel          assuranceLevel
+	Executables         []string
+	Installed           func(home string) bool
+	SetupCommand        func(opts *rootOptions) *cobra.Command
+	VerifyChecks        func(ctx context.Context, timeout time.Duration) []verificationCheck
+	OpenClaw            bool
+	AutoProtect         bool
+	ServiceRequired     bool
+	Platforms           []string
+	Configured          func(home string) bool
 }
 
 func supportedIntegrationDrivers() []integrationDriver {
@@ -73,6 +76,24 @@ func supportedIntegrationDrivers() []integrationDriver {
 			Configured:   codexHooksConfiguredForHome,
 			VerifyChecks: func(ctx context.Context, _ time.Duration) []verificationCheck {
 				return []verificationCheck{verifyCodexHooksInstalled(), verifyCodexHookAdapter(ctx)}
+			},
+		},
+		{
+			ID: "hermes", DisplayName: "Hermes Agent", Boundary: "experimental native plugin",
+			VerificationCommand: "rampart doctor", Executables: []string{"hermes"},
+			AutoProtect: false, ServiceRequired: true, Platforms: []string{"linux", "darwin"},
+			Installed: func(home string) bool {
+				state := detectHermesPluginStateForHome(home)
+				if state.Installed {
+					return true
+				}
+				_, err := execLookPath("hermes")
+				return err == nil
+			},
+			SetupCommand: func(_ *rootOptions) *cobra.Command { return newSetupHermesCmd() },
+			Configured: func(home string) bool {
+				state := detectHermesPluginStateForHome(home)
+				return state.Installed && state.Enabled && state.ManifestValid && state.HookDeclared
 			},
 		},
 		{
@@ -170,6 +191,16 @@ func integrationDriverSupportsPlatform(driver integrationDriver, goos string) bo
 		}
 	}
 	return false
+}
+
+func integrationDriverVerificationCommand(driver integrationDriver) string {
+	if command := strings.TrimSpace(driver.VerificationCommand); command != "" {
+		return command
+	}
+	if target := strings.TrimSpace(driver.VerifyTarget); target != "" && driver.VerifyChecks != nil {
+		return "rampart verify " + target
+	}
+	return ""
 }
 
 func detectInstalledIntegrationDrivers() ([]integrationDriver, error) {

--- a/cmd/rampart/cli/integration_driver_test.go
+++ b/cmd/rampart/cli/integration_driver_test.go
@@ -43,15 +43,25 @@ func TestIntegrationDriversMatchAssuranceManifest(t *testing.T) {
 		if driver.DisplayName != integration.DisplayName {
 			t.Errorf("driver %q display name = %q, manifest = %q", driver.ID, driver.DisplayName, integration.DisplayName)
 		}
-		if driver.VerifyTarget != integration.ID {
-			t.Errorf("driver %q verify target = %q, manifest id = %q", driver.ID, driver.VerifyTarget, integration.ID)
-		}
-		wantProof := assuranceAdapterVerified
-		if integration.Verification.HostBoundary && integration.Verification.Command == "rampart verify "+driver.VerifyTarget {
-			wantProof = assuranceHostVerified
-		}
-		if driver.ProofLevel != wantProof {
-			t.Errorf("driver %q proof level = %q, manifest host boundary = %t", driver.ID, driver.ProofLevel, integration.Verification.HostBoundary)
+		activeVerification := integration.Verification.Level == "active"
+		if activeVerification {
+			if driver.VerifyTarget != integration.ID || driver.VerifyChecks == nil {
+				t.Errorf("driver %q active verification target/checks = %q/%t, want %q/true", driver.ID, driver.VerifyTarget, driver.VerifyChecks != nil, integration.ID)
+			}
+			wantProof := assuranceAdapterVerified
+			if integration.Verification.HostBoundary && integration.Verification.Command == "rampart verify "+driver.VerifyTarget {
+				wantProof = assuranceHostVerified
+			}
+			if driver.ProofLevel != wantProof {
+				t.Errorf("driver %q proof level = %q, manifest host boundary = %t", driver.ID, driver.ProofLevel, integration.Verification.HostBoundary)
+			}
+		} else {
+			if driver.VerifyTarget != "" || driver.VerifyChecks != nil {
+				t.Errorf("driver %q must not advertise behavioral verification for manifest level %q", driver.ID, integration.Verification.Level)
+			}
+			if got := integrationDriverVerificationCommand(driver); got != integration.Verification.Command {
+				t.Errorf("driver %q verification command = %q, manifest = %q", driver.ID, got, integration.Verification.Command)
+			}
 		}
 		if len(driver.Executables) == 0 {
 			t.Errorf("driver %q has no executable identity for receipt invalidation", driver.ID)
@@ -139,8 +149,9 @@ func TestFindIntegrationDriverResolvesCanonicalIDsAndAliases(t *testing.T) {
 	if !ok || gemini.AutoProtect {
 		t.Fatal("experimental Gemini CLI must remain explicit setup/verification, not zero-configuration protection")
 	}
-	if _, ok := findIntegrationDriver("hermes"); ok {
-		t.Fatal("experimental Hermes must not be advertised as zero-configuration protection")
+	hermes, ok := findIntegrationDriver("hermes")
+	if !ok || hermes.AutoProtect || hermes.VerifyTarget != "" || hermes.VerifyChecks != nil || integrationDriverVerificationCommand(hermes) != "rampart doctor" {
+		t.Fatal("experimental Hermes must use explicit setup and static verification without entering verify --all")
 	}
 }
 

--- a/cmd/rampart/cli/verify.go
+++ b/cmd/rampart/cli/verify.go
@@ -177,6 +177,13 @@ implementation.`,
 				if !ok {
 					return fmt.Errorf("verify: unsupported target %q (supported: openclaw, claude-code, cline, codex, gemini, antigravity, copilot, policy)", target)
 				}
+				if strings.TrimSpace(driver.VerifyTarget) == "" || driver.VerifyChecks == nil {
+					command := integrationDriverVerificationCommand(driver)
+					if command == "" {
+						command = "rampart doctor"
+					}
+					return fmt.Errorf("verify: %s has static verification only; run `%s`", driver.DisplayName, command)
+				}
 				target = driver.VerifyTarget
 			}
 
@@ -217,13 +224,11 @@ func configuredVerificationTargets(home string) []string {
 	targets := []string{"policy"}
 	seen := map[string]struct{}{"policy": {}}
 	for _, driver := range supportedIntegrationDrivers() {
-		if !integrationDriverSupportsPlatform(driver, runtime.GOOS) || driver.Configured == nil || !driver.Configured(home) {
+		if !integrationDriverSupportsPlatform(driver, runtime.GOOS) || driver.Configured == nil || !driver.Configured(home) ||
+			strings.TrimSpace(driver.VerifyTarget) == "" || driver.VerifyChecks == nil {
 			continue
 		}
 		target := strings.TrimSpace(driver.VerifyTarget)
-		if target == "" {
-			target = driver.ID
-		}
 		if _, exists := seen[target]; exists {
 			continue
 		}

--- a/cmd/rampart/cli/verify_test.go
+++ b/cmd/rampart/cli/verify_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	hermesplugin "github.com/peg/rampart/internal/plugin/hermes"
 	ocplugin "github.com/peg/rampart/internal/plugin/openclaw"
 )
 
@@ -27,10 +28,17 @@ func TestConfiguredVerificationTargetsIncludesPolicyAndConfiguredHooks(t *testin
 	if err := installCodexHooks(hooksPath, command, commandWindows, false); err != nil {
 		t.Fatal(err)
 	}
+	hermesHome := filepath.Join(home, ".hermes")
+	if err := hermesplugin.Extract(filepath.Join(hermesHome, "plugins", "rampart")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(hermesHome, "config.yaml"), []byte("plugins:\n  enabled: [rampart]\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
 
 	targets := configuredVerificationTargets(home)
 	if got := strings.Join(targets, ","); got != "policy,codex" {
-		t.Fatalf("configured verification targets = %q, want policy,codex", got)
+		t.Fatalf("configured verification targets = %q, want policy,codex (static Hermes must be skipped)", got)
 	}
 }
 

--- a/docs-site/getting-started/troubleshooting.md
+++ b/docs-site/getting-started/troubleshooting.md
@@ -165,7 +165,8 @@ rampart test --tool read "/etc/shadow"
 
 ```bash
 openclaw plugins list
-# Should show: rampart  1.6.0  ✓ active
+# Should show the rampart plugin as active (its component version may differ
+# from the Rampart CLI patch version).
 
 rampart doctor
 # Should show: ✓ OpenClaw plugin: installed (before_tool_call hook active)

--- a/docs-site/index.html
+++ b/docs-site/index.html
@@ -27,7 +27,7 @@
       "url": "https://rampart.sh",
       "applicationCategory": "SecurityApplication",
       "operatingSystem": "Linux, macOS, Windows",
-      "softwareVersion": "1.6.0",
+      "softwareVersion": "1.6.1",
       "offers": {
         "@type": "Offer",
         "price": "0",
@@ -1114,7 +1114,7 @@
 <section class="hero">
     <div class="container hero-grid">
         <div>
-            <div class="eyebrow"><span class="eyebrow-dot"></span>v1.6.0 · verified agent boundaries</div>
+            <div class="eyebrow"><span class="eyebrow-dot"></span>v1.6.1 · verified agent boundaries</div>
             <h1>Your agent has root.<br><span class="accent">That’s the problem.</span></h1>
             <p class="hero-sub">Rampart sits in the execution path. Run <code>rampart protect openclaw</code> for a managed, fail-closed OpenClaw guard that verifies itself, or use <code>rampart quickstart</code> for other supported agents.</p>
             <div class="install-cluster">

--- a/docs-site/integrations/hermes.md
+++ b/docs-site/integrations/hermes.md
@@ -126,6 +126,10 @@ python scripts/compat-hermes-latest.py
 ```
 
 The harness creates a temporary Hermes state, installs the Rampart plugin there, exercises Hermes plugin discovery plus `pre_tool_call` dispatch, and verifies deny, allow, `ask` blocking, and fail-closed behavior without restarting any long-running Hermes gateway.
+By default it resolves Hermes' official latest stable GitHub release and uses
+an isolated editable checkout of that exact tag, the development install path
+Hermes permits. `--package` is an explicit maintainer
+override; it is not the definition of the latest supported Hermes release.
 
 Maintainers can also run the opt-in real-host harness:
 
@@ -157,6 +161,16 @@ contract and remaining gaps.
     can conservatively block an `ask` decision, but it cannot honestly promise
     a first-class pause and resume flow or fail-closed behavior after every
     host-level plugin failure.
+
+## Provider authentication errors
+
+If Hermes reports `Provider authentication failed`, the failure happened before
+Hermes attempted a tool call, so it is outside Rampart's policy boundary. From
+a terminal on the Hermes host, use `hermes auth status <provider>` to inspect the
+selected provider without printing credential values. Run `hermes model` to
+renew OAuth or replace an API key, then restart the long-running gateway so it
+loads the updated provider state. Do not paste raw gateway logs into a public
+issue; they can contain provider details.
 
 For manual verification, use a deny rule for a harmless command and confirm Hermes blocks it before execution:
 

--- a/docs-site/integrations/openclaw.md
+++ b/docs-site/integrations/openclaw.md
@@ -213,7 +213,8 @@ Or check plugin status directly:
 
 ```bash
 openclaw plugins list
-# rampart  v1.6.0  active
+# The rampart plugin should be active. Its component version can differ from
+# the Rampart CLI patch version when the embedded plugin did not change.
 ```
 
 ## Troubleshooting

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -138,6 +138,10 @@ policies/            Built-in profiles (standard, paranoid, yolo)
 
 **Pattern matching has gaps.** Common evasion techniques (shell wrappers like `bash -c`, quoted binaries, escaped characters) are handled via normalization and `command_contains` substring matching. However, novel obfuscation (`find / -delete`, variable expansion, encoded payloads) can bypass static patterns. Combine with [semantic verification](https://github.com/peg/rampart-verify) for intent-based classification.
 
-**Proxy mode is voluntary.** A compromised agent could bypass `localhost:9090` by making direct calls. `rampart wrap` is harder to bypass (it controls `$SHELL`), but not impossible. For mandatory enforcement, pair with network-level controls (iptables, network namespaces).
+**Compatibility boundaries are voluntary.** A compromised agent can bypass an
+HTTP proxy by making direct calls, and it can bypass `rampart wrap` by ignoring
+`$SHELL`, using an absolute shell path, or calling a process API directly. Use a
+native hook/plugin where one is supported. For mandatory process or network
+enforcement, pair Rampart with operating-system sandboxing or network controls.
 
 **Response-side evaluation is pattern-based.** Rampart scans tool responses for credential patterns (AWS keys, private keys, API tokens) using regex matching. This catches accidental credential leaks but is not a full DLP solution.

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -1,6 +1,6 @@
 # Threat Model
 
-> Last reviewed: 2026-08-07 | Applies to: v1.6.0+
+> Last reviewed: 2026-08-10 | Applies to: v1.6.1+
 
 Rampart is a policy engine for AI agents — not a sandbox, not a hypervisor, not a full isolation boundary. This document describes what Rampart protects against, what it doesn't, and why.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -27,7 +27,7 @@
       "url": "https://rampart.sh",
       "applicationCategory": "SecurityApplication",
       "operatingSystem": "Linux, macOS, Windows",
-      "softwareVersion": "1.6.0",
+      "softwareVersion": "1.6.1",
       "offers": {
         "@type": "Offer",
         "price": "0",
@@ -1114,7 +1114,7 @@
 <section class="hero">
     <div class="container hero-grid">
         <div>
-            <div class="eyebrow"><span class="eyebrow-dot"></span>v1.6.0 · verified agent boundaries</div>
+            <div class="eyebrow"><span class="eyebrow-dot"></span>v1.6.1 · verified agent boundaries</div>
             <h1>Your agent has root.<br><span class="accent">That’s the problem.</span></h1>
             <p class="hero-sub">Rampart sits in the execution path. Run <code>rampart protect openclaw</code> for a managed, fail-closed OpenClaw guard that verifies itself, or use <code>rampart quickstart</code> for other supported agents.</p>
             <div class="install-cluster">

--- a/internal/assurance/manifest.go
+++ b/internal/assurance/manifest.go
@@ -137,7 +137,7 @@ func (m *Manifest) Validate(repoRoot string) error {
 				problems = append(problems, prefix+": missing coverage."+surface)
 				continue
 			}
-			if !oneOf(value, "verified", "tested", "partial", "not_covered", "unknown") {
+			if !oneOf(value, "verified", "tested", "partial", "not_covered") {
 				problems = append(problems, prefix+": invalid coverage."+surface+" "+value)
 			}
 		}
@@ -153,7 +153,7 @@ func (m *Manifest) Validate(repoRoot string) error {
 				problems = append(problems, prefix+": missing degraded."+failure)
 				continue
 			}
-			if !oneOf(value, "deny", "allow", "local", "mixed", "host_defined", "unknown") {
+			if !oneOf(value, "deny", "allow", "local", "mixed", "host_defined") {
 				problems = append(problems, prefix+": invalid degraded."+failure+" "+value)
 			}
 		}
@@ -254,12 +254,12 @@ func needsLimitations(integration Integration) bool {
 		return true
 	}
 	for _, value := range integration.Coverage {
-		if value == "partial" || value == "not_covered" || value == "unknown" {
+		if value == "partial" || value == "not_covered" {
 			return true
 		}
 	}
 	for _, value := range integration.Degraded {
-		if value == "allow" || value == "mixed" || value == "host_defined" || value == "unknown" {
+		if value == "allow" || value == "mixed" || value == "host_defined" {
 			return true
 		}
 	}

--- a/internal/assurance/manifest_test.go
+++ b/internal/assurance/manifest_test.go
@@ -108,6 +108,20 @@ func TestCompletedLiveEvidenceMustBeJSON(t *testing.T) {
 	}
 }
 
+func TestManifestRejectsAmbiguousAssuranceStates(t *testing.T) {
+	root := repositoryRoot(t)
+	manifest, err := LoadManifest(filepath.Join(root, "assurance", "integrations.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest.Integrations[0].Coverage["mcp"] = "unknown"
+	manifest.Integrations[0].Degraded["adapter_error"] = "unknown"
+	err = manifest.Validate(root)
+	if err == nil || !strings.Contains(err.Error(), "invalid coverage.mcp unknown") || !strings.Contains(err.Error(), "invalid degraded.adapter_error unknown") {
+		t.Fatalf("expected ambiguous assurance states to be rejected, got %v", err)
+	}
+}
+
 func TestPublicSupportMatrixNamesEveryAssuredIntegration(t *testing.T) {
 	root := repositoryRoot(t)
 	manifest, err := LoadManifest(filepath.Join(root, "assurance", "integrations.yaml"))
@@ -162,16 +176,10 @@ func TestReleaseMetadataIsSynchronized(t *testing.T) {
 	version := string(matches[1])
 
 	expectations := map[string][]string{
-		"assurance/integrations.yaml":                   {"baseline_release: v" + version},
-		"internal/plugin/openclaw/package.json":         {`"version": "` + version + `"`},
-		"internal/plugin/openclaw/openclaw.plugin.json": {`"version": "` + version + `"`},
-		"internal/plugin/openclaw/index.js":             {`export const version = "` + version + `";`},
-		"internal/plugin/hermes/plugin.yaml":            {"version: " + version},
-		"internal/plugin/hermes/__init__.py":            {`VERSION = "` + version + `"`},
-		"policies/openclaw.yaml":                        {"# rampart-policy-version: " + version},
-		"docs-site/index.html":                          {`"softwareVersion": "` + version + `"`, "v" + version + " ·"},
-		"docs/index.html":                               {`"softwareVersion": "` + version + `"`, "v" + version + " ·"},
-		"docs/THREAT-MODEL.md":                          {"Applies to: v" + version},
+		"assurance/integrations.yaml": {"baseline_release: v" + version},
+		"docs-site/index.html":        {`"softwareVersion": "` + version + `"`, "v" + version + " ·"},
+		"docs/index.html":             {`"softwareVersion": "` + version + `"`, "v" + version + " ·"},
+		"docs/THREAT-MODEL.md":        {"Applies to: v" + version},
 	}
 	for name, required := range expectations {
 		data, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(name)))
@@ -184,6 +192,40 @@ func TestReleaseMetadataIsSynchronized(t *testing.T) {
 				t.Errorf("%s does not identify current release %s with %q", name, version, marker)
 			}
 		}
+	}
+}
+
+func TestBundledIntegrationVersionsAreInternallySynchronized(t *testing.T) {
+	root := repositoryRoot(t)
+	read := func(name string) string {
+		t.Helper()
+		data, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(name)))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		return string(data)
+	}
+	openClawPackage := read("internal/plugin/openclaw/package.json")
+	openClawVersion := regexp.MustCompile(`"version"\s*:\s*"([^"]+)"`).FindStringSubmatch(openClawPackage)
+	if len(openClawVersion) != 2 {
+		t.Fatal("OpenClaw package.json must declare a version")
+	}
+	for name, marker := range map[string]string{
+		"internal/plugin/openclaw/openclaw.plugin.json": `"version": "` + openClawVersion[1] + `"`,
+		"internal/plugin/openclaw/index.js":             `export const version = "` + openClawVersion[1] + `";`,
+	} {
+		if !strings.Contains(read(name), marker) {
+			t.Errorf("%s does not match bundled OpenClaw component version %s", name, openClawVersion[1])
+		}
+	}
+
+	hermesManifest := read("internal/plugin/hermes/plugin.yaml")
+	hermesVersion := regexp.MustCompile(`(?m)^version:\s*([^\s]+)\s*$`).FindStringSubmatch(hermesManifest)
+	if len(hermesVersion) != 2 {
+		t.Fatal("Hermes plugin.yaml must declare a version")
+	}
+	if marker := `VERSION = "` + hermesVersion[1] + `"`; !strings.Contains(read("internal/plugin/hermes/__init__.py"), marker) {
+		t.Errorf("Hermes runtime does not match bundled component version %s", hermesVersion[1])
 	}
 }
 
@@ -309,8 +351,8 @@ func TestVerifiedTierCannotUsePolicyOnlyEvidence(t *testing.T) {
 			UpstreamCI:   "none",
 			Approval:     "native",
 			Coverage: map[string]string{
-				"shell": "tested", "file_read": "unknown", "file_write": "unknown",
-				"network": "unknown", "mcp": "unknown", "subagents": "unknown",
+				"shell": "tested", "file_read": "not_covered", "file_write": "not_covered",
+				"network": "not_covered", "mcp": "not_covered", "subagents": "not_covered",
 			},
 			Degraded: map[string]string{
 				"policy_unavailable": "deny", "adapter_error": "deny", "timeout": "deny",

--- a/scripts/compat-hermes-latest.py
+++ b/scripts/compat-hermes-latest.py
@@ -67,6 +67,10 @@ URL_CHILD_ENV_KEYS = (
     "GOPROXY",
 )
 
+HERMES_RELEASE_API = "https://api.github.com/repos/NousResearch/hermes-agent/releases/latest"
+HERMES_RELEASE_TAG = re.compile(r"^v[0-9]{4}\.[0-9]{1,2}\.[0-9]{1,2}(?:\.[0-9]+)?$")
+HERMES_RELEASE_NAME = re.compile(r"^Hermes Agent v([0-9]+\.[0-9]+\.[0-9]+)(?:\s|$)")
+
 
 def credential_free_url_setting(value: str) -> str:
     """Return a URL/list setting only when none of its entries has userinfo."""
@@ -127,6 +131,9 @@ def build_compat_env(source: dict[str, str], home: Path, temp_dir: Path) -> dict
             "XDG_STATE_HOME": str(home / ".local" / "state"),
             "PIP_DISABLE_PIP_VERSION_CHECK": "1",
             "PYTHONNOUSERSITE": "1",
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_TERMINAL_PROMPT": "0",
         }
     )
     return env
@@ -262,6 +269,7 @@ def make_venv(
     package: str,
     env: dict[str, str],
     base_python: str | None = None,
+    editable: bool = False,
 ) -> tuple[Path, Path]:
     venv_dir = root / "venv"
     resolved_python = resolve_executable(base_python or sys.executable)
@@ -269,7 +277,11 @@ def make_venv(
     python = venv_dir / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
     hermes = venv_dir / ("Scripts/hermes.exe" if os.name == "nt" else "bin/hermes")
     run([str(python), "-m", "pip", "install", "--upgrade", "pip"], env=env, cwd=root)
-    run([str(python), "-m", "pip", "install", package], env=env, cwd=root)
+    install = [str(python), "-m", "pip", "install"]
+    if editable:
+        install.append("--editable")
+    install.append(package)
+    run(install, env=env, cwd=root)
     return python, hermes
 
 
@@ -285,12 +297,9 @@ def distribution_version(python: Path, distribution: str, env: dict[str, str]) -
     return result.stdout.strip()
 
 
-def pypi_latest_version(distribution: str, env: dict[str, str]) -> str:
-    name = urllib.parse.quote(distribution, safe="")
-    request = urllib.request.Request(
-        f"https://pypi.org/pypi/{name}/json",
-        headers={"User-Agent": "rampart-hermes-compat/1"},
-    )
+def url_opener(env: dict[str, str]) -> urllib.request.OpenerDirector:
+    """Build an opener from the already credential-scrubbed environment."""
+
     proxies: dict[str, str] = {}
     all_proxy = env.get("all_proxy") or env.get("ALL_PROXY")
     for scheme in ("http", "https"):
@@ -301,10 +310,33 @@ def pypi_latest_version(distribution: str, env: dict[str, str]) -> str:
         )
         if value:
             proxies[scheme] = value
-    opener = urllib.request.build_opener(urllib.request.ProxyHandler(proxies))
-    with opener.open(request, timeout=15) as response:
+    return urllib.request.build_opener(urllib.request.ProxyHandler(proxies))
+
+
+def github_latest_release(env: dict[str, str]) -> tuple[str, str, str]:
+    """Resolve Hermes' official stable GitHub release and exact source checkout."""
+
+    request = urllib.request.Request(
+        HERMES_RELEASE_API,
+        headers={"User-Agent": "rampart-hermes-compat/1"},
+    )
+    with url_opener(env).open(request, timeout=15) as response:
         payload = json.load(response)
-    return str(payload["info"]["version"])
+    if payload.get("draft") or payload.get("prerelease"):
+        raise RuntimeError("Hermes latest release API returned a draft or prerelease")
+    tag = str(payload.get("tag_name", ""))
+    name = str(payload.get("name", ""))
+    if not HERMES_RELEASE_TAG.fullmatch(tag):
+        raise RuntimeError(f"Hermes latest release returned an invalid tag: {tag!r}")
+    version_match = HERMES_RELEASE_NAME.match(name)
+    if not version_match:
+        raise RuntimeError(f"Hermes latest release returned an invalid name: {name!r}")
+    source = (
+        "git+https://github.com/NousResearch/hermes-agent.git@"
+        + urllib.parse.quote(tag, safe="")
+        + "#egg=hermes-agent"
+    )
+    return tag, version_match.group(1), source
 
 
 def free_port() -> int:
@@ -426,7 +458,10 @@ def child_probe_code(unused_port: int) -> str:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Validate Rampart's Hermes plugin against an isolated latest Hermes runtime.")
-    parser.add_argument("--package", default="hermes-agent", help="pip package spec to install, default: hermes-agent")
+    parser.add_argument(
+        "--package",
+        help="Explicit pip package spec to test instead of Hermes' official latest GitHub release",
+    )
     parser.add_argument("--python", help="Base Python interpreter used to create the isolated environment")
     parser.add_argument("--hermes-python", help="Use an existing Python interpreter with Hermes installed instead of creating a venv")
     parser.add_argument("--hermes-bin", help="Hermes executable to report version from when --hermes-python is used")
@@ -442,7 +477,8 @@ def main() -> int:
         env = build_compat_env(dict(os.environ), home, child_temp)
 
         installed_package_version = None
-        published_package_version = None
+        official_release_version = None
+        official_release_tag = None
         if args.hermes_python:
             hermes_python = resolve_executable(args.hermes_python)
             hermes_bin_path = resolve_executable(args.hermes_bin) if args.hermes_bin else None
@@ -450,15 +486,18 @@ def main() -> int:
                 hermes_bin = shutil.which("hermes")
                 hermes_bin_path = Path(hermes_bin) if hermes_bin else None
         else:
-            hermes_python, hermes_bin_path = make_venv(temp, args.package, env, args.python)
-            if args.package == "hermes-agent":
+            package = args.package
+            editable = False
+            if package is None:
+                official_release_tag, official_release_version, package = github_latest_release(env)
+                editable = True
+            hermes_python, hermes_bin_path = make_venv(temp, package, env, args.python, editable=editable)
+            if args.package is None:
                 installed_package_version = distribution_version(hermes_python, "hermes-agent", env)
-                published_package_version = pypi_latest_version("hermes-agent", env)
-                if installed_package_version != published_package_version:
+                if installed_package_version != official_release_version:
                     raise RuntimeError(
-                        "hermes-agent resolved to "
-                        f"{installed_package_version}, but PyPI latest is {published_package_version}; "
-                        "use a Python version supported by the latest Hermes release"
+                        f"Hermes release {official_release_tag} installed distribution "
+                        f"{installed_package_version}, expected {official_release_version}"
                     )
 
         hermes_home = temp / "hermes-home"
@@ -536,7 +575,8 @@ def main() -> int:
                         "ok": True,
                         "hermes_version": hermes_version,
                         "installed_package_version": installed_package_version,
-                        "published_package_version": published_package_version,
+                        "official_release_version": official_release_version,
+                        "official_release_tag": official_release_tag,
                         "hermes_home_isolated": str(hermes_home),
                         "plugin_dir": str(plugin_dir),
                         "requests_seen": RampartStub.requests_seen,

--- a/scripts/test_compat_hermes_env.py
+++ b/scripts/test_compat_hermes_env.py
@@ -4,7 +4,11 @@
 from __future__ import annotations
 
 import importlib.util
+import io
+import json
+import os
 import unittest
+from unittest import mock
 from pathlib import Path
 
 
@@ -43,6 +47,9 @@ class CompatEnvironmentTests(unittest.TestCase):
         self.assertEqual(env["TMPDIR"], "/tmp/isolated-tmp")
         self.assertEqual(env["NO_PROXY"], "127.0.0.1,localhost,::1")
         self.assertEqual(env["no_proxy"], env["NO_PROXY"])
+        self.assertEqual(env["GIT_CONFIG_NOSYSTEM"], "1")
+        self.assertEqual(env["GIT_CONFIG_GLOBAL"], os.devnull)
+        self.assertEqual(env["GIT_TERMINAL_PROMPT"], "0")
         for key in (
             "HTTP_PROXY",
             "ALL_PROXY",
@@ -55,6 +62,42 @@ class CompatEnvironmentTests(unittest.TestCase):
             "PIP_TRUSTED_HOST",
         ):
             self.assertNotIn(key, env)
+
+    def test_official_release_resolves_validated_github_checkout(self) -> None:
+        payload = {
+            "tag_name": "v2026.8.3",
+            "name": "Hermes Agent v0.20.0 (2026.8.3)",
+            "draft": False,
+            "prerelease": False,
+        }
+        response = mock.MagicMock()
+        response.__enter__.return_value = io.BytesIO(json.dumps(payload).encode())
+        opener = mock.Mock()
+        opener.open.return_value = response
+        with mock.patch.object(MODULE, "url_opener", return_value=opener):
+            tag, version, source = MODULE.github_latest_release({})
+
+        self.assertEqual(tag, "v2026.8.3")
+        self.assertEqual(version, "0.20.0")
+        self.assertEqual(
+            source,
+            "git+https://github.com/NousResearch/hermes-agent.git@v2026.8.3#egg=hermes-agent",
+        )
+
+    def test_official_release_rejects_untrusted_metadata(self) -> None:
+        for payload in (
+            {"tag_name": "../../main", "name": "Hermes Agent v0.20.0", "draft": False, "prerelease": False},
+            {"tag_name": "v2026.8.3", "name": "Hermes 0.20.0", "draft": False, "prerelease": False},
+            {"tag_name": "v2026.8.3", "name": "Hermes Agent v0.20.0", "draft": False, "prerelease": True},
+        ):
+            with self.subTest(payload=payload):
+                response = mock.MagicMock()
+                response.__enter__.return_value = io.BytesIO(json.dumps(payload).encode())
+                opener = mock.Mock()
+                opener.open.return_value = response
+                with mock.patch.object(MODULE, "url_opener", return_value=opener):
+                    with self.assertRaises(RuntimeError):
+                        MODULE.github_latest_release({})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- eliminates indefinite unknown assurance states and records each surface as evidenced, partial, not covered, or host-defined
- brings experimental Hermes into the common status registry while keeping static verification out of verify --all
- compares installed OpenClaw and Hermes files with the exact bundled plugin payload instead of the Rampart core patch version
- follows the official stable Hermes GitHub release channel with a credential-free tagged checkout
- reconciles v1.6.1 release metadata and corrects stale architecture and maintenance documentation

## Validation

- full Go race suite
- go vet and production build
- security-assurance gate
- focused CLI, manifest, and plugin suites
- official Hermes Agent 0.20.0 / v2026.8.3 isolated dispatcher gate: deny, allow, ask blocking, auth-error fail-closed, and multi-path deny-wins
- documentation source synchronization, formatting, and diff checks

## Live host note

The reported Hermes provider-authentication message occurs before tool dispatch and is not a Rampart denial. Agent01 remains offline on Tailscale, and the available SSH identities on this Mac are not authorized on the online Proxmox nodes, so no live credentials, memories, sessions, or gateway configuration were read or changed.