### PR TITLE
ci: coordinate dependency and Go toolchain updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,10 @@
+# Ordinary version updates flow through staging. GitHub still opens security
+# update pull requests against the default branch.
 version: 2
 updates:
   - package-ecosystem: gomod
     directory: /
+    target-branch: staging
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
@@ -12,18 +15,22 @@ updates:
 
   - package-ecosystem: docker
     directory: /
+    target-branch: staging
     schedule:
       interval: weekly
     open-pull-requests-limit: 3
+    # CI requires Docker Go updates to include the matching go.mod change.
 
   - package-ecosystem: github-actions
     directory: /
+    target-branch: staging
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
 
   - package-ecosystem: pip
     directory: /
+    target-branch: staging
     schedule:
       interval: weekly
     open-pull-requests-limit: 3
@@ -32,6 +39,7 @@ updates:
 
   - package-ecosystem: pip
     directory: /sdks/python
+    target-branch: staging
     schedule:
       interval: weekly
     open-pull-requests-limit: 3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,14 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Go toolchain pins are synchronized
+        if: runner.os == 'Linux'
+        run: scripts/check-toolchain-sync.sh
+
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.25.12'
+          go-version-file: go.mod
 
       - name: Set up Node
         if: runner.os != 'Windows'
@@ -239,7 +243,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.25.12'
+          go-version-file: go.mod
 
       - name: GoReleaser snapshot (all platforms, no publish)
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: "1.25.12"
+          go-version-file: go.mod
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7

--- a/.github/workflows/upstream-compat.yml
+++ b/.github/workflows/upstream-compat.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.25.12'
+          go-version-file: go.mod
 
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -55,7 +55,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.25.12'
+          go-version-file: go.mod
 
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -77,7 +77,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.25.12'
+          go-version-file: go.mod
 
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -99,7 +99,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.25.12'
+          go-version-file: go.mod
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -121,7 +121,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.25.12'
+          go-version-file: go.mod
 
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -165,7 +165,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.25.12'
+          go-version-file: go.mod
 
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ LDFLAGS  = -s -w \
 	-X github.com/peg/rampart/internal/build.Commit=$(COMMIT) \
 	-X github.com/peg/rampart/internal/build.Date=$(DATE)
 
-.PHONY: build test vet clean linux security-assurance
+.PHONY: build test vet clean linux toolchain-check security-assurance
 
 build:
 	go build -ldflags "$(LDFLAGS)" -o rampart ./cmd/rampart
@@ -23,5 +23,8 @@ vet:
 clean:
 	rm -f rampart rampart-linux
 
-security-assurance:
+toolchain-check:
+	scripts/check-toolchain-sync.sh
+
+security-assurance: toolchain-check
 	scripts/security-assurance.sh

--- a/scripts/check-toolchain-sync.sh
+++ b/scripts/check-toolchain-sync.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+set -eu
+
+go_directive=$(sed -n 's/^go[[:space:]][[:space:]]*\([0-9][0-9.]*\)$/\1/p' go.mod)
+toolchain_directive=$(sed -n 's/^toolchain[[:space:]][[:space:]]*go\([0-9][0-9.]*\)$/\1/p' go.mod)
+toolchain_count=$(sed -n '/^toolchain[[:space:]]/p' go.mod | wc -l | tr -d ' ')
+docker_version=$(sed -n 's/.*golang:\([0-9][0-9.]*\)-bookworm.*/\1/p' Dockerfile)
+
+if [ -z "$go_directive" ]; then
+  echo 'Could not read the Go toolchain version from go.mod.' >&2
+  exit 1
+fi
+
+if [ "$toolchain_count" -gt 1 ] || { [ "$toolchain_count" -eq 1 ] && [ -z "$toolchain_directive" ]; }; then
+  echo 'go.mod contains an unsupported or ambiguous toolchain directive.' >&2
+  echo 'Rampart release builds must use one stable numeric Go toolchain.' >&2
+  exit 1
+fi
+
+if [ -n "$toolchain_directive" ]; then
+  effective_version=$toolchain_directive
+else
+  effective_version=$go_directive
+fi
+
+if [ -z "$docker_version" ]; then
+  echo 'Could not read the Go toolchain version from Dockerfile.' >&2
+  exit 1
+fi
+
+if [ "$effective_version" != "$docker_version" ]; then
+  echo "Go toolchain mismatch: go.mod selects $effective_version but Dockerfile uses $docker_version." >&2
+  echo 'Update the complete Rampart toolchain in one coordinated change.' >&2
+  exit 1
+fi
+
+echo "Go toolchain pins agree on $effective_version."


### PR DESCRIPTION
## Summary

- route ordinary Dependabot version updates through `staging` while preserving GitHub security updates against `main`
- make every Actions Go setup read the canonical version from `go.mod`
- fail CI and local security assurance when the effective Go toolchain and Docker builder diverge

PR #372 was closed separately and Dependabot was told to suppress the incomplete Go 1.26.x Docker-only line. A private support monitor will prepare a coordinated toolchain PR when the current Go line leaves the supported window.

## Validation

- `go test ./...`
- `go vet ./...`
- `make security-assurance`
- actionlint v1.7.12
- Dependabot YAML structure check
- positive, mismatch, stable `toolchain`, and RC fail-closed cases for `check-toolchain-sync.sh`
- `git diff --check`