### PR TITLE
chore: isolate local maintainer state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,10 @@ __pycache__/
 *.swp
 *~
 
+# Local maintainer workspace
+/AGENTS.md
+/_tmp/
+
 # OS
 .DS_Store
 Thumbs.db

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -361,7 +361,8 @@ func TestCleanup_EmptyDir(t *testing.T) {
 }
 
 func TestCleanup_NonExistentDir(t *testing.T) {
-	m := NewManager("/tmp/rampart-test-nonexistent-cleanup-dir-xyz", "", slog.Default())
+	dir := filepath.Join(t.TempDir(), "missing")
+	m := NewManager(dir, "", slog.Default())
 	// Should not return error — directory just doesn't exist yet.
 	if err := m.Cleanup(24 * time.Hour); err != nil {
 		t.Fatalf("Cleanup on nonexistent dir: %v", err)


### PR DESCRIPTION
## Summary

- ignore only the root-level private maintainer guide and scratch workspace
- make the nonexistent-session-directory test use an isolated temporary path
- avoid broad ignore patterns that could hide legitimate public fixtures or evidence

## Why

The fixed global temporary path could collide across users or repeated test runs. The isolated child of `t.TempDir()` preserves the test's nonexistent-directory behavior while remaining cross-platform and self-cleaning.

## Validation

- `go test ./...`
- `go vet ./...`
- `make security-assurance`
- focused cleanup test repeated 20 times
- `git diff --check`

