### PR TITLE
feat: unify managed protection lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -714,7 +714,7 @@ rampart protect                             # Detect, configure, and verify supp
 rampart verify --all                        # Safely verify policy + configured active-verifier integrations
 rampart protect openclaw                    # Zero-config guard + live behavioral verification
 rampart verify openclaw                     # Re-run safe canaries through the live plugin
-rampart quickstart                           # Auto-detect, install, configure, health check
+rampart quickstart                           # Deprecated compatibility flow; prefer protect
 rampart setup claude-code                    # Claude Code native hooks
 rampart setup cline                          # Cline native hooks
 rampart setup openclaw                       # Advanced/manual OpenClaw integration management

--- a/cmd/rampart/cli/protect.go
+++ b/cmd/rampart/cli/protect.go
@@ -44,23 +44,18 @@ Without an agent argument, Rampart detects installed supported agents and
 protects each one through its strongest available native boundary.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := ensureDefaultRampartDirAccessible(); err != nil {
-				return fmt.Errorf("protect: prepare Rampart data directory: %w", err)
+			if err := prepareManagedProtection(rootOpts); err != nil {
+				return err
 			}
 			target := ""
 			if len(args) == 1 {
 				target = strings.ToLower(strings.TrimSpace(args[0]))
 			}
-			var drivers []integrationDriver
+			drivers, err := resolveProtectionTargets(target)
+			if err != nil {
+				return err
+			}
 			if target == "" {
-				detected, err := detectInstalledIntegrationDrivers()
-				if err != nil {
-					return fmt.Errorf("protect: detect installed agents: %w", err)
-				}
-				if len(detected) == 0 {
-					return fmt.Errorf("protect: no supported agent detected (supported: OpenClaw, Claude Code, Codex, Antigravity, GitHub Copilot, Cline; Gemini CLI and Hermes remain experimental)")
-				}
-				drivers = detected
 				fmt.Fprintf(cmd.OutOrStdout(), "Detected %d supported agent(s): ", len(drivers))
 				for i, driver := range drivers {
 					if i > 0 {
@@ -70,42 +65,20 @@ protects each one through its strongest available native boundary.`,
 				}
 				fmt.Fprintln(cmd.OutOrStdout())
 			} else {
-				driver, ok := findIntegrationDriver(target)
-				if !ok {
-					return fmt.Errorf("protect: unsupported target %q (supported: openclaw, claude-code, codex, antigravity, copilot, cline; Gemini CLI and Hermes remain experimental)", target)
-				}
-				if !driver.AutoProtect {
-					return fmt.Errorf("protect: %s remains experimental; use `rampart setup %s` and `rampart verify %s` for explicit testing", driver.DisplayName, driver.ID, driver.VerifyTarget)
-				}
-				if !integrationDriverSupportsPlatform(driver, runtime.GOOS) {
-					return fmt.Errorf("protect: %s is not supported on %s", driver.DisplayName, runtime.GOOS)
-				}
-				home, err := os.UserHomeDir()
-				if err != nil {
-					return fmt.Errorf("protect: resolve home: %w", err)
-				}
-				if driver.Installed == nil || !driver.Installed(home) {
-					return fmt.Errorf("protect: %s was not found; install it first, then rerun `rampart protect %s`", driver.DisplayName, driver.ID)
-				}
-				drivers = []integrationDriver{driver}
+				driver := drivers[0]
 				if !driver.OpenClaw && (cmd.Flags().Changed("no-restart") || cmd.Flags().Changed("reinstall")) {
 					return fmt.Errorf("protect: --no-restart and --reinstall apply only to OpenClaw")
 				}
 			}
 
-			var protectErrors []error
-			for _, driver := range drivers {
-				if driver.OpenClaw {
-					if err := runProtectOpenClaw(cmd, protectOpenClawOptions{NoRestart: noRestart, NoVerify: noVerify, Reinstall: reinstall, ServeURL: serveURL, Timeout: timeout}); err != nil {
-						protectErrors = append(protectErrors, fmt.Errorf("%s: %w", driver.DisplayName, err))
-					}
-					continue
-				}
-				if err := runProtectHookDriver(cmd, rootOpts, driver, protectHookOptions{NoVerify: noVerify, ServeURL: serveURL, Timeout: timeout}); err != nil {
-					protectErrors = append(protectErrors, fmt.Errorf("%s: %w", driver.DisplayName, err))
-				}
-			}
-			return errors.Join(protectErrors...)
+			_, err = runProtectionPlan(cmd, rootOpts, drivers, protectionPlanOptions{
+				NoRestart: noRestart,
+				NoVerify:  noVerify,
+				Reinstall: reinstall,
+				ServeURL:  serveURL,
+				Timeout:   timeout,
+			})
+			return err
 		},
 	}
 
@@ -117,6 +90,157 @@ protects each one through its strongest available native boundary.`,
 	return cmd
 }
 
+func resolveProtectionTargets(target string) ([]integrationDriver, error) {
+	target = strings.ToLower(strings.TrimSpace(target))
+	if target == "" {
+		drivers, err := detectInstalledIntegrationDrivers()
+		if err != nil {
+			return nil, fmt.Errorf("protect: detect installed agents: %w", err)
+		}
+		if len(drivers) == 0 {
+			return nil, fmt.Errorf("protect: no supported agent detected (supported: OpenClaw, Claude Code, Codex, Antigravity, GitHub Copilot, Cline; Gemini CLI and Hermes remain experimental)")
+		}
+		return drivers, nil
+	}
+
+	driver, ok := findIntegrationDriver(target)
+	if !ok {
+		return nil, fmt.Errorf("protect: unsupported target %q (supported: openclaw, claude-code, codex, antigravity, copilot, cline; Gemini CLI and Hermes remain experimental)", target)
+	}
+	if !driver.AutoProtect {
+		verification := integrationDriverVerificationCommand(driver)
+		if verification == "" {
+			verification = "rampart doctor"
+		}
+		return nil, fmt.Errorf("protect: %s remains experimental; use `rampart setup %s` and `%s` for explicit testing", driver.DisplayName, driver.ID, verification)
+	}
+	if !integrationDriverSupportsPlatform(driver, runtime.GOOS) {
+		return nil, fmt.Errorf("protect: %s is not supported on %s", driver.DisplayName, runtime.GOOS)
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("protect: resolve home: %w", err)
+	}
+	if driver.Installed == nil || !driver.Installed(home) {
+		return nil, fmt.Errorf("protect: %s was not found; install it first, then rerun `rampart protect %s`", driver.DisplayName, driver.ID)
+	}
+	return []integrationDriver{driver}, nil
+}
+
+type protectionPlanOptions struct {
+	NoRestart bool
+	NoVerify  bool
+	Reinstall bool
+	ServeURL  string
+	Timeout   time.Duration
+}
+
+type protectionPlanSummary struct {
+	Attempted int
+	Succeeded int
+}
+
+// runProtectionPlan is the single managed setup-and-verification path used by
+// protect and compatibility onboarding commands. Global Guard installation is
+// performed once, while each integration retains ownership of its host-specific
+// transaction and verification semantics.
+func runProtectionPlan(cmd *cobra.Command, rootOpts *rootOptions, drivers []integrationDriver, opts protectionPlanOptions) (protectionPlanSummary, error) {
+	summary := protectionPlanSummary{Attempted: len(drivers)}
+	if err := prepareManagedProtection(rootOpts); err != nil {
+		return summary, err
+	}
+	resolvedURL, err := resolveServeURLStrict(opts.ServeURL, fmt.Sprintf("http://localhost:%d", defaultServePort))
+	if err != nil {
+		return summary, fmt.Errorf("protect: resolve serve URL: %w", err)
+	}
+	guardPath, err := installManagedGuardPolicy()
+	if err != nil {
+		return summary, fmt.Errorf("protect: install managed Guard policy: %w", err)
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "✓ Managed Guard policy installed at %s\n", guardPath)
+
+	ordered := make([]integrationDriver, 0, len(drivers))
+	for _, driver := range drivers {
+		if driver.OpenClaw {
+			ordered = append(ordered, driver)
+		}
+	}
+	for _, driver := range drivers {
+		if !driver.OpenClaw {
+			ordered = append(ordered, driver)
+		}
+	}
+
+	serviceReady := false
+	var protectErrors []error
+	for _, driver := range ordered {
+		if driver.OpenClaw {
+			err := runProtectOpenClaw(cmd, protectOpenClawOptions{
+				NoRestart: opts.NoRestart,
+				NoVerify:  opts.NoVerify,
+				Reinstall: opts.Reinstall,
+				ServeURL:  resolvedURL,
+				Timeout:   opts.Timeout,
+			})
+			if err != nil {
+				protectErrors = append(protectErrors, fmt.Errorf("%s: %w", driver.DisplayName, err))
+				continue
+			}
+			serviceReady = true
+			summary.Succeeded++
+			continue
+		}
+
+		if !serviceReady {
+			if err := ensureServeRunningForURL(cmd.OutOrStdout(), cmd.ErrOrStderr(), resolvedURL); err != nil {
+				protectErrors = append(protectErrors, fmt.Errorf("start Rampart policy service: %w", err))
+				break
+			}
+			serviceReady = true
+		}
+		if err := runProtectHookDriver(cmd, rootOpts, driver, protectHookOptions{
+			NoVerify: opts.NoVerify,
+			ServeURL: resolvedURL,
+			Timeout:  opts.Timeout,
+		}); err != nil {
+			protectErrors = append(protectErrors, fmt.Errorf("%s: %w", driver.DisplayName, err))
+			continue
+		}
+		summary.Succeeded++
+	}
+
+	// quickstart historically supports a policy-and-service-only mode through
+	// --agents none. Preserve that compatibility without inventing a second
+	// service startup path.
+	if len(ordered) == 0 {
+		if err := ensureServeRunningForURL(cmd.OutOrStdout(), cmd.ErrOrStderr(), resolvedURL); err != nil {
+			protectErrors = append(protectErrors, fmt.Errorf("start Rampart policy service: %w", err))
+		}
+	}
+	return summary, errors.Join(protectErrors...)
+}
+
+func validateManagedProtectionConfig(rootOpts *rootOptions) error {
+	if rootOpts == nil {
+		return nil
+	}
+	configPath := strings.TrimSpace(rootOpts.configPath)
+	if configPath == "" || configPath == "rampart.yaml" {
+		return nil
+	}
+	return fmt.Errorf("protect: custom --config is not supported by managed protection yet; use the default configuration or manage the service explicitly with `rampart serve install`")
+}
+
+func prepareManagedProtection(rootOpts *rootOptions) error {
+	if err := validateManagedProtectionConfig(rootOpts); err != nil {
+		return err
+	}
+	if err := ensureDefaultRampartDirAccessible(); err != nil {
+		return fmt.Errorf("protect: prepare Rampart data directory: %w", err)
+	}
+	return nil
+}
+
 type protectHookOptions struct {
 	NoVerify bool
 	ServeURL string
@@ -125,20 +249,7 @@ type protectHookOptions struct {
 
 func runProtectHookDriver(cmd *cobra.Command, rootOpts *rootOptions, driver integrationDriver, opts protectHookOptions) error {
 	w := cmd.OutOrStdout()
-	errW := cmd.ErrOrStderr()
 	fmt.Fprintf(w, "\nProtecting %s through %s...\n", driver.DisplayName, driver.Boundary)
-	resolvedURL, err := resolveServeURLStrict(opts.ServeURL, fmt.Sprintf("http://localhost:%d", defaultServePort))
-	if err != nil {
-		return fmt.Errorf("protect %s: resolve serve URL: %w", driver.ID, err)
-	}
-	guardPath, err := installManagedGuardPolicy()
-	if err != nil {
-		return fmt.Errorf("protect %s: install managed Guard policy: %w", driver.ID, err)
-	}
-	fmt.Fprintf(w, "✓ Managed Guard policy installed at %s\n", guardPath)
-	if err := ensureServeRunningForURL(w, errW, resolvedURL); err != nil {
-		return fmt.Errorf("protect %s: start Rampart policy service: %w", driver.ID, err)
-	}
 	if err := runIntegrationSetup(cmd, rootOpts, driver); err != nil {
 		return fmt.Errorf("protect %s: configure native integration: %w", driver.ID, err)
 	}
@@ -148,7 +259,7 @@ func runProtectHookDriver(cmd *cobra.Command, rootOpts *rootOptions, driver inte
 		return nil
 	}
 	time.Sleep(150 * time.Millisecond)
-	report := runBehavioralVerification(cmd.Context(), driver.VerifyTarget, resolvedURL, opts.Timeout)
+	report := runBehavioralVerification(cmd.Context(), driver.VerifyTarget, opts.ServeURL, opts.Timeout)
 	receiptErr := writeVerificationReceipt(report)
 	fmt.Fprintln(w)
 	printVerificationReport(w, report)
@@ -185,12 +296,6 @@ func runProtectOpenClaw(cmd *cobra.Command, opts protectOpenClawOptions) error {
 		return fmt.Errorf("protect: invalid OpenClaw policy service URL: %w", err)
 	}
 	fmt.Fprintln(w, "Protecting OpenClaw with Rampart managed defaults...")
-
-	guardPath, err := installManagedGuardPolicy()
-	if err != nil {
-		return fmt.Errorf("protect: install managed Guard policy: %w", err)
-	}
-	fmt.Fprintf(w, "✓ Managed Guard policy installed at %s\n", guardPath)
 	// Install every managed policy before setup starts rampart serve. A fresh
 	// protect run must never briefly start with only the Guard layer loaded.
 	if err := installOpenClawPolicy(w, errW); err != nil {

--- a/cmd/rampart/cli/protect_test.go
+++ b/cmd/rampart/cli/protect_test.go
@@ -14,6 +14,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	ocplugin "github.com/peg/rampart/internal/plugin/openclaw"
 	"github.com/peg/rampart/policies"
@@ -31,6 +32,20 @@ func TestProtectKeepsExperimentalGeminiExplicit(t *testing.T) {
 	err := cmd.Execute()
 	if err == nil || !strings.Contains(err.Error(), "remains experimental") || !strings.Contains(err.Error(), "rampart setup gemini") {
 		t.Fatalf("error = %v, want experimental setup guidance", err)
+	}
+}
+
+func TestProtectionPlanRejectsCustomConfigUntilServiceLifecycleOwnsIt(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+	custom := filepath.Join(home, "custom.yaml")
+	cmd := NewRootCmd(context.Background(), &bytes.Buffer{}, &bytes.Buffer{})
+	_, err := runProtectionPlan(cmd, &rootOptions{configPath: custom}, nil, protectionPlanOptions{})
+	if err == nil || !strings.Contains(err.Error(), "custom --config is not supported") {
+		t.Fatalf("error = %v, want fail-closed custom config rejection", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(home, ".rampart", "policies", "guard.yaml")); !os.IsNotExist(statErr) {
+		t.Fatalf("custom config rejection mutated Guard policy: %v", statErr)
 	}
 }
 
@@ -272,6 +287,67 @@ func TestEnsureServeRunningDoesNotReplaceUnreachableExplicitEndpoint(t *testing.
 	err := ensureServeRunningForURL(&bytes.Buffer{}, &bytes.Buffer{}, "http://127.0.0.1:1")
 	if err == nil || !strings.Contains(err.Error(), "configured Rampart policy service") {
 		t.Fatalf("error = %v, want explicit-endpoint failure", err)
+	}
+}
+
+func TestProtectionPlanConfiguresVerifiesAndRecordsCodex(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+	t.Setenv("RAMPART_TOKEN", "verification-token")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/healthz" {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"service": "rampart", "status": "ok", "mode": "enforce",
+				"version": "test", "uptime_seconds": 1,
+			})
+			return
+		}
+		if r.Header.Get("Authorization") != "Bearer verification-token" {
+			http.Error(w, "missing test authorization", http.StatusUnauthorized)
+			return
+		}
+		var body struct {
+			Params map[string]any `json:"params"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, "invalid test request", http.StatusBadRequest)
+			return
+		}
+		decision := "deny"
+		if body.Params["command"] == "pwd" {
+			decision = "allow"
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"allowed": decision == "allow", "decision": decision,
+		})
+	}))
+	defer server.Close()
+
+	driver, ok := findIntegrationDriver("codex")
+	if !ok {
+		t.Fatal("Codex integration driver is missing")
+	}
+	var out, errOut bytes.Buffer
+	cmd := NewRootCmd(context.Background(), &out, &errOut)
+	summary, err := runProtectionPlan(cmd, &rootOptions{}, []integrationDriver{driver}, protectionPlanOptions{
+		ServeURL: server.URL,
+		Timeout:  time.Second,
+	})
+	if err != nil {
+		t.Fatalf("runProtectionPlan: %v\nstdout:\n%s\nstderr:\n%s", err, out.String(), errOut.String())
+	}
+	if summary.Attempted != 1 || summary.Succeeded != 1 {
+		t.Fatalf("summary = %#v, want one successful integration", summary)
+	}
+	if !codexHooksConfiguredForHome(home) {
+		t.Fatal("canonical protection plan did not install current Codex hooks")
+	}
+	if _, err := os.Stat(filepath.Join(home, ".rampart", "policies", "guard.yaml")); err != nil {
+		t.Fatalf("canonical protection plan did not install the managed Guard policy: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".rampart", "verification", "codex.json")); err != nil {
+		t.Fatalf("canonical protection plan did not record verification: %v", err)
 	}
 }
 

--- a/cmd/rampart/cli/quickstart.go
+++ b/cmd/rampart/cli/quickstart.go
@@ -14,18 +14,16 @@
 package cli
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
 	"github.com/peg/rampart/internal/detect"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 )
 
 type quickstartAgent struct {
@@ -58,7 +56,7 @@ func quickstartAgents() []quickstartAgent {
 	)
 }
 
-func newQuickstartCmd() *cobra.Command {
+func newQuickstartCmd(rootOpts *rootOptions) *cobra.Command {
 	var agentsFlag string
 	var profile string
 	var skipDoctor bool
@@ -66,17 +64,18 @@ func newQuickstartCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "quickstart",
-		Short: "One-shot setup: install service, configure agent hooks, verify",
+		Short: "Compatibility onboarding flow (use rampart protect)",
 		Long: `quickstart scans your environment, installs Rampart service, wires up detected
 AI agents, installs a policy profile, and runs a health summary.
 
-Supported setup agents are sourced from Rampart's native integration registry.
-Detected unsupported agents receive wrap guidance.
+Native integrations use the same managed protection lifecycle as rampart
+protect. Detected unsupported agents receive wrap guidance.
 
 Quickstart is non-interactive. --yes remains accepted for compatibility with
 existing CI, scripts, and agent-driven installs.`,
+		Deprecated: "use `rampart protect`; quickstart remains as a compatibility workflow",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runQuickstart(cmd, agentsFlag, profile, skipDoctor, yes)
+			return runQuickstart(cmd, rootOpts, agentsFlag, profile, skipDoctor, yes)
 		},
 	}
 
@@ -87,10 +86,15 @@ existing CI, scripts, and agent-driven installs.`,
 	return cmd
 }
 
-func runQuickstart(cmd *cobra.Command, agentsFlag, profile string, skipDoctor, yes bool) error {
+func runQuickstart(cmd *cobra.Command, rootOpts *rootOptions, agentsFlag, profile string, skipDoctor, yes bool) error {
 	w := cmd.OutOrStdout()
+	_ = yes // Retained as a no-op compatibility flag for existing scripts.
+	if err := prepareManagedProtection(rootOpts); err != nil {
+		return err
+	}
 
 	fmt.Fprintln(w, "◆ Rampart quickstart")
+	fmt.Fprintln(w, "  Compatibility mode: new installations should use `rampart protect`.")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "  Scanning environment...")
 	fmt.Fprintln(w)
@@ -109,50 +113,10 @@ func runQuickstart(cmd *cobra.Command, agentsFlag, profile string, skipDoctor, y
 	if err != nil {
 		return err
 	}
-
-	// Install the fail-closed managed baseline before starting a fresh service,
-	// so quickstart never creates an unprotected policy window.
-	guardPath, err := installManagedGuardPolicy()
+	drivers, unsupported, err := quickstartProtectionTargets(selectedAgents)
 	if err != nil {
-		return fmt.Errorf("install managed Guard policy: %w", err)
+		return err
 	}
-	fmt.Fprintf(w, "  ✓ Managed Guard policy installed at %s\n", guardPath)
-
-	fmt.Fprintln(w, "  Starting Rampart service...")
-	if err := ensureServeRunning(w, cmd.ErrOrStderr()); err != nil {
-		return fmt.Errorf("start Rampart service: %w", err)
-	}
-	fmt.Fprintln(w)
-
-	fmt.Fprintln(w, "  Configuring hooks...")
-	hooksConfigured := 0
-	var setupFailures []string
-	for _, agent := range selectedAgents {
-		if agent.HasSetup {
-			hooksAlreadyConfigured := quickstartHooksConfigured(agent.SetupCmd)
-			setupArgs := []string{"setup", agent.SetupCmd}
-			if err := runSubcmd(setupArgs...); err != nil {
-				fmt.Fprintf(w, "  ⚠ %s: setup failed (%v)\n", agent.Name, err)
-				fmt.Fprintf(w, "    → Retry with: rampart setup %s\n", agent.SetupCmd)
-				setupFailures = append(setupFailures, agent.Name)
-				continue
-			}
-			hooksConfigured++
-			if hooksAlreadyConfigured {
-				fmt.Fprintf(w, "  ✓ %s: hooks already configured\n", agent.Name)
-			} else {
-				fmt.Fprintf(w, "  ✓ %s: hooks installed\n", agent.Name)
-			}
-			continue
-		}
-
-		fmt.Fprintf(w, "  ⚠ %s detected but setup not yet supported\n", agent.Name)
-		fmt.Fprintf(w, "    → Use: %s\n", agent.WrapCmd)
-	}
-	if len(selectedAgents) == 0 {
-		fmt.Fprintln(w, "  ⚠ No agents selected for setup")
-	}
-	fmt.Fprintln(w)
 
 	selectedProfile := strings.TrimSpace(profile)
 	if selectedProfile == "" {
@@ -172,7 +136,7 @@ func runQuickstart(cmd *cobra.Command, agentsFlag, profile string, skipDoctor, y
 
 	fmt.Fprintln(w, "  Installing policies...")
 	if !hasInstalledPolicy() || strings.TrimSpace(profile) != "" {
-		if err := runSubcmd("init", "--profile", selectedProfile); err != nil {
+		if err := runQuickstartInitProfile(cmd, rootOpts, selectedProfile); err != nil {
 			return fmt.Errorf("policy init failed for profile %q: %w", selectedProfile, err)
 		}
 		fmt.Fprintf(w, "  ✓ %s profile installed\n", selectedProfile)
@@ -187,93 +151,71 @@ func runQuickstart(cmd *cobra.Command, agentsFlag, profile string, skipDoctor, y
 	}
 	fmt.Fprintln(w)
 
-	fmt.Fprintln(w, "  Verifying configured boundaries...")
-	verifiedAgents := 0
-	var verificationFailures []string
-	for _, agent := range selectedAgents {
-		if !agent.HasSetup || !quickstartHooksConfigured(agent.SetupCmd) {
-			continue
-		}
-		driver, ok := findIntegrationDriver(agent.SetupCmd)
-		if !ok {
-			verificationFailures = append(verificationFailures, agent.Name)
-			fmt.Fprintf(w, "  ⚠ %s: no verification driver registered\n", agent.Name)
-			continue
-		}
-		report := runBehavioralVerification(cmd.Context(), driver.VerifyTarget, quickstartServiceURL(), 5*time.Second)
-		if report.Summary.Failed > 0 || report.Summary.Unverified > 0 {
-			verificationFailures = append(verificationFailures, agent.Name)
-			fmt.Fprintf(w, "  ⚠ %s: behavioral verification incomplete\n", agent.Name)
-			printVerificationReport(w, report)
-			continue
-		}
-		verifiedAgents++
-		fmt.Fprintf(w, "  ✓ %s: %d behavioral checks passed\n", agent.Name, report.Summary.Passed)
+	for _, agent := range unsupported {
+		fmt.Fprintf(w, "  ⚠ %s detected but native setup is not yet supported\n", agent.Name)
+		fmt.Fprintf(w, "    → Cooperative fallback: %s\n", agent.WrapCmd)
 	}
-	if hooksConfigured == 0 {
-		fmt.Fprintln(w, "  ⚠ No native agent boundary was configured or verified")
+	if len(selectedAgents) == 0 {
+		fmt.Fprintln(w, "  ⚠ No agents selected; configuring policy and service only")
 	}
+
+	summary, err := runProtectionPlan(cmd, rootOpts, drivers, protectionPlanOptions{Timeout: 5 * time.Second})
+	if err != nil {
+		return fmt.Errorf("quickstart did not protect every selected native integration: %w", err)
+	}
+
 	fmt.Fprintln(w)
-
-	if !skipDoctor {
-		fmt.Fprintln(w, "  Running health check...")
-		if quickstartServeRunning() {
-			fmt.Fprintln(w, "  ✓ Service reachable")
-		} else {
-			fmt.Fprintln(w, "  ⚠ Service unreachable (try: rampart serve)")
-		}
-
-		if hooksConfigured == 0 {
-			fmt.Fprintln(w, "  ⚠ Hooks configured for 0 agents")
-		} else {
-			fmt.Fprintf(w, "  ✓ Hooks configured for %d agents\n", hooksConfigured)
-		}
-
-		profiles, rules := installedPolicyStats()
-		if profiles == 0 {
-			fmt.Fprintln(w, "  ⚠ No active policy profiles found")
-		} else {
-			noun := "profiles"
-			if profiles == 1 {
-				noun = "profile"
-			}
-			fmt.Fprintf(w, "  ✓ %d policy %s active (%d rules)\n", profiles, noun, rules)
-		}
-		fmt.Fprintln(w)
-	}
-
-	if len(setupFailures) > 0 || len(verificationFailures) > 0 {
-		failed := append(append([]string(nil), setupFailures...), verificationFailures...)
-		return fmt.Errorf("quickstart did not verify every selected native integration: %s", strings.Join(failed, ", "))
-	}
-	if verifiedAgents > 0 {
-		fmt.Fprintf(w, "◆ Rampart protection verified for %d agent(s).\n", verifiedAgents)
+	if summary.Succeeded > 0 {
+		fmt.Fprintf(w, "◆ Rampart protection verified for %d agent(s).\n", summary.Succeeded)
 	} else {
-		fmt.Fprintln(w, "◆ Rampart setup complete; no native agent boundary was selected for verification.")
+		fmt.Fprintln(w, "◆ Rampart policy and service setup complete; no native agent boundary was selected.")
 	}
-	fmt.Fprintln(w)
-
-	svcURL := quickstartServiceURL()
-	dashURL := strings.TrimSuffix(svcURL, "/") + "/dashboard/"
-	fmt.Fprintf(w, "  Dashboard:  %s\n", dashURL)
-
-	if tok, err := readPersistedToken(); err == nil && tok != "" {
-		masked := tok
-		if len(tok) > 8 {
-			masked = tok[:8] + "..."
+	if !skipDoctor {
+		fmt.Fprintln(w, "\nCurrent protection status:")
+		if err := runStatus(w, false); err != nil {
+			return fmt.Errorf("quickstart status: %w", err)
 		}
-		fmt.Fprintf(w, "  Token:      %s  (full token in ~/.rampart/token)\n", masked)
 	}
-	fmt.Fprintln(w)
-	fmt.Fprintln(w, "  Next steps:")
-	if verifiedAgents > 0 {
-		fmt.Fprintln(w, "    • Restart or reload configured agents if their setup output requested it")
-	}
+
+	fmt.Fprintln(w, "\n  Next steps:")
+	fmt.Fprintln(w, "    • rampart status       — see protection and assurance state")
 	fmt.Fprintln(w, "    • rampart watch        — see decisions in real time")
-	fmt.Fprintln(w, "    • rampart policy list  — browse available policies")
 	fmt.Fprintln(w, "    • Docs: https://docs.rampart.sh")
 
 	return nil
+}
+
+func runQuickstartInitProfile(parent *cobra.Command, rootOpts *rootOptions, profile string) error {
+	initCmd := newInitCmd(rootOpts)
+	initCmd.SetContext(parent.Context())
+	initCmd.SetIn(parent.InOrStdin())
+	initCmd.SetOut(parent.OutOrStdout())
+	initCmd.SetErr(parent.ErrOrStderr())
+	if err := initCmd.Flags().Set("profile", profile); err != nil {
+		return err
+	}
+	if initCmd.RunE == nil {
+		return fmt.Errorf("init command has no implementation")
+	}
+	return initCmd.RunE(initCmd, nil)
+}
+
+func quickstartProtectionTargets(selected []quickstartAgent) (drivers []integrationDriver, unsupported []quickstartAgent, err error) {
+	for _, agent := range selected {
+		if !agent.HasSetup {
+			unsupported = append(unsupported, agent)
+			continue
+		}
+		driver, ok := findIntegrationDriver(agent.SetupCmd)
+		if !ok || !driver.AutoProtect {
+			return nil, unsupported, fmt.Errorf("quickstart: no managed protection driver registered for %s", agent.Name)
+		}
+		if !integrationDriverSupportsPlatform(driver, runtime.GOOS) {
+			return nil, unsupported, fmt.Errorf("quickstart: %s is not supported on %s", driver.DisplayName, runtime.GOOS)
+		}
+		drivers = append(drivers, driver)
+	}
+	return drivers, unsupported, nil
 }
 
 func selectQuickstartAgents(result *detect.DetectResult, agentsFlag string) ([]quickstartAgent, error) {
@@ -461,77 +403,6 @@ func installedPolicyNames() map[string]bool {
 	return names
 }
 
-func installedPolicyStats() (int, int) {
-	home, err := os.UserHomeDir()
-	if err != nil || home == "" {
-		return 0, 0
-	}
-	policyDir := filepath.Join(home, ".rampart", "policies")
-	entries, err := os.ReadDir(policyDir)
-	if err != nil {
-		return 0, 0
-	}
-
-	profiles := 0
-	totalRules := 0
-	for _, e := range entries {
-		if e.IsDir() {
-			continue
-		}
-		name := strings.ToLower(e.Name())
-		if name == "custom.yaml" || (!strings.HasSuffix(name, ".yaml") && !strings.HasSuffix(name, ".yml")) {
-			continue
-		}
-		profiles++
-
-		data, err := os.ReadFile(filepath.Join(policyDir, e.Name()))
-		if err != nil {
-			continue
-		}
-		var parsed struct {
-			Policies []struct {
-				Rules []any `yaml:"rules"`
-			} `yaml:"policies"`
-			Rules []any `yaml:"rules"`
-		}
-		if err := yaml.Unmarshal(data, &parsed); err != nil {
-			continue
-		}
-		totalRules += len(parsed.Rules)
-		for _, p := range parsed.Policies {
-			totalRules += len(p.Rules)
-		}
-	}
-	return profiles, totalRules
-}
-
-// quickstartServiceURL returns the base URL for the Rampart service.
-func quickstartServiceURL() string {
-	return fmt.Sprintf("http://127.0.0.1:%d", defaultServePort)
-}
-
-// quickstartServeRunning checks whether the Rampart service is reachable.
-func quickstartServeRunning() bool {
-	client := newRampartHTTPClient(2 * time.Second)
-	url := quickstartServiceURL() + "/healthz"
-	return isRampartHealthReady(context.Background(), client, url)
-}
-
-// runSubcmd runs a rampart subcommand as a subprocess, inheriting
-// stdout/stderr/stdin. This avoids mutating global cobra state and keeps
-// each step independently observable.
-func runSubcmd(args ...string) error {
-	self, err := os.Executable()
-	if err != nil {
-		self = "rampart"
-	}
-	c := exec.Command(self, args...)
-	c.Stdout = os.Stdout
-	c.Stderr = os.Stderr
-	c.Stdin = os.Stdin
-	return c.Run()
-}
-
 func hasInstalledPolicy() bool {
 	home, err := os.UserHomeDir()
 	if err != nil || home == "" {
@@ -547,10 +418,10 @@ func hasInstalledPolicy() bool {
 			continue
 		}
 		name := strings.ToLower(e.Name())
-		// custom.yaml is an auto-managed placeholder — it is always present and
-		// contains no policies by default. Exclude it so a fresh install with only
-		// custom.yaml still triggers standard policy auto-init.
-		if name == "custom.yaml" {
+		// custom.yaml is an empty managed placeholder. guard.yaml is a supplemental
+		// layer with no default_action. Neither is a complete base profile, so a
+		// home containing only these files still needs standard/openclaw auto-init.
+		if name == "custom.yaml" || name == "guard.yaml" {
 			continue
 		}
 		if strings.HasSuffix(name, ".yaml") || strings.HasSuffix(name, ".yml") {
@@ -558,16 +429,4 @@ func hasInstalledPolicy() bool {
 		}
 	}
 	return false
-}
-
-func quickstartHooksConfigured(env string) bool {
-	home, err := os.UserHomeDir()
-	if err != nil || home == "" {
-		return false
-	}
-	driver, ok := findIntegrationDriver(env)
-	if !ok || driver.Configured == nil {
-		return false
-	}
-	return driver.Configured(home)
 }

--- a/cmd/rampart/cli/quickstart_test.go
+++ b/cmd/rampart/cli/quickstart_test.go
@@ -14,10 +14,15 @@
 package cli
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/peg/rampart/internal/detect"
@@ -166,7 +171,7 @@ func TestQuickstartUnsupportedAgentWrapSuggestion(t *testing.T) {
 }
 
 func TestQuickstartCmd_Flags(t *testing.T) {
-	cmd := newQuickstartCmd()
+	cmd := newQuickstartCmd(&rootOptions{})
 
 	agentsFlag := cmd.Flags().Lookup("agents")
 	if agentsFlag == nil {
@@ -180,6 +185,25 @@ func TestQuickstartCmd_Flags(t *testing.T) {
 	profileFlag := cmd.Flags().Lookup("profile")
 	if profileFlag == nil {
 		t.Fatal("--profile flag not registered")
+	}
+}
+
+func TestQuickstartProtectionTargetsUseManagedOpenClawPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("OpenClaw managed protection is not supported on Windows")
+	}
+	drivers, unsupported, err := quickstartProtectionTargets([]quickstartAgent{
+		{Key: "openclaw", Name: "OpenClaw", HasSetup: true, SetupCmd: "openclaw"},
+		{Key: "cursor", Name: "Cursor", WrapCmd: "rampart wrap -- cursor"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(drivers) != 1 || drivers[0].ID != "openclaw" || !drivers[0].OpenClaw {
+		t.Fatalf("managed drivers = %#v, want OpenClaw protect driver", drivers)
+	}
+	if len(unsupported) != 1 || unsupported[0].Key != "cursor" {
+		t.Fatalf("unsupported = %#v, want Cursor wrap guidance", unsupported)
 	}
 }
 
@@ -215,6 +239,14 @@ func TestHasInstalledPolicy(t *testing.T) {
 	if err := os.MkdirAll(policyDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
+	for _, name := range []string{"custom.yaml", "guard.yaml"} {
+		if err := os.WriteFile(filepath.Join(policyDir, name), []byte("version: \"1\"\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if hasInstalledPolicy() {
+		t.Fatal("supplemental custom and Guard files must not suppress base profile initialization")
+	}
 	if err := os.WriteFile(filepath.Join(policyDir, "standard.yaml"), []byte("version: \"1\"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -223,128 +255,48 @@ func TestHasInstalledPolicy(t *testing.T) {
 	}
 }
 
-func TestQuickstartHooksConfigured_OpenClaw(t *testing.T) {
+func TestQuickstartFreshHomeInstallsSelectedProfileBeforeGuard(t *testing.T) {
 	home := t.TempDir()
 	testSetHome(t, home)
-	testSetOpenClawBinary(t, home)
+	t.Chdir(t.TempDir())
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/healthz" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"service": "rampart", "status": "ok", "mode": "enforce",
+			"version": "test", "uptime_seconds": 1,
+		})
+	}))
+	defer server.Close()
+	t.Setenv("RAMPART_URL", server.URL)
 
-	if quickstartHooksConfigured("openclaw") {
-		t.Fatal("expected openclaw hooks to be false without plugin or legacy bridge")
+	var out, errOut bytes.Buffer
+	cmd := NewRootCmd(context.Background(), &out, &errOut)
+	if err := runQuickstart(cmd, &rootOptions{configPath: "rampart.yaml"}, "none", "", true, false); err != nil {
+		t.Fatalf("runQuickstart: %v\nstdout:\n%s\nstderr:\n%s", err, out.String(), errOut.String())
 	}
-
-	pluginDir := filepath.Join(home, ".openclaw", "extensions", "rampart")
-	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	configPath := filepath.Join(home, ".openclaw", "openclaw.json")
-	if err := os.WriteFile(configPath, []byte(`{"plugins":{"allow":["rampart"],"entries":{"rampart":{"enabled":true}}}}`), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	if !quickstartHooksConfigured("openclaw") {
-		t.Fatal("expected openclaw hooks to be true with native plugin")
-	}
-	if err := os.WriteFile(configPath, []byte(`{"plugins":{"allow":[]}}`), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if quickstartHooksConfigured("openclaw") {
-		t.Fatal("expected openclaw hooks to be false when plugin is not allowed to load")
-	}
-
-	if err := os.RemoveAll(filepath.Join(home, ".openclaw")); err != nil {
-		t.Fatal(err)
-	}
-
-	shimPath := filepath.Join(home, ".local", "bin", "rampart-shim")
-	if err := os.MkdirAll(filepath.Dir(shimPath), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(shimPath, []byte("#!/bin/sh\n"), 0o700); err != nil {
-		t.Fatal(err)
-	}
-
-	if quickstartHooksConfigured("openclaw") {
-		t.Fatal("legacy OpenClaw shim must not be reported as the current native plugin boundary")
+	for _, name := range []string{"standard.yaml", "guard.yaml"} {
+		if _, err := os.Stat(filepath.Join(home, ".rampart", "policies", name)); err != nil {
+			t.Fatalf("fresh quickstart did not install %s: %v", name, err)
+		}
 	}
 }
 
-func TestQuickstartHooksConfigured_ClaudeCode(t *testing.T) {
+func TestQuickstartRejectsCustomConfigBeforeMutation(t *testing.T) {
 	home := t.TempDir()
 	testSetHome(t, home)
-	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o755); err != nil {
-		t.Fatal(err)
+	custom := filepath.Join(home, "custom.yaml")
+	cmd := NewRootCmd(context.Background(), &bytes.Buffer{}, &bytes.Buffer{})
+	err := runQuickstart(cmd, &rootOptions{configPath: custom}, "none", "", true, false)
+	if err == nil || !strings.Contains(err.Error(), "custom --config is not supported") {
+		t.Fatalf("error = %v, want fail-closed custom config rejection", err)
 	}
-	hookCommand := currentClaudeHookCommand()
-	settings := map[string]any{
-		"hooks": map[string]any{
-			"PreToolUse": []any{
-				map[string]any{
-					"matcher": ".*",
-					"hooks":   []any{map[string]any{"type": "command", "command": hookCommand}},
-				},
-			},
-			"PostToolUse": []any{
-				map[string]any{
-					"matcher": ".*",
-					"hooks":   []any{map[string]any{"type": "command", "command": hookCommand}},
-				},
-			},
-			"PostToolUseFailure": []any{
-				map[string]any{
-					"matcher": ".*",
-					"hooks":   []any{map[string]any{"type": "command", "command": hookCommand}},
-				},
-			},
-		},
-	}
-	data, err := json.Marshal(settings)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(home, ".claude", "settings.json"), data, 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	if !quickstartHooksConfigured("claude-code") {
-		t.Fatal("expected claude-code hooks to be detected")
-	}
-}
-
-func TestQuickstartHooksConfigured_Codex(t *testing.T) {
-	home := t.TempDir()
-	testSetHome(t, home)
-
-	hooksPath := filepath.Join(home, ".codex", "hooks.json")
-	if err := os.MkdirAll(filepath.Dir(hooksPath), 0o700); err != nil {
-		t.Fatal(err)
-	}
-	command, commandWindows := currentCodexHookCommands()
-	if err := installCodexHooks(hooksPath, command, commandWindows, false); err != nil {
-		t.Fatal(err)
-	}
-
-	if !quickstartHooksConfigured("codex") {
-		t.Fatal("expected Codex lifecycle hooks to be detected")
-	}
-}
-
-func TestQuickstartHooksConfigured_Cline(t *testing.T) {
-	home := t.TempDir()
-	testSetHome(t, home)
-
-	hookDir := filepath.Join(home, "Documents", "Cline", "Hooks")
-	if _, _, err := installClineHooks(hookDir, resolveRampartHookBinary(), runtime.GOOS, false); err != nil {
-		t.Fatal(err)
-	}
-
-	if !quickstartHooksConfigured("cline") {
-		t.Fatal("expected cline hooks to be detected")
-	}
-	if err := os.WriteFile(clineHookPath(hookDir, "PreToolUse", runtime.GOOS), []byte("user hook"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if quickstartHooksConfigured("cline") {
-		t.Fatal("non-Rampart Cline hook must not be reported as protection")
+	for _, path := range []string{custom, filepath.Join(home, ".rampart")} {
+		if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+			t.Fatalf("custom config rejection mutated %s: %v", path, statErr)
+		}
 	}
 }
 

--- a/cmd/rampart/cli/root.go
+++ b/cmd/rampart/cli/root.go
@@ -125,7 +125,7 @@ func NewRootCmd(ctx context.Context, outWriter, errWriter io.Writer) *cobra.Comm
 	tokenCmd := newTokenShowCmd()
 	testCmd := newTestCmd(opts)
 	benchCmd := newBenchCmd(opts)
-	quickstartCmd := newQuickstartCmd()
+	quickstartCmd := newQuickstartCmd(opts)
 	protectCmd := newProtectCmd(opts)
 	verifyCmd := newVerifyCmd()
 	upgradeCmd := newUpgradeCmd(opts)

--- a/cmd/rampart/cli/setup_openclaw_plugin.go
+++ b/cmd/rampart/cli/setup_openclaw_plugin.go
@@ -1497,16 +1497,6 @@ func modernOpenClawVersion() (string, bool) {
 	return version, err == nil && ok
 }
 
-// ensureServeRunning checks whether rampart serve is reachable, and if not,
-// installs and starts it as a systemd/launchd service via `rampart serve install`.
-func ensureServeRunning(w io.Writer, errW io.Writer) error {
-	serveURL, err := resolveServeURLStrict("", fmt.Sprintf("http://localhost:%d", defaultServePort))
-	if err != nil {
-		return fmt.Errorf("resolve Rampart policy service URL: %w", err)
-	}
-	return ensureServeRunningForURL(w, errW, serveURL)
-}
-
 func ensureServeRunningForURL(w io.Writer, errW io.Writer, serveURL string) error {
 	serveURL = strings.TrimRight(strings.TrimSpace(serveURL), "/")
 	if serveURL == "" {

--- a/docs-site/getting-started/how-it-works.md
+++ b/docs-site/getting-started/how-it-works.md
@@ -10,7 +10,10 @@ This is the shared local policy service. It loads your policies, evaluates tool 
 rampart serve
 ```
 
-You don't usually run this directly. `rampart quickstart` and the service-backed setup flows handle it for you by installing a system service (systemd on Linux, launchd on macOS).
+You don't usually run this directly. `rampart protect` and the service-backed
+setup flows start or verify it for you. They install a system service through
+systemd on Linux or launchd on macOS; Windows uses a login-scoped background
+process.
 
 **What happens if it's not running?** Behavior depends on the integration:
 
@@ -35,8 +38,8 @@ enforcement path before execution. Some paths call into `rampart serve`;
 Claude/Cline/Codex native hooks can also evaluate allow/deny policy locally.
 
 ```
-rampart setup claude-code   # one-time, survives agent updates
-rampart setup codex         # native lifecycle hooks; no wrapper replacement
+rampart protect claude-code # managed native hooks + active verification
+rampart protect codex       # native lifecycle hooks; no wrapper replacement
 rampart protect openclaw    # managed fail-closed guard + behavioral verification
 ```
 
@@ -103,10 +106,15 @@ Ask   → native agent prompt or external approval flow, depending on integratio
 ## Common questions
 
 **Do I need to run `rampart serve` manually?**
-Not usually. `rampart quickstart` installs it as a system service when the chosen integration needs it. Direct Claude Code and Cline hook protection can still work locally without it.
+Not usually. `rampart protect` installs a persistent service on Linux and macOS;
+Windows uses a login-scoped background process. Direct Claude Code and Cline
+hook protection can still evaluate ordinary allow/deny policy locally if the
+service later becomes unavailable.
 
 **What if I installed with `nohup rampart serve &`?**
-That works but won't survive reboots. Run `rampart serve install` to create a persistent service, or use `rampart quickstart` which handles this.
+That works but won't survive reboots. On Linux or macOS, run
+`rampart serve install` or `rampart protect` to create a persistent service.
+On Windows, Rampart currently uses a login-scoped background process.
 
 **Can I run on a different port?**
 Yes: `rampart serve --port 19090`. Set `RAMPART_URL=http://localhost:19090` so other commands find it.

--- a/docs-site/getting-started/quickstart.md
+++ b/docs-site/getting-started/quickstart.md
@@ -38,15 +38,23 @@ Before you dive in, skim the [integration support matrix](support-matrix.md) if 
 ## One-Command Setup
 
 ```bash
-rampart quickstart
-rampart verify --all
+rampart protect
 ```
 
 This discovers integrations in Rampart's current auto-protect registry, installs
-the service when the selected path needs it, wires up the appropriate boundary,
-and verifies the result. The second command gives you one aggregate re-check of
-the policy engine and every configured integration with an active behavioral
-verifier.
+the managed Guard policy, starts or verifies the local service, wires up the
+appropriate boundary, and verifies the result. No agent name or policy authoring
+is required.
+
+`rampart quickstart` remains as a deprecated compatibility workflow for scripts
+that rely on its `--profile`, `--agents none`, or wrap-only agent guidance. Its
+supported native integrations now use the same managed protection path.
+
+For a later aggregate re-check, run:
+
+```bash
+rampart verify --all
+```
 
 `rampart verify --all` uses fixed safe canaries. It does not invoke a model,
 execute commands, read files, send messages, or contact external hosts. Static-only
@@ -70,14 +78,13 @@ See [Configuration](configuration.md) for the full `url` / `serve_url` / `api` s
 === "Claude Code"
 
     ```bash
-    rampart setup claude-code
+    rampart protect claude-code
     ```
 
 === "Cline"
 
     ```bash
-    rampart setup cline
-    rampart verify cline
+    rampart protect cline
     ```
 
     Keep both hooks enabled in Cline. Legacy Cline CLI `--yolo` disables
@@ -86,8 +93,7 @@ See [Configuration](configuration.md) for the full `url` / `serve_url` / `api` s
 === "Codex"
 
     ```bash
-    rampart setup codex
-    rampart verify codex
+    rampart protect codex
     ```
 
 === "Gemini CLI (experimental)"
@@ -105,8 +111,7 @@ See [Configuration](configuration.md) for the full `url` / `serve_url` / `api` s
 
     ```bash
     # CLI adapter; also installs the shared VS Code Preview hook contract
-    rampart setup copilot
-    rampart verify copilot
+    rampart protect copilot
     ```
 
 === "Any CLI Agent"

--- a/docs-site/getting-started/tutorial.md
+++ b/docs-site/getting-started/tutorial.md
@@ -57,26 +57,19 @@ rampart version
 ## Step 2: One Command to Get Protected
 
 ```bash
-rampart quickstart
+rampart protect
 ```
 
 That's it. This single command:
 
 1. Detects your AI agent (Claude Code, Codex, Cline, etc.)
 2. Installs the right Rampart integration for that agent
-3. Starts or verifies `rampart serve` when that integration needs the local service
-4. Runs `rampart doctor` to verify everything is healthy
+3. Starts or verifies the local `rampart serve` policy service
+4. Runs active safe verification and records the resulting assurance evidence
 
-```
-✓ Detected Claude Code
-✓ Rampart service installed and running
-✓ Hooks registered in ~/.claude/settings.json
-✓ Hook binary path verified
-✓ Token auth working
-✓ 1 policy loaded
-
-🛡️  Rampart is active. Use Claude Code normally.
-```
+The command exits unsuccessfully if a selected native integration cannot be
+configured or its active safe verification is incomplete. Its final report
+shows the checks that passed and gives a specific repair hint for any failure.
 
 Now start Claude Code:
 
@@ -91,7 +84,7 @@ observe work performed inside an already allowed process.
 
 !!! note "Different agents use different integration paths"
     Claude Code, Cline, and Codex use native hooks; Gemini CLI has an experimental native-hook path. OpenClaw uses a native
-    plugin. The exact setup varies by agent, but `rampart quickstart` picks the
+    plugin. The exact setup varies by agent, but `rampart protect` picks the
     right path automatically. See the [support matrix](support-matrix.md).
 
 ---

--- a/docs-site/guides/agent-install.md
+++ b/docs-site/guides/agent-install.md
@@ -45,18 +45,26 @@ Expected output: `rampart vX.Y.Z`
 
 ---
 
-## Step 2: Run quickstart (non-interactive)
+## Step 2: Protect detected agents (non-interactive)
 
-This single command auto-detects the running AI environment, installs the background policy service, wires up hooks, and runs a health check:
+This single command auto-detects supported AI tools, starts or verifies the
+local policy service, wires up their native boundaries, and runs safe active
+verification:
 
 ```bash
-rampart quickstart --yes
+rampart protect
 ```
 
-Quickstart is non-interactive. The `--yes` flag remains accepted for
-compatibility with existing CI, remote-shell, and agent-driven install scripts.
+`rampart protect` is non-interactive. It installs the managed Guard policy,
+starts or verifies the local policy service, configures every detected supported
+native integration, and runs safe active verification without invoking a model.
+On Windows, the service helper uses a login-scoped background process rather
+than a persistent system service. The deprecated `rampart quickstart --yes`
+spelling remains available for existing scripts.
 
-**OpenClaw note:** protection applies to future tool calls, not the current session. Restart the OpenClaw gateway after this step for hooks to take effect.
+**OpenClaw note:** protection applies to future tool calls, not the current
+session. `rampart protect` restarts the OpenClaw gateway automatically; restart
+it manually only if you explicitly use `--no-restart`.
 
 **Serve note:** direct Claude Code and Cline native hooks can evaluate policy locally without `rampart serve`, but dashboard views, approval APIs, and OpenClaw plugin evaluation rely on the local service.
 
@@ -181,9 +189,10 @@ policies:
 Re-run protection or setup for your specific agent:
 
 ```bash
-rampart protect openclaw   # OpenClaw managed guard + behavioral verification
-rampart setup claude-code  # Claude Code native hooks
-rampart setup cline        # Cline native hooks
+rampart protect             # Detect and repair supported integrations
+rampart protect openclaw    # OpenClaw managed guard + behavioral verification
+rampart protect claude-code # Claude Code native hooks + verification
+rampart protect cline       # Cline native hooks + verification
 ```
 
 **Service not running**
@@ -209,7 +218,8 @@ Then add an allow rule for your specific use case. See [Securing Claude Code](ht
 
 | Command | What it does |
 |---------|--------------|
-| `rampart quickstart --yes` | Full non-interactive setup |
+| `rampart protect` | Detect, configure, and verify supported integrations |
+| `rampart quickstart --yes` | Deprecated compatibility workflow |
 | `rampart doctor` | Health check — hooks, service, permissions |
 | `rampart status` | Show configured agents, assurance evidence, mode, and today's counts |
 | `rampart watch` | Live feed of tool decisions observed by Rampart |

--- a/docs-site/index.html
+++ b/docs-site/index.html
@@ -1116,7 +1116,7 @@
         <div>
             <div class="eyebrow"><span class="eyebrow-dot"></span>v1.6.2 · verified agent boundaries</div>
             <h1>Your agent has root.<br><span class="accent">That’s the problem.</span></h1>
-            <p class="hero-sub">Rampart sits in the execution path. Run <code>rampart protect openclaw</code> for a managed, fail-closed OpenClaw guard that verifies itself, or use <code>rampart quickstart</code> for other supported agents.</p>
+            <p class="hero-sub">Rampart sits in the execution path. Run <code>rampart protect</code> to detect supported agents, install their strongest managed boundary, and verify the result.</p>
             <div class="install-cluster">
                 <div class="install-inline" onclick="copyCode(this)" title="Click to copy">
                     <span class="prompt">$</span>
@@ -1128,7 +1128,7 @@
                     <span>Claude Code · Codex · Antigravity · Copilot · Cline · OpenClaw · Hermes preview · MCP</span>
                 </div>
                 <div class="hero-actions">
-                    <a href="#install" class="btn btn-primary">Quickstart</a>
+                    <a href="#install" class="btn btn-primary">Get protected</a>
                     <a href="https://docs.rampart.sh/getting-started/support-matrix/" class="btn btn-ghost">Support matrix</a>
                 </div>
             </div>
@@ -1259,11 +1259,11 @@
         <p class="section-desc">Use the native path where Rampart knows the agent. Use preload, wrapping, MCP proxy, or the HTTP API everywhere else. For exact support tiers, approval UX, and whether <code>rampart serve</code> is required, check the support matrix.</p>
         <div class="integrations-grid">
             <div class="integration-row header"><span>Agent</span><span>Setup</span><span>Enforcement path</span><span>Status</span></div>
-            <div class="integration-row interactive"><span class="integration-agent">Claude Code</span><span class="integration-code">rampart setup claude-code</span><span class="integration-path">native hooks</span><span class="integration-status">native</span></div>
-            <div class="integration-row interactive"><span class="integration-agent">Codex CLI, IDE, desktop</span><span class="integration-code">rampart setup codex</span><span class="integration-path">native hooks</span><span class="integration-status">native</span></div>
-            <div class="integration-row interactive"><span class="integration-agent">GitHub Copilot CLI, VS Code</span><span class="integration-code">rampart setup copilot</span><span class="integration-path">shared native hooks</span><span class="integration-status">CLI adapter-tested · VS Code Preview</span></div>
-            <div class="integration-row interactive"><span class="integration-agent">Antigravity CLI, IDE</span><span class="integration-code">rampart setup antigravity</span><span class="integration-path">shared policy plugin</span><span class="integration-status">installed-plugin + adapter tested</span></div>
-            <div class="integration-row interactive"><span class="integration-agent">Cline</span><span class="integration-code">rampart setup cline</span><span class="integration-path">native hooks</span><span class="integration-status">native</span></div>
+            <div class="integration-row interactive"><span class="integration-agent">Claude Code</span><span class="integration-code">rampart protect claude-code</span><span class="integration-path">native hooks</span><span class="integration-status">native</span></div>
+            <div class="integration-row interactive"><span class="integration-agent">Codex CLI, IDE, desktop</span><span class="integration-code">rampart protect codex</span><span class="integration-path">native hooks</span><span class="integration-status">native</span></div>
+            <div class="integration-row interactive"><span class="integration-agent">GitHub Copilot CLI, VS Code</span><span class="integration-code">rampart protect copilot</span><span class="integration-path">shared native hooks</span><span class="integration-status">CLI adapter-tested · VS Code Preview</span></div>
+            <div class="integration-row interactive"><span class="integration-agent">Antigravity CLI, IDE</span><span class="integration-code">rampart protect antigravity</span><span class="integration-path">shared policy plugin</span><span class="integration-status">installed-plugin + adapter tested</span></div>
+            <div class="integration-row interactive"><span class="integration-agent">Cline</span><span class="integration-code">rampart protect cline</span><span class="integration-path">native hooks</span><span class="integration-status">native</span></div>
             <div class="integration-row interactive"><span class="integration-agent">OpenClaw</span><span class="integration-code">rampart protect openclaw</span><span class="integration-path">managed native guard</span><span class="integration-status">verified</span></div>
             <div class="integration-row interactive"><span class="integration-agent">Hermes Agent</span><span class="integration-code">rampart setup hermes</span><span class="integration-path">user plugin</span><span class="integration-status">experimental</span></div>
             <div class="integration-row interactive"><span class="integration-agent">Gemini CLI (enterprise/API key)</span><span class="integration-code">rampart setup gemini</span><span class="integration-path">native hooks</span><span class="integration-status">experimental · no host proof</span></div>
@@ -1328,9 +1328,9 @@
 
 <section class="section install-section" id="install">
     <div class="container reveal">
-        <div class="section-label">Quickstart</div>
-        <h2 class="section-title">Install, then run <code>rampart quickstart</code>.</h2>
-        <p class="section-desc" style="margin:0 auto;">That is the default path now. It detects your agent, installs what it needs, wires the right integration path, and verifies the setup without making you memorize the matrix first.</p>
+        <div class="section-label">Protect</div>
+        <h2 class="section-title">Install, then run <code>rampart protect</code>.</h2>
+        <p class="section-desc" style="margin:0 auto;">One command detects supported agents, installs the managed Guard policy, wires each strongest native integration path, and verifies the setup.</p>
 
         <div class="install-tabs">
             <button id="tab-unix" class="install-tab active" onclick="switchTab('unix')">macOS / Linux</button>
@@ -1370,10 +1370,10 @@
 
         <div class="setup-box panel">
             <p style="color:var(--heading);font-weight:700;margin-bottom:12px;text-align:center;">Then do the part that actually wires protection:</p>
-            <pre><span style="color:var(--accent)">$</span> rampart quickstart     <span style="color:var(--text-dim)"># detect agent, install service, wire integration, verify setup</span>
-<span style="color:var(--accent)">$</span> rampart verify --all   <span style="color:var(--text-dim)"># safe aggregate check; no model calls</span>
+            <pre><span style="color:var(--accent)">$</span> rampart protect        <span style="color:var(--text-dim)"># detect, configure, and verify supported agents</span>
+<span style="color:var(--accent)">$</span> rampart verify --all   <span style="color:var(--text-dim)"># optional safe aggregate re-check; no model calls</span>
 
-<span style="color:var(--accent)">$</span> rampart protect openclaw <span style="color:var(--text-dim)"># managed fail-closed guard + verification</span>
+<span style="color:var(--accent)">$</span> rampart protect openclaw <span style="color:var(--text-dim)"># target one integration explicitly</span>
 
 <span style="color:var(--text-dim)"># Want the manual path instead?</span>
 <span style="color:var(--accent)">$</span> rampart setup claude-code

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -89,20 +89,15 @@ context. [Learn more →](reference/owasp-mapping.md#response-scanning-asi06)
 # Install
 brew install peg/tap/rampart
 
-# Claude Code
-rampart setup claude-code
-
-# OpenClaw
-rampart protect openclaw
-
-# Codex CLI, IDE, and desktop
-rampart setup codex
+# Detect, configure, and verify supported installed agents
+rampart protect
 
 # Re-check policy and every configured active-verifier integration
 rampart verify --all
 ```
 
-That's it. Pick the integration that matches your agent. [Full setup guide →](getting-started/quickstart.md) · [Support matrix →](getting-started/support-matrix.md)
+That's it. Rampart selects the strongest supported native boundary for each
+detected agent. [Full setup guide →](getting-started/quickstart.md) · [Support matrix →](getting-started/support-matrix.md)
 
 ## Frequently Asked Questions
 

--- a/docs-site/reference/cli-commands.md
+++ b/docs-site/reference/cli-commands.md
@@ -9,19 +9,6 @@ Complete reference for all `rampart` commands.
 
 ## Agent Setup
 
-### `rampart quickstart`
-
-Auto-detects your environment, installs `rampart serve`, configures integration hooks, and runs a health check.
-
-```bash
-rampart quickstart                  # Detect, configure, and verify non-interactively
-rampart quickstart --yes            # Compatibility spelling for existing scripts
-rampart quickstart -y               # Short compatibility spelling
-```
-
-Quickstart currently has no confirmation prompts. `--yes` / `-y` remains
-accepted so existing CI, scripts, and agent-driven installs continue to work.
-
 ### `rampart protect`
 
 Detect installed supported agents, install their strongest native Rampart
@@ -45,6 +32,26 @@ An explicit `--serve-url` is authoritative for startup checks, host
 configuration, and verification. OpenClaw's native plugin accepts only a
 loopback HTTP(S) service. A non-default explicit endpoint must already be
 reachable; Rampart does not silently start or verify against the default port.
+Managed protection currently rejects the global `--config` override because it
+cannot yet prove that an already-running or installed service uses the same
+file. Advanced custom-config deployments should use `rampart serve install`,
+the appropriate `rampart setup <agent>` command, and explicit verification.
+
+### `rampart quickstart` (deprecated compatibility)
+
+Preserves the older profile-selection and wrap-guidance workflow while routing
+supported native integrations through the same managed protection path as
+`rampart protect`. New installations should use `rampart protect`.
+
+```bash
+rampart quickstart                  # Legacy compatibility workflow
+rampart quickstart --yes            # Compatibility spelling for existing scripts
+rampart quickstart -y               # Short compatibility spelling
+```
+
+Quickstart remains non-interactive. `--yes` / `-y`, `--profile`, and wrap-only
+agent guidance remain available so existing scripts continue to work, but new
+onboarding and repair flows should use `rampart protect`.
 
 ### `rampart verify`
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1116,7 +1116,7 @@
         <div>
             <div class="eyebrow"><span class="eyebrow-dot"></span>v1.6.2 · verified agent boundaries</div>
             <h1>Your agent has root.<br><span class="accent">That’s the problem.</span></h1>
-            <p class="hero-sub">Rampart sits in the execution path. Run <code>rampart protect openclaw</code> for a managed, fail-closed OpenClaw guard that verifies itself, or use <code>rampart quickstart</code> for other supported agents.</p>
+            <p class="hero-sub">Rampart sits in the execution path. Run <code>rampart protect</code> to detect supported agents, install their strongest managed boundary, and verify the result.</p>
             <div class="install-cluster">
                 <div class="install-inline" onclick="copyCode(this)" title="Click to copy">
                     <span class="prompt">$</span>
@@ -1128,7 +1128,7 @@
                     <span>Claude Code · Codex · Antigravity · Copilot · Cline · OpenClaw · Hermes preview · MCP</span>
                 </div>
                 <div class="hero-actions">
-                    <a href="#install" class="btn btn-primary">Quickstart</a>
+                    <a href="#install" class="btn btn-primary">Get protected</a>
                     <a href="https://docs.rampart.sh/getting-started/support-matrix/" class="btn btn-ghost">Support matrix</a>
                 </div>
             </div>
@@ -1259,11 +1259,11 @@
         <p class="section-desc">Use the native path where Rampart knows the agent. Use preload, wrapping, MCP proxy, or the HTTP API everywhere else. For exact support tiers, approval UX, and whether <code>rampart serve</code> is required, check the support matrix.</p>
         <div class="integrations-grid">
             <div class="integration-row header"><span>Agent</span><span>Setup</span><span>Enforcement path</span><span>Status</span></div>
-            <div class="integration-row interactive"><span class="integration-agent">Claude Code</span><span class="integration-code">rampart setup claude-code</span><span class="integration-path">native hooks</span><span class="integration-status">native</span></div>
-            <div class="integration-row interactive"><span class="integration-agent">Codex CLI, IDE, desktop</span><span class="integration-code">rampart setup codex</span><span class="integration-path">native hooks</span><span class="integration-status">native</span></div>
-            <div class="integration-row interactive"><span class="integration-agent">GitHub Copilot CLI, VS Code</span><span class="integration-code">rampart setup copilot</span><span class="integration-path">shared native hooks</span><span class="integration-status">CLI adapter-tested · VS Code Preview</span></div>
-            <div class="integration-row interactive"><span class="integration-agent">Antigravity CLI, IDE</span><span class="integration-code">rampart setup antigravity</span><span class="integration-path">shared policy plugin</span><span class="integration-status">installed-plugin + adapter tested</span></div>
-            <div class="integration-row interactive"><span class="integration-agent">Cline</span><span class="integration-code">rampart setup cline</span><span class="integration-path">native hooks</span><span class="integration-status">native</span></div>
+            <div class="integration-row interactive"><span class="integration-agent">Claude Code</span><span class="integration-code">rampart protect claude-code</span><span class="integration-path">native hooks</span><span class="integration-status">native</span></div>
+            <div class="integration-row interactive"><span class="integration-agent">Codex CLI, IDE, desktop</span><span class="integration-code">rampart protect codex</span><span class="integration-path">native hooks</span><span class="integration-status">native</span></div>
+            <div class="integration-row interactive"><span class="integration-agent">GitHub Copilot CLI, VS Code</span><span class="integration-code">rampart protect copilot</span><span class="integration-path">shared native hooks</span><span class="integration-status">CLI adapter-tested · VS Code Preview</span></div>
+            <div class="integration-row interactive"><span class="integration-agent">Antigravity CLI, IDE</span><span class="integration-code">rampart protect antigravity</span><span class="integration-path">shared policy plugin</span><span class="integration-status">installed-plugin + adapter tested</span></div>
+            <div class="integration-row interactive"><span class="integration-agent">Cline</span><span class="integration-code">rampart protect cline</span><span class="integration-path">native hooks</span><span class="integration-status">native</span></div>
             <div class="integration-row interactive"><span class="integration-agent">OpenClaw</span><span class="integration-code">rampart protect openclaw</span><span class="integration-path">managed native guard</span><span class="integration-status">verified</span></div>
             <div class="integration-row interactive"><span class="integration-agent">Hermes Agent</span><span class="integration-code">rampart setup hermes</span><span class="integration-path">user plugin</span><span class="integration-status">experimental</span></div>
             <div class="integration-row interactive"><span class="integration-agent">Gemini CLI (enterprise/API key)</span><span class="integration-code">rampart setup gemini</span><span class="integration-path">native hooks</span><span class="integration-status">experimental · no host proof</span></div>
@@ -1328,9 +1328,9 @@
 
 <section class="section install-section" id="install">
     <div class="container reveal">
-        <div class="section-label">Quickstart</div>
-        <h2 class="section-title">Install, then run <code>rampart quickstart</code>.</h2>
-        <p class="section-desc" style="margin:0 auto;">That is the default path now. It detects your agent, installs what it needs, wires the right integration path, and verifies the setup without making you memorize the matrix first.</p>
+        <div class="section-label">Protect</div>
+        <h2 class="section-title">Install, then run <code>rampart protect</code>.</h2>
+        <p class="section-desc" style="margin:0 auto;">One command detects supported agents, installs the managed Guard policy, wires each strongest native integration path, and verifies the setup.</p>
 
         <div class="install-tabs">
             <button id="tab-unix" class="install-tab active" onclick="switchTab('unix')">macOS / Linux</button>
@@ -1370,10 +1370,10 @@
 
         <div class="setup-box panel">
             <p style="color:var(--heading);font-weight:700;margin-bottom:12px;text-align:center;">Then do the part that actually wires protection:</p>
-            <pre><span style="color:var(--accent)">$</span> rampart quickstart     <span style="color:var(--text-dim)"># detect agent, install service, wire integration, verify setup</span>
-<span style="color:var(--accent)">$</span> rampart verify --all   <span style="color:var(--text-dim)"># safe aggregate check; no model calls</span>
+            <pre><span style="color:var(--accent)">$</span> rampart protect        <span style="color:var(--text-dim)"># detect, configure, and verify supported agents</span>
+<span style="color:var(--accent)">$</span> rampart verify --all   <span style="color:var(--text-dim)"># optional safe aggregate re-check; no model calls</span>
 
-<span style="color:var(--accent)">$</span> rampart protect openclaw <span style="color:var(--text-dim)"># managed fail-closed guard + verification</span>
+<span style="color:var(--accent)">$</span> rampart protect openclaw <span style="color:var(--text-dim)"># target one integration explicitly</span>
 
 <span style="color:var(--text-dim)"># Want the manual path instead?</span>
 <span style="color:var(--accent)">$</span> rampart setup claude-code

--- a/docs/install
+++ b/docs/install
@@ -533,12 +533,12 @@ printf "\n%s\n" "$VALIDATION_OUTPUT"
 
 case ":${PATH}:" in
 *":${INSTALL_DIR}:"*)
-    printf "\n${GREEN}${BOLD}Ready!${RESET} Run ${BOLD}rampart quickstart${RESET} to get started.\n"
+    printf "\n${GREEN}${BOLD}Ready!${RESET} Run ${BOLD}rampart protect${RESET} to get started.\n"
     ;;
 *)
     printf "\n${YELLOW}Note:${RESET} ${INSTALL_DIR} may not be in your PATH.\n"
     printf "Add it: ${BOLD}export PATH=\"${INSTALL_DIR}:\$PATH\"${RESET}\n"
-    printf "Then run: ${BOLD}rampart quickstart${RESET}\n"
+    printf "Then run: ${BOLD}rampart protect${RESET}\n"
     ;;
 esac
 

--- a/docs/install.sh
+++ b/docs/install.sh
@@ -533,12 +533,12 @@ printf "\n%s\n" "$VALIDATION_OUTPUT"
 
 case ":${PATH}:" in
 *":${INSTALL_DIR}:"*)
-    printf "\n${GREEN}${BOLD}Ready!${RESET} Run ${BOLD}rampart quickstart${RESET} to get started.\n"
+    printf "\n${GREEN}${BOLD}Ready!${RESET} Run ${BOLD}rampart protect${RESET} to get started.\n"
     ;;
 *)
     printf "\n${YELLOW}Note:${RESET} ${INSTALL_DIR} may not be in your PATH.\n"
     printf "Add it: ${BOLD}export PATH=\"${INSTALL_DIR}:\$PATH\"${RESET}\n"
-    printf "Then run: ${BOLD}rampart quickstart${RESET}\n"
+    printf "Then run: ${BOLD}rampart protect${RESET}\n"
     ;;
 esac
 

--- a/install.sh
+++ b/install.sh
@@ -533,12 +533,12 @@ printf "\n%s\n" "$VALIDATION_OUTPUT"
 
 case ":${PATH}:" in
 *":${INSTALL_DIR}:"*)
-    printf "\n${GREEN}${BOLD}Ready!${RESET} Run ${BOLD}rampart quickstart${RESET} to get started.\n"
+    printf "\n${GREEN}${BOLD}Ready!${RESET} Run ${BOLD}rampart protect${RESET} to get started.\n"
     ;;
 *)
     printf "\n${YELLOW}Note:${RESET} ${INSTALL_DIR} may not be in your PATH.\n"
     printf "Add it: ${BOLD}export PATH=\"${INSTALL_DIR}:\$PATH\"${RESET}\n"
-    printf "Then run: ${BOLD}rampart quickstart${RESET}\n"
+    printf "Then run: ${BOLD}rampart protect${RESET}\n"
     ;;
 esac
 


### PR DESCRIPTION
## Summary

- add one managed protection plan shared by `rampart protect` and the legacy `quickstart` workflow
- install Guard and start the policy service once per multi-agent run, with the strict OpenClaw path ordered before native-hook integrations
- route quickstart setup, active verification, and assurance receipts through the canonical lifecycle while preserving its profile, agent-selection, and wrap-guidance compatibility
- make `rampart protect` the single recommended onboarding command across installers, README, docs, and the mirrored website

## Correctness and security

- repairs the Windows legacy Rampart-directory ACL before either onboarding path mutates policy state
- initializes a real base profile before adding supplemental Guard policy, including repair when an older install contains only `custom.yaml` and `guard.yaml`
- fails before mutation when managed protection receives a custom `--config`, avoiding a service/config identity mismatch until lifecycle reconciliation can prove it safely
- removes duplicate quickstart subprocess, hook-state, service-health, policy-stat, and verification orchestration; production Go code is 36 lines smaller

## Validation

- full maintainer gate: `go test ./...`, `go vet ./...`, and `make security-assurance`
- full CLI package and focused lifecycle regressions
- Windows/amd64 CLI test cross-compilation
- Unix installer transaction suite and installer syntax/mirror checks
- MkDocs build and canonical document checks
- landing-page mirror and `git diff --check`

No model calls, credentials, private lab material, or host-specific evidence are included.
