### PR TITLE
fix: enforce OpenClaw bridge audit boundaries

### DIFF
--- a/cmd/rampart/cli/serve.go
+++ b/cmd/rampart/cli/serve.go
@@ -566,7 +566,7 @@ func newServeCmd(opts *rootOptions, deps *serveDeps) *cobra.Command {
 
 			// Auto-start OpenClaw bridge if gateway is discoverable.
 			var openclawBridge *bridge.OpenClawBridge
-			if !noOpenClawBridge {
+			if !noOpenClawBridge && mode != "disabled" {
 				gwURL, gwToken, autoResolveAllowDecisions, discoverErr := bridge.DiscoverGatewayConfigForBridge()
 				if discoverErr == nil {
 					openclawBridge = bridge.NewOpenClawBridge(eng, bridge.Config{
@@ -575,6 +575,7 @@ func newServeCmd(opts *rootOptions, deps *serveDeps) *cobra.Command {
 						Logger:                    logger,
 						AuditSink:                 sink,
 						AutoResolveAllowDecisions: &autoResolveAllowDecisions,
+						Mode:                      mode,
 					})
 					bridgeCtx, bridgeCancel := context.WithCancel(cmd.Context())
 					defer bridgeCancel()

--- a/internal/bridge/openclaw.go
+++ b/internal/bridge/openclaw.go
@@ -56,6 +56,9 @@ const (
 	maxOpenClawFrameBytes      = 4 << 20
 	maxPendingBridgeCommands   = 1000
 	maxPendingBridgeCommandLen = 256 << 10
+	bridgeModeEnforce          = "enforce"
+	bridgeModeMonitor          = "monitor"
+	bridgeModeDisabled         = "disabled"
 )
 
 // OpenClawBridge connects to the OpenClaw gateway and handles exec approval
@@ -67,6 +70,7 @@ type OpenClawBridge struct {
 	sink                      audit.AuditSink
 	logger                    *slog.Logger
 	autoResolveAllowDecisions bool
+	mode                      string
 
 	reconnectInterval time.Duration
 
@@ -105,6 +109,13 @@ type Config struct {
 	// OpenClaw's own/manual approval layer and must stay human-owned unless
 	// Rampart explicitly denies it.
 	AutoResolveAllowDecisions *bool
+
+	// Mode controls the bridge's decision authority. "enforce" (the default)
+	// may resolve OpenClaw approvals. "monitor" records observational policy
+	// evaluations without resolving or consuming enforcement state. "disabled"
+	// prevents the bridge from connecting. Unknown values fail closed as
+	// "enforce".
+	Mode string
 }
 
 // NewOpenClawBridge creates a new bridge.
@@ -127,8 +138,22 @@ func NewOpenClawBridge(eng *engine.Engine, cfg Config) *OpenClawBridge {
 		sink:                      cfg.AuditSink,
 		logger:                    cfg.Logger,
 		autoResolveAllowDecisions: autoResolveAllowDecisions,
+		mode:                      normalizeOpenClawBridgeMode(cfg.Mode),
 		reconnectInterval:         cfg.ReconnectInterval,
 		pendingCommands:           make(map[string]string),
+	}
+}
+
+func normalizeOpenClawBridgeMode(mode string) string {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case bridgeModeMonitor:
+		return bridgeModeMonitor
+	case bridgeModeDisabled:
+		return bridgeModeDisabled
+	case "", bridgeModeEnforce:
+		return bridgeModeEnforce
+	default:
+		return bridgeModeEnforce
 	}
 }
 
@@ -146,6 +171,11 @@ func (b *OpenClawBridge) Close() {
 // Start connects to the gateway and processes approval events until the context
 // is cancelled. It automatically reconnects on disconnect with backoff.
 func (b *OpenClawBridge) Start(ctx context.Context) error {
+	if b.mode == bridgeModeDisabled {
+		b.logger.Info("bridge: OpenClaw bridge disabled")
+		return nil
+	}
+
 	backoff := b.reconnectInterval
 	for {
 		err := b.connectAndListen(ctx)
@@ -344,14 +374,17 @@ func (b *OpenClawBridge) handleEvent(ctx context.Context, conn *websocket.Conn, 
 			b.logger.Error("bridge: failed to parse approval request", "error", err)
 			return
 		}
-		// Store the command immediately so allow-always writeback works
-		// regardless of who ultimately resolves the approval (Rampart or OpenClaw native flow).
-		if req.ID != "" && req.command() != "" && !b.rememberPendingCommand(req.ID, req.command()) {
+		// In enforce mode, store the command immediately so allow-always writeback
+		// works regardless of who resolves the approval (Rampart or OpenClaw).
+		if b.mode == bridgeModeEnforce && req.ID != "" && req.command() != "" && !b.rememberPendingCommand(req.ID, req.command()) {
 			b.logger.Warn("bridge: pending command correlation limit reached; allow-always writeback unavailable", "id", req.ID)
 		}
 		b.handleApprovalRequested(ctx, conn, req)
 
 	case "exec.approval.resolved":
+		if b.mode != bridgeModeEnforce {
+			return
+		}
 		// Another client resolved this approval — cancel any pending escalation.
 		// If decision is "allow-always", write a user override rule.
 		var resolved struct {
@@ -398,7 +431,14 @@ func (b *OpenClawBridge) handleApprovalRequested(ctx context.Context, conn *webs
 	}
 
 	start := time.Now()
-	decision := b.engine.Enforce(call, engine.EvalOptions{})
+	var decision engine.Decision
+	if b.mode == bridgeModeMonitor {
+		// Monitor mode is observational: it must not consume one-time allows or
+		// increment call-count enforcement state for an approval it does not own.
+		decision = b.engine.Evaluate(call)
+	} else {
+		decision = b.engine.Enforce(call, engine.EvalOptions{})
+	}
 	evalDuration := time.Since(start)
 
 	b.logger.Info("bridge: evaluated approval request",
@@ -410,6 +450,9 @@ func (b *OpenClawBridge) handleApprovalRequested(ctx context.Context, conn *webs
 	)
 
 	// Write audit event so bridge-evaluated commands appear in the JSONL trail.
+	// A configured sink is part of the enforcement boundary: Rampart must not
+	// auto-authorize execution when it cannot persist the decision it owns.
+	var auditErr error
 	if b.sink != nil {
 		ev := audit.Event{
 			ID:        audit.NewEventID(),
@@ -426,12 +469,23 @@ func (b *OpenClawBridge) handleApprovalRequested(ctx context.Context, conn *webs
 			},
 		}
 		if err := b.sink.Write(ev); err != nil {
+			auditErr = err
 			b.logger.Warn("bridge: failed to write audit event", "error", err)
 		}
+	}
+	if b.mode == bridgeModeMonitor {
+		// The host owns every approval in monitor mode, including when audit
+		// persistence is unavailable. Keep the approval pending and only log it.
+		return
 	}
 
 	switch decision.Action {
 	case engine.ActionAllow, engine.ActionWatch:
+		if auditErr != nil {
+			b.logger.Warn("bridge: audit persistence failed; leaving approval pending (fail-closed)",
+				"id", req.ID, "action", decision.Action.String())
+			return
+		}
 		if !b.autoResolveAllowDecisions {
 			b.leavePendingForOpenClawReview(req, decision)
 			return

--- a/internal/bridge/openclaw_test.go
+++ b/internal/bridge/openclaw_test.go
@@ -207,6 +207,24 @@ policies:
             - "rm -rf /"
             - "rm -rf ~"
         message: "Destructive command blocked"
+  - name: approve-production-change
+    match:
+      tool: exec
+    rules:
+      - action: ask
+        when:
+          command_matches:
+            - "kubectl apply*"
+        message: "Production change requires approval"
+  - name: observe-safe-command
+    match:
+      tool: exec
+    rules:
+      - action: watch
+        when:
+          command_matches:
+            - "echo watched"
+        message: "Safe command observed"
 `
 	path := filepath.Join(dir, "policy.yaml")
 	require.NoError(t, os.WriteFile(path, []byte(policy), 0o644))
@@ -782,6 +800,59 @@ policies:
 	}
 }
 
+func TestBridgeMonitorModeDoesNotCorrelateOrPersistAllowAlways(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
+
+	mg := newMockGateway(t)
+	defer mg.close()
+
+	observed := make(chan struct{}, 1)
+	b := NewOpenClawBridge(newTestEngine(t, writeTestPolicy(t, tmpDir)), Config{
+		GatewayURL:        mg.url(),
+		GatewayToken:      "test-token",
+		ReconnectInterval: 100 * time.Millisecond,
+		AuditSink: &testAuditSink{writeFn: func(audit.Event) error {
+			observed <- struct{}{}
+			return nil
+		}},
+		Mode: bridgeModeMonitor,
+	})
+	defer b.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	go func() { b.Start(ctx) }() //nolint:errcheck
+
+	const approvalID = "monitor-allow-always-001"
+	mg.sendApprovalRequest(approvalID, "kubectl apply -f prod.yaml", "test-agent")
+	select {
+	case <-observed:
+	case <-ctx.Done():
+		t.Fatal("monitor request was not observed")
+	}
+
+	b.pendingMu.Lock()
+	_, correlated := b.pendingCommands[approvalID]
+	b.pendingMu.Unlock()
+	assert.False(t, correlated, "monitor request must not create allow-always correlation")
+
+	mg.sendApprovalResolved(approvalID, "allow-always")
+	overridesPath := filepath.Join(tmpDir, ".rampart", "policies", "user-overrides.yaml")
+	require.Never(t, func() bool {
+		_, err := os.Stat(overridesPath)
+		return err == nil
+	}, 300*time.Millisecond, 20*time.Millisecond, "monitor resolution must not write a user override")
+
+	b.pendingMu.Lock()
+	assert.Empty(t, b.pendingCommands, "monitor mode must retain no pending-command correlation")
+	b.pendingMu.Unlock()
+	if resp, ok := mg.readResponseWithin(200 * time.Millisecond); ok {
+		t.Fatalf("monitor mode unexpectedly resolved approval: %#v", resp)
+	}
+}
+
 // TestBridgeAuditSinkWrite verifies that bridge-evaluated approvals are written
 // to the audit sink, fixing the empty-params audit trail bug.
 func TestBridgeAuditSinkWrite(t *testing.T) {
@@ -850,6 +921,124 @@ func TestBridgeAuditSinkWrite(t *testing.T) {
 	}
 
 	cancel()
+}
+
+func TestBridgeAuditFailureRespectsMode(t *testing.T) {
+	tests := []struct {
+		name         string
+		command      string
+		mode         string
+		wantDecision string
+		wantPending  bool
+	}{
+		{name: "enforce allow remains pending", command: "git status", mode: "enforce", wantPending: true},
+		{name: "enforce watch remains pending", command: "echo watched", mode: "enforce", wantPending: true},
+		{name: "enforce deny remains denied", command: "rm -rf /", mode: "enforce", wantDecision: "deny"},
+		{name: "enforce ask remains pending", command: "kubectl apply -f prod.yaml", mode: "enforce", wantPending: true},
+		{name: "monitor remains observational", command: "rm -rf /", mode: "monitor", wantPending: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mg := newMockGateway(t)
+			defer mg.close()
+
+			policyPath := writeTestPolicy(t, t.TempDir())
+			bridge := NewOpenClawBridge(newTestEngine(t, policyPath), Config{
+				GatewayURL:        mg.url(),
+				GatewayToken:      "test-token",
+				ReconnectInterval: 100 * time.Millisecond,
+				AuditSink: &testAuditSink{writeFn: func(audit.Event) error {
+					return errors.New("audit storage unavailable")
+				}},
+				Mode: test.mode,
+			})
+			defer bridge.Close()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			go func() { bridge.Start(ctx) }() //nolint:errcheck
+
+			approvalID := "audit-failure-" + strings.ReplaceAll(test.name, " ", "-")
+			mg.sendApprovalRequest(approvalID, test.command, "test-agent")
+			if test.wantDecision == "" {
+				if resp, ok := mg.readResponseWithin(300 * time.Millisecond); ok {
+					t.Fatalf("audit failure unexpectedly resolved approval: %#v", resp)
+				}
+			} else {
+				resp := mg.readResponse()
+				params, ok := resp["params"].(map[string]any)
+				require.True(t, ok, "expected params in response")
+				assert.Equal(t, approvalID, params["id"])
+				assert.Equal(t, test.wantDecision, params["decision"])
+			}
+
+			bridge.pendingMu.Lock()
+			_, pending := bridge.pendingCommands[approvalID]
+			bridge.pendingMu.Unlock()
+			assert.Equal(t, test.wantPending, pending)
+		})
+	}
+}
+
+func TestBridgeDisabledModeDoesNotConnect(t *testing.T) {
+	bridge := NewOpenClawBridge(newTestEngine(t, writeTestPolicy(t, t.TempDir())), Config{
+		GatewayURL:   "ws://127.0.0.1:1",
+		GatewayToken: "test-token",
+		Mode:         "disabled",
+	})
+	defer bridge.Close()
+
+	if err := bridge.Start(context.Background()); err != nil {
+		t.Fatalf("disabled bridge Start() error = %v", err)
+	}
+}
+
+func TestOpenClawBridgeModeNormalizationFailsClosed(t *testing.T) {
+	for _, test := range []struct {
+		input string
+		want  string
+	}{
+		{input: "", want: bridgeModeEnforce},
+		{input: " MONITOR ", want: bridgeModeMonitor},
+		{input: "disabled", want: bridgeModeDisabled},
+		{input: "typo", want: bridgeModeEnforce},
+	} {
+		t.Run(test.input, func(t *testing.T) {
+			if got := normalizeOpenClawBridgeMode(test.input); got != test.want {
+				t.Fatalf("normalizeOpenClawBridgeMode(%q) = %q, want %q", test.input, got, test.want)
+			}
+		})
+	}
+}
+
+func TestBridgeMonitorModeDoesNotConsumeEnforcementState(t *testing.T) {
+	policyPath := filepath.Join(t.TempDir(), "policy.yaml")
+	policy := `version: "1"
+default_action: allow
+policies:
+  - name: exec-limit
+    match:
+      tool: exec
+    rules:
+      - action: deny
+        when:
+          call_count:
+            gte: 2
+            window: 1h
+`
+	require.NoError(t, os.WriteFile(policyPath, []byte(policy), 0o644))
+	eng := newTestEngine(t, policyPath)
+	bridge := NewOpenClawBridge(eng, Config{Mode: "monitor"})
+
+	var req approvalRequestParams
+	req.Request.Command = "git status"
+	bridge.handleApprovalRequested(context.Background(), nil, req)
+
+	decision := eng.Enforce(engine.ToolCall{Tool: "exec", Params: map[string]any{"command": "git status"}}, engine.EvalOptions{})
+	if decision.Action != engine.ActionAllow {
+		t.Fatalf("first enforced command after monitor evaluation = %s, want allow", decision.Action)
+	}
 }
 
 func TestPendingCommandCorrelationIsBounded(t *testing.T) {


### PR DESCRIPTION
## Summary
- keep native OpenClaw approvals pending when enforce-mode audit persistence fails
- make monitor mode observational: no approval resolution, enforcement-state consumption, or allow-always writeback
- avoid constructing the bridge in disabled mode

## Validation
- full Go test suite
- focused and race-enabled OpenClaw bridge tests
- CLI package tests and vet
- security assurance and diff checks

This is a focused behavior repair; it does not expand integration support claims.