### PR TITLE
feat: add native Hermes approval resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Experimental integrations are explicit opt-ins and stay outside bare
 `rampart protect` auto-detection:
 
 ```bash
-# Hermes Agent (experimental; native approval/resume pending)
+# Hermes Agent (experimental; native approval on current Hermes)
 rampart setup hermes
 
 # Gemini CLI (experimental enterprise/API-key path; no authenticated host proof)
@@ -354,7 +354,7 @@ rampart setup hermes
 hermes plugins enable rampart
 ```
 
-The plugin registers a Hermes `pre_tool_call` hook and sends sanitized tool metadata to Rampart before execution. It defaults to `/v1/preflight/{tool}` with execution intent, so one-time grants and call counters are enforced without creating hidden approvals that Hermes cannot resume. `ask` decisions block with an approval-required message until Hermes has a first-class plugin approval/resume flow. Service outages deny every Hermes tool by default.
+The plugin registers a Hermes `pre_tool_call` hook and sends sanitized tool metadata to Rampart before execution. It defaults to `/v1/preflight/{tool}` with execution intent, so one-time grants and call counters are enforced without creating a second Rampart approval queue. On current Hermes releases, `ask` decisions use Hermes' native approval flow to pause and resume the same tool call. Older Hermes releases block with an upgrade message. Service outages deny every Hermes tool by default.
 
 Hermes currently has a static installation check rather than a safe built-in
 host verifier. Use `rampart doctor` for local status, then the isolated Hermes
@@ -727,7 +727,7 @@ rampart verify copilot                       # Verify dual-host deny response + 
 # Experimental, explicit opt-in integrations
 rampart setup gemini                         # Enterprise/API-key Gemini CLI; no authenticated host proof
 rampart verify gemini                        # Verify generated hooks + adapter response
-rampart setup hermes                         # Hermes plugin; native approval/resume pending
+rampart setup hermes                         # Experimental Hermes plugin; current Hermes uses native approval
 rampart setup <agent> --remove               # Clean uninstall
 
 # Run

--- a/assurance/integrations.yaml
+++ b/assurance/integrations.yaml
@@ -216,7 +216,7 @@ integrations:
       policy_unavailable: deny
       adapter_error: deny
       timeout: deny
-    approval: block_and_retry
+    approval: native
     verification:
       level: static
       command: rampart doctor
@@ -225,16 +225,16 @@ integrations:
     evidence:
       - path: internal/plugin/hermes/test_hermes_plugin.py
         kind: unit
-        proves: Tool normalization, redaction, allow, deny, ask, malformed responses, unknown-tool fail-closed behavior, adapter exceptions, and service failure are tested.
+        proves: Tool normalization, redaction, allow, deny, native ask approval identity, malformed responses, unknown-tool fail-closed behavior, adapter exceptions, and service failure are tested.
       - path: scripts/compat-hermes-latest.py
         kind: upstream_latest
-        proves: Hermes' official latest stable GitHub release is resolved independently of PyPI, then discovery, dispatcher decisions, degraded mode, and multi-path deny-wins behavior are checked in isolation.
+        proves: Hermes' official latest stable GitHub release is resolved independently of PyPI, then discovery, native approval allow/deny resolution, dispatcher decisions, degraded mode, and multi-path deny-wins behavior are checked in isolation.
     limitations:
       - Hermes documents that a crashing plugin callback is skipped and the agent continues.
-      - Hermes approval observer hooks cannot answer or resume an approval.
+      - Native approval/resume requires a Hermes release that exposes the plugin approval directive; older releases block `ask` decisions with an upgrade message.
       - Operators may explicitly weaken degraded behavior by configuring selected tools to fail open; the default denies every tool.
       - Hermes tools outside the plugin's typed map, including MCP and delegated-agent tools, fail closed but are not claimed as covered policy surfaces.
-      - Delegated-agent and approved-execution E2E are not present.
+      - Delegated-agent and authenticated live-host E2E are not present.
 
   - id: gemini
     display_name: Gemini CLI

--- a/cmd/rampart/cli/doctor.go
+++ b/cmd/rampart/cli/doctor.go
@@ -2105,7 +2105,7 @@ func doctorHermesIntegration(emit emitFn, serveURL, token string) (warnings int)
 			"Set endpoint_mode: preflight")
 		warnings++
 	} else {
-		emit("Hermes policy mode", "ok", "preflight mode; ask decisions block until Hermes exposes plugin approval/resume")
+		emit("Hermes policy mode", "ok", "preflight mode; current Hermes releases use native approval for ask decisions, while older releases fail closed")
 	}
 
 	failOpenTools := hermesFailOpenTools(pluginConfig)
@@ -2135,7 +2135,7 @@ func doctorHermesIntegration(emit emitFn, serveURL, token string) (warnings int)
 		}
 	}
 
-	emit("Hermes support tier", "info", "experimental policy gate; full approval/resume support requires Hermes-owned approval APIs and E2E validation")
+	emit("Hermes support tier", "info", "experimental policy gate; native approval requires a current Hermes release, and authenticated live-host E2E remains unverified")
 	return warnings
 }
 

--- a/cmd/rampart/cli/doctor_test.go
+++ b/cmd/rampart/cli/doctor_test.go
@@ -1004,7 +1004,7 @@ func TestDoctorHermesIntegrationReportsReadyExperimentalGate(t *testing.T) {
 	if !strings.Contains(out, "experimental policy gate configured") {
 		t.Fatalf("expected Hermes readiness message, got: %s", out)
 	}
-	if !strings.Contains(out, "full approval/resume support requires") {
+	if !strings.Contains(out, "native approval requires a current Hermes release") {
 		t.Fatalf("expected support-tier boundary, got: %s", out)
 	}
 }

--- a/cmd/rampart/cli/setup.go
+++ b/cmd/rampart/cli/setup.go
@@ -153,9 +153,11 @@ $HERMES_HOME/plugins/rampart (normally ~/.hermes/plugins/rampart) without
 patching Hermes itself.
 
 The plugin uses Hermes' pre_tool_call hook, calls Rampart's policy API before
-sensitive tool calls execute, defaults to /v1/preflight/{tool}, blocks ask
-responses instead of creating hidden approvals, and fails closed for every tool
-when Rampart serve is unavailable unless an operator explicitly opts a tool out.
+sensitive tool calls execute, defaults to /v1/preflight/{tool}, routes ask
+responses through current Hermes releases' native approval/resume flow instead
+of creating hidden approvals, and fails closed for every tool when Rampart serve
+is unavailable unless an operator explicitly opts a tool out. Older Hermes
+releases that lack the required approval contract block ask decisions.
 
 By default this command installs the plugin files only. Use --enable to run
 "hermes plugins enable rampart" after installation. Restart long-running Hermes

--- a/docs-site/getting-started/support-matrix.md
+++ b/docs-site/getting-started/support-matrix.md
@@ -104,8 +104,8 @@ and the isolated latest-Hermes compatibility check for runtime evidence.
       <td data-label="Best path">Experimental user plugin<br><code>rampart setup hermes</code></td>
       <td data-label="Bare protect">No</td>
       <td data-label="rampart serve">Required</td>
-      <td data-label="Approval UX"><code>ask</code> blocks until plugin approval/resume support exists</td>
-      <td data-label="Support tier"><strong>Experimental</strong><br>latest-runtime compatibility; native approval/resume pending</td>
+      <td data-label="Approval UX">Current Hermes native approval; older releases block <code>ask</code></td>
+      <td data-label="Support tier"><strong>Experimental</strong><br>latest-runtime compatibility; authenticated live-host proof pending</td>
     </tr>
     <tr class="tier-supported">
       <td data-label="Surface"><strong>OpenClaw 2026.4.29 - 2026.5.1</strong></td>

--- a/docs-site/integrations/hermes.md
+++ b/docs-site/integrations/hermes.md
@@ -8,7 +8,7 @@ description: "Experimental Rampart integration for Hermes Agent using a user plu
 Rampart can protect Hermes Agent through an **experimental user plugin**. The plugin registers a Hermes `pre_tool_call` hook, sends a sanitized policy check to Rampart before selected tools execute, passes Hermes' top-level `tool_call_id` for audit correlation, and blocks the tool call when policy denies it.
 
 !!! warning "Experimental integration"
-    This integration is intentionally conservative. It does not patch Hermes, does not create a hidden approval queue, and does not resume `ask` decisions automatically. Policies that return `ask` are blocked with an approval-required message until Hermes has a first-class plugin approval/resume flow.
+    This integration is intentionally conservative. It does not patch Hermes or create a hidden Rampart approval queue. Current Hermes releases own the `ask` prompt and resume the same tool call; older releases fail closed with an upgrade message. It remains experimental because authenticated live-host proof and full host-failure behavior are not yet established.
 
 ## What it covers
 
@@ -91,17 +91,25 @@ plugins:
 | --- | --- |
 | `allow`, `watch`, `log` | Tool call continues. |
 | `deny` | Tool call is blocked with the policy reason. |
-| `ask` | Tool call is blocked with an approval-required message. No hidden Rampart approval is created by default. When Rampart returns an `audit_id`, the block message includes it for correlation. |
+| `ask` | Current Hermes releases show Hermes' native approval and resume the same tool call when approved. Older releases block with an upgrade message. No hidden Rampart approval is created. When Rampart returns an `audit_id`, the prompt message includes it for correlation. |
 | Rampart unavailable | Every tool fails closed by default. Advanced operators can explicitly configure selected tools to fail open. |
 
-The default endpoint mode is `preflight`, which calls `POST /v1/preflight/{tool}` with `enforce: true`. This is deliberate: it consumes one-time grants and records call-count state at Hermes' actual pre-execution boundary without creating pending Rampart approvals that Hermes cannot yet resume from a plugin hook. Rampart records the evaluation audit ID, and the plugin sends Hermes' top-level `tool_call_id` when Hermes provides one.
+The default endpoint mode is `preflight`, which calls `POST /v1/preflight/{tool}` with `enforce: true`. This consumes one-time grants and records call-count state at Hermes' actual pre-execution boundary without creating pending Rampart approvals. A current Hermes host owns the approval UI and resumes the same call after approval. Rampart records the evaluation audit ID, and the plugin sends Hermes' top-level `tool_call_id` when Hermes provides one.
+
+For session or `always` choices, the plugin supplies Hermes an opaque, token-keyed
+identity of both the original call and its resolved policy paths. This prevents
+an approval for one command, URL, content payload, or relative path in one task
+directory from applying to another. A Rampart token is therefore required for
+native `ask` approval; without one, `ask` fails closed while ordinary allow and
+deny decisions continue to work.
 
 For an availability-first deployment, `fail_open_tools` can explicitly list
 individual Hermes names such as `web_search`. This weakens the enforcement
 boundary and is never enabled by default; credential-bearing reads should stay
 fail closed.
 
-Rampart's hosted approval API is ready for hosts that can create a single user-facing approval and resume the exact tool call. This plugin does not request hosted approvals yet because current Hermes plugin hooks do not expose that exact approval/resume contract as a stable plugin primitive.
+Rampart does not request a second hosted approval from its own service. Hermes'
+native approval surface is the sole approval owner for this integration.
 
 For experiments that need raw `/v1/tool/{tool}` semantics, set:
 
@@ -125,7 +133,7 @@ Use the isolated latest-Hermes compatibility harness before enabling the plugin 
 python scripts/compat-hermes-latest.py
 ```
 
-The harness creates a temporary Hermes state, installs the Rampart plugin there, exercises Hermes plugin discovery plus `pre_tool_call` dispatch, and verifies deny, allow, `ask` blocking, and fail-closed behavior without restarting any long-running Hermes gateway.
+The harness creates a temporary Hermes state, installs the Rampart plugin there, exercises Hermes plugin discovery plus `pre_tool_call` dispatch, and verifies deny, allow, native `ask` approval/denial, and fail-closed behavior without restarting any long-running Hermes gateway.
 By default it resolves Hermes' official latest stable GitHub release and uses
 an isolated editable checkout of that exact tag, the development install path
 Hermes permits. `--package` is an explicit maintainer override; it is not the
@@ -133,13 +141,12 @@ definition of the latest supported Hermes release. The check does not use
 provider credentials or invoke a model.
 
 !!! warning "Why this remains experimental"
-    Rampart converts ordinary adapter exceptions into explicit blocks, but
-    Hermes currently documents that a plugin callback which fails outside that
-    wrapper can be skipped while agent execution continues. Its plugin hooks
-    also do not expose a stable exact-call approval/resume primitive. Rampart
-    can conservatively block an `ask` decision, but it cannot honestly promise
-    a first-class pause and resume flow or fail-closed behavior after every
-    host-level plugin failure.
+    Hermes currently documents that a plugin callback which fails outside
+    Rampart's adapter wrapper can be skipped while agent execution continues.
+    Rampart converts ordinary adapter exceptions into explicit blocks, but it
+    cannot honestly claim fail-closed behavior after every host-level plugin
+    failure. The credential-free compatibility harness proves current-host
+    dispatcher behavior, not an authenticated live-agent journey.
 
 ## Provider authentication errors
 

--- a/internal/plugin/hermes/__init__.py
+++ b/internal/plugin/hermes/__init__.py
@@ -4,25 +4,34 @@
 
 The plugin is intentionally conservative:
 
-* It uses Hermes' ``pre_tool_call`` hook and only returns a block directive.
-* It defaults to ``/v1/preflight/{tool}`` so Rampart does not create a hidden
-  approval queue while Hermes lacks a plugin-owned approval/resume primitive.
+* It uses Hermes' ``pre_tool_call`` hook and returns only host control
+  directives: block, native approval, or no directive.
+* It defaults to ``/v1/preflight/{tool}`` so Rampart does not create a second,
+  hidden approval queue alongside Hermes' native approval UI.
 * It passes Hermes' native ``tool_call_id`` as top-level Rampart metadata so
   Rampart audit IDs can be correlated with the exact Hermes tool call.
-* ``ask`` / ``require_approval`` decisions block with a clear message instead
-  of polling or creating a second approval surface, and include Rampart's
-  ``audit_id`` when available.
+* On current Hermes releases, ``ask`` / ``require_approval`` decisions return
+  Hermes' native ``approve`` directive so the host pauses and resumes the exact
+  tool call. Older hosts that lack that directive fail closed with an upgrade
+  message instead of silently executing the call.
 * If Rampart serve is unavailable, every tool fails closed by default. Advanced
   operators may explicitly opt selected tools into degraded fail-open behavior.
 """
 
 from __future__ import annotations
 
+import ast
+import hashlib
+import hmac
 import ipaddress
+import inspect
 import json
 import logging
 import os
+import re
 import socket
+import textwrap
+import unicodedata
 import urllib.error
 import urllib.request
 from dataclasses import dataclass
@@ -30,7 +39,7 @@ from pathlib import Path
 from typing import Any, Callable, Mapping
 from urllib.parse import quote, urlsplit
 
-VERSION = "1.6.0"
+VERSION = "1.7.0"
 
 DEFAULT_SERVE_URL = "http://127.0.0.1:9090"
 DEFAULT_TIMEOUT_MS = 3000
@@ -38,6 +47,11 @@ DEFAULT_ENDPOINT_MODE = "preflight"
 DEFAULT_AGENT_NAME = "hermes"
 MAX_PATCH_PATHS = 100
 MAX_RESPONSE_BYTES = 1024 * 1024
+# Native approval keys are persisted by Hermes for session and "always"
+# choices. Refuse unusually large, unrepresentable calls rather than doing
+# unbounded serialization on the execution boundary.
+MAX_APPROVAL_IDENTITY_BYTES = 64 * 1024
+MAX_APPROVAL_IDENTITY_DEPTH = 32
 
 # The default integration is an enforcement boundary, so service outages deny
 # every tool. Advanced operators may explicitly opt selected read-only tools
@@ -92,6 +106,83 @@ SENSITIVE_KEY_MARKERS = (
     "apikey",
     "private_key",
 )
+
+_APPROVAL_REDACTIONS = (
+    # Quoted JSON/YAML keys need their own rule: the quote between the key and
+    # colon prevents the generic assignment rules below from seeing them.
+    # Keep this display-only and deliberately conservative; the exact original
+    # arguments remain available to policy evaluation and the HMAC identity.
+    (
+        re.compile(
+            r'''(?ix)
+            (
+              ["']
+              [a-z0-9_.-]*
+              (?:api[-_]?key|apikey|authorization|auth(?:orization)?[-_]?token|access[-_]?token|
+                 access[-_]?key|token|secret|password|passwd|credentials?|private[-_]?key)
+              [a-z0-9_.-]*
+              ["']\s*:\s*
+            )
+            (?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[^\s,}\]]+)
+            '''
+        ),
+        r"\1[REDACTED]",
+    ),
+    # Shell environment assignments, including AWS_SECRET_ACCESS_KEY,
+    # OPENAI_API_KEY, and GITHUB_TOKEN. At this display edge, a value that
+    # merely looks secret is treated exactly like a credential.
+    (
+        re.compile(
+            r"(?i)(\b[A-Z][A-Z0-9_]*(?:API_KEY|APIKEY|TOKEN|SECRET|PASSWORD|PASSWD|ACCESS_KEY|CREDENTIALS?)\s*=\s*)(?:\"[^\"]*\"|'[^']*'|[^\s;|&]+)"
+        ),
+        r"\1[REDACTED]",
+    ),
+    # Common secret-bearing flags and HTTP header forms. Header values may be
+    # quoted as curl arguments, so stop before either quote as well as space.
+    (
+        re.compile(
+            r"(?i)(--(?:api[-_]?key|auth(?:orization)?[-_]?token|access[-_]?token|password|token|secret|user)(?:=|\s+))(?:\"[^\"]*\"|'[^']*'|[^\s]+)"
+        ),
+        r"\1[REDACTED]",
+    ),
+    (
+        re.compile(
+            r"(?i)((?:proxy[-_])?authorization\s*[:=]\s*(?:(?:bearer|basic|token)\s+)?)(?:\"[^\"]*\"|'[^']*'|[^\s,;]+)"
+        ),
+        r"\1[REDACTED]",
+    ),
+    (
+        re.compile(
+            r"(?i)((?:x[-_])?(?:api[-_]?key|auth[-_]?token|access[-_]?token)\s*[:=]\s*)(?:\"[^\"]*\"|'[^']*'|[^\s,;]+)"
+        ),
+        r"\1[REDACTED]",
+    ),
+    (
+        re.compile(
+            r"(?i)(\b(?:api[-_]?key|auth(?:orization)?[-_]?token|access[-_]?token|password|token|secret)\b\s*[=:]\s*)(?:\"[^\"]*\"|'[^']*'|[^\s&]+)"
+        ),
+        r"\1[REDACTED]",
+    ),
+    # curl's short form has no key name to trigger the assignment rules, and
+    # curl accepts both "-u user:pass" and the attached "-uuser:pass" form.
+    (
+        re.compile(r"(?i)((?:^|\s)-u)(?:\s+|(?=[^\s]))(?:\"[^\"]*\"|'[^']*'|[^\s]+)"),
+        r"\1 [REDACTED]",
+    ),
+    # Shell tools also accept URL-like credential userinfo without a scheme,
+    # for example ``ssh user:password@host``. It is not found by urlsplit or
+    # the ``//userinfo@`` rule, so hide the entire userinfo component here.
+    (
+        re.compile(r"(?i)(?<![a-z0-9])[^\s/:@]+:[^\s/@]+@(?=[a-z0-9.\[\]-])"),
+        "[REDACTED]@",
+    ),
+    (re.compile(r"(?i)(//)[^/\s@]+@"), r"\1[REDACTED]@"),
+    (re.compile(r"\b(?:gh[opurs]_[A-Za-z0-9]+|xox[aboprs]-[A-Za-z0-9-]+|sk-[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16})\b"), "[REDACTED]"),
+)
+_URL_REFERENCE = re.compile(
+    r"(?i)\b(?:[a-z][a-z0-9+.-]*://|(?:mailto|data|urn):)[^\s<>'\"]+"
+)
+_ANSI_ESCAPE = re.compile(r"\x1b(?:\[[0-?]*[ -/]*[@-~]|\][^\x07\x1b]*(?:\x07|\x1b\\)?)?")
 
 logger = logging.getLogger(__name__)
 
@@ -246,6 +337,110 @@ def _preview(value: Any, max_chars: int = 240) -> str | None:
     if len(text) <= max_chars:
         return text
     return text[: max_chars - 1].rstrip() + "…"
+
+
+def _clean_approval_display(value: Any) -> str | None:
+    """Remove formatting characters that could change prompt interpretation."""
+
+    if value is None:
+        return None
+    # Approval messages are rendered by Hermes. Remove ANSI, C0/C1 control,
+    # and Unicode format characters (including bidi overrides) before any
+    # human-facing truncation or redaction so a policy response cannot spoof
+    # another action or conceal a credential in the prompt.
+    text = _ANSI_ESCAPE.sub("�", str(value))
+    text = "".join(
+        " " if char in "\r\n\t" else "�"
+        if unicodedata.category(char) in {"Cc", "Cf", "Cs"}
+        else char
+        for char in text
+    )
+    return " ".join(text.split()) or None
+
+
+def _redact_approval_text(value: Any, max_chars: int = 240) -> str | None:
+    """Return a one-line human summary without common credential material."""
+
+    text = _clean_approval_display(value)
+    if text is None:
+        return None
+    if len(text) > max_chars * 4:
+        text = text[: max_chars * 4]
+    text = _URL_REFERENCE.sub(_redact_url_reference, text)
+    for pattern, replacement in _APPROVAL_REDACTIONS:
+        text = pattern.sub(replacement, text)
+    return _preview(text, max_chars)
+
+
+def _redact_url_reference(match: re.Match[str]) -> str:
+    """Replace an embedded URL with the same conservative approval display."""
+
+    return _safe_url_display(match.group(0))
+
+
+def _safe_url_display(value: Any) -> str:
+    """Render only an HTTP(S) origin for approval UI."""
+
+    if not isinstance(value, str) or not value.strip():
+        return "<missing URL>"
+    # Apply character handling before urlsplit; it otherwise accepts some
+    # leading controls and can render a different-looking target than Hermes.
+    cleaned = _clean_approval_display(value)
+    if cleaned is None:
+        return "<missing URL>"
+    try:
+        parsed = urlsplit(cleaned)
+        hostname = parsed.hostname
+        port = parsed.port
+    except ValueError:
+        return "<invalid URL>"
+    if parsed.scheme in {"http", "https"} and hostname:
+        display_host = f"[{hostname}]" if ":" in hostname else hostname
+        origin = f"{parsed.scheme}://{display_host}"
+        if port is not None:
+            origin += f":{port}"
+        # Paths, queries, and fragments commonly contain signed object names,
+        # reset tokens, and private resource IDs. The exact URL stays in the
+        # HMAC-bound identity; no part beyond the origin reaches the prompt.
+        return origin
+    if parsed.scheme:
+        return f"<non-HTTP URL ({parsed.scheme.lower()}) redacted>"
+    return "<invalid URL>"
+
+
+def _approval_action_summary(
+    tool_name: str,
+    rampart_tool: str,
+    args: Mapping[str, Any] | None,
+    resolved_params: Mapping[str, Any],
+) -> str:
+    """Describe the represented action without exposing content-bearing fields."""
+
+    raw_args = args if isinstance(args, Mapping) else {}
+    if tool_name == "terminal":
+        command = _redact_approval_text(raw_args.get("command"), 240)
+        return f"terminal command: {command or '<missing command>'}"
+    if tool_name.startswith("browser_"):
+        action = tool_name.removeprefix("browser_") or "action"
+        if "url" in raw_args:
+            return f"browser {action}: {_safe_url_display(raw_args.get('url'))}"
+        ref = _redact_approval_text(raw_args.get("ref"), 80)
+        return f"browser {action}" + (f" target {ref}" if ref else "")
+    if rampart_tool in {"read", "write", "edit"}:
+        paths = resolved_params.get("touched_paths")
+        if isinstance(paths, list) and paths:
+            shown = [(_redact_approval_text(path, 100) or "<invalid path>") for path in paths[:3]]
+            suffix = f" (+{len(paths) - 3} more)" if len(paths) > 3 else ""
+            return f"{rampart_tool} paths: {', '.join(shown)}{suffix}"
+        path = _redact_approval_text(resolved_params.get("path"), 180)
+        return f"{rampart_tool} path: {path or '<missing path>'}"
+    if rampart_tool in {"fetch", "web_fetch"}:
+        return f"{rampart_tool}: {_safe_url_display(raw_args.get('url'))}"
+    if rampart_tool == "message":
+        target = _redact_approval_text(raw_args.get("target"), 120)
+        return f"message target: {target or '<unspecified>'}"
+    action = _redact_approval_text(resolved_params.get("action"), 80)
+    return f"{tool_name}" + (f" action: {action}" if action else "")
 
 
 def _byte_len(value: Any) -> int:
@@ -594,6 +789,291 @@ def _block(message: str) -> dict[str, str]:
     return {"action": "block", "message": message}
 
 
+def _hermes_supports_native_approval() -> bool:
+    """Return whether this Hermes runtime owns plugin approval/resume.
+
+    Older Hermes releases understand only ``action=block``. Returning a newer
+    directive to one of those hosts could be ignored and fail open, so feature
+    detection is a security boundary rather than a convenience check.
+    """
+
+    try:
+        import hermes_cli.plugins as hermes_plugins  # type: ignore
+    except (ImportError, AttributeError):
+        return False
+
+    directive_type = getattr(hermes_plugins, "_PreToolCallDirective", None)
+    directive_fields = getattr(directive_type, "__dataclass_fields__", {})
+    public_getter = getattr(hermes_plugins, "get_pre_tool_call_directive", None)
+    details_getter = getattr(
+        hermes_plugins, "_get_pre_tool_call_directive_details", None
+    )
+    resolver = getattr(hermes_plugins, "resolve_pre_tool_block", None)
+    if not (
+        callable(public_getter)
+        and callable(details_getter)
+        and callable(resolver)
+        and "rule_key" in directive_fields
+    ):
+        return False
+
+    # A field on the directive alone is not a capability guarantee. Prove the
+    # two released-v2026.8.3 data-flow legs from installed source: the private
+    # dispatcher copies the hook's ``result["rule_key"]`` into the directive,
+    # and the resolver supplies ``details.rule_key`` to the approval gate. If
+    # source is unavailable or a future host delegates this differently, fail
+    # closed until that contract is reviewed instead of guessing from names.
+    try:
+        details_tree = ast.parse(textwrap.dedent(inspect.getsource(details_getter)))
+        resolver_tree = ast.parse(textwrap.dedent(inspect.getsource(resolver)))
+    except (OSError, TypeError, SyntaxError, IndentationError):
+        return False
+
+    def call_name(node: ast.Call) -> str:
+        if isinstance(node.func, ast.Name):
+            return node.func.id
+        if isinstance(node.func, ast.Attribute):
+            return node.func.attr
+        return ""
+
+    result_rule_key_is_captured = any(
+        isinstance(node, ast.Assign)
+        and any(
+            isinstance(target, ast.Name) and target.id == "rule_key"
+            for target in node.targets
+        )
+        and any(
+            isinstance(child, ast.Call)
+            and isinstance(child.func, ast.Attribute)
+            and child.func.attr == "get"
+            and child.args
+            and isinstance(child.args[0], ast.Constant)
+            and child.args[0].value == "rule_key"
+            for child in ast.walk(node.value)
+        )
+        for node in ast.walk(details_tree)
+    )
+    captured_rule_key_reaches_directive = any(
+        isinstance(node, ast.Call)
+        and call_name(node) == "_PreToolCallDirective"
+        and any(
+            keyword.arg == "rule_key"
+            and isinstance(keyword.value, ast.Name)
+            and keyword.value.id == "rule_key"
+            for keyword in node.keywords
+        )
+        for node in ast.walk(details_tree)
+    )
+    resolver_loads_same_details = any(
+        isinstance(node, ast.Assign)
+        and any(
+            isinstance(target, ast.Name) and target.id == "details"
+            for target in node.targets
+        )
+        and isinstance(node.value, ast.Call)
+        and call_name(node.value) == "_get_pre_tool_call_directive_details"
+        for node in ast.walk(resolver_tree)
+    )
+    details_rule_key_reaches_gate = any(
+        isinstance(node, ast.Call)
+        and call_name(node) == "request_tool_approval"
+        and any(
+            keyword.arg == "rule_key"
+            and any(
+                isinstance(child, ast.Attribute)
+                and isinstance(child.value, ast.Name)
+                and child.value.id == "details"
+                and child.attr == "rule_key"
+                for child in ast.walk(keyword.value)
+            )
+            for keyword in node.keywords
+        )
+        for node in ast.walk(resolver_tree)
+    )
+    return (
+        result_rule_key_is_captured
+        and captured_rule_key_reaches_directive
+        and resolver_loads_same_details
+        and details_rule_key_reaches_gate
+    )
+
+
+def _effective_terminal_cwd(task_id: str) -> str | None:
+    """Mirror Hermes' no-workdir CWD resolution for approval identity."""
+
+    try:
+        import tools.terminal_tool as hermes_terminal  # type: ignore
+        from tools.approval import get_current_session_key  # type: ignore
+
+        get_config = getattr(hermes_terminal, "_get_env_config")
+        resolve_overrides = getattr(hermes_terminal, "resolve_task_overrides")
+        get_session_cwd = getattr(hermes_terminal, "get_session_cwd")
+        resolve_cwd = getattr(hermes_terminal, "_resolve_command_cwd")
+        container_backends = getattr(hermes_terminal, "_CONTAINER_BACKENDS")
+        unusable_container_cwd = getattr(
+            hermes_terminal, "_is_unusable_container_cwd"
+        )
+        if not all(
+            callable(item)
+            for item in (
+                get_config,
+                resolve_overrides,
+                get_session_cwd,
+                resolve_cwd,
+                unusable_container_cwd,
+                get_current_session_key,
+            )
+        ):
+            return None
+
+        config = get_config()
+        overrides = resolve_overrides(task_id)
+        if not isinstance(config, Mapping) or not isinstance(overrides, Mapping):
+            return None
+        env_type = config.get("env_type")
+        cwd = overrides.get("cwd") or get_session_cwd(task_id) or config.get("cwd")
+        if not isinstance(env_type, str) or not isinstance(cwd, str) or not cwd:
+            return None
+        if env_type in container_backends and unusable_container_cwd(cwd):
+            cwd = config.get("cwd")
+            if not isinstance(cwd, str) or not cwd:
+                return None
+        session_key = get_current_session_key(default="") or (task_id or "")
+        effective_cwd = resolve_cwd(
+            workdir=None,
+            default_cwd=cwd,
+            session_key=session_key,
+        )
+    except (ImportError, AttributeError, KeyError, OSError, TypeError, ValueError):
+        return None
+    return effective_cwd if isinstance(effective_cwd, str) and effective_cwd else None
+
+
+def _approval_rule_key(
+    config: PluginConfig,
+    tool_name: str,
+    args: Mapping[str, Any] | None,
+    resolved_params: Mapping[str, Any],
+    task_id: str,
+) -> str | None:
+    """Bind Hermes session/always approval to one exact represented call.
+
+    Hermes uses ``rule_key`` as the persistence grain for native approval.
+    Bind both the original arguments and Rampart's resolved policy identity so
+    an approval for a relative file path cannot follow the same spelling into a
+    different task directory. HMAC makes the persisted key opaque: raw command
+    arguments and file contents are never written to Hermes configuration.
+
+    A token is required for this persistent identity. A local policy service
+    without one can still allow or deny, but an ``ask`` fails closed rather than
+    storing a plain, dictionary-attackable digest of sensitive arguments.
+    """
+
+    token = _load_token(config)
+    if not token:
+        return None
+    token_bytes = token.encode("utf-8")
+    if len(token_bytes) > 4096:
+        return None
+    identity = {
+        "tool": tool_name,
+        "args": args or {},
+        "resolved_params": resolved_params,
+        # Relative terminal/file semantics depend on the task workspace. A
+        # session or persistent approval must not silently cross that boundary.
+        "task_id": task_id,
+    }
+    if tool_name == "terminal":
+        raw_args = args if isinstance(args, Mapping) else {}
+        workdir = raw_args.get("workdir")
+        if workdir:
+            # Hermes passes an explicit relative workdir through to the
+            # execution backend, where its meaning depends on mutable ambient
+            # state. Native persistent approval cannot safely key that call by
+            # spelling alone. Accept only an absolute path on this platform.
+            if not isinstance(workdir, str) or not os.path.isabs(workdir):
+                return None
+            terminal_cwd = workdir
+        else:
+            # Hermes treats a missing/empty workdir as the mutable session CWD.
+            # Bind the same effective value its terminal dispatcher will use.
+            # If host internals cannot resolve it exactly, do not mint a key
+            # that Hermes could persist across a different directory.
+            if workdir is not None and workdir != "":
+                return None
+            terminal_cwd = _effective_terminal_cwd(task_id)
+            if terminal_cwd is None:
+                return None
+        identity["effective_terminal_cwd"] = terminal_cwd
+    if not _approval_identity_within_bounds(identity):
+        return None
+    try:
+        encoded = json.dumps(
+            identity,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError):
+        return None
+    if len(encoded) > MAX_APPROVAL_IDENTITY_BYTES:
+        return None
+    digest = hmac.new(token_bytes, encoded, hashlib.sha256).hexdigest()
+    return f"rampart:{tool_name}:{digest}"
+
+
+def _approval_identity_within_bounds(value: Any) -> bool:
+    """Bound approval-key work before JSON serialization copies tool input."""
+
+    remaining = MAX_APPROVAL_IDENTITY_BYTES
+    stack: list[tuple[Any, int]] = [(value, 0)]
+    seen: set[int] = set()
+    while stack:
+        current, depth = stack.pop()
+        if depth > MAX_APPROVAL_IDENTITY_DEPTH:
+            return False
+        if current is None or isinstance(current, (bool, float)):
+            remaining -= len(str(current))
+        elif isinstance(current, int):
+            # Avoid converting an attacker-controlled arbitrary-precision
+            # integer to a potentially enormous decimal string just to reject
+            # it. The bit bound is conservative relative to the byte budget.
+            if current.bit_length() > max(remaining, 0) * 4:
+                return False
+            try:
+                remaining -= len(str(current))
+            except ValueError:
+                return False
+        elif isinstance(current, str):
+            if len(current) > remaining:
+                return False
+            remaining -= len(current.encode("utf-8"))
+        elif isinstance(current, Mapping):
+            identity = id(current)
+            if identity in seen:
+                return False
+            seen.add(identity)
+            remaining -= len(current) * 2
+            for key, item in current.items():
+                if not isinstance(key, str):
+                    return False
+                stack.append((key, depth + 1))
+                stack.append((item, depth + 1))
+        elif isinstance(current, (list, tuple)):
+            identity = id(current)
+            if identity in seen:
+                return False
+            seen.add(identity)
+            remaining -= len(current)
+            stack.extend((item, depth + 1) for item in current)
+        else:
+            return False
+        if remaining < 0:
+            return False
+    return True
+
+
 def _decision_from_result(result: Mapping[str, Any]) -> str:
     decision = result.get("decision")
     if result.get("error"):
@@ -638,9 +1118,9 @@ def _policy_param_variants(rampart_tool: str, params: Mapping[str, Any]) -> list
 
 
 def _audit_suffix(result: Mapping[str, Any]) -> str:
-    audit_id = result.get("audit_id")
-    if isinstance(audit_id, str) and audit_id.strip():
-        return f" [audit_id: {audit_id.strip()}]"
+    audit_id = _redact_approval_text(result.get("audit_id"), 120)
+    if audit_id:
+        return f" [audit_id: {audit_id}]"
     return ""
 
 
@@ -654,7 +1134,7 @@ def evaluate_pre_tool_call(
     config_overrides: Mapping[str, Any] | None = None,
     requester: Callable[[PluginConfig, str, Mapping[str, Any]], Mapping[str, Any]] | None = None,
 ) -> dict[str, str] | None:
-    """Evaluate a Hermes tool call and return a Hermes block directive or None."""
+    """Evaluate a Hermes tool call and return a Hermes control directive or None."""
 
     if not isinstance(tool_name, str) or tool_name not in SUPPORTED_HERMES_TOOLS:
         display_name = tool_name if isinstance(tool_name, str) and tool_name else "unknown"
@@ -707,22 +1187,38 @@ def evaluate_pre_tool_call(
     if decision in {"allow", "watch", "log"}:
         return None
 
-    reason = str(result.get("message") or result.get("reason") or "policy violation")
+    reason = _redact_approval_text(
+        result.get("message") or result.get("reason") or "policy violation",
+        240,
+    ) or "policy violation"
     policy = result.get("policy") or result.get("matched_policies")
     audit_suffix = _audit_suffix(result)
     policy_suffix = ""
     if isinstance(policy, str) and policy:
-        policy_suffix = f" [policy: {policy}]"
+        policy_suffix = f" [policy: {_redact_approval_text(policy, 120) or '<redacted>'}]"
     elif isinstance(policy, list) and policy:
-        policy_suffix = f" [policy: {policy[0]}]"
+        policy_suffix = f" [policy: {_redact_approval_text(policy[0], 120) or '<redacted>'}]"
 
     if decision in {"ask", "require_approval"}:
-        return _block(
+        action_summary = _approval_action_summary(tool_name, rampart_tool, args, params)
+        message = (
             "rampart: approval required"
             f" for {tool_name}→{rampart_tool}{policy_suffix}{audit_suffix} — {reason}. "
-            "Hermes Rampart integration is experimental and does not yet resume plugin-driven approvals; "
-            "adjust policy or use a first-class Hermes approval flow before retrying."
+            f"Action: {action_summary}."
         )
+        if not _hermes_supports_native_approval():
+            return _block(
+                message
+                + " This Hermes version does not support plugin-owned approval/resume; "
+                "upgrade Hermes before retrying."
+            )
+        rule_key = _approval_rule_key(config, tool_name, args, params, task_id)
+        if rule_key is None:
+            return _block(
+                message
+                + " Rampart could not derive a non-secret approval key for the exact tool call."
+            )
+        return {"action": "approve", "message": message, "rule_key": rule_key}
 
     return _block(f"rampart: {reason}{policy_suffix}{audit_suffix}")
 

--- a/internal/plugin/hermes/embed_test.go
+++ b/internal/plugin/hermes/embed_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestVersionReadsManifest(t *testing.T) {
-	if got, want := Version(), "1.6.0"; got != want {
+	if got, want := Version(), "1.7.0"; got != want {
 		t.Fatalf("Version() = %q, want %q", got, want)
 	}
 }
@@ -97,7 +97,7 @@ func TestExtractRollsBackManagedPluginOnActivationFailure(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	oldManifest = bytes.Replace(oldManifest, []byte("version: 1.6.0"), []byte("version: 1.5.0"), 1)
+	oldManifest = bytes.Replace(oldManifest, []byte("version: 1.7.0"), []byte("version: 1.6.0"), 1)
 	if err := os.WriteFile(manifestPath, oldManifest, 0o600); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/plugin/hermes/plugin.yaml
+++ b/internal/plugin/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: rampart
-version: 1.6.0
+version: 1.7.0
 description: Experimental Rampart policy gate for Hermes Agent pre_tool_call hooks
 author: peg
 provides_hooks:

--- a/internal/plugin/hermes/test_hermes_plugin.py
+++ b/internal/plugin/hermes/test_hermes_plugin.py
@@ -8,6 +8,7 @@ import io
 import json
 import os
 import sys
+import types
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -36,6 +37,63 @@ class HermesPluginTests(unittest.TestCase):
 
     def tearDown(self) -> None:
         self.env_patch.stop()
+
+    def test_native_approval_requires_exact_rule_key_contract(self) -> None:
+        hermes_package = types.ModuleType("hermes_cli")
+        hermes_package.__path__ = []
+        hermes_plugins = types.ModuleType("hermes_cli.plugins")
+        hermes_plugins.get_pre_tool_call_directive = lambda *_: None
+
+        def details_getter(*_):
+            return None
+
+        def resolve_pre_tool_block(*_):
+            return None
+
+        hermes_plugins._get_pre_tool_call_directive_details = details_getter
+        hermes_plugins.resolve_pre_tool_block = resolve_pre_tool_block
+        directive_type = type(
+            "_PreToolCallDirective",
+            (),
+            {"__dataclass_fields__": {"rule_key": object()}},
+        )
+        hermes_plugins._PreToolCallDirective = directive_type
+        hermes_package.plugins = hermes_plugins
+        modules = {
+            "hermes_cli": hermes_package,
+            "hermes_cli.plugins": hermes_plugins,
+        }
+        sources = {
+            details_getter: """
+                def _get_pre_tool_call_directive_details():
+                    rule_key = result.get("rule_key") if action == "approve" else None
+                    return _PreToolCallDirective(action=action, rule_key=rule_key)
+            """,
+            resolve_pre_tool_block: """
+                def resolve_pre_tool_block(tool_name, args):
+                    details = _get_pre_tool_call_directive_details(tool_name, args)
+                    return request_tool_approval(
+                        tool_name, details.message or "",
+                        rule_key=details.rule_key or tool_name,
+                    )
+            """,
+        }
+
+        with (
+            mock.patch.dict(sys.modules, modules),
+            mock.patch.object(
+                plugin.inspect,
+                "getsource",
+                side_effect=lambda function: sources[function],
+            ),
+        ):
+            self.assertTrue(plugin._hermes_supports_native_approval())
+            sources[resolve_pre_tool_block] = """
+                def resolve_pre_tool_block(tool_name, args):
+                    details = _get_pre_tool_call_directive_details(tool_name, args)
+                    return request_tool_approval(tool_name, details.message, rule_key=tool_name)
+            """
+            self.assertFalse(plugin._hermes_supports_native_approval())
 
     def test_terminal_maps_to_exec_with_command_metadata(self) -> None:
         rampart_tool, params = plugin.normalize_tool_call(
@@ -241,7 +299,7 @@ class HermesPluginTests(unittest.TestCase):
         self.assertIn("danger", result["message"])
         self.assertIn("audit-deny-1", result["message"])
 
-    def test_ask_decision_blocks_without_hidden_approval(self) -> None:
+    def test_ask_decision_uses_native_approval_with_exact_call_key(self) -> None:
         def requester(config, rampart_tool, payload):
             self.assertEqual(config.endpoint_mode, "preflight")
             self.assertIs(payload["enforce"], True)
@@ -256,18 +314,264 @@ class HermesPluginTests(unittest.TestCase):
                 "audit_id": "audit-ask-1",
             }
 
-        result = plugin.evaluate_pre_tool_call(
-            "terminal",
-            {"command": "kubectl apply -f prod.yaml"},
-            tool_call_id="call-ask-1",
-            requester=requester,
-        )
+        args = {"command": "kubectl apply -f prod.yaml", "workdir": "/workspace"}
+        with (
+            mock.patch.object(plugin, "_hermes_supports_native_approval", return_value=True),
+            mock.patch.object(plugin, "_load_token", return_value="unit-test-token"),
+        ):
+            result = plugin.evaluate_pre_tool_call(
+                "terminal",
+                args,
+                tool_call_id="call-ask-1",
+                requester=requester,
+            )
 
-        self.assertEqual(result["action"], "block")
+        self.assertEqual(result["action"], "approve")
         self.assertIn("approval required", result["message"])
-        self.assertIn("does not yet resume", result["message"])
         self.assertIn("prod-change", result["message"])
         self.assertIn("audit-ask-1", result["message"])
+        self.assertIn("kubectl apply -f prod.yaml", result["message"])
+        config = plugin.load_config()
+        params = plugin.normalize_tool_call("terminal", args)[1]
+        with mock.patch.object(plugin, "_load_token", return_value="unit-test-token"):
+            expected = plugin._approval_rule_key(config, "terminal", args, params, "")
+            different = plugin._approval_rule_key(
+                config,
+                "terminal",
+                {"command": "kubectl apply -f other.yaml", "workdir": "/workspace"},
+                plugin.normalize_tool_call(
+                    "terminal",
+                    {"command": "kubectl apply -f other.yaml", "workdir": "/workspace"},
+                )[1],
+                "",
+            )
+        self.assertEqual(result["rule_key"], expected)
+        self.assertNotEqual(result["rule_key"], different)
+
+    def test_browser_approval_shows_redacted_target(self) -> None:
+        target = "https://user:browser-password@example.com/batches/current?token=query-secret#private"
+        with (
+            mock.patch.object(plugin, "_hermes_supports_native_approval", return_value=True),
+            mock.patch.object(plugin, "_load_token", return_value="unit-test-token"),
+        ):
+            result = plugin.evaluate_pre_tool_call(
+                "browser_navigate",
+                {"url": target},
+                task_id="task-browser",
+                requester=lambda *_: {
+                    "decision": "ask",
+                    "allowed": False,
+                    "message": "unclassified navigation",
+                },
+            )
+
+        self.assertEqual(result["action"], "approve")
+        self.assertEqual(plugin._safe_url_display(target), "https://example.com")
+        self.assertIn(
+            "browser navigate: https://example.com.",
+            result["message"],
+        )
+        self.assertNotIn("browser-password", result["message"])
+        self.assertNotIn("query-secret", result["message"])
+        self.assertNotIn("private", result["message"])
+
+    def test_approval_display_redacts_credentials_urls_and_format_controls(self) -> None:
+        summary = plugin._redact_approval_text(
+            "AWS_SECRET_ACCESS_KEY=aws-secret OPENAI_API_KEY=openai-secret "
+            "GITHUB_TOKEN=github-secret curl -ualice:curl-secret "
+            "-H 'Authorization: Bearer header-secret' "
+            "https://user:url-secret@example.com/private/object?token=query-secret#fragment "
+            "ssh://alice:ssh-secret@internal.example/private-key "
+            'json={"api_key":"json-secret","password":"json-password",'
+            '"Authorization":"Bearer json-auth-secret"} '
+            "access_token: yaml-secret ssh alice:ssh-cli-secret@internal.example "
+            "mailto:person+mail-secret@example.com "
+            "\x1b[31mshown\u202e",
+            600,
+        )
+
+        self.assertIsNotNone(summary)
+        assert summary is not None
+        for secret in (
+            "aws-secret",
+            "openai-secret",
+            "github-secret",
+            "curl-secret",
+            "header-secret",
+            "url-secret",
+            "query-secret",
+            "fragment",
+            "ssh-secret",
+            "ssh-cli-secret",
+            "private-key",
+            "mail-secret",
+            "json-secret",
+            "json-password",
+            "json-auth-secret",
+            "yaml-secret",
+        ):
+            self.assertNotIn(secret, summary)
+        self.assertIn("AWS_SECRET_ACCESS_KEY=[REDACTED]", summary)
+        self.assertIn("OPENAI_API_KEY=[REDACTED]", summary)
+        self.assertIn("GITHUB_TOKEN=[REDACTED]", summary)
+        self.assertIn("curl -u [REDACTED]", summary)
+        self.assertIn("Authorization: Bearer [REDACTED]", summary)
+        self.assertIn("https://example.com", summary)
+        self.assertIn("<non-HTTP URL (ssh) redacted>", summary)
+        self.assertIn("<non-HTTP URL (mailto) redacted>", summary)
+        self.assertIn('"api_key":[REDACTED]', summary)
+        self.assertIn('"password":[REDACTED]', summary)
+        self.assertIn('"Authorization":[REDACTED]', summary)
+        self.assertIn("access_token: [REDACTED]", summary)
+        self.assertIn("ssh [REDACTED]@internal.example", summary)
+        self.assertNotIn("\x1b", summary)
+        self.assertNotIn("[31m", summary)
+        self.assertNotIn("\u202e", summary)
+
+    def test_approval_key_binds_resolved_path_and_does_not_expose_arguments(self) -> None:
+        config = plugin.load_config()
+        args = {"path": "notes.txt", "content": "API_TOKEN=super-secret"}
+        with mock.patch.object(plugin, "_load_token", return_value="unit-test-token"):
+            safe_key = plugin._approval_rule_key(
+                config, "write_file", args, {"path": "/safe/notes.txt"}, "task-safe"
+            )
+            protected_key = plugin._approval_rule_key(
+                config, "write_file", args, {"path": "/protected/notes.txt"}, "task-safe"
+            )
+            other_task_key = plugin._approval_rule_key(
+                config, "write_file", args, {"path": "/safe/notes.txt"}, "task-other"
+            )
+
+        self.assertIsNotNone(safe_key)
+        self.assertNotEqual(safe_key, protected_key)
+        self.assertNotEqual(safe_key, other_task_key)
+        self.assertNotIn("super-secret", safe_key)
+
+    def test_terminal_approval_key_binds_effective_cwd_and_refuses_ambiguity(self) -> None:
+        config = plugin.load_config()
+        args = {"command": "printf safe"}
+        params = plugin.normalize_tool_call("terminal", args)[1]
+        with (
+            mock.patch.object(plugin, "_load_token", return_value="unit-test-token"),
+            mock.patch.object(plugin, "_effective_terminal_cwd", return_value="/safe"),
+        ):
+            safe_key = plugin._approval_rule_key(config, "terminal", args, params, "task")
+        with (
+            mock.patch.object(plugin, "_load_token", return_value="unit-test-token"),
+            mock.patch.object(plugin, "_effective_terminal_cwd", return_value="/other"),
+        ):
+            other_key = plugin._approval_rule_key(config, "terminal", args, params, "task")
+        with (
+            mock.patch.object(plugin, "_load_token", return_value="unit-test-token"),
+            mock.patch.object(plugin, "_effective_terminal_cwd", return_value=None),
+        ):
+            ambiguous_key = plugin._approval_rule_key(
+                config, "terminal", args, params, "task"
+            )
+
+        self.assertIsNotNone(safe_key)
+        self.assertNotEqual(safe_key, other_key)
+        self.assertIsNone(ambiguous_key)
+
+    def test_terminal_approval_key_requires_absolute_explicit_workdir(self) -> None:
+        config = plugin.load_config()
+
+        def key_for(workdir):
+            args = {"command": "printf safe", "workdir": workdir}
+            params = plugin.normalize_tool_call("terminal", args)[1]
+            return plugin._approval_rule_key(
+                config, "terminal", args, params, "task"
+            )
+
+        with mock.patch.object(plugin, "_load_token", return_value="unit-test-token"):
+            absolute_key = key_for(os.path.abspath("workspace"))
+            dot_key = key_for(".")
+            named_key = key_for("project")
+            windows_key = key_for(r"C:\workspace")
+
+        self.assertIsNotNone(absolute_key)
+        self.assertIsNone(dot_key)
+        self.assertIsNone(named_key)
+        if os.name == "nt":
+            self.assertIsNotNone(windows_key)
+        else:
+            self.assertIsNone(windows_key)
+
+    def test_approval_key_refuses_unbounded_or_non_json_identity(self) -> None:
+        config = plugin.load_config()
+        recursive = {}
+        recursive["self"] = recursive
+        with mock.patch.object(plugin, "_load_token", return_value="unit-test-token"):
+            oversized = plugin._approval_rule_key(
+                config,
+                "write_file",
+                {"path": "/tmp/notes.txt", "content": "x" * plugin.MAX_APPROVAL_IDENTITY_BYTES},
+                {"path": "/tmp/notes.txt"},
+                "task",
+            )
+            non_json = plugin._approval_rule_key(
+                config,
+                "terminal",
+                {"command": object(), "workdir": "/tmp"},
+                {"command": "safe"},
+                "task",
+            )
+            recursive["workdir"] = "/tmp"
+            recursive_key = plugin._approval_rule_key(
+                config,
+                "terminal",
+                recursive,
+                {"command": "safe"},
+                "task",
+            )
+            huge_integer_key = plugin._approval_rule_key(
+                config,
+                "terminal",
+                {
+                    "timeout": 1 << (plugin.MAX_APPROVAL_IDENTITY_BYTES * 8),
+                    "workdir": "/tmp",
+                },
+                {"command": "safe"},
+                "task",
+            )
+
+        self.assertIsNone(oversized)
+        self.assertIsNone(non_json)
+        self.assertIsNone(recursive_key)
+        self.assertIsNone(huge_integer_key)
+
+    def test_ask_blocks_without_a_token_for_opaque_approval_identity(self) -> None:
+        with (
+            mock.patch.object(plugin, "_hermes_supports_native_approval", return_value=True),
+            mock.patch.object(plugin, "_load_token", return_value=None),
+        ):
+            result = plugin.evaluate_pre_tool_call(
+                "browser_navigate",
+                {"url": "https://example.com"},
+                requester=lambda *_: {
+                    "decision": "ask",
+                    "allowed": False,
+                    "message": "navigation requires approval",
+                },
+            )
+
+        self.assertEqual(result["action"], "block")
+        self.assertIn("non-secret approval key", result["message"])
+
+    def test_ask_decision_blocks_on_older_hermes(self) -> None:
+        with mock.patch.object(plugin, "_hermes_supports_native_approval", return_value=False):
+            result = plugin.evaluate_pre_tool_call(
+                "browser_navigate",
+                {"url": "https://example.com"},
+                requester=lambda *_: {
+                    "decision": "ask",
+                    "allowed": False,
+                    "message": "navigation requires approval",
+                },
+            )
+
+        self.assertEqual(result["action"], "block")
+        self.assertIn("does not support plugin-owned approval/resume", result["message"])
 
     def test_unavailable_blocks_mutating_tool(self) -> None:
         def requester(config, rampart_tool, payload):

--- a/scripts/compat-hermes-latest.py
+++ b/scripts/compat-hermes-latest.py
@@ -170,6 +170,7 @@ class RampartStub(BaseHTTPRequestHandler):
             "path": self.path,
             "agent": payload.get("agent") if isinstance(payload, dict) else None,
             "session": payload.get("session") if isinstance(payload, dict) else None,
+            "tool_call_id": payload.get("tool_call_id") if isinstance(payload, dict) else None,
             "tool_call_id_present": bool(payload.get("tool_call_id")) if isinstance(payload, dict) else False,
             "enforce": payload.get("enforce") if isinstance(payload, dict) else None,
             "command_marker": _marker_from_command(command),
@@ -202,6 +203,14 @@ class RampartStub(BaseHTTPRequestHandler):
                 "message": "requires compatibility harness approval",
                 "matched_policies": ["compat-ask"],
                 "audit_id": "compat-audit-ask",
+            }
+        elif "rampart-ask-browser" in str(params.get("url") or ""):
+            body = {
+                "decision": "ask",
+                "allowed": False,
+                "message": "browser navigation requires compatibility approval",
+                "matched_policies": ["compat-browser-ask"],
+                "audit_id": "compat-audit-browser-ask",
             }
         elif "rampart-auth-error-marker" in command:
             status = 401
@@ -373,7 +382,13 @@ def child_probe_code(unused_port: int) -> str:
         f"""
         import json
         import os
-        from hermes_cli.plugins import discover_plugins, get_plugin_manager, get_pre_tool_call_block_message
+        from unittest import mock
+        from hermes_cli.plugins import (
+            discover_plugins,
+            get_plugin_manager,
+            get_pre_tool_call_directive,
+            resolve_pre_tool_block,
+        )
 
         discover_plugins(force=True)
         manager = get_plugin_manager()
@@ -386,8 +401,8 @@ def child_probe_code(unused_port: int) -> str:
         if not hooks:
             raise SystemExit('rampart plugin did not register a pre_tool_call hook')
 
-        def block(tool, args, call_id):
-            return get_pre_tool_call_block_message(
+        def directive(tool, args, call_id):
+            return get_pre_tool_call_directive(
                 tool,
                 args,
                 task_id='compat-task',
@@ -395,23 +410,75 @@ def child_probe_code(unused_port: int) -> str:
                 tool_call_id=call_id,
             )
 
-        deny = block('terminal', {{'command': 'printf rampart-deny-marker'}}, 'compat-deny-call')
-        if not deny or 'blocked by compatibility harness' not in deny or 'compat-audit-deny' not in deny:
-            raise SystemExit(f'deny did not block as expected: {{deny!r}}')
+        deny_action, deny = directive('terminal', {{'command': 'printf rampart-deny-marker'}}, 'compat-deny-call')
+        if deny_action != 'block' or not deny or 'blocked by compatibility harness' not in deny or 'compat-audit-deny' not in deny:
+            raise SystemExit(f'deny did not block as expected: {{(deny_action, deny)!r}}')
 
-        ask = block('terminal', {{'command': 'printf rampart-ask-marker'}}, 'compat-ask-call')
-        if not ask or 'approval required' not in ask or 'does not yet resume' not in ask or 'compat-audit-ask' not in ask:
-            raise SystemExit(f'ask did not block with no-resume message: {{ask!r}}')
+        ask_args = {{'command': 'printf rampart-ask-marker'}}
+        ask_action, ask = directive('terminal', ask_args, 'compat-ask-call')
+        if ask_action != 'approve' or not ask or 'approval required' not in ask or 'compat-audit-ask' not in ask:
+            raise SystemExit(f'ask did not request Hermes native approval: {{(ask_action, ask)!r}}')
 
-        allow = block('terminal', {{'command': 'printf rampart-allow-marker'}}, 'compat-allow-call')
-        if allow is not None:
-            raise SystemExit(f'allow should continue without a block message: {{allow!r}}')
+        with mock.patch('tools.approval.request_tool_approval', return_value={{'approved': True, 'message': 'approved'}}):
+            resumed = resolve_pre_tool_block(
+                'terminal', ask_args, task_id='compat-task',
+                session_id='compat-session', tool_call_id='compat-ask-resume-call',
+            )
+        if resumed is not None:
+            raise SystemExit(f'approved Hermes native call did not resume: {{resumed!r}}')
 
-        auth_error = block('terminal', {{'command': 'printf rampart-auth-error-marker'}}, 'compat-auth-error-call')
-        if not auth_error or 'invalid authorization token' not in auth_error:
-            raise SystemExit(f'auth error did not fail closed: {{auth_error!r}}')
+        with mock.patch('tools.approval.request_tool_approval', return_value={{'approved': False, 'message': 'operator denied'}}):
+            approval_denied = resolve_pre_tool_block(
+                'terminal', ask_args, task_id='compat-task',
+                session_id='compat-session', tool_call_id='compat-ask-deny-call',
+            )
+        if approval_denied != 'operator denied':
+            raise SystemExit(f'denied Hermes native approval did not block: {{approval_denied!r}}')
 
-        patch = block(
+        browser_targets = [
+            'https://compat-user:compat-browser-password@example.com/rampart-ask-browser/compat-secret-path/one?token=compat-query-secret#compat-fragment-secret',
+            'https://example.com/rampart-ask-browser/two',
+        ]
+        browser_action, browser_message = directive(
+            'browser_navigate', {{'url': browser_targets[0]}}, 'compat-browser-directive-call',
+        )
+        if browser_action != 'approve' or not browser_message or 'browser navigate: https://example.com.' not in browser_message:
+            raise SystemExit(f'browser approval did not show its safe origin: {{(browser_action, browser_message)!r}}')
+        for forbidden in (
+            browser_targets[0], 'compat-user', 'compat-browser-password',
+            'compat-secret-path', 'compat-query-secret', 'compat-fragment-secret',
+        ):
+            if forbidden in browser_message:
+                raise SystemExit(f'browser approval exposed secret URL material: {{forbidden!r}} in {{browser_message!r}}')
+
+        approval_calls = []
+        def approve_and_capture(*call_args, **call_kwargs):
+            approval_calls.append((call_args, call_kwargs))
+            return {{'approved': True, 'message': 'approved'}}
+
+        with mock.patch('tools.approval.request_tool_approval', side_effect=approve_and_capture):
+            for index, target in enumerate(browser_targets):
+                resumed = resolve_pre_tool_block(
+                    'browser_navigate', {{'url': target}}, task_id='compat-task',
+                    session_id='compat-session', tool_call_id=f'compat-browser-resume-{{index}}',
+                )
+                if resumed is not None:
+                    raise SystemExit(f'approved browser call did not resume: {{resumed!r}}')
+        rule_keys = [kwargs.get('rule_key') for _, kwargs in approval_calls]
+        if len(rule_keys) != 2 or not all(isinstance(key, str) and key.startswith('rampart:') for key in rule_keys):
+            raise SystemExit(f'Hermes did not receive Rampart approval rule keys: {{rule_keys!r}}')
+        if rule_keys[0] == rule_keys[1]:
+            raise SystemExit('distinct browser targets received the same approval rule key')
+
+        allow_action, allow = directive('terminal', {{'command': 'printf rampart-allow-marker'}}, 'compat-allow-call')
+        if allow_action is not None or allow is not None:
+            raise SystemExit(f'allow should continue without a directive: {{(allow_action, allow)!r}}')
+
+        auth_action, auth_error = directive('terminal', {{'command': 'printf rampart-auth-error-marker'}}, 'compat-auth-error-call')
+        if auth_action != 'block' or not auth_error or 'invalid authorization token' not in auth_error:
+            raise SystemExit(f'auth error did not fail closed: {{(auth_action, auth_error)!r}}')
+
+        patch_action, patch = directive(
             'patch',
             {{
                 'mode': 'patch',
@@ -426,18 +493,18 @@ def child_probe_code(unused_port: int) -> str:
             }},
             'compat-patch-call',
         )
-        if not patch or 'protected compatibility path' not in patch or 'compat-audit-path-deny' not in patch:
-            raise SystemExit(f'multi-path patch did not block protected second target: {{patch!r}}')
+        if patch_action != 'block' or not patch or 'protected compatibility path' not in patch or 'compat-audit-path-deny' not in patch:
+            raise SystemExit(f'multi-path patch did not block protected second target: {{(patch_action, patch)!r}}')
 
         os.environ['RAMPART_HERMES_URL'] = 'http://127.0.0.1:{unused_port}'
         os.environ['RAMPART_HERMES_TIMEOUT_MS'] = '250'
-        fail_closed = block('terminal', {{'command': 'printf rampart-fail-closed-marker'}}, 'compat-fail-closed-call')
-        if not fail_closed or 'unavailable' not in fail_closed:
-            raise SystemExit(f'mutating terminal did not fail closed: {{fail_closed!r}}')
+        fail_closed_action, fail_closed = directive('terminal', {{'command': 'printf rampart-fail-closed-marker'}}, 'compat-fail-closed-call')
+        if fail_closed_action != 'block' or not fail_closed or 'unavailable' not in fail_closed:
+            raise SystemExit(f'mutating terminal did not fail closed: {{(fail_closed_action, fail_closed)!r}}')
 
-        fail_open = block('read_file', {{'path': '/tmp/rampart-compat-read.txt'}}, 'compat-fail-open-call')
-        if fail_open is not None:
-            raise SystemExit(f'configured read_file fail-open should continue: {{fail_open!r}}')
+        fail_open_action, fail_open = directive('read_file', {{'path': '/tmp/rampart-compat-read.txt'}}, 'compat-fail-open-call')
+        if fail_open_action is not None or fail_open is not None:
+            raise SystemExit(f'configured read_file fail-open should continue: {{(fail_open_action, fail_open)!r}}')
 
         print(json.dumps({{
             'ok': True,
@@ -445,7 +512,8 @@ def child_probe_code(unused_port: int) -> str:
             'hooks_registered': loaded.hooks_registered,
             'pre_tool_call_hooks': len(hooks),
             'deny_blocked': True,
-            'ask_blocked_without_resume': True,
+            'ask_native_approval_resumed': True,
+            'ask_native_approval_denied': True,
             'allow_continued': True,
             'auth_error_fail_closed': True,
             'multi_path_patch_deny_wins': True,
@@ -553,6 +621,21 @@ def main() -> int:
             expected = {"rampart-deny-marker", "rampart-ask-marker", "rampart-allow-marker", "rampart-auth-error-marker"}
             if not expected.issubset(markers):
                 raise RuntimeError(f"expected request markers {sorted(expected)}, saw {sorted(markers)}")
+            ask_call_ids = [
+                entry["tool_call_id"]
+                for entry in RampartStub.requests_seen
+                if entry["command_marker"] == "rampart-ask-marker"
+            ]
+            expected_ask_call_ids = {
+                "compat-ask-call",
+                "compat-ask-resume-call",
+                "compat-ask-deny-call",
+            }
+            if set(ask_call_ids) != expected_ask_call_ids:
+                raise RuntimeError(
+                    "native approval did not preserve each Hermes tool-call identity: "
+                    f"saw {ask_call_ids}"
+                )
             patch_paths = [
                 entry["policy_path"]
                 for entry in RampartStub.requests_seen


### PR DESCRIPTION
## Summary
- let current Hermes pause and resume approval-required decisions through its native approval UI
- bind persistent approval identity to the exact action and effective terminal working directory
- fail closed when the installed Hermes approval contract cannot be proven
- redact credentials and sensitive URL components before approval display
- keep Hermes experimental and document its remaining host-owned callback limitation

## Validation
- 32 focused Python plugin tests
- current released Hermes v2026.8.3 / package 0.20.0 credential-free compatibility harness
- full Go test suite and vet
- security assurance and diff checks

No model or provider traffic was invoked during compatibility testing. This PR does not attempt the separate integration-token boundary migration.
