### PR TITLE
fix: harden MCP identity correlation

### DIFF
--- a/internal/mcp/jsonrpc.go
+++ b/internal/mcp/jsonrpc.go
@@ -18,7 +18,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/big"
+	"strconv"
 	"strings"
+	"unicode/utf8"
 )
 
 // Request is the minimal JSON-RPC 2.0 request/notification envelope used by MCP.
@@ -49,14 +52,166 @@ type ToolsCallParams struct {
 	Arguments map[string]any `json:"arguments"`
 }
 
-// NormalizedID returns a stable key for request/response ID tracking.
+// NormalizedID returns a stable key for request/response ID tracking. It
+// distinguishes JSON strings from JSON numbers and normalizes equivalent JSON
+// spellings to the same value. Invalid IDs return the empty string.
 func NormalizedID(id json.RawMessage) string {
-	return string(bytes.TrimSpace(id))
+	key, err := normalizedID(id)
+	if err != nil {
+		return ""
+	}
+	return key
 }
 
 // HasID reports whether the JSON-RPC message has a non-empty id field.
 func HasID(id json.RawMessage) bool {
 	return len(bytes.TrimSpace(id)) > 0
+}
+
+// maxRequestIDBytes bounds exact ID normalization work. MCP request IDs are
+// opaque correlation tokens, not payload carriers; UUID-sized IDs are typical.
+// Without a separate bound, a child can force expensive big-integer parsing up
+// to the four-megabyte JSON-RPC line limit.
+const maxRequestIDBytes = 1024
+
+// normalizedID decodes an MCP request ID before deriving its correlation key.
+// The raw JSON spelling is not an identity: for example, "a" and "\\u0061"
+// are the same JSON string. Numeric identities stay exact by using big.Rat,
+// rather than float64, and only integral values are accepted for MCP IDs.
+func normalizedID(id json.RawMessage) (string, error) {
+	trimmed := bytes.TrimSpace(id)
+	if len(trimmed) == 0 {
+		return "", fmt.Errorf("missing id")
+	}
+	if len(trimmed) > maxRequestIDBytes {
+		return "", fmt.Errorf("id exceeds %d-byte limit", maxRequestIDBytes)
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(trimmed))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return "", fmt.Errorf("decode id: %w", err)
+	}
+	if err := ensureJSONEOF(decoder); err != nil {
+		return "", err
+	}
+
+	switch value := value.(type) {
+	case string:
+		if err := validateJSONStringEncoding(trimmed); err != nil {
+			return "", err
+		}
+		canonical, err := json.Marshal(value)
+		if err != nil {
+			return "", fmt.Errorf("encode string id: %w", err)
+		}
+		if len(canonical) > maxRequestIDBytes {
+			return "", fmt.Errorf("normalized id exceeds %d-byte limit", maxRequestIDBytes)
+		}
+		// Keep the JSON type in the key. Without this prefix, the string ID
+		// "1" would collide with the numeric ID 1 after numeric
+		// canonicalization.
+		return "s:" + string(canonical), nil
+	case json.Number:
+		canonical, err := canonicalIntegerID(value.String())
+		if err != nil {
+			return "", err
+		}
+		return "n:" + canonical, nil
+	default:
+		return "", fmt.Errorf("id must be a string or integer")
+	}
+}
+
+// validateJSONStringEncoding rejects encodings that encoding/json repairs by
+// substitution. In particular, JavaScript preserves lone UTF-16 surrogates
+// while Go converts them to U+FFFD; accepting both would make distinct peer IDs
+// share a correlation key.
+func validateJSONStringEncoding(raw []byte) error {
+	if len(raw) < 2 || raw[0] != '"' || raw[len(raw)-1] != '"' || !utf8.Valid(raw) {
+		return fmt.Errorf("id must be a valid UTF-8 JSON string")
+	}
+	for index := 1; index < len(raw)-1; index++ {
+		if raw[index] != '\\' {
+			continue
+		}
+		index++
+		if index >= len(raw)-1 {
+			return fmt.Errorf("invalid string escape in id")
+		}
+		if raw[index] != 'u' {
+			continue
+		}
+		unit, ok := decodeJSONHexUnit(raw, index+1)
+		if !ok {
+			return fmt.Errorf("invalid unicode escape in id")
+		}
+		index += 4
+		switch {
+		case unit >= 0xd800 && unit <= 0xdbff:
+			if index+6 >= len(raw) || raw[index+1] != '\\' || raw[index+2] != 'u' {
+				return fmt.Errorf("unpaired high surrogate in id")
+			}
+			low, validLow := decodeJSONHexUnit(raw, index+3)
+			if !validLow || low < 0xdc00 || low > 0xdfff {
+				return fmt.Errorf("unpaired high surrogate in id")
+			}
+			index += 6
+		case unit >= 0xdc00 && unit <= 0xdfff:
+			return fmt.Errorf("unpaired low surrogate in id")
+		}
+	}
+	return nil
+}
+
+func decodeJSONHexUnit(raw []byte, start int) (uint16, bool) {
+	if start < 0 || start+4 > len(raw) {
+		return 0, false
+	}
+	var value uint16
+	for _, char := range raw[start : start+4] {
+		value <<= 4
+		switch {
+		case char >= '0' && char <= '9':
+			value |= uint16(char - '0')
+		case char >= 'a' && char <= 'f':
+			value |= uint16(char-'a') + 10
+		case char >= 'A' && char <= 'F':
+			value |= uint16(char-'A') + 10
+		default:
+			return 0, false
+		}
+	}
+	return value, true
+}
+
+func ensureJSONEOF(decoder *json.Decoder) error {
+	if _, err := decoder.Token(); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("multiple JSON values")
+		}
+		return err
+	}
+	return nil
+}
+
+func canonicalIntegerID(raw string) (string, error) {
+	if exponentAt := strings.IndexAny(raw, "eE"); exponentAt >= 0 {
+		exponent, err := strconv.Atoi(raw[exponentAt+1:])
+		if err != nil || exponent > maxRequestIDBytes || exponent < -maxRequestIDBytes {
+			return "", fmt.Errorf("id exponent exceeds normalization limit")
+		}
+	}
+	rational, ok := new(big.Rat).SetString(raw)
+	if !ok || !rational.IsInt() {
+		return "", fmt.Errorf("id must be an integer")
+	}
+	canonical := rational.Num().String()
+	if len(canonical) > maxRequestIDBytes {
+		return "", fmt.Errorf("normalized id exceeds %d-byte limit", maxRequestIDBytes)
+	}
+	return canonical, nil
 }
 
 // MarshalErrorResponse builds a JSON-RPC error response for a given id.
@@ -102,13 +257,14 @@ func decodeCanonicalJSONObject(data []byte, canonicalKeys ...string) (map[string
 	if object == nil {
 		return nil, fmt.Errorf("expected JSON object")
 	}
-	canonical := make(map[string]string, len(canonicalKeys))
-	for _, key := range canonicalKeys {
-		canonical[strings.ToLower(key)] = key
-	}
 	for key := range object {
-		if expected, protected := canonical[strings.ToLower(key)]; protected && key != expected {
-			return nil, fmt.Errorf("noncanonical object member %q; use %q", key, expected)
+		for _, expected := range canonicalKeys {
+			// encoding/json matches struct fields with Unicode simple folding,
+			// not strings.ToLower. EqualFold mirrors that behavior and catches
+			// spellings such as the long-s variant of "scheme" or "result".
+			if key != expected && strings.EqualFold(key, expected) {
+				return nil, fmt.Errorf("noncanonical object member %q; use %q", key, expected)
+			}
 		}
 	}
 	return object, nil

--- a/internal/mcp/proxy.go
+++ b/internal/mcp/proxy.go
@@ -145,13 +145,49 @@ type Proxy struct {
 	stopOnce sync.Once
 
 	pendingMu       sync.Mutex
+	pendingCond     *sync.Cond
+	pendingOwner    uint64
 	pendingCalls    map[string]pendingCall
-	pendingToolList map[string]time.Time
+	pendingToolList map[string]struct{}
+	pendingGeneric  map[string]struct{}
 }
 
+type pendingCallState uint8
+
+const (
+	pendingCallReserved pendingCallState = iota + 1
+	pendingCallWriting
+	pendingCallResponseActive
+	pendingCallRejected
+)
+
 type pendingCall struct {
+	state   pendingCallState
+	owner   uint64
 	call    engine.ToolCall
 	request map[string]any
+}
+
+type pendingCallReservation struct {
+	key   string
+	owner uint64
+}
+
+func (r pendingCallReservation) valid() bool {
+	return r.key != "" && r.owner != 0
+}
+
+type pendingResponseKind uint8
+
+const (
+	pendingResponseGeneric pendingResponseKind = iota + 1
+	pendingResponseToolList
+	pendingResponseToolCall
+)
+
+type pendingResponse struct {
+	kind     pendingResponseKind
+	toolCall pendingCall
 }
 
 // NewProxy creates a new MCP stdio proxy.
@@ -165,8 +201,10 @@ func NewProxy(eng *engine.Engine, sink audit.AuditSink, childIn io.WriteCloser, 
 		childOut:        childOut,
 		stopCh:          make(chan struct{}),
 		pendingCalls:    make(map[string]pendingCall),
-		pendingToolList: make(map[string]time.Time),
+		pendingToolList: make(map[string]struct{}),
+		pendingGeneric:  make(map[string]struct{}),
 	}
+	p.pendingCond = sync.NewCond(&p.pendingMu)
 	for _, opt := range opts {
 		if opt != nil {
 			opt(p)
@@ -354,19 +392,48 @@ func (p *Proxy) handleClientLineWithContext(ctx context.Context, line []byte) er
 		return p.handleToolsCall(ctx, req, line)
 	}
 
+	pendingToolListID := ""
+	pendingGenericID := ""
 	if p.filterTools && req.Method == "tools/list" && HasID(req.ID) {
-		if err := p.trackPendingToolList(req.ID); err != nil {
-			return p.writeErrorToClient(responseID(req.ID), jsonRPCDenyCode, "Rampart: "+err.Error())
+		var err error
+		pendingToolListID, err = p.trackPendingToolList(req.ID)
+		if err != nil {
+			if p.mode == "enforce" {
+				return p.writeErrorToClient(responseID(req.ID), jsonRPCDenyCode, "Rampart: "+err.Error())
+			}
+			p.logger.Debug("mcp: untrackable tools/list id in monitor mode; passing through", "error", err)
+			pendingToolListID = ""
+		}
+	} else if req.Method != "" && HasID(req.ID) {
+		var err error
+		pendingGenericID, err = p.reservePendingGeneric(req.ID)
+		if err != nil {
+			if p.mode == "enforce" {
+				return p.writeErrorToClient(responseID(req.ID), jsonRPCDenyCode, "Rampart: "+err.Error())
+			}
+			p.logger.Debug("mcp: untrackable request id in monitor mode; passing through", "method", req.Method, "error", err)
+			pendingGenericID = ""
 		}
 	}
 
-	return p.writeToChild(line)
+	if err := p.writeToChild(line); err != nil {
+		p.releasePendingToolList(pendingToolListID)
+		p.releasePendingGeneric(pendingGenericID)
+		return err
+	}
+	return nil
 }
 
 func (p *Proxy) handleToolsCall(ctx context.Context, req Request, rawLine []byte) error {
 	if p.mode == "enforce" {
-		if _, err := decodeCanonicalJSONObject(req.Params, "name", "arguments"); err != nil {
+		paramsFields, err := decodeCanonicalJSONObject(req.Params, "name", "arguments")
+		if err != nil {
 			return p.writeErrorToClient(responseID(req.ID), jsonRPCDenyCode, "Rampart: invalid tools/call params")
+		}
+		if arguments, ok := paramsFields["arguments"]; ok && !bytes.Equal(bytes.TrimSpace(arguments), []byte("null")) {
+			if _, err := decodeCanonicalJSONObject(arguments, securitySensitiveArgumentKeys...); err != nil {
+				return p.writeErrorToClient(responseID(req.ID), jsonRPCDenyCode, "Rampart: invalid tools/call arguments")
+			}
 		}
 	}
 	var params ToolsCallParams
@@ -391,20 +458,17 @@ func (p *Proxy) handleToolsCall(ctx context.Context, req Request, rawLine []byte
 		params.Arguments = map[string]any{}
 	}
 
-	pendingID := ""
-	reservationActive := false
+	var reservation pendingCallReservation
 	if HasID(req.ID) {
 		var reserveErr error
-		pendingID, reserveErr = p.reservePendingCall(req.ID)
+		reservation, reserveErr = p.reservePendingCall(req.ID)
 		if reserveErr != nil {
-			return p.writeErrorToClient(responseID(req.ID), jsonRPCDenyCode, "Rampart: "+reserveErr.Error())
-		}
-		reservationActive = true
-		defer func() {
-			if reservationActive {
-				p.releasePendingCall(pendingID)
+			if p.mode == "enforce" {
+				return p.writeErrorToClient(responseID(req.ID), jsonRPCDenyCode, "Rampart: "+reserveErr.Error())
 			}
-		}()
+			p.logger.Debug("mcp: untrackable tools/call id in monitor mode; passing through", "error", reserveErr)
+		}
+		defer p.releasePendingCall(reservation)
 	}
 
 	requestData := buildRequestData(req.Method, params.Name, params.Arguments)
@@ -515,17 +579,20 @@ func (p *Proxy) handleToolsCall(ctx context.Context, req Request, rawLine []byte
 		// Webhook allowed — fall through to forward the call.
 	}
 
-	if pendingID != "" {
-		p.pendingMu.Lock()
-		p.pendingCalls[pendingID] = pendingCall{call: call, request: requestData}
-		p.pendingMu.Unlock()
+	if reservation.valid() {
+		forwarded, err := p.forwardReservedCall(reservation, pendingCall{call: call, request: requestData}, rawLine)
+		if err != nil {
+			return err
+		}
+		if forwarded {
+			return nil
+		}
+		if p.mode == "enforce" {
+			return p.writeErrorToClient(responseID(req.ID), jsonRPCDenyCode, "Rampart: tools/call correlation was invalidated before forwarding")
+		}
+		p.logger.Debug("mcp: tools/call correlation invalidated in monitor mode; passing through untracked")
 	}
-
-	if err := p.writeToChild(rawLine); err != nil {
-		return err
-	}
-	reservationActive = false
-	return nil
+	return p.writeToChild(rawLine)
 }
 
 func responseID(id json.RawMessage) json.RawMessage {
@@ -539,89 +606,152 @@ func responseID(id json.RawMessage) json.RawMessage {
 // JSON-RPC discourages fractional numeric IDs, and MCP requires a request ID to
 // be a string or integer that is not null.
 func validRequestID(id json.RawMessage) bool {
-	trimmed := bytes.TrimSpace(id)
-	if len(trimmed) == 0 {
-		return false
-	}
-	if trimmed[0] == '"' {
-		var value string
-		return json.Unmarshal(trimmed, &value) == nil
-	}
-	for index, char := range trimmed {
-		if index == 0 && char == '-' {
-			if len(trimmed) == 1 {
-				return false
-			}
-			continue
-		}
-		if char < '0' || char > '9' {
-			return false
-		}
-	}
-	return true
+	_, err := normalizedID(id)
+	return err == nil
 }
 
-func (p *Proxy) reservePendingCall(id json.RawMessage) (string, error) {
-	key := NormalizedID(id)
+func (p *Proxy) reservePendingCall(id json.RawMessage) (pendingCallReservation, error) {
+	key, err := normalizedID(id)
+	if err != nil {
+		return pendingCallReservation{}, fmt.Errorf("invalid request id: %w", err)
+	}
 	p.pendingMu.Lock()
 	defer p.pendingMu.Unlock()
-	p.evictStalePendingCalls()
-	if _, exists := p.pendingCalls[key]; exists {
+	if p.pendingIDExistsLocked(key) {
+		return pendingCallReservation{}, fmt.Errorf("request id %s is already pending", key)
+	}
+	if p.pendingCountLocked() >= maxPendingRequests {
+		return pendingCallReservation{}, fmt.Errorf("pending tools/call capacity reached")
+	}
+	p.pendingOwner++
+	if p.pendingOwner == 0 {
+		p.pendingOwner++
+	}
+	reservation := pendingCallReservation{key: key, owner: p.pendingOwner}
+	// Reservation blocks duplicate IDs during evaluation and approval, but is
+	// deliberately not eligible to correlate a child response.
+	p.pendingCalls[key] = pendingCall{state: pendingCallReserved, owner: reservation.owner}
+	return reservation, nil
+}
+
+func (p *Proxy) releasePendingCall(reservation pendingCallReservation) {
+	if !reservation.valid() {
+		return
+	}
+	p.pendingMu.Lock()
+	if pending, ok := p.pendingCalls[reservation.key]; ok && pending.owner == reservation.owner {
+		delete(p.pendingCalls, reservation.key)
+	}
+	p.pendingMu.Unlock()
+}
+
+// forwardReservedCall moves an owned reservation through a non-correlatable
+// writing state and makes it response-active only after the child write
+// succeeds. Responses that arrive while the write is in progress wait for the
+// outcome, so an immediate legitimate response cannot outrun activation.
+func (p *Proxy) forwardReservedCall(reservation pendingCallReservation, call pendingCall, line []byte) (bool, error) {
+	p.pendingMu.Lock()
+	pending, owned := p.pendingCalls[reservation.key]
+	if !owned || pending.owner != reservation.owner || pending.state != pendingCallReserved {
+		p.pendingMu.Unlock()
+		return false, nil
+	}
+	call.state = pendingCallWriting
+	call.owner = reservation.owner
+	p.pendingCalls[reservation.key] = call
+	p.pendingMu.Unlock()
+
+	writeErr := p.writeToChild(line)
+
+	p.pendingMu.Lock()
+	pending, owned = p.pendingCalls[reservation.key]
+	owned = owned && pending.owner == reservation.owner && pending.state == pendingCallWriting
+	if owned {
+		if writeErr != nil {
+			delete(p.pendingCalls, reservation.key)
+		} else {
+			pending.state = pendingCallResponseActive
+			pending.owner = 0
+			p.pendingCalls[reservation.key] = pending
+		}
+	}
+	p.pendingCond.Broadcast()
+	p.pendingMu.Unlock()
+
+	if writeErr != nil {
+		return false, writeErr
+	}
+	if !owned {
+		return false, fmt.Errorf("mcp: tools/call correlation lost while forwarding")
+	}
+	return true, nil
+}
+
+func (p *Proxy) trackPendingToolList(id json.RawMessage) (string, error) {
+	key, err := normalizedID(id)
+	if err != nil {
+		return "", fmt.Errorf("invalid request id: %w", err)
+	}
+	p.pendingMu.Lock()
+	defer p.pendingMu.Unlock()
+	if p.pendingIDExistsLocked(key) {
 		return "", fmt.Errorf("request id %s is already pending", key)
 	}
-	if _, exists := p.pendingToolList[key]; exists {
-		return "", fmt.Errorf("request id %s is already pending", key)
+	if p.pendingCountLocked() >= maxPendingRequests {
+		return "", fmt.Errorf("pending tools/list capacity reached")
 	}
-	if len(p.pendingCalls) >= maxPendingRequests {
-		return "", fmt.Errorf("pending tools/call capacity reached")
-	}
-	// Reserve before evaluating so concurrent requests cannot race past the
-	// duplicate-ID check. The child cannot answer before writeToChild, which only
-	// happens after this placeholder is replaced with the complete pending call.
-	p.pendingCalls[key] = pendingCall{}
+	p.pendingToolList[key] = struct{}{}
 	return key, nil
 }
 
-func (p *Proxy) releasePendingCall(key string) {
+func (p *Proxy) releasePendingToolList(key string) {
 	if key == "" {
 		return
 	}
 	p.pendingMu.Lock()
-	delete(p.pendingCalls, key)
+	delete(p.pendingToolList, key)
 	p.pendingMu.Unlock()
 }
 
-func (p *Proxy) trackPendingToolList(id json.RawMessage) error {
-	key := NormalizedID(id)
+func (p *Proxy) reservePendingGeneric(id json.RawMessage) (string, error) {
+	key, err := normalizedID(id)
+	if err != nil {
+		return "", fmt.Errorf("invalid request id: %w", err)
+	}
 	p.pendingMu.Lock()
 	defer p.pendingMu.Unlock()
-	p.evictStalePendingCalls()
-	if _, exists := p.pendingCalls[key]; exists {
-		return fmt.Errorf("request id %s is already pending", key)
+	if p.pendingIDExistsLocked(key) {
+		return "", fmt.Errorf("request id %s is already pending", key)
 	}
-	if _, exists := p.pendingToolList[key]; exists {
-		return fmt.Errorf("request id %s is already pending", key)
+	if p.pendingCountLocked() >= maxPendingRequests {
+		return "", fmt.Errorf("pending request capacity reached")
 	}
-	if len(p.pendingToolList) >= maxPendingRequests {
-		return fmt.Errorf("pending tools/list capacity reached")
-	}
-	p.pendingToolList[key] = time.Now()
-	return nil
+	p.pendingGeneric[key] = struct{}{}
+	return key, nil
 }
 
-// evictStalePendingCalls removes stale tool-list correlation only. Tool-call
-// correlation is bounded by maxPendingRequests but is intentionally never
-// discarded by age: a slow child response must still pass response policy and
-// audit enforcement. Must be called with pendingMu held.
-func (p *Proxy) evictStalePendingCalls() {
-	const maxAge = 5 * time.Minute
-	now := time.Now()
-	// Evict stale pendingToolList entries using the same TTL.
-	for id, insertedAt := range p.pendingToolList {
-		if now.Sub(insertedAt) > maxAge {
-			delete(p.pendingToolList, id)
-		}
+func (p *Proxy) releasePendingGeneric(key string) {
+	if key == "" {
+		return
 	}
+	p.pendingMu.Lock()
+	delete(p.pendingGeneric, key)
+	p.pendingMu.Unlock()
+}
+
+func (p *Proxy) pendingIDExistsLocked(key string) bool {
+	if _, exists := p.pendingCalls[key]; exists {
+		return true
+	}
+	if _, exists := p.pendingToolList[key]; exists {
+		return true
+	}
+	_, exists := p.pendingGeneric[key]
+	return exists
+}
+
+func (p *Proxy) pendingCountLocked() int {
+	return len(p.pendingCalls) + len(p.pendingToolList) + len(p.pendingGeneric)
 }
 
 func (p *Proxy) handleChildLine(line []byte, parentOut io.Writer) error {
@@ -633,7 +763,7 @@ func (p *Proxy) handleChildLine(line []byte, parentOut io.Writer) error {
 			return fmt.Errorf("mcp: reject child JSON-RPC response: %w", err)
 		}
 		var err error
-		responseFields, err = decodeCanonicalJSONObject(trimmed, "jsonrpc", "id", "result", "error")
+		responseFields, err = decodeCanonicalJSONObject(trimmed, "jsonrpc", "id", "method", "params", "result", "error")
 		if err != nil {
 			p.logger.Warn("mcp: rejecting case-shadowed child JSON-RPC envelope", "error", err)
 			return fmt.Errorf("mcp: reject child JSON-RPC response: %w", err)
@@ -649,36 +779,67 @@ func (p *Proxy) handleChildLine(line []byte, parentOut io.Writer) error {
 		return p.writeToClient(parentOut, line)
 	}
 	if responseFields == nil {
-		responseFields, _ = decodeCanonicalJSONObject(trimmed, "jsonrpc", "id", "result", "error")
+		responseFields, _ = decodeCanonicalJSONObject(trimmed, "jsonrpc", "id", "method", "params", "result", "error")
 	}
 
-	if p.mode == "enforce" && HasID(resp.ID) && p.hasPendingResponse(resp.ID) {
+	var responseIDKey string
+	if HasID(resp.ID) {
+		var err error
+		responseIDKey, err = normalizedID(resp.ID)
+		if err != nil {
+			if p.mode == "enforce" {
+				return fmt.Errorf("mcp: reject child JSON-RPC response: invalid response id: %w", err)
+			}
+			return p.writeToClient(parentOut, line)
+		}
+	}
+
+	_, hasMethod := responseFields["method"]
+	_, hasResult := responseFields["result"]
+	_, hasError := responseFields["error"]
+	if hasMethod {
+		if p.mode == "enforce" && (hasResult || hasError) {
+			return fmt.Errorf("mcp: reject ambiguous child JSON-RPC request/response envelope")
+		}
+		// MCP is bidirectional: a child server request or notification is not a
+		// response to a client request, even when their ID values happen to match.
+		return p.writeToClient(parentOut, line)
+	}
+
+	if responseIDKey == "" {
+		if p.mode == "enforce" {
+			return fmt.Errorf("mcp: reject child JSON-RPC response: uncorrelated response")
+		}
+		return p.writeToClient(parentOut, line)
+	}
+
+	if !p.preparePendingResponse(responseIDKey) {
+		if p.mode == "enforce" {
+			return fmt.Errorf("mcp: reject child JSON-RPC response: uncorrelated response")
+		}
+		return p.writeToClient(parentOut, line)
+	}
+	if p.mode == "enforce" {
 		if err := validateCorrelatedResponse(resp, responseFields); err != nil {
 			return fmt.Errorf("mcp: reject child JSON-RPC response: %w", err)
 		}
 	}
 
-	if p.filterTools && HasID(resp.ID) {
-		if filtered, handled, err := p.maybeFilterToolsList(resp); err != nil {
-			return err
-		} else if handled {
-			return p.writeToClient(parentOut, filtered)
+	pending, correlated := p.consumePendingResponse(responseIDKey)
+	if !correlated {
+		if p.mode == "enforce" {
+			return fmt.Errorf("mcp: reject child JSON-RPC response: uncorrelated response")
 		}
-	}
-
-	if !HasID(resp.ID) {
 		return p.writeToClient(parentOut, line)
 	}
-
-	id := NormalizedID(resp.ID)
-	p.pendingMu.Lock()
-	pending, ok := p.pendingCalls[id]
-	if ok {
-		delete(p.pendingCalls, id)
+	if pending.kind == pendingResponseToolList && p.filterTools {
+		filtered, err := p.filterToolsListResponse(resp)
+		if err != nil {
+			return err
+		}
+		return p.writeToClient(parentOut, filtered)
 	}
-	p.pendingMu.Unlock()
-
-	if !ok {
+	if pending.kind != pendingResponseToolCall {
 		return p.writeToClient(parentOut, line)
 	}
 
@@ -690,10 +851,10 @@ func (p *Proxy) handleChildLine(line []byte, parentOut io.Writer) error {
 		p.logger.Debug("mcp: response canonicalization failed in monitor mode", "error", responseErr)
 	}
 	if responseBody != "" {
-		result := p.engine.EvaluateResponse(pending.call, responseBody)
-		responseRequest := cloneMap(pending.request)
+		result := p.engine.EvaluateResponse(pending.toolCall.call, responseBody)
+		responseRequest := cloneMap(pending.toolCall.request)
 		responseRequest["mcp_phase"] = "response"
-		if err := p.writeAudit(pending.call, result, responseRequest, &audit.ToolResponse{DurationMS: result.EvalDuration.Milliseconds()}); err != nil {
+		if err := p.writeAudit(pending.toolCall.call, result, responseRequest, &audit.ToolResponse{DurationMS: result.EvalDuration.Milliseconds()}); err != nil {
 			p.logger.Error("mcp: response audit write failed", "error", err)
 			if p.mode == "enforce" {
 				return p.writeErrorToClient(resp.ID, jsonRPCResponseDenyCode, "Rampart: audit storage is unavailable; refusing tool response")
@@ -712,13 +873,56 @@ func (p *Proxy) handleChildLine(line []byte, parentOut io.Writer) error {
 	return p.writeToClient(parentOut, line)
 }
 
-func (p *Proxy) hasPendingResponse(id json.RawMessage) bool {
-	normalized := NormalizedID(id)
+// preparePendingResponse waits for an in-progress child write to commit before
+// allowing correlation. A response that arrives while a tools/call is merely
+// reserved invalidates that reservation; it must never consume empty metadata
+// or allow the request to be forwarded later.
+func (p *Proxy) preparePendingResponse(normalized string) bool {
 	p.pendingMu.Lock()
 	defer p.pendingMu.Unlock()
-	_, toolCall := p.pendingCalls[normalized]
-	_, toolList := p.pendingToolList[normalized]
-	return toolCall || toolList
+	for {
+		if call, ok := p.pendingCalls[normalized]; ok {
+			switch call.state {
+			case pendingCallReserved:
+				call.state = pendingCallRejected
+				p.pendingCalls[normalized] = call
+				return false
+			case pendingCallWriting:
+				p.pendingCond.Wait()
+				continue
+			case pendingCallResponseActive:
+				return true
+			default:
+				return false
+			}
+		}
+		if _, ok := p.pendingToolList[normalized]; ok {
+			return true
+		}
+		_, ok := p.pendingGeneric[normalized]
+		return ok
+	}
+}
+
+func (p *Proxy) consumePendingResponse(normalized string) (pendingResponse, bool) {
+	p.pendingMu.Lock()
+	defer p.pendingMu.Unlock()
+	if call, ok := p.pendingCalls[normalized]; ok {
+		if call.state != pendingCallResponseActive {
+			return pendingResponse{}, false
+		}
+		delete(p.pendingCalls, normalized)
+		return pendingResponse{kind: pendingResponseToolCall, toolCall: call}, true
+	}
+	if _, ok := p.pendingToolList[normalized]; ok {
+		delete(p.pendingToolList, normalized)
+		return pendingResponse{kind: pendingResponseToolList}, true
+	}
+	if _, ok := p.pendingGeneric[normalized]; ok {
+		delete(p.pendingGeneric, normalized)
+		return pendingResponse{kind: pendingResponseGeneric}, true
+	}
+	return pendingResponse{}, false
 }
 
 func validateCorrelatedResponse(resp Response, fields map[string]json.RawMessage) error {
@@ -733,27 +937,16 @@ func validateCorrelatedResponse(resp Response, fields map[string]json.RawMessage
 	return nil
 }
 
-func (p *Proxy) maybeFilterToolsList(resp Response) ([]byte, bool, error) {
-	id := NormalizedID(resp.ID)
-	p.pendingMu.Lock()
-	_, requested := p.pendingToolList[id]
-	if requested {
-		delete(p.pendingToolList, id)
-	}
-	p.pendingMu.Unlock()
-	if !requested {
-		return nil, false, nil
-	}
-
+func (p *Proxy) filterToolsListResponse(resp Response) ([]byte, error) {
 	var result map[string]any
 	if err := json.Unmarshal(resp.Result, &result); err != nil {
 		p.logger.Debug("mcp: tools/list result parse failed; skipping filter", "error", err)
-		return ensureTrailingNewline(mustJSONMarshal(resp)), true, nil
+		return ensureTrailingNewline(mustJSONMarshal(resp)), nil
 	}
 
 	toolsAny, ok := result["tools"].([]any)
 	if !ok {
-		return ensureTrailingNewline(mustJSONMarshal(resp)), true, nil
+		return ensureTrailingNewline(mustJSONMarshal(resp)), nil
 	}
 
 	filtered := make([]any, 0, len(toolsAny))
@@ -795,7 +988,15 @@ func (p *Proxy) maybeFilterToolsList(resp Response) ([]byte, bool, error) {
 
 	result["tools"] = filtered
 	resp.Result = mustJSONMarshal(result)
-	return ensureTrailingNewline(mustJSONMarshal(resp)), true, nil
+	return ensureTrailingNewline(mustJSONMarshal(resp)), nil
+}
+
+var securitySensitiveArgumentKeys = []string{
+	"command", "cmd", "input",
+	"path", "file_path", "file", "filepath", "target",
+	"url", "uri", "href",
+	"workdir", "cwd",
+	"domain", "scheme",
 }
 
 func buildRequestData(method, toolName string, arguments map[string]any) map[string]any {

--- a/internal/mcp/proxy_test.go
+++ b/internal/mcp/proxy_test.go
@@ -95,6 +95,39 @@ type nopWriteCloser struct {
 
 func (nopWriteCloser) Close() error { return nil }
 
+type failingWriteCloser struct{}
+
+func (failingWriteCloser) Write([]byte) (int, error) { return 0, fmt.Errorf("write unavailable") }
+func (failingWriteCloser) Close() error              { return nil }
+
+type gatedWriteCloser struct {
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+	writes  int
+	err     error
+}
+
+func newGatedWriteCloser(err error) *gatedWriteCloser {
+	return &gatedWriteCloser{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+		err:     err,
+	}
+}
+
+func (w *gatedWriteCloser) Write(data []byte) (int, error) {
+	w.writes++
+	w.once.Do(func() { close(w.started) })
+	<-w.release
+	if w.err != nil {
+		return 0, w.err
+	}
+	return len(data), nil
+}
+
+func (*gatedWriteCloser) Close() error { return nil }
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -175,6 +208,53 @@ func TestHandleToolsCall_Allow(t *testing.T) {
 		t.Errorf("expected 1 pending call, got %d", len(p.pendingCalls))
 	}
 	p.pendingMu.Unlock()
+}
+
+func TestHandleToolsCall_EnforceRejectsCaseShadowedSecurityArguments(t *testing.T) {
+	tests := make([]struct {
+		name      string
+		arguments string
+	}, 0, len(securitySensitiveArgumentKeys)+1)
+	for _, key := range securitySensitiveArgumentKeys {
+		tests = append(tests, struct {
+			name      string
+			arguments string
+		}{
+			name:      key,
+			arguments: fmt.Sprintf(`{"%s":"safe","%s":"dangerous"}`, key, strings.ToUpper(key)),
+		})
+	}
+	// encoding/json uses Unicode simple folding, not ASCII-only casing.
+	tests = append(tests, struct {
+		name      string
+		arguments string
+	}{name: "unicode simple fold", arguments: `{"scheme":"https","ſcheme":"file"}`})
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			childIn := &bytes.Buffer{}
+			parentOut := &bytes.Buffer{}
+			p := NewProxy(buildAllowAllEngine(t), &mockSink{}, nopWriteCloser{childIn}, strings.NewReader(""),
+				WithMode("enforce"), WithLogger(silentLogger()))
+			p.parentOut = parentOut
+
+			line := []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"execute_command","arguments":` + test.arguments + `}}` + "\n")
+			require.NoError(t, p.handleClientLine(line))
+			assert.Empty(t, childIn.String(), "case-shadowed arguments reached child: %s", test.arguments)
+			assert.Contains(t, parentOut.String(), "invalid tools/call arguments")
+		})
+	}
+}
+
+func TestHandleToolsCall_EnforcePreservesUnknownArguments(t *testing.T) {
+	childIn := &bytes.Buffer{}
+	p := NewProxy(buildAllowAllEngine(t), &mockSink{}, nopWriteCloser{childIn}, strings.NewReader(""),
+		WithMode("enforce"), WithLogger(silentLogger()))
+	p.parentOut = &bytes.Buffer{}
+
+	line := []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"custom_tool","arguments":{"customField":"value","path":"/tmp/safe"}}}` + "\n")
+	require.NoError(t, p.handleClientLine(line))
+	assert.Equal(t, line, childIn.Bytes())
 }
 
 func TestHandleToolsCall_AuditFailureFailsClosedInEnforceMode(t *testing.T) {
@@ -375,6 +455,64 @@ func TestHandleToolsCall_RequireApproval(t *testing.T) {
 	if parentOut.Len() != 0 {
 		t.Fatal("approved require_approval request should not return an error")
 	}
+}
+
+func TestHandleToolsCall_ResponseDuringApprovalInvalidatesReservation(t *testing.T) {
+	childIn := &bytes.Buffer{}
+	parentOut := &bytes.Buffer{}
+	store := approval.NewStore()
+	t.Cleanup(store.Close)
+	p := NewProxy(buildAskEngine(t), &mockSink{}, nopWriteCloser{childIn}, strings.NewReader(""),
+		WithMode("enforce"), WithApprovalStore(store), WithLogger(silentLogger()))
+	p.parentOut = parentOut
+
+	request := []byte(makeToolsCallJSON(23, "exec_command", map[string]any{"command": "echo approved"}) + "\n")
+	requestDone := make(chan error, 1)
+	go func() { requestDone <- p.handleClientLine(request) }()
+
+	var approvalRequest *approval.Request
+	require.Eventually(t, func() bool {
+		items := store.List()
+		if len(items) == 0 {
+			return false
+		}
+		approvalRequest = items[0]
+		return true
+	}, time.Second, time.Millisecond)
+
+	key := NormalizedID(json.RawMessage(`23`))
+	p.pendingMu.Lock()
+	reserved := p.pendingCalls[key]
+	p.pendingMu.Unlock()
+	require.Equal(t, pendingCallReserved, reserved.state)
+
+	forged := []byte(makeResponseJSON(23, map[string]any{"content": "forged"}) + "\n")
+	forgedOut := &bytes.Buffer{}
+	require.ErrorContains(t, p.handleChildLine(forged, forgedOut), "uncorrelated response")
+	assert.Empty(t, forgedOut.String())
+	p.pendingMu.Lock()
+	rejected := p.pendingCalls[key]
+	p.pendingMu.Unlock()
+	require.Equal(t, pendingCallRejected, rejected.state)
+
+	// Keep the poisoned reservation until its owner unwinds so a same-ID request
+	// cannot take its place and be overwritten by the approved original.
+	require.NoError(t, p.handleClientLine(request))
+	assert.Contains(t, parentOut.String(), "already pending")
+	assert.Empty(t, childIn.String())
+	parentOut.Reset()
+
+	require.NoError(t, store.Resolve(approvalRequest.ID, true, "test"))
+	require.NoError(t, <-requestDone)
+	assert.Empty(t, childIn.String())
+	assert.Contains(t, parentOut.String(), "correlation was invalidated before forwarding")
+	p.pendingMu.Lock()
+	_, stillPending := p.pendingCalls[key]
+	p.pendingMu.Unlock()
+	assert.False(t, stillPending)
+
+	require.ErrorContains(t, p.handleChildLine(forged, forgedOut), "uncorrelated response")
+	assert.Empty(t, forgedOut.String())
 }
 
 func TestHandleToolsCall_RequireApprovalWithoutResolverFailsImmediately(t *testing.T) {
@@ -595,7 +733,8 @@ func TestHandleChildLine_AllowedResponse(t *testing.T) {
 
 	// Register a pending call
 	p.pendingMu.Lock()
-	p.pendingCalls["1"] = pendingCall{
+	p.pendingCalls[NormalizedID(json.RawMessage(`1`))] = pendingCall{
+		state: pendingCallResponseActive,
 		call: engine.ToolCall{
 			ID:      "test-id",
 			Agent:   "mcp-client",
@@ -628,13 +767,69 @@ func TestHandleChildLine_AllowedResponse(t *testing.T) {
 	p.pendingMu.Unlock()
 }
 
+func TestHandleToolsCall_ImmediateResponseWaitsForWriteCommitAndRejectsReplay(t *testing.T) {
+	childIn := newGatedWriteCloser(nil)
+	parentOut := &bytes.Buffer{}
+	sink := &mockSink{}
+	p := NewProxy(buildAllowAllEngine(t), sink, childIn, strings.NewReader(""),
+		WithMode("enforce"), WithLogger(silentLogger()))
+	p.parentOut = parentOut
+
+	request := []byte(makeToolsCallJSON(24, "read_file", map[string]any{"path": "/tmp/safe"}) + "\n")
+	requestDone := make(chan error, 1)
+	go func() { requestDone <- p.handleClientLine(request) }()
+	select {
+	case <-childIn.started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for child write")
+	}
+
+	key := NormalizedID(json.RawMessage(`24`))
+	p.pendingMu.Lock()
+	writing := p.pendingCalls[key]
+	p.pendingMu.Unlock()
+	require.Equal(t, pendingCallWriting, writing.state)
+	assert.NotEmpty(t, writing.call.ID)
+	assert.Equal(t, "read_file", writing.request["mcp_tool"])
+
+	response := []byte(makeResponseJSON(24, map[string]any{"content": "safe"}) + "\n")
+	responseDone := make(chan error, 1)
+	responseStarted := make(chan struct{})
+	go func() {
+		close(responseStarted)
+		responseDone <- p.handleChildLine(response, parentOut)
+	}()
+	<-responseStarted
+	select {
+	case err := <-responseDone:
+		t.Fatalf("response completed before child write committed: %v", err)
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	close(childIn.release)
+	require.NoError(t, <-requestDone)
+	require.NoError(t, <-responseDone)
+	assert.Equal(t, 1, childIn.writes)
+	assert.Equal(t, response, parentOut.Bytes())
+
+	events := sink.getEvents()
+	require.Len(t, events, 2)
+	assert.NotEmpty(t, events[0].ToolCallID)
+	assert.Equal(t, events[0].ToolCallID, events[1].ToolCallID)
+
+	require.ErrorContains(t, p.handleChildLine(response, parentOut), "uncorrelated response")
+	assert.Equal(t, response, parentOut.Bytes())
+	assert.Equal(t, 1, childIn.writes)
+}
+
 func TestHandleChildLine_AuditFailureBlocksResponseInEnforceMode(t *testing.T) {
 	eng := buildAllowAllEngine(t)
 	parentOut := &bytes.Buffer{}
 	p := NewProxy(eng, &failingSink{}, nopWriteCloser{&bytes.Buffer{}}, strings.NewReader(""),
 		WithMode("enforce"), WithLogger(silentLogger()))
 	p.parentOut = parentOut
-	p.pendingCalls["1"] = pendingCall{
+	p.pendingCalls[NormalizedID(json.RawMessage(`1`))] = pendingCall{
+		state: pendingCallResponseActive,
 		call: engine.ToolCall{
 			ID: "test-id", Agent: "mcp-client", Session: "mcp-proxy", Tool: "read_file",
 		},
@@ -666,7 +861,8 @@ func TestHandleChildLine_DeniedResponse(t *testing.T) {
 
 	// Register pending call
 	p.pendingMu.Lock()
-	p.pendingCalls["1"] = pendingCall{
+	p.pendingCalls[NormalizedID(json.RawMessage(`1`))] = pendingCall{
+		state: pendingCallResponseActive,
 		call: engine.ToolCall{
 			ID:      "test-id",
 			Agent:   "mcp-client",
@@ -701,7 +897,8 @@ func TestHandleChildLine_DecodesEscapedResponseBeforePolicy(t *testing.T) {
 	p := NewProxy(eng, &mockSink{}, nopWriteCloser{&bytes.Buffer{}}, strings.NewReader(""),
 		WithMode("enforce"), WithLogger(silentLogger()))
 	p.parentOut = parentOut
-	p.pendingCalls["1"] = pendingCall{
+	p.pendingCalls[NormalizedID(json.RawMessage(`1`))] = pendingCall{
+		state:   pendingCallResponseActive,
 		call:    engine.ToolCall{ID: "escaped", Tool: "read_file"},
 		request: map[string]any{"mcp_method": "tools/call", "mcp_tool": "read_file"},
 	}
@@ -725,7 +922,7 @@ func TestHandleChildLine_RejectsAmbiguousCorrelatedResponse(t *testing.T) {
 	} {
 		p := NewProxy(eng, &mockSink{}, nopWriteCloser{&bytes.Buffer{}}, strings.NewReader(""),
 			WithMode("enforce"), WithLogger(silentLogger()))
-		p.pendingCalls["1"] = pendingCall{call: engine.ToolCall{ID: "ambiguous", Tool: "read_file"}}
+		p.pendingCalls[NormalizedID(json.RawMessage(`1`))] = pendingCall{state: pendingCallResponseActive, call: engine.ToolCall{ID: "ambiguous", Tool: "read_file"}}
 		parentOut := &bytes.Buffer{}
 		err := p.handleChildLine([]byte(line+"\n"), parentOut)
 		if err == nil || !strings.Contains(err.Error(), "reject child JSON-RPC response") {
@@ -737,32 +934,198 @@ func TestHandleChildLine_RejectsAmbiguousCorrelatedResponse(t *testing.T) {
 	}
 }
 
-func TestHandleChildLine_NoPendingCall_PassesThrough(t *testing.T) {
+func TestHandleChildLine_EnforceRejectsUncorrelatedResponses(t *testing.T) {
 	eng := buildAllowAllEngine(t)
-	parentOut := &bytes.Buffer{}
-	sink := &mockSink{}
-
-	p := NewProxy(eng, sink, nopWriteCloser{&bytes.Buffer{}}, strings.NewReader(""),
-		WithLogger(silentLogger()))
-	p.parentOut = parentOut
-
-	respLine := []byte(makeResponseJSON(999, "ok") + "\n")
-	err := p.handleChildLine(respLine, parentOut)
-	if err != nil {
-		t.Fatalf("handleChildLine: %v", err)
-	}
-
-	// Should pass through without evaluation
-	if parentOut.Len() == 0 {
-		t.Fatal("unmatched response should pass through")
+	for _, line := range []string{
+		makeResponseJSON(999, "ok"),
+		`{"jsonrpc":"2.0","id":999,"error":{"code":-32603,"message":"failed"}}`,
+	} {
+		parentOut := &bytes.Buffer{}
+		p := NewProxy(eng, &mockSink{}, nopWriteCloser{&bytes.Buffer{}}, strings.NewReader(""),
+			WithMode("enforce"), WithLogger(silentLogger()))
+		err := p.handleChildLine([]byte(line+"\n"), parentOut)
+		require.ErrorContains(t, err, "uncorrelated response")
+		assert.Empty(t, parentOut.String())
 	}
 }
 
+func TestHandleChildLine_MonitorPreservesUncorrelatedResponse(t *testing.T) {
+	parentOut := &bytes.Buffer{}
+	p := NewProxy(buildAllowAllEngine(t), &mockSink{}, nopWriteCloser{&bytes.Buffer{}}, strings.NewReader(""),
+		WithMode("monitor"), WithLogger(silentLogger()))
+
+	line := []byte(makeResponseJSON(999, "ok") + "\n")
+	require.NoError(t, p.handleChildLine(line, parentOut))
+	assert.Equal(t, line, parentOut.Bytes())
+}
+
+func TestPendingCorrelationSurvivesDelayAndRejectsReplacementAndReplay(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		filterTools bool
+		request     []byte
+		response    []byte
+	}{
+		{
+			name:     "generic",
+			request:  []byte(`{"jsonrpc":"2.0","id":"delayed","method":"initialize","params":{}}` + "\n"),
+			response: []byte(`{"jsonrpc":"2.0","id":"delayed","result":{"protocolVersion":"2025-06-18"}}` + "\n"),
+		},
+		{
+			name:        "tools-list",
+			filterTools: true,
+			request:     []byte(`{"jsonrpc":"2.0","id":"delayed","method":"tools/list","params":{}}` + "\n"),
+			response:    []byte(`{"jsonrpc":"2.0","id":"delayed","result":{"tools":[]}}` + "\n"),
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			childIn := &bytes.Buffer{}
+			parentOut := &bytes.Buffer{}
+			p := NewProxy(buildAllowAllEngine(t), &mockSink{}, nopWriteCloser{childIn}, strings.NewReader(""),
+				WithMode("enforce"), WithFilterTools(test.filterTools), WithLogger(silentLogger()))
+			p.parentOut = parentOut
+
+			require.NoError(t, p.handleClientLine(test.request))
+			assert.Equal(t, test.request, childIn.Bytes())
+			key := NormalizedID(json.RawMessage(`"delayed"`))
+			assert.True(t, p.preparePendingResponse(key))
+
+			// Correlation stores no age. Keeping the request pending while a
+			// same-ID request arrives deterministically models an arbitrary delay.
+			replacement := []byte(`{"jsonrpc":"2.0","id":"delayed","method":"resources/list","params":{}}` + "\n")
+			require.NoError(t, p.handleClientLine(replacement))
+			assert.Equal(t, test.request, childIn.Bytes())
+			assert.Contains(t, parentOut.String(), "already pending")
+			assert.True(t, p.preparePendingResponse(key))
+			parentOut.Reset()
+
+			require.NoError(t, p.handleChildLine(test.response, parentOut))
+			assert.NotEmpty(t, parentOut.Bytes())
+			assert.False(t, p.preparePendingResponse(key))
+
+			require.ErrorContains(t, p.handleChildLine(test.response, parentOut), "uncorrelated response")
+		})
+	}
+}
+
+func TestGenericAndToolRequestIDsCannotCollide(t *testing.T) {
+	for _, genericFirst := range []bool{true, false} {
+		t.Run(fmt.Sprintf("generic-first-%t", genericFirst), func(t *testing.T) {
+			childIn := &bytes.Buffer{}
+			parentOut := &bytes.Buffer{}
+			p := NewProxy(buildAllowAllEngine(t), &mockSink{}, nopWriteCloser{childIn}, strings.NewReader(""),
+				WithMode("enforce"), WithLogger(silentLogger()))
+			p.parentOut = parentOut
+
+			generic := []byte(`{"jsonrpc":"2.0","id":7,"method":"initialize","params":{}}` + "\n")
+			tool := []byte(makeToolsCallJSON(7, "read_file", map[string]any{"path": "/tmp/test"}) + "\n")
+			first, second := tool, generic
+			if genericFirst {
+				first, second = generic, tool
+			}
+			require.NoError(t, p.handleClientLine(first))
+			require.NoError(t, p.handleClientLine(second))
+			assert.Equal(t, first, childIn.Bytes())
+			assert.Contains(t, parentOut.String(), "already pending")
+		})
+	}
+}
+
+func TestGenericPendingCapacityIsCombinedAndBounded(t *testing.T) {
+	newFullProxy := func(t *testing.T, mode string, childIn *bytes.Buffer) *Proxy {
+		p := NewProxy(buildAllowAllEngine(t), &mockSink{}, nopWriteCloser{childIn}, strings.NewReader(""),
+			WithMode(mode), WithLogger(silentLogger()))
+		p.parentOut = &bytes.Buffer{}
+		p.pendingCalls[NormalizedID(json.RawMessage(`"call"`))] = pendingCall{state: pendingCallResponseActive}
+		p.pendingToolList[NormalizedID(json.RawMessage(`"list"`))] = struct{}{}
+		for index := 0; index < maxPendingRequests-2; index++ {
+			key := NormalizedID(json.RawMessage(fmt.Sprintf(`"generic-%d"`, index)))
+			p.pendingGeneric[key] = struct{}{}
+		}
+		return p
+	}
+
+	line := []byte(`{"jsonrpc":"2.0","id":"overflow","method":"initialize","params":{}}` + "\n")
+	childIn := &bytes.Buffer{}
+	p := newFullProxy(t, "enforce", childIn)
+	require.NoError(t, p.handleClientLine(line))
+	assert.Empty(t, childIn.String())
+	assert.Contains(t, p.parentOut.(*bytes.Buffer).String(), "pending request capacity reached")
+	p.pendingMu.Lock()
+	count := p.pendingCountLocked()
+	p.pendingMu.Unlock()
+	assert.Equal(t, maxPendingRequests, count)
+
+	monitorChild := &bytes.Buffer{}
+	monitor := newFullProxy(t, "monitor", monitorChild)
+	require.NoError(t, monitor.handleClientLine(line))
+	assert.Equal(t, line, monitorChild.Bytes())
+	monitor.pendingMu.Lock()
+	monitorCount := monitor.pendingCountLocked()
+	monitor.pendingMu.Unlock()
+	assert.Equal(t, maxPendingRequests, monitorCount)
+}
+
+func TestGenericReservationReleasedWhenChildWriteFails(t *testing.T) {
+	p := NewProxy(buildAllowAllEngine(t), &mockSink{}, failingWriteCloser{}, strings.NewReader(""),
+		WithMode("enforce"), WithLogger(silentLogger()))
+	p.parentOut = &bytes.Buffer{}
+
+	line := []byte(`{"jsonrpc":"2.0","id":"init-1","method":"initialize","params":{}}` + "\n")
+	require.ErrorContains(t, p.handleClientLine(line), "write to child stdin")
+	assert.False(t, p.preparePendingResponse(NormalizedID(json.RawMessage(`"init-1"`))))
+}
+
+func TestHandleChildLine_EnforceRejectsReplayedResponse(t *testing.T) {
+	parentOut := &bytes.Buffer{}
+	p := NewProxy(buildResponseDenyEngine(t), &mockSink{}, nopWriteCloser{&bytes.Buffer{}}, strings.NewReader(""),
+		WithMode("enforce"), WithLogger(silentLogger()))
+	p.pendingCalls[NormalizedID(json.RawMessage(`1`))] = pendingCall{
+		state:   pendingCallResponseActive,
+		call:    engine.ToolCall{ID: "replay", Tool: "read_file"},
+		request: map[string]any{"mcp_method": "tools/call", "mcp_tool": "read_file"},
+	}
+
+	safe := []byte(makeResponseJSON(1, map[string]any{"content": "safe"}) + "\n")
+	require.NoError(t, p.handleChildLine(safe, parentOut))
+	assert.Equal(t, safe, parentOut.Bytes())
+
+	secret := []byte(makeResponseJSON(1, map[string]any{"content": "SECRET_TOKEN"}) + "\n")
+	err := p.handleChildLine(secret, parentOut)
+	require.ErrorContains(t, err, "uncorrelated response")
+	assert.Equal(t, safe, parentOut.Bytes())
+}
+
+func TestHandleChildLine_PreservesServerRequestsAndNotifications(t *testing.T) {
+	parentOut := &bytes.Buffer{}
+	p := NewProxy(buildAllowAllEngine(t), &mockSink{}, nopWriteCloser{&bytes.Buffer{}}, strings.NewReader(""),
+		WithMode("enforce"), WithLogger(silentLogger()))
+	p.pendingCalls[NormalizedID(json.RawMessage(`1`))] = pendingCall{
+		state: pendingCallResponseActive,
+		call:  engine.ToolCall{ID: "client-call", Tool: "read_file"},
+	}
+
+	for _, line := range [][]byte{
+		[]byte(`{"jsonrpc":"2.0","id":1,"method":"sampling/createMessage","params":{}}` + "\n"),
+		[]byte(`{"jsonrpc":"2.0","method":"notifications/message","params":{"level":"info"}}` + "\n"),
+	} {
+		require.NoError(t, p.handleChildLine(line, parentOut))
+	}
+	assert.Contains(t, parentOut.String(), `"method":"sampling/createMessage"`)
+	assert.Contains(t, parentOut.String(), `"method":"notifications/message"`)
+	_, stillPending := p.pendingCalls[NormalizedID(json.RawMessage(`1`))]
+	assert.True(t, stillPending, "server request consumed client response correlation")
+
+	mixed := []byte(`{"jsonrpc":"2.0","id":1,"method":"sampling/createMessage","result":{"content":"SECRET_TOKEN"}}` + "\n")
+	require.ErrorContains(t, p.handleChildLine(mixed, parentOut), "ambiguous child JSON-RPC request/response")
+	assert.NotContains(t, parentOut.String(), "SECRET_TOKEN")
+}
+
 // ---------------------------------------------------------------------------
-// Test: maybeFilterToolsList
+// Test: filterToolsListResponse
 // ---------------------------------------------------------------------------
 
-func TestMaybeFilterToolsList_FiltersBlockedTools(t *testing.T) {
+func TestFilterToolsListResponse_FiltersBlockedTools(t *testing.T) {
 	eng := buildDenyExecEngine(t)
 	sink := &mockSink{}
 
@@ -772,7 +1135,7 @@ func TestMaybeFilterToolsList_FiltersBlockedTools(t *testing.T) {
 
 	// Register pending tools/list
 	p.pendingMu.Lock()
-	p.pendingToolList["1"] = time.Now()
+	p.pendingToolList[NormalizedID(json.RawMessage(`1`))] = struct{}{}
 	p.pendingMu.Unlock()
 
 	toolsResult := map[string]any{
@@ -789,12 +1152,9 @@ func TestMaybeFilterToolsList_FiltersBlockedTools(t *testing.T) {
 		Result:  resultBytes,
 	}
 
-	filtered, handled, err := p.maybeFilterToolsList(resp)
+	filtered, err := p.filterToolsListResponse(resp)
 	if err != nil {
-		t.Fatalf("maybeFilterToolsList: %v", err)
-	}
-	if !handled {
-		t.Fatal("expected handled=true")
+		t.Fatalf("filterToolsListResponse: %v", err)
 	}
 
 	var filteredResp Response
@@ -815,29 +1175,7 @@ func TestMaybeFilterToolsList_FiltersBlockedTools(t *testing.T) {
 	}
 }
 
-func TestMaybeFilterToolsList_NotRequested_Noop(t *testing.T) {
-	eng := buildAllowAllEngine(t)
-	sink := &mockSink{}
-
-	p := NewProxy(eng, sink, nopWriteCloser{&bytes.Buffer{}}, strings.NewReader(""),
-		WithFilterTools(true), WithLogger(silentLogger()))
-
-	resp := Response{
-		JSONRPC: "2.0",
-		ID:      json.RawMessage(`99`),
-		Result:  json.RawMessage(`{"tools":[]}`),
-	}
-
-	_, handled, err := p.maybeFilterToolsList(resp)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if handled {
-		t.Error("should not handle response for unrequested tools/list")
-	}
-}
-
-func TestMaybeFilterToolsList_RequireApprovalVisible(t *testing.T) {
+func TestFilterToolsListResponse_RequireApprovalVisible(t *testing.T) {
 	eng := buildAskEngine(t)
 	sink := &mockSink{}
 
@@ -846,7 +1184,7 @@ func TestMaybeFilterToolsList_RequireApprovalVisible(t *testing.T) {
 	p.parentOut = &bytes.Buffer{}
 
 	p.pendingMu.Lock()
-	p.pendingToolList["1"] = time.Now()
+	p.pendingToolList[NormalizedID(json.RawMessage(`1`))] = struct{}{}
 	p.pendingMu.Unlock()
 
 	toolsResult := map[string]any{
@@ -862,12 +1200,9 @@ func TestMaybeFilterToolsList_RequireApprovalVisible(t *testing.T) {
 		Result:  resultBytes,
 	}
 
-	filtered, handled, err := p.maybeFilterToolsList(resp)
+	filtered, err := p.filterToolsListResponse(resp)
 	if err != nil {
-		t.Fatalf("maybeFilterToolsList: %v", err)
-	}
-	if !handled {
-		t.Fatal("expected handled=true")
+		t.Fatalf("filterToolsListResponse: %v", err)
 	}
 
 	var filteredResp Response
@@ -944,6 +1279,143 @@ func TestPendingCallIDMatching(t *testing.T) {
 			if stillPending {
 				t.Error("pending call should be consumed after matching response")
 			}
+		})
+	}
+}
+
+func TestCorrelatedResponseIDsUseDecodedJSONIdentity(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		requestID  string
+		responseID string
+	}{
+		{name: "escaped string", requestID: `"client-id"`, responseID: `"client-\u0069d"`},
+		{name: "large integer exponent", requestID: `9007199254740993123456789`, responseID: `9007199254740993123456789e0`},
+		{name: "integral decimal", requestID: `-42`, responseID: `-42.0`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			childIn := &bytes.Buffer{}
+			parentOut := &bytes.Buffer{}
+			p := NewProxy(buildResponseDenyEngine(t), &mockSink{}, nopWriteCloser{childIn}, strings.NewReader(""),
+				WithMode("enforce"), WithLogger(silentLogger()))
+			p.parentOut = parentOut
+
+			req := []byte(`{"jsonrpc":"2.0","id":` + test.requestID + `,"method":"tools/call","params":{"name":"read_file","arguments":{"path":"/tmp/test"}}}` + "\n")
+			require.NoError(t, p.handleClientLine(req))
+			response := []byte(`{"jsonrpc":"2.0","id":` + test.responseID + `,"result":{"content":"SECRET_TOKEN"}}` + "\n")
+			require.NoError(t, p.handleChildLine(response, parentOut))
+
+			var blocked Response
+			require.NoError(t, json.Unmarshal(bytes.TrimSpace(parentOut.Bytes()), &blocked))
+			require.NotNil(t, blocked.Error, "equivalent response ID bypassed response policy")
+			assert.Equal(t, jsonRPCResponseDenyCode, blocked.Error.Code)
+		})
+	}
+}
+
+func TestNormalizedIDPreservesJSONTypeAndLargeIntegerIdentity(t *testing.T) {
+	assert.NotEqual(t, NormalizedID(json.RawMessage(`"1"`)), NormalizedID(json.RawMessage(`1`)))
+	assert.Equal(t, NormalizedID(json.RawMessage(`9007199254740993123456789`)), NormalizedID(json.RawMessage(`9007199254740993123456789.0`)))
+	assert.NotEqual(t, NormalizedID(json.RawMessage(`9007199254740993123456789`)), NormalizedID(json.RawMessage(`9007199254740993123456790`)))
+	// encoding/json expands '<' to a six-byte escape, so enforce the bound
+	// after canonicalization as well as on the received line.
+	assert.Empty(t, NormalizedID(json.RawMessage(`"`+strings.Repeat("<", maxRequestIDBytes/2)+`"`)))
+}
+
+func TestValidRequestIDAcceptsEquivalentIntegralJSONNumbers(t *testing.T) {
+	assert.True(t, validRequestID(json.RawMessage(`1.0`)))
+	assert.True(t, validRequestID(json.RawMessage(`1e0`)))
+	assert.True(t, validRequestID(json.RawMessage(`-0`)))
+	assert.False(t, validRequestID(json.RawMessage(`1.5`)))
+}
+
+func TestMonitorModePreservesUntrackableRequestIDs(t *testing.T) {
+	ids := []string{
+		`1.5`, `null`, `true`, `[]`, `1e1000000`,
+		`"` + strings.Repeat("x", maxRequestIDBytes) + `"`,
+	}
+	for _, method := range []string{"tools/call", "tools/list", "initialize"} {
+		for index, id := range ids {
+			t.Run(fmt.Sprintf("%s-%d", method, index), func(t *testing.T) {
+				childIn := &bytes.Buffer{}
+				p := NewProxy(buildAllowAllEngine(t), &mockSink{}, nopWriteCloser{childIn}, strings.NewReader(""),
+					WithMode("monitor"), WithFilterTools(true), WithLogger(silentLogger()))
+				p.parentOut = &bytes.Buffer{}
+				params := `{}`
+				if method == "tools/call" {
+					params = `{"name":"read_file","arguments":{"path":"/tmp/test"}}`
+				}
+				line := []byte(`{"jsonrpc":"2.0","id":` + id + `,"method":"` + method + `","params":` + params + `}` + "\n")
+				require.NoError(t, p.handleClientLine(line))
+				assert.Equal(t, line, childIn.Bytes())
+			})
+		}
+	}
+}
+
+func TestMonitorModePreservesUntrackableResponseID(t *testing.T) {
+	parentOut := &bytes.Buffer{}
+	p := NewProxy(buildAllowAllEngine(t), &mockSink{}, nopWriteCloser{&bytes.Buffer{}}, strings.NewReader(""),
+		WithMode("monitor"), WithFilterTools(true), WithLogger(silentLogger()))
+	p.parentOut = parentOut
+
+	line := []byte(`{"jsonrpc":"2.0","id":"\ud800","result":{"content":"untracked"}}` + "\n")
+	require.NoError(t, p.handleChildLine(line, parentOut))
+	assert.Equal(t, line, parentOut.Bytes())
+}
+
+func TestNormalizedIDRejectsAmbiguousUnicodeAndPreservesValidPairs(t *testing.T) {
+	assert.Empty(t, NormalizedID(json.RawMessage(`"\ud800"`)))
+	assert.Empty(t, NormalizedID(json.RawMessage(`"\udc00"`)))
+	assert.NotEqual(t, NormalizedID(json.RawMessage(`"\ud800\udc00"`)), NormalizedID(json.RawMessage(`"\ufffd"`)))
+	assert.Equal(t, NormalizedID(json.RawMessage(`"\ud800\udc00"`)), NormalizedID(json.RawMessage(`"𐀀"`)))
+}
+
+func TestToolsListFilteringUsesCanonicalResponseID(t *testing.T) {
+	childIn := &bytes.Buffer{}
+	parentOut := &bytes.Buffer{}
+	p := NewProxy(buildDenyExecEngine(t), &mockSink{}, nopWriteCloser{childIn}, strings.NewReader(""),
+		WithMode("enforce"), WithFilterTools(true), WithLogger(silentLogger()))
+	p.parentOut = parentOut
+
+	require.NoError(t, p.handleClientLine([]byte(`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`+"\n")))
+	response := []byte(`{"jsonrpc":"2.0","id":1.0,"result":{"tools":[{"name":"read_file"},{"name":"execute_command"}]}}` + "\n")
+	require.NoError(t, p.handleChildLine(response, parentOut))
+
+	var filtered Response
+	require.NoError(t, json.Unmarshal(bytes.TrimSpace(parentOut.Bytes()), &filtered))
+	var result struct {
+		Tools []struct {
+			Name string `json:"name"`
+		} `json:"tools"`
+	}
+	require.NoError(t, json.Unmarshal(filtered.Result, &result))
+	require.Len(t, result.Tools, 1)
+	assert.Equal(t, "read_file", result.Tools[0].Name)
+}
+
+func TestHandleChildLine_EnforceRejectsInvalidResponseID(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		id   string
+	}{
+		{name: "fractional", id: `1.5`},
+		{name: "oversized", id: `"` + strings.Repeat("x", maxRequestIDBytes) + `"`},
+		{name: "expansion", id: `1e1000000`},
+		{name: "unpaired surrogate", id: `"\ud800"`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			childIn := &bytes.Buffer{}
+			parentOut := &bytes.Buffer{}
+			p := NewProxy(buildResponseDenyEngine(t), &mockSink{}, nopWriteCloser{childIn}, strings.NewReader(""),
+				WithMode("enforce"), WithLogger(silentLogger()))
+			p.parentOut = parentOut
+
+			require.NoError(t, p.handleClientLine([]byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"read_file","arguments":{"path":"/tmp/test"}}}`+"\n")))
+			err := p.handleChildLine([]byte(`{"jsonrpc":"2.0","id":`+test.id+`,"result":{"content":"SECRET_TOKEN"}}`+"\n"), parentOut)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid response id")
+			assert.Empty(t, parentOut.String())
 		})
 	}
 }
@@ -1138,18 +1610,21 @@ func TestHandleToolsCall_NilArguments(t *testing.T) {
 	sink := &mockSink{}
 
 	p := NewProxy(eng, sink, nopWriteCloser{childIn}, strings.NewReader(""),
-		WithLogger(silentLogger()))
+		WithMode("enforce"), WithLogger(silentLogger()))
 	p.parentOut = &bytes.Buffer{}
 
-	// tools/call with no arguments field
-	line := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"read_file"}}` + "\n"
-	err := p.handleClientLine([]byte(line))
-	if err != nil {
-		t.Fatalf("handleClientLine: %v", err)
+	for index, params := range []string{
+		`{"name":"read_file"}`,
+		`{"name":"read_file","arguments":null}`,
+	} {
+		line := fmt.Sprintf(`{"jsonrpc":"2.0","id":%d,"method":"tools/call","params":%s}`, index+1, params) + "\n"
+		if err := p.handleClientLine([]byte(line)); err != nil {
+			t.Fatalf("handleClientLine: %v", err)
+		}
 	}
 
-	if childIn.Len() == 0 {
-		t.Error("should forward even without arguments")
+	if lines := strings.Count(childIn.String(), "\n"); lines != 2 {
+		t.Errorf("forwarded lines = %d, want 2", lines)
 	}
 }
 
@@ -1215,11 +1690,12 @@ func TestHandleChildLine_CaseShadowedResponseKeysFailClosed(t *testing.T) {
 	for _, line := range []string{
 		`{"jsonrpc":"2.0","id":1,"ID":999,"result":{"content":"safe"}}`,
 		`{"jsonrpc":"2.0","id":1,"result":{"content":"safe"},"Result":{"content":"bypass"}}`,
+		`{"jsonrpc":"2.0","id":1,"result":{"content":"safe"},"reſult":{"content":"bypass"}}`,
 	} {
 		parentOut := &bytes.Buffer{}
 		p := NewProxy(eng, &mockSink{}, nopWriteCloser{&bytes.Buffer{}}, strings.NewReader(""),
 			WithMode("enforce"), WithLogger(silentLogger()))
-		p.pendingCalls["1"] = pendingCall{call: engine.ToolCall{ID: "case-shadow", Tool: "read_file"}}
+		p.pendingCalls[NormalizedID(json.RawMessage(`1`))] = pendingCall{state: pendingCallResponseActive, call: engine.ToolCall{ID: "case-shadow", Tool: "read_file"}}
 		err := p.handleChildLine([]byte(line+"\n"), parentOut)
 		if err == nil || !strings.Contains(err.Error(), "noncanonical object member") {
 			t.Fatalf("case-shadowed response error = %v", err)
@@ -1435,7 +1911,7 @@ func TestSecurityBypass_DuplicateID(t *testing.T) {
 	}
 
 	p.pendingMu.Lock()
-	pending, ok := p.pendingCalls["1"]
+	pending, ok := p.pendingCalls[NormalizedID(json.RawMessage(`1`))]
 	p.pendingMu.Unlock()
 
 	if !ok {
@@ -1460,9 +1936,8 @@ func TestPendingToolListCapacityFailsClosed(t *testing.T) {
 		WithFilterTools(true), WithMode("enforce"), WithLogger(silentLogger()))
 	p.parentOut = parentOut
 
-	now := time.Now()
 	for index := 0; index < maxPendingRequests; index++ {
-		p.pendingToolList[fmt.Sprintf("%d", index)] = now
+		p.pendingToolList[fmt.Sprintf("%d", index)] = struct{}{}
 	}
 	line := []byte(`{"jsonrpc":"2.0","id":"overflow","method":"tools/list","params":{}}` + "\n")
 	if err := p.handleClientLine(line); err != nil {
@@ -1488,7 +1963,7 @@ func TestPendingToolCallCapacityNeverAgeEvictsSecurityCorrelation(t *testing.T) 
 	// calls whose responses are delayed indefinitely; bounded correlation must
 	// remain fail-closed instead of being silently forgotten.
 	for index := 0; index < maxPendingRequests; index++ {
-		p.pendingCalls[fmt.Sprintf("old-%d", index)] = pendingCall{}
+		p.pendingCalls[fmt.Sprintf("old-%d", index)] = pendingCall{state: pendingCallResponseActive}
 	}
 	line := []byte(makeToolsCallJSON("overflow", "read_file", map[string]any{"path": "/tmp/x"}) + "\n")
 	require.NoError(t, p.handleClientLine(line))


### PR DESCRIPTION
## Summary
- preserve JSON-RPC request identity across equivalent string and integer encodings
- reject ambiguous security-sensitive tool arguments before policy evaluation and forwarding
- correlate ordinary, tool-list, and tool-call responses with bounded, replay-safe state
- prevent responses from racing policy evaluation, approval, or child-write activation
- preserve monitor-mode raw passthrough while enforce mode fails closed on invalid correlation

## Validation
- full Go test suite and vet
- full security-assurance gate
- MCP race suite
- focused lifecycle/security race runs and 100-run interleaving stress
- independent adversarial review of identity, replay, and approval-boundary behavior

The three-file diff is intentionally self-contained. More than half of the additions are distinct regression coverage for the protocol and concurrency boundaries.
