### PR TITLE
fix: require eval scope for evaluation

### DIFF
--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -30,6 +30,8 @@ curl -H "Authorization: Bearer $TOKEN" http://127.0.0.1:9090/v1/status
 Notes:
 
 - `GET /healthz` does not require authentication.
+- `POST /v1/tool/*` and `POST /v1/preflight/*` require either the local admin
+  token or a per-agent token carrying `eval` scope.
 - `GET /v1/events/stream` accepts either bearer auth or `?token=<token>` query parameter.
 - `POST /v1/approvals/{id}/resolve` may also be authorized by signed URL query params (`sig`, `exp`) when server-side signing is enabled.
 
@@ -298,6 +300,7 @@ Same schema as `POST /v1/tool/{toolName}`. Optional `enforce` defaults to
 - `200 OK`
 - `400 Bad Request`
 - `401 Unauthorized`
+- `403 Forbidden` authenticated per-agent token lacks `eval` scope
 
 ### curl
 ```bash

--- a/internal/proxy/auth.go
+++ b/internal/proxy/auth.go
@@ -121,6 +121,21 @@ func (s *Server) checkAuthIdentity(w http.ResponseWriter, r *http.Request) *auth
 	return id
 }
 
+// checkEvalAuth validates auth and positively requires evaluation authority.
+// The local admin token remains universal; per-agent tokens must explicitly
+// carry eval scope.
+func (s *Server) checkEvalAuth(w http.ResponseWriter, r *http.Request) *authIdentity {
+	id := s.checkAuthIdentity(w, r)
+	if id == nil {
+		return nil
+	}
+	if !id.HasScope(token.ScopeEval) {
+		writeError(w, http.StatusForbidden, "this endpoint requires eval scope")
+		return nil
+	}
+	return id
+}
+
 // checkAdminAuth validates auth and requires admin scope. Writes 401/403 on failure.
 func (s *Server) checkAdminAuth(w http.ResponseWriter, r *http.Request) bool {
 	id, errMsg := s.identify(r)

--- a/internal/proxy/auth_test.go
+++ b/internal/proxy/auth_test.go
@@ -76,6 +76,57 @@ func TestMetricsRequireAdminScope(t *testing.T) {
 	}
 }
 
+func TestEvaluationEndpointsRequireEvalScope(t *testing.T) {
+	store, err := token.NewStore(filepath.Join(t.TempDir(), "tokens.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	evalToken, _, err := store.Create("eval-agent", "", "", []string{token.ScopeEval}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	adminOnlyToken, _, err := store.Create("admin-agent", "", "", []string{token.ScopeAdmin}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	combinedToken, _, err := store.Create("combined-agent", "", "", []string{token.ScopeEval, token.ScopeAdmin}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srv := New(nil, nil, WithToken("admin-token"), WithTokenStore(store), WithMode("disabled"))
+	t.Cleanup(srv.approvals.Close)
+	handler := srv.handler()
+
+	for _, endpoint := range []string{"/v1/tool/exec", "/v1/preflight/exec"} {
+		for _, test := range []struct {
+			name   string
+			bearer string
+			status int
+		}{
+			{name: "eval token", bearer: evalToken, status: http.StatusOK},
+			{name: "local admin", bearer: "admin-token", status: http.StatusOK},
+			{name: "admin-only agent token", bearer: adminOnlyToken, status: http.StatusForbidden},
+			{name: "combined token", bearer: combinedToken, status: http.StatusOK},
+			{name: "invalid token", bearer: "invalid-token", status: http.StatusUnauthorized},
+			{name: "missing token", status: http.StatusUnauthorized},
+		} {
+			t.Run(endpoint+"/"+test.name, func(t *testing.T) {
+				body := `{"agent":"untrusted","session":"scope-test","params":{"command":"true"}}`
+				req := httptest.NewRequest(http.MethodPost, endpoint, strings.NewReader(body))
+				if test.bearer != "" {
+					req.Header.Set("Authorization", "Bearer "+test.bearer)
+				}
+				rr := httptest.NewRecorder()
+				handler.ServeHTTP(rr, req)
+				if rr.Code != test.status {
+					t.Fatalf("status = %d, want %d; body = %s", rr.Code, test.status, rr.Body.String())
+				}
+			})
+		}
+	}
+}
+
 func TestDecodeJSONBodyRejectsAdditionalValues(t *testing.T) {
 	for _, tt := range []struct {
 		name    string

--- a/internal/proxy/eval_handlers.go
+++ b/internal/proxy/eval_handlers.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (s *Server) handleToolCall(w http.ResponseWriter, r *http.Request) {
-	identity := s.checkAuthIdentity(w, r)
+	identity := s.checkEvalAuth(w, r)
 	if identity == nil {
 		return
 	}
@@ -554,7 +554,7 @@ func notificationActionMatches(configured, actual string) bool {
 // Returns the decision that would be made — agents use this to plan around
 // policy restrictions before attempting blocked actions.
 func (s *Server) handlePreflight(w http.ResponseWriter, r *http.Request) {
-	identity := s.checkAuthIdentity(w, r)
+	identity := s.checkEvalAuth(w, r)
 	if identity == nil {
 		return
 	}

--- a/internal/token/store.go
+++ b/internal/token/store.go
@@ -44,7 +44,7 @@ const (
 	Prefix = "rampart_"
 
 	// ScopeEval allows tool-call evaluation and enforcement through the
-	// /v1/preflight/{tool} endpoint.
+	// /v1/tool/{tool} and /v1/preflight/{tool} endpoints.
 	// Audit reads, status checks, approvals, and rule management require ScopeAdmin.
 	ScopeEval = "eval"
 


### PR DESCRIPTION
## Summary
- positively require `eval` scope on both tool evaluation and preflight endpoints
- keep the local administrative token compatible while rejecting per-agent tokens that lack evaluation authority
- clarify the scope contract in the API reference

## Validation
- full Go test suite and vet
- full security-assurance gate
- focused proxy/token race tests and repeated scope regression
- independent route-table and compatibility review

This is the small prerequisite for later integration credential separation. It does not add a new approval API, token type, or integration migration.
