### PR TITLE
fix(cli): align diagnostic tool call evaluation

### DIFF
--- a/cmd/rampart/cli/diagnostic_call.go
+++ b/cmd/rampart/cli/diagnostic_call.go
@@ -1,0 +1,59 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"fmt"
+	"net/url"
+	"time"
+
+	"github.com/peg/rampart/internal/engine"
+)
+
+const (
+	diagnosticToolNames    = "exec, read, write, edit, fetch, web_fetch, http, browser"
+	diagnosticToolFlagHelp = "Tool type: " + diagnosticToolNames
+)
+
+// newDiagnosticToolCall maps the CLI's single argument to the same canonical
+// ToolCall shape for test and explain diagnostics.
+func newDiagnosticToolCall(tool, argument, agent, session string, timestamp time.Time) (engine.ToolCall, error) {
+	arguments := make(map[string]any)
+	call := engine.ToolCall{
+		Agent:     agent,
+		Session:   session,
+		Tool:      tool,
+		Params:    arguments,
+		Input:     arguments,
+		Timestamp: timestamp,
+	}
+
+	switch tool {
+	case "exec":
+		call.Params["command"] = argument
+	case "read", "write", "edit":
+		call.Params["path"] = argument
+	case "fetch", "web_fetch", "http", "browser":
+		call.Params["url"] = argument
+		if parsed, err := url.Parse(argument); err == nil && parsed.Host != "" {
+			call.Params["domain"] = parsed.Hostname()
+			call.Params["scheme"] = parsed.Scheme
+			call.Params["path"] = parsed.Path
+		}
+	default:
+		return engine.ToolCall{}, fmt.Errorf("unsupported tool %q (supported: %s)", tool, diagnosticToolNames)
+	}
+
+	return call, nil
+}

--- a/cmd/rampart/cli/policy.go
+++ b/cmd/rampart/cli/policy.go
@@ -17,7 +17,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
@@ -96,11 +95,21 @@ func newPolicyExplainCmd(opts *rootOptions) *cobra.Command {
 	var session string
 
 	cmd := &cobra.Command{
-		Use:   "explain <command>",
-		Short: "Explain how policy evaluates a command",
+		Use:   "explain <command-or-path-or-url>",
+		Short: "Explain how policy evaluates a tool call",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			command := args[0]
+			call, err := newDiagnosticToolCall(
+				tool,
+				command,
+				normalizeAgent(agent),
+				normalizeSession(session),
+				time.Now().UTC(),
+			)
+			if err != nil {
+				return fmt.Errorf("policy: explain: %w", err)
+			}
 
 			policyPath, err := resolveExplainPolicyPath(cmd, opts.configPath)
 			if err != nil {
@@ -116,24 +125,6 @@ func newPolicyExplainCmd(opts *rootOptions) *cobra.Command {
 				return fmt.Errorf("policy: create engine: %w", err)
 			}
 
-			params := map[string]any{"command": command}
-			// For URL-based tools, parse the argument as a URL and enrich params
-			// so domain_matches and url_matches policies evaluate correctly.
-			if tool == "web_fetch" || tool == "fetch" || tool == "http" || tool == "browser" {
-				params = map[string]any{"url": command}
-				if parsed, err := url.Parse(command); err == nil && parsed.Host != "" {
-					params["domain"] = parsed.Hostname()
-					params["scheme"] = parsed.Scheme
-					params["path"] = parsed.Path
-				}
-			}
-			call := engine.ToolCall{
-				Agent:     normalizeAgent(agent),
-				Session:   normalizeSession(session),
-				Tool:      tool,
-				Params:    params,
-				Timestamp: time.Now().UTC(),
-			}
 			decision := eng.Evaluate(call)
 			explanations := collectExplanations(cfg, call)
 
@@ -226,7 +217,7 @@ func newPolicyExplainCmd(opts *rootOptions) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&tool, "tool", "exec", "Tool type to evaluate")
+	cmd.Flags().StringVar(&tool, "tool", "exec", diagnosticToolFlagHelp)
 	cmd.Flags().StringVar(&agent, "agent", "*", "Agent identity to evaluate")
 	cmd.Flags().StringVar(&session, "session", "*", "Session identity to evaluate")
 

--- a/cmd/rampart/cli/test_cmd.go
+++ b/cmd/rampart/cli/test_cmd.go
@@ -38,12 +38,13 @@ func newTestCmd(opts *rootOptions) *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "test [command-or-path | test-file.yaml]",
-		Short: "Test how policies evaluate commands or run a test suite",
+		Use:   "test [command-or-path-or-url | test-file.yaml]",
+		Short: "Test how policies evaluate tool calls or run a test suite",
 		Long: `Dry-run a tool call through the policy engine and display the result.
 
-By default, the argument is treated as an exec command. Use --tool to
-change the tool type (read, write) in which case the argument is a path.
+By default, the argument is treated as an exec command. For read, write, and
+edit tools the argument is a path. For fetch, web_fetch, http, and browser
+tools the argument is a URL.
 
 If the argument is a YAML file, it is loaded as a test suite containing
 multiple test cases. A policy file with an inline "tests:" key can also
@@ -56,6 +57,7 @@ Examples:
   rampart test "rm -rf /"
   rampart test "git status"
   rampart test --tool read "/etc/shadow"
+  rampart test --tool fetch "https://example.com/path"
   rampart test tests.yaml
   rampart test --verbose tests.yaml
   rampart test --run "blocks*" tests.yaml
@@ -75,14 +77,14 @@ Examples:
 				arg = args[0]
 			}
 
-			if isYAMLFile(arg) {
+			if isYAMLFile(arg) && (len(args) == 0 || !cmd.Flags().Changed("tool")) {
 				return runTestSuite(cmd.OutOrStdout(), cmd.ErrOrStderr(), opts, arg, noColor, verbose, run, jsonOut)
 			}
 			return runTest(cmd.OutOrStdout(), cmd.ErrOrStderr(), opts, arg, toolName, noColor, jsonOut)
 		},
 	}
 
-	cmd.Flags().StringVar(&toolName, "tool", "exec", "Tool type: exec, read, write")
+	cmd.Flags().StringVar(&toolName, "tool", "exec", diagnosticToolFlagHelp)
 	cmd.Flags().BoolVar(&noColor, "no-color", false, "Disable color output")
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Show match details for each test case")
 	cmd.Flags().StringVar(&run, "run", "", "Run only tests matching this glob pattern")
@@ -282,6 +284,11 @@ type bareCmdJSONResult struct {
 }
 
 func runTest(w, errW io.Writer, opts *rootOptions, arg, toolName string, noColor, jsonOut bool) error {
+	call, err := newDiagnosticToolCall(toolName, arg, "", "", time.Now())
+	if err != nil {
+		return fmt.Errorf("test: %w", err)
+	}
+
 	policyPath, cleanup, err := resolveTestPolicyPath(opts.configPath)
 	if err != nil {
 		return err
@@ -295,19 +302,6 @@ func runTest(w, errW io.Writer, opts *rootOptions, arg, toolName string, noColor
 	eng, err := engine.New(store, nil)
 	if err != nil {
 		return fmt.Errorf("test: create engine: %w", err)
-	}
-
-	call := engine.ToolCall{
-		Tool:      toolName,
-		Params:    make(map[string]any),
-		Timestamp: time.Now(),
-	}
-
-	switch toolName {
-	case "read", "write":
-		call.Params["path"] = arg
-	default:
-		call.Params["command"] = arg
 	}
 
 	decision := eng.Evaluate(call)

--- a/cmd/rampart/cli/test_cmd_test.go
+++ b/cmd/rampart/cli/test_cmd_test.go
@@ -16,6 +16,7 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -204,6 +205,82 @@ policies:
 	output := out.String()
 	if !strings.Contains(output, "DENY") {
 		t.Errorf("expected DENY in output, got: %s", output)
+	}
+}
+
+func TestDiagnosticCommandsUseCanonicalToolCalls(t *testing.T) {
+	dir := t.TempDir()
+	dangerousPath := filepath.ToSlash(filepath.Join(dir, "private", "credentials.key"))
+	dangerousURL := "https://webhook.site/danger/collect.yaml"
+	policyFile := filepath.Join(dir, "rampart.yaml")
+	policy := fmt.Sprintf(`
+version: "1"
+default_action: allow
+policies:
+  - {name: block-command, match: {tool: exec}, rules: [{action: deny, when: {command_matches: ["rm -rf *"]}}]}
+  - {name: block-path, match: {tool: [read, write, edit]}, rules: [{action: deny, when: {path_matches: [%q]}}]}
+  - {name: block-url, match: {tool: [fetch, web_fetch, http]}, rules: [{action: deny, when: {url_matches: [%q], domain_matches: [webhook.site], path_matches: [/danger/collect.yaml]}}]}
+  - {name: block-browser-param, match: {tool: browser}, rules: [{action: deny, when: {tool_param_matches: {url: "https://webhook.site/*"}}}]}
+`, dangerousPath, dangerousURL)
+	if err := os.WriteFile(policyFile, []byte(policy), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Date(2026, time.August, 12, 12, 0, 0, 0, time.UTC)
+	call, err := newDiagnosticToolCall("fetch", dangerousURL, "diagnostic-agent", "diagnostic-session", now)
+	if err != nil || call.Agent != "diagnostic-agent" || call.Session != "diagnostic-session" || !call.Timestamp.Equal(now) ||
+		call.URL() != dangerousURL || call.Domain() != "webhook.site" ||
+		call.Param("scheme") != "https" || call.Param("path") != "/danger/collect.yaml" || call.Input["url"] != dangerousURL {
+		t.Fatalf("canonical URL call not preserved and enriched: call=%#v err=%v", call, err)
+	}
+	tests := []struct {
+		tool       string
+		argument   string
+		wantPolicy string
+	}{
+		{tool: "exec", argument: "rm -rf /"},
+		{tool: "read", argument: dangerousPath},
+		{tool: "write", argument: dangerousPath},
+		{tool: "edit", argument: dangerousPath},
+		{tool: "fetch", argument: dangerousURL},
+		{tool: "web_fetch", argument: dangerousURL},
+		{tool: "http", argument: dangerousURL},
+		{tool: "browser", argument: dangerousURL, wantPolicy: "block-browser-param"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.tool, func(t *testing.T) {
+			testCmd := newTestCmd(&rootOptions{configPath: policyFile})
+			var testOut, testErr bytes.Buffer
+			testCmd.SetOut(&testOut)
+			testCmd.SetErr(&testErr)
+			testCmd.SetArgs([]string{tc.argument, "--tool", tc.tool, "--no-color"})
+			runErr := testCmd.Execute()
+			if runErr == nil || !strings.Contains(testOut.String(), "DENY") {
+				t.Fatalf("test diagnostic did not deny: err=%v output=%s", runErr, testOut.String())
+			}
+			if tc.wantPolicy != "" && !strings.Contains(testOut.String(), tc.wantPolicy) {
+				t.Fatalf("test diagnostic did not match %s: %s", tc.wantPolicy, testOut.String())
+			}
+
+			explain := newPolicyExplainCmd(&rootOptions{configPath: policyFile})
+			var explainOut strings.Builder
+			explain.SetOut(&explainOut)
+			explain.SetArgs([]string{tc.argument, "--tool", tc.tool})
+			if err := explain.Execute(); err != nil {
+				t.Fatalf("explain diagnostic: %v", err)
+			}
+			if !strings.Contains(explainOut.String(), "Final decision: DENY") {
+				t.Fatalf("explain diagnostic did not deny: %s", explainOut.String())
+			}
+			if tc.wantPolicy != "" && !strings.Contains(explainOut.String(), tc.wantPolicy) {
+				t.Fatalf("explain diagnostic did not match %s: %s", tc.wantPolicy, explainOut.String())
+			}
+		})
+	}
+
+	if _, err := newDiagnosticToolCall("mcp", "danger", "", "", now); err == nil {
+		t.Fatal("expected unsupported MCP tool to be rejected")
 	}
 }
 


### PR DESCRIPTION
## Summary
- build one canonical tool-call shape for both policy diagnostics
- align exec, file, URL, and browser inputs with live enforcement fields
- reject unsupported diagnostic tool types instead of producing misleading results

## Security impact
This closes a diagnostic parity gap where a policy could match a live request but be missed by rampart test or policy explain.

## Validation
- go test ./...
- go vet ./...
- make security-assurance
- git diff --check

Base reviewed against exact staging commit 52c4c2b64f4e00be9a621aa1df42937bf7faec84.