### PR TITLE
fix(cli): fail interactive setup on integration errors

### DIFF
--- a/cmd/rampart/cli/setup_interactive.go
+++ b/cmd/rampart/cli/setup_interactive.go
@@ -15,6 +15,7 @@ package cli
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -241,25 +242,12 @@ func runInteractiveSetup(cmd *cobra.Command, opts *rootOptions) error {
 		}
 	}
 
-	// Run setup for each selected agent via subcommands
-	for _, a := range selectedAgents {
-		subCmd, _, err := cmd.Find([]string{a.SetupCmd})
-		if err != nil {
-			return fmt.Errorf("setup: find subcommand %s: %w", a.SetupCmd, err)
-		}
-		// Set --force so subcommands don't prompt
-		if f := subCmd.Flags().Lookup("force"); f != nil {
-			_ = f.Value.Set("true")
-		}
-		// Set --patch-tools if user opted in
-		if a.SetupCmd == "openclaw" && patchFileTools {
-			if f := subCmd.Flags().Lookup("patch-tools"); f != nil {
-				_ = f.Value.Set("true")
-			}
-		}
-		if err := subCmd.RunE(subCmd, nil); err != nil {
-			fmt.Fprintf(cmd.ErrOrStderr(), "⚠ %s setup failed: %v\n", a.Name, err)
-		}
+	// Run every selected setup so one broken integration does not hide the
+	// state of the others, then refuse to report success if any failed.
+	if err := runInteractiveAgentSetups(cmd, selectedAgents, patchFileTools); err != nil {
+		fmt.Fprintln(out, "")
+		fmt.Fprintln(out, "❌ Setup incomplete — one or more integrations failed.")
+		return err
 	}
 
 	// 7. Shell completions
@@ -289,6 +277,37 @@ func runInteractiveSetup(cmd *cobra.Command, opts *rootOptions) error {
 	fmt.Fprintln(out, "")
 	fmt.Fprintln(out, "Need help? https://docs.rampart.sh")
 
+	return nil
+}
+
+func runInteractiveAgentSetups(cmd *cobra.Command, selectedAgents []agentInfo, patchFileTools bool) error {
+	var failures []error
+	for _, a := range selectedAgents {
+		subCmd, _, err := cmd.Find([]string{a.SetupCmd})
+		if err != nil {
+			failure := fmt.Errorf("%s: find setup command: %w", a.Name, err)
+			fmt.Fprintf(cmd.ErrOrStderr(), "⚠ %s setup failed: %v\n", a.Name, err)
+			failures = append(failures, failure)
+			continue
+		}
+		// Set --force so subcommands don't prompt
+		if f := subCmd.Flags().Lookup("force"); f != nil {
+			_ = f.Value.Set("true")
+		}
+		// Set --patch-tools if user opted in
+		if a.SetupCmd == "openclaw" && patchFileTools {
+			if f := subCmd.Flags().Lookup("patch-tools"); f != nil {
+				_ = f.Value.Set("true")
+			}
+		}
+		if err := subCmd.RunE(subCmd, nil); err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "⚠ %s setup failed: %v\n", a.Name, err)
+			failures = append(failures, fmt.Errorf("%s: %w", a.Name, err))
+		}
+	}
+	if len(failures) > 0 {
+		return fmt.Errorf("setup: integration setup failed: %w", errors.Join(failures...))
+	}
 	return nil
 }
 

--- a/cmd/rampart/cli/setup_interactive_test.go
+++ b/cmd/rampart/cli/setup_interactive_test.go
@@ -14,9 +14,14 @@
 package cli
 
 import (
+	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 func TestDetectAgents_ReturnsAllKnownAgents(t *testing.T) {
@@ -94,6 +99,42 @@ func TestIsTerminal_PipeIsNotTerminal(t *testing.T) {
 
 	if isTerminal(r) {
 		t.Error("pipe should not be detected as terminal")
+	}
+}
+
+func TestRunInteractiveAgentSetupsAggregatesFailures(t *testing.T) {
+	setup := &cobra.Command{Use: "setup"}
+	var stderr bytes.Buffer
+	setup.SetErr(&stderr)
+
+	var succeeded bool
+	good := &cobra.Command{Use: "good", RunE: func(*cobra.Command, []string) error {
+		succeeded = true
+		return nil
+	}}
+	badOne := &cobra.Command{Use: "bad-one", RunE: func(*cobra.Command, []string) error {
+		return errors.New("first failure")
+	}}
+	badTwo := &cobra.Command{Use: "bad-two", RunE: func(*cobra.Command, []string) error {
+		return errors.New("second failure")
+	}}
+	setup.AddCommand(good, badOne, badTwo)
+
+	err := runInteractiveAgentSetups(setup, []agentInfo{
+		{Name: "First", SetupCmd: "bad-one"},
+		{Name: "Working", SetupCmd: "good"},
+		{Name: "Second", SetupCmd: "bad-two"},
+	}, false)
+	if err == nil || !strings.Contains(err.Error(), "First: first failure") ||
+		!strings.Contains(err.Error(), "Second: second failure") {
+		t.Fatalf("aggregated error = %v", err)
+	}
+	if !succeeded {
+		t.Fatal("later setup was not attempted after an earlier failure")
+	}
+	if got := stderr.String(); !strings.Contains(got, "First setup failed") ||
+		!strings.Contains(got, "Second setup failed") {
+		t.Fatalf("failure output = %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- attempt every selected integration setup even when an earlier one fails
- return a nonzero result when any integration setup fails
- prevent partial setup from printing the overall success guidance

## Validation
- focused interactive setup regression
- full CLI package tests
- CLI vet
- diff integrity check

Independent review found no conflict with the in-flight lifecycle consolidation.