### PR TITLE
security: bind approval replay to token owner

### DIFF
--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -30,6 +30,8 @@ curl -H "Authorization: Bearer $TOKEN" http://127.0.0.1:9090/v1/status
 Notes:
 
 - `GET /healthz` does not require authentication.
+- `POST /v1/tool/*` and `POST /v1/preflight/*` require either the local admin
+  token or a per-agent token carrying `eval` scope.
 - `GET /v1/events/stream` accepts either bearer auth or `?token=<token>` query parameter.
 - `POST /v1/approvals/{id}/resolve` may also be authorized by signed URL query params (`sig`, `exp`) when server-side signing is enabled.
 
@@ -298,6 +300,7 @@ Same schema as `POST /v1/tool/{toolName}`. Optional `enforce` defaults to
 - `200 OK`
 - `400 Bad Request`
 - `401 Unauthorized`
+- `403 Forbidden` authenticated per-agent token lacks `eval` scope
 
 ### curl
 ```bash

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -482,6 +482,8 @@ Approving a `/v1/tool/*` request that supplied both `run_id` and
 `tool_call_id` creates a short-lived, one-shot grant for the exact original
 request. Requests without both stable identifiers retain the existing polling
 flow and are not given a reusable command-level grant.
+Per-agent requests must retry with the same `eval` token; another token for the
+same agent cannot inherit either the pending approval or its one-shot grant.
 
 `persist: true` stores an exact rule for `exec`, `read`, `write`, or `edit`.
 Unsupported tool types return `400` and leave the approval pending so the

--- a/internal/approval/store.go
+++ b/internal/approval/store.go
@@ -40,9 +40,6 @@ import (
 	"github.com/peg/rampart/internal/securefile"
 )
 
-// dedupWindow is the time window for deduplicating identical approval requests.
-const dedupWindow = 60 * time.Second
-
 // approvedReplayWindow is intentionally short: an allow-once approval is only
 // useful for the host's immediate retry of the exact tool call.
 const approvedReplayWindow = 60 * time.Second
@@ -120,6 +117,9 @@ type Request struct {
 	// dedupKey scopes retries to one host-provided tool-call identity.
 	dedupKey string
 
+	// ownerScope is a one-way digest binding token-originated approvals.
+	ownerScope string
+
 	// done is closed when the approval is resolved.
 	done chan struct{}
 }
@@ -147,9 +147,10 @@ type replayGrant struct {
 // identity. Host-provided run IDs are not globally unique and must never be an
 // authorization capability by themselves.
 type autoApproveScope struct {
-	Agent   string
-	Session string
-	RunID   string
+	Agent      string
+	Session    string
+	RunID      string
+	OwnerScope string
 }
 
 // persistRecord is the on-disk representation of an approval request.
@@ -174,13 +175,16 @@ type persistRecord struct {
 	ResolvedBy      string         `json:"resolved_by,omitempty"`
 	Status          string         `json:"status"`
 	Persisted       bool           `json:"persisted,omitempty"`
+	OwnerScope      string         `json:"owner_scope,omitempty"`
 }
+
+const scopedPendingStatus = "pending-v2"
 
 // Store manages pending approval requests.
 type Store struct {
 	mu              sync.Mutex
 	pending         map[string]*Request
-	approvedOnce    map[string]replayGrant // exact call fingerprint -> one-shot grant
+	approvedOnce    map[string]replayGrant // exact call/owner key -> one-shot grant
 	autoApproveRuns map[autoApproveScope]time.Time
 	timeout         time.Duration
 	onExpire        func(*Request)
@@ -343,48 +347,73 @@ func replayKey(call engine.ToolCall) string {
 	return dedupKey(call)
 }
 
+func ownerScopeDigest(scope string) string {
+	if strings.TrimSpace(scope) == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte("approval-owner-v1\x00" + scope))
+	return hex.EncodeToString(sum[:])
+}
+
+// ownerBoundKey domain-separates token-owned state from v1 action-only replay
+// paths. Older binaries therefore cannot consume a scoped grant unscoped.
+func ownerBoundKey(key, ownerScope string) string {
+	if key == "" || ownerScope == "" {
+		return key
+	}
+	sum := sha256.Sum256([]byte("approval-replay-v2\x00" + key + "\x00" + ownerScope))
+	return "v2-" + hex.EncodeToString(sum[:])
+}
+
+func replayGrantVersion(key string) int {
+	if strings.HasPrefix(key, "v2-") {
+		return 2
+	}
+	return 1
+}
+
 // Create adds a new pending approval and returns it.
 // The caller should wait on request.Done() for resolution.
 // Returns nil and an error if the pending approval limit has been reached.
 //
-// If the same host-identified tool call was submitted by the same agent,
-// session, and run within the last 60 seconds, the existing approval is
-// returned. Calls without a stable host-provided tool-call ID are never
-// deduplicated.
+// A still-pending request with the same stable host identity is returned.
+// Calls without a stable host-provided tool-call ID are never deduplicated.
 func (s *Store) Create(call engine.ToolCall, decision engine.Decision) (*Request, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.createLocked(call, decision)
+	return s.createLocked(call, decision, "")
 }
 
 // CreateOrAutoApproved atomically checks the run-scoped auto-approval cache
 // and, only when no live entry exists, enqueues a pending approval. Keeping
 // both operations under one lock prevents a bulk-approval publication from
 // racing a stale IsAutoApproved check and leaving an orphan pending request.
-func (s *Store) CreateOrAutoApproved(call engine.ToolCall, decision engine.Decision) (*Request, bool, error) {
+// A non-empty owner scope binds pending and replay state to that caller.
+func (s *Store) CreateOrAutoApproved(call engine.ToolCall, decision engine.Decision, ownerScope string) (*Request, bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if s.isAutoApprovedLocked(call) {
+	ownerScope = ownerScopeDigest(ownerScope)
+	if s.isAutoApprovedLocked(call, ownerScope) {
 		return nil, true, nil
 	}
-	req, err := s.createLocked(call, decision)
+	req, err := s.createLocked(call, decision, ownerScope)
 	return req, false, err
 }
 
 // createLocked enqueues one request. The caller must hold s.mu.
-func (s *Store) createLocked(call engine.ToolCall, decision engine.Decision) (*Request, error) {
+func (s *Store) createLocked(call engine.ToolCall, decision engine.Decision, ownerScope string) (*Request, error) {
 	if s.closed {
 		return nil, ErrStoreClosed
 	}
 
 	now := time.Now()
-	key := dedupKey(call)
+	key := ownerBoundKey(dedupKey(call), ownerScope)
 
-	// Check for an existing identical pending approval within the dedup window.
+	// Stable invocation identity remains singular for its full pending lifetime.
 	if key != "" {
 		for _, req := range s.pending {
-			if req.Status == StatusPending && req.dedupKey == key && now.Sub(req.CreatedAt) < dedupWindow {
+			if req.Status == StatusPending && req.dedupKey == key && now.Before(req.ExpiresAt) {
 				return req, nil
 			}
 		}
@@ -401,14 +430,15 @@ func (s *Store) createLocked(call engine.ToolCall, decision engine.Decision) (*R
 		return nil, ErrTooManyPending
 	}
 	req := &Request{
-		ID:        ulid.Make().String(),
-		Call:      call,
-		Decision:  decision,
-		Status:    StatusPending,
-		CreatedAt: now,
-		ExpiresAt: now.Add(s.timeout),
-		dedupKey:  key,
-		done:      make(chan struct{}),
+		ID:         ulid.Make().String(),
+		Call:       call,
+		Decision:   decision,
+		Status:     StatusPending,
+		CreatedAt:  now,
+		ExpiresAt:  now.Add(s.timeout),
+		dedupKey:   key,
+		ownerScope: ownerScope,
+		done:       make(chan struct{}),
 	}
 
 	s.pending[req.ID] = req
@@ -507,10 +537,10 @@ func (s *Store) ResolveBeforePublish(
 	var grant replayGrant
 	grantKey := ""
 	if approved {
-		grantKey = replayKey(req.Call)
+		grantKey = ownerBoundKey(replayKey(req.Call), req.ownerScope)
 		if grantKey != "" {
 			grant = replayGrant{
-				Version:     1,
+				Version:     replayGrantVersion(grantKey),
 				ApprovalID:  req.ID,
 				Fingerprint: grantKey,
 				ResolvedBy:  resolvedBy,
@@ -576,7 +606,12 @@ func (s *Store) MarkPersisted(id string) error {
 // marker is intentionally retained after consumption: failure to clean up
 // must fail closed, never recreate authorization.
 func (s *Store) ConsumeApproved(call engine.ToolCall) (*ConsumedApproval, bool, error) {
-	key := replayKey(call)
+	return s.ConsumeApprovedFor(call, "")
+}
+
+// ConsumeApprovedFor binds exact replay to an opaque caller-owned scope.
+func (s *Store) ConsumeApprovedFor(call engine.ToolCall, ownerScope string) (*ConsumedApproval, bool, error) {
+	key := ownerBoundKey(replayKey(call), ownerScopeDigest(ownerScope))
 	if key == "" {
 		return nil, false, nil
 	}
@@ -644,6 +679,12 @@ func (r *Request) Done() <-chan struct{} {
 	return r.done
 }
 
+// OwnerScopeID is an opaque store-owned identifier used only to keep bulk
+// authorization within the caller boundary that created this request.
+func (r *Request) OwnerScopeID() string {
+	return r.ownerScope
+}
+
 // Cleanup removes resolved/expired requests older than the given duration
 // and evicts expired auto-approve cache entries.
 func (s *Store) Cleanup(olderThan time.Duration) int {
@@ -684,11 +725,12 @@ func (s *Store) Cleanup(olderThan time.Duration) int {
 // present. Missing identity fails closed: the approval still resolves the
 // pending requests selected by the operator, but it cannot authorize future
 // calls through the bulk-approval cache.
-func autoApproveScopeFor(call engine.ToolCall) (autoApproveScope, bool) {
+func autoApproveScopeFor(call engine.ToolCall, ownerScope string) (autoApproveScope, bool) {
 	scope := autoApproveScope{
-		Agent:   strings.TrimSpace(call.Agent),
-		Session: strings.TrimSpace(call.Session),
-		RunID:   strings.TrimSpace(call.RunID),
+		Agent:      strings.TrimSpace(call.Agent),
+		Session:    strings.TrimSpace(call.Session),
+		RunID:      strings.TrimSpace(call.RunID),
+		OwnerScope: ownerScope,
 	}
 	return scope, scope.Agent != "" && scope.Session != "" && scope.RunID != ""
 }
@@ -711,7 +753,20 @@ func (s *Store) AutoApproveRun(call engine.ToolCall, ttl time.Duration) bool {
 // check/create race: either creation wins and must be resolved first, or cache
 // publication wins and the creator observes auto-approved state.
 func (s *Store) AutoApproveRunIfNoPending(call engine.ToolCall, ttl time.Duration) ([]*Request, bool) {
-	scope, ok := autoApproveScopeFor(call)
+	return s.autoApproveRunIfNoPending(call, "", ttl)
+}
+
+// AutoApproveRunIfNoPendingForRequest installs only the owner scope carried by
+// a request the operator explicitly selected for bulk resolution.
+func (s *Store) AutoApproveRunIfNoPendingForRequest(call engine.ToolCall, source *Request, ttl time.Duration) ([]*Request, bool) {
+	if source == nil {
+		return nil, false
+	}
+	return s.autoApproveRunIfNoPending(call, source.ownerScope, ttl)
+}
+
+func (s *Store) autoApproveRunIfNoPending(call engine.ToolCall, ownerScope string, ttl time.Duration) ([]*Request, bool) {
+	scope, ok := autoApproveScopeFor(call, ownerScope)
 	if !ok || ttl <= 0 {
 		return nil, false
 	}
@@ -721,7 +776,7 @@ func (s *Store) AutoApproveRunIfNoPending(call engine.ToolCall, ttl time.Duratio
 
 	pending := make([]*Request, 0)
 	for _, req := range s.pending {
-		requestScope, valid := autoApproveScopeFor(req.Call)
+		requestScope, valid := autoApproveScopeFor(req.Call, req.ownerScope)
 		if req.Status != StatusPending || !valid || requestScope != scope {
 			continue
 		}
@@ -747,12 +802,12 @@ func (s *Store) AutoApproveRunIfNoPending(call engine.ToolCall, ttl time.Duratio
 func (s *Store) IsAutoApproved(call engine.ToolCall) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.isAutoApprovedLocked(call)
+	return s.isAutoApprovedLocked(call, "")
 }
 
 // isAutoApprovedLocked checks one call. The caller must hold s.mu.
-func (s *Store) isAutoApprovedLocked(call engine.ToolCall) bool {
-	scope, ok := autoApproveScopeFor(call)
+func (s *Store) isAutoApprovedLocked(call engine.ToolCall, ownerScope string) bool {
+	scope, ok := autoApproveScopeFor(call, ownerScope)
 	if !ok {
 		return false
 	}
@@ -876,7 +931,7 @@ func (s *Store) consumePersistedReplayGrant(key string) (replayGrant, bool, erro
 	if err := json.Unmarshal(encoded, &grant); err != nil {
 		return replayGrant{}, false, fmt.Errorf("decode claimed replay grant: %w", err)
 	}
-	if grant.Version != 1 || grant.Fingerprint != key || grant.ApprovalID == "" {
+	if grant.Version != replayGrantVersion(key) || grant.Fingerprint != key || grant.ApprovalID == "" {
 		return replayGrant{}, false, fmt.Errorf("claimed replay grant failed integrity validation")
 	}
 
@@ -950,7 +1005,7 @@ func (s *Store) cleanupPersistedReplayState(olderThan time.Duration) {
 				return nil
 			}
 			var grant replayGrant
-			if json.Unmarshal(encoded, &grant) != nil || grant.Version != 1 || grant.Fingerprint == "" {
+			if json.Unmarshal(encoded, &grant) != nil || grant.Fingerprint == "" || grant.Version != replayGrantVersion(grant.Fingerprint) {
 				return nil
 			}
 			if now.After(grant.ExpiresAt) {
@@ -1075,6 +1130,10 @@ func readBoundedApprovalFile(path string, maxBytes int64) ([]byte, error) {
 
 // toRecord converts a Request to its on-disk representation.
 func toRecord(req *Request) persistRecord {
+	status := req.Status.String()
+	if status == "pending" && req.ownerScope != "" {
+		status = scopedPendingStatus
+	}
 	return persistRecord{
 		ID:              req.ID,
 		Tool:            req.Call.Tool,
@@ -1093,20 +1152,16 @@ func toRecord(req *Request) persistRecord {
 		ExpiresAt:       req.ExpiresAt,
 		ResolvedAt:      req.ResolvedAt,
 		ResolvedBy:      req.ResolvedBy,
-		Status:          req.Status.String(),
+		Status:          status,
 		Persisted:       req.Persisted,
+		OwnerScope:      req.ownerScope,
 	}
 }
 
 // fromRecord reconstructs an in-memory Request from a persist record.
 // Returns (nil, false) if the record should be discarded (expired or non-pending).
 func fromRecord(rec persistRecord) (*Request, bool) {
-	// Only restore truly pending approvals.
-	if rec.Status != "pending" {
-		return nil, false
-	}
-	// Discard expired approvals.
-	if time.Now().After(rec.ExpiresAt) {
+	if !pendingRecordLive(rec, time.Now()) {
 		return nil, false
 	}
 
@@ -1131,16 +1186,29 @@ func fromRecord(rec persistRecord) (*Request, bool) {
 	}
 
 	req := &Request{
-		ID:        rec.ID,
-		Call:      call,
-		Decision:  decision,
-		Status:    StatusPending,
-		CreatedAt: rec.CreatedAt,
-		ExpiresAt: rec.ExpiresAt,
-		dedupKey:  dedupKey(call),
-		done:      make(chan struct{}),
+		ID:         rec.ID,
+		Call:       call,
+		Decision:   decision,
+		Status:     StatusPending,
+		CreatedAt:  rec.CreatedAt,
+		ExpiresAt:  rec.ExpiresAt,
+		dedupKey:   ownerBoundKey(dedupKey(call), rec.OwnerScope),
+		ownerScope: rec.OwnerScope,
+		done:       make(chan struct{}),
 	}
 	return req, true
+}
+
+func pendingRecordLive(rec persistRecord, now time.Time) bool {
+	switch rec.Status {
+	case "pending":
+		return rec.OwnerScope == "" && now.Before(rec.ExpiresAt)
+	case scopedPendingStatus:
+		_, err := hex.DecodeString(rec.OwnerScope)
+		return len(rec.OwnerScope) == sha256.Size*2 && err == nil && now.Before(rec.ExpiresAt)
+	default:
+		return false
+	}
 }
 
 // readLatestRecordsLocked replays the JSONL journal into its latest record per
@@ -1195,7 +1263,7 @@ func (s *Store) readLatestRecordsLocked() (map[string]persistRecord, error) {
 			s.logger.Warn("approval: skipping persistence record without an id")
 			continue
 		}
-		if rec.Status != "pending" || !now.Before(rec.ExpiresAt) {
+		if !pendingRecordLive(rec, now) {
 			activeBytes -= recordSizes[rec.ID]
 			delete(recordSizes, rec.ID)
 			delete(records, rec.ID)
@@ -1253,7 +1321,7 @@ func (s *Store) loadFromDisk() {
 		// but before the pending JSONL is rewritten. Treat either the ready
 		// marker or its consumed tombstone as authoritative so the resolved
 		// request is never resurrected after restart.
-		if key := replayKey(req.Call); key != "" {
+		if key := ownerBoundKey(replayKey(req.Call), req.ownerScope); key != "" {
 			_, readyPath, consumedPath := s.replayGrantPaths(key)
 			settled := false
 			for _, path := range []string{readyPath, consumedPath} {
@@ -1356,7 +1424,7 @@ func (s *Store) rewriteDisk() error {
 		pending := make([]persistRecord, 0, len(records))
 		now := time.Now()
 		for _, rec := range records {
-			if rec.Status == "pending" && now.Before(rec.ExpiresAt) {
+			if pendingRecordLive(rec, now) {
 				pending = append(pending, rec)
 			}
 		}

--- a/internal/approval/store_test.go
+++ b/internal/approval/store_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -409,7 +410,7 @@ func TestCreateOrAutoApprovedDoesNotEnqueueAuthorizedCall(t *testing.T) {
 	call := testCall()
 	require.True(t, store.AutoApproveRun(call, time.Minute))
 
-	req, autoApproved, err := store.CreateOrAutoApproved(call, testDecision())
+	req, autoApproved, err := store.CreateOrAutoApproved(call, testDecision(), "")
 	require.NoError(t, err)
 	assert.True(t, autoApproved)
 	assert.Nil(t, req)
@@ -439,7 +440,7 @@ func TestAutoApprovePublicationAndCreateAreAtomic(t *testing.T) {
 
 		go func() {
 			<-start
-			req, autoApproved, err := store.CreateOrAutoApproved(call, testDecision())
+			req, autoApproved, err := store.CreateOrAutoApproved(call, testDecision(), "")
 			created <- createResult{req: req, autoApproved: autoApproved, err: err}
 		}()
 		go func() {
@@ -488,7 +489,7 @@ func TestAutoApproveRunIfNoPendingOnlyReturnsExactScope(t *testing.T) {
 	assert.False(t, store.IsAutoApproved(target))
 }
 
-func TestDeduplicateWithinWindow(t *testing.T) {
+func TestDeduplicateStablePendingCall(t *testing.T) {
 	store := NewStore()
 	call := testCall()
 	decision := testDecision()
@@ -496,11 +497,14 @@ func TestDeduplicateWithinWindow(t *testing.T) {
 	req1, err := store.Create(call, decision)
 	require.NoError(t, err)
 
-	// Same call within window should return the same approval.
+	// Same stable call stays singular for its full pending lifetime.
 	req2, err := store.Create(call, decision)
 	require.NoError(t, err)
-
-	assert.Equal(t, req1.ID, req2.ID, "duplicate call within window should return same approval")
+	assert.Equal(t, req1.ID, req2.ID)
+	req1.CreatedAt = time.Now().Add(-time.Hour)
+	req2, err = store.Create(call, decision)
+	require.NoError(t, err)
+	assert.Equal(t, req1.ID, req2.ID)
 
 	// Different call should get a new approval.
 	call2 := testCall()
@@ -509,6 +513,39 @@ func TestDeduplicateWithinWindow(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.NotEqual(t, req1.ID, req3.ID, "different call should get different approval")
+}
+
+func TestOwnerScopedPendingDedupSurvivesRestart(t *testing.T) {
+	persistFile := filepath.Join(t.TempDir(), "approvals.jsonl")
+	ownerA, ownerB := strings.Repeat("a", 64), strings.Repeat("b", 64)
+	store := NewStore(WithPersistenceFile(persistFile))
+	call := testCall()
+	first, autoApproved, err := store.CreateOrAutoApproved(call, testDecision(), ownerA)
+	require.NoError(t, err)
+	require.False(t, autoApproved)
+	store.Close()
+
+	journal, err := os.ReadFile(persistFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(journal), `"owner_scope"`)
+	assert.NotContains(t, string(journal), ownerA, "persist only a domain-separated owner digest")
+	var record persistRecord
+	require.NoError(t, json.Unmarshal(bytes.TrimSpace(journal), &record))
+	assert.Equal(t, scopedPendingStatus, record.Status)
+	assert.NotEqual(t, "pending", record.Status, "v1.6.2 must discard scoped pending state on rollback")
+
+	restarted := NewStore(WithPersistenceFile(persistFile))
+	defer restarted.Close()
+	retry, autoApproved, err := restarted.CreateOrAutoApproved(call, testDecision(), ownerA)
+	require.NoError(t, err)
+	require.False(t, autoApproved)
+	assert.Equal(t, first.ID, retry.ID, "a lost response retry must reuse the restored pending approval")
+
+	other, autoApproved, err := restarted.CreateOrAutoApproved(call, testDecision(), ownerB)
+	require.NoError(t, err)
+	require.False(t, autoApproved)
+	assert.NotEqual(t, first.ID, other.ID, "a sibling token must not inherit pending state")
+	assert.Len(t, restarted.List(), 2)
 }
 
 func TestDeduplicationIsBoundToExecutionContext(t *testing.T) {
@@ -696,20 +733,43 @@ func TestExpiredApprovedReplayCannotBeConsumed(t *testing.T) {
 	assert.Nil(t, consumedGrant)
 }
 
-func TestPersistentApprovedReplayIsCrossStoreAndOneShot(t *testing.T) {
+func TestOwnerScopedPersistentReplayIsCrossStoreAndOneShot(t *testing.T) {
 	persistFile := filepath.Join(t.TempDir(), "approvals.jsonl")
+	ownerA, ownerB := strings.Repeat("a", 64), strings.Repeat("b", 64)
 	store1 := NewStore(WithPersistenceFile(persistFile))
 	defer store1.Close()
 
 	call := testCall()
-	req, err := store1.Create(call, testDecision())
+	req, autoApproved, err := store1.CreateOrAutoApproved(call, testDecision(), ownerA)
 	require.NoError(t, err)
+	require.False(t, autoApproved)
 	require.NoError(t, store1.Resolve(req.ID, true, "operator"))
+	legacyKey := replayKey(call)
+	scopedKey := ownerBoundKey(legacyKey, ownerScopeDigest(ownerA))
+	_, legacyReady, _ := store1.replayGrantPaths(legacyKey)
+	dataPath, scopedReady, _ := store1.replayGrantPaths(scopedKey)
+	_, err = os.Stat(legacyReady)
+	assert.True(t, os.IsNotExist(err), "v1.6.2 must not find a scoped replay grant at its legacy path")
+	require.FileExists(t, scopedReady)
+	encoded, err := os.ReadFile(dataPath)
+	require.NoError(t, err)
+	var persisted replayGrant
+	require.NoError(t, json.Unmarshal(encoded, &persisted))
+	assert.Equal(t, 2, persisted.Version)
+	assert.Equal(t, scopedKey, persisted.Fingerprint)
 
 	// A separate Store models a restarted or concurrently running process.
 	store2 := NewStore(WithPersistenceFile(persistFile))
 	defer store2.Close()
 	assert.Empty(t, store2.List(), "a durably approved request must not be resurrected as pending")
+	grant, consumed, err := store2.ConsumeApproved(call)
+	require.NoError(t, err)
+	assert.False(t, consumed, "legacy unscoped consumption must fail closed")
+	assert.Nil(t, grant)
+	grant, consumed, err = store2.ConsumeApprovedFor(call, ownerB)
+	require.NoError(t, err)
+	assert.False(t, consumed, "a sibling owner must not consume the grant")
+	assert.Nil(t, grant)
 
 	type result struct {
 		grant    *ConsumedApproval
@@ -721,7 +781,7 @@ func TestPersistentApprovedReplayIsCrossStoreAndOneShot(t *testing.T) {
 	for _, store := range []*Store{store1, store2} {
 		go func(candidate *Store) {
 			<-start
-			grant, consumed, err := candidate.ConsumeApproved(call)
+			grant, consumed, err := candidate.ConsumeApprovedFor(call, ownerA)
 			results <- result{grant: grant, consumed: consumed, err: err}
 		}(store)
 	}
@@ -741,10 +801,53 @@ func TestPersistentApprovedReplayIsCrossStoreAndOneShot(t *testing.T) {
 	}
 	assert.Equal(t, 1, winners, "the durable allow-once grant must have exactly one cross-process winner")
 
-	grant, consumed, err := store2.ConsumeApproved(call)
+	grant, consumed, err = store2.ConsumeApprovedFor(call, ownerA)
 	require.NoError(t, err)
 	assert.False(t, consumed)
 	assert.Nil(t, grant)
+}
+
+func TestLegacyReplayRemainsAdminOnly(t *testing.T) {
+	store := NewStore()
+	defer store.Close()
+	call := testCall()
+	req, err := store.Create(call, testDecision())
+	require.NoError(t, err)
+	require.NoError(t, store.Resolve(req.ID, true, "operator"))
+
+	grant, consumed, err := store.ConsumeApprovedFor(call, strings.Repeat("a", 64))
+	require.NoError(t, err)
+	assert.False(t, consumed, "ambiguous legacy state must not authorize an eval token")
+	assert.Nil(t, grant)
+	grant, consumed, err = store.ConsumeApproved(call)
+	require.NoError(t, err)
+	require.True(t, consumed, "deliberate unscoped admin/local behavior must remain available")
+	assert.Equal(t, req.ID, grant.ID)
+}
+
+func TestRunAutoApprovalIsBoundToResolvedOwner(t *testing.T) {
+	store := NewStore()
+	defer store.Close()
+	ownerA, ownerB := strings.Repeat("a", 64), strings.Repeat("b", 64)
+	call := testCall()
+	request, autoApproved, err := store.CreateOrAutoApproved(call, testDecision(), ownerA)
+	require.NoError(t, err)
+	require.False(t, autoApproved)
+	require.NoError(t, store.Resolve(request.ID, true, "operator"))
+	_, installed := store.AutoApproveRunIfNoPendingForRequest(call, request, time.Minute)
+	require.True(t, installed)
+
+	next := call
+	next.ToolCallID = "next-call"
+	next.Params = map[string]any{"command": "different sensitive action"}
+	owned, autoApproved, err := store.CreateOrAutoApproved(next, testDecision(), ownerA)
+	require.NoError(t, err)
+	assert.True(t, autoApproved)
+	assert.Nil(t, owned)
+	sibling, autoApproved, err := store.CreateOrAutoApproved(next, testDecision(), ownerB)
+	require.NoError(t, err)
+	assert.False(t, autoApproved)
+	assert.NotNil(t, sibling)
 }
 
 func TestPersistentApprovalAuthorizationFilesAreOwnerOnly(t *testing.T) {

--- a/internal/proxy/approval_handlers.go
+++ b/internal/proxy/approval_handlers.go
@@ -54,7 +54,7 @@ func (s *Server) handleCreateApproval(w http.ResponseWriter, r *http.Request) {
 	// Check run-scoped authorization and enqueue atomically. A bulk cache
 	// publication can never slip between a stale check and Create, leaving an
 	// orphan pending request for a call that should have been auto-approved.
-	pending, autoApproved, err := s.approvals.CreateOrAutoApproved(call, decision)
+	pending, autoApproved, err := s.approvals.CreateOrAutoApproved(call, decision, "")
 	if err != nil {
 		s.logger.Error("proxy: approval store full", "error", err)
 		writeError(w, http.StatusServiceUnavailable, err.Error())
@@ -526,22 +526,32 @@ func (s *Server) handleBulkResolve(w http.ResponseWriter, r *http.Request) {
 	// if publication wins, the creator observes auto-approved state atomically.
 	if approved && resolveErr == nil && len(matching) > 0 {
 		scopeCall := engine.ToolCall{Agent: req.Agent, Session: req.Session, RunID: req.RunID}
-		for resolveErr == nil {
-			select {
-			case <-r.Context().Done():
-				resolveErr = fmt.Errorf("bulk approval request cancelled before cache publication: %w", r.Context().Err())
-				continue
-			default:
+		owners := make([]*approval.Request, 0, len(matching))
+		seenOwners := make(map[string]struct{}, len(matching))
+		for _, ap := range matching {
+			if _, seen := seenOwners[ap.OwnerScopeID()]; !seen {
+				seenOwners[ap.OwnerScopeID()] = struct{}{}
+				owners = append(owners, ap)
 			}
-			raced, installed := s.approvals.AutoApproveRunIfNoPending(scopeCall, autoApproveTTL)
-			if installed {
-				break
+		}
+		for _, owner := range owners {
+			for resolveErr == nil {
+				select {
+				case <-r.Context().Done():
+					resolveErr = fmt.Errorf("bulk approval request cancelled before cache publication: %w", r.Context().Err())
+					continue
+				default:
+				}
+				raced, installed := s.approvals.AutoApproveRunIfNoPendingForRequest(scopeCall, owner, autoApproveTTL)
+				if installed {
+					break
+				}
+				if len(raced) == 0 {
+					resolveErr = fmt.Errorf("bulk approval scope could not be installed")
+					break
+				}
+				resolveBatch(raced)
 			}
-			if len(raced) == 0 {
-				resolveErr = fmt.Errorf("bulk approval scope could not be installed")
-				break
-			}
-			resolveBatch(raced)
 		}
 		if resolveErr != nil {
 			s.logger.Error("proxy: bulk-resolve could not install auto-approval scope",

--- a/internal/proxy/auth.go
+++ b/internal/proxy/auth.go
@@ -121,6 +121,21 @@ func (s *Server) checkAuthIdentity(w http.ResponseWriter, r *http.Request) *auth
 	return id
 }
 
+// checkEvalAuth validates auth and positively requires evaluation authority.
+// The local admin token remains universal; per-agent tokens must explicitly
+// carry eval scope.
+func (s *Server) checkEvalAuth(w http.ResponseWriter, r *http.Request) *authIdentity {
+	id := s.checkAuthIdentity(w, r)
+	if id == nil {
+		return nil
+	}
+	if !id.HasScope(token.ScopeEval) {
+		writeError(w, http.StatusForbidden, "this endpoint requires eval scope")
+		return nil
+	}
+	return id
+}
+
 // checkAdminAuth validates auth and requires admin scope. Writes 401/403 on failure.
 func (s *Server) checkAdminAuth(w http.ResponseWriter, r *http.Request) bool {
 	id, errMsg := s.identify(r)

--- a/internal/proxy/auth_test.go
+++ b/internal/proxy/auth_test.go
@@ -76,6 +76,57 @@ func TestMetricsRequireAdminScope(t *testing.T) {
 	}
 }
 
+func TestEvaluationEndpointsRequireEvalScope(t *testing.T) {
+	store, err := token.NewStore(filepath.Join(t.TempDir(), "tokens.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	evalToken, _, err := store.Create("eval-agent", "", "", []string{token.ScopeEval}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	adminOnlyToken, _, err := store.Create("admin-agent", "", "", []string{token.ScopeAdmin}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	combinedToken, _, err := store.Create("combined-agent", "", "", []string{token.ScopeEval, token.ScopeAdmin}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srv := New(nil, nil, WithToken("admin-token"), WithTokenStore(store), WithMode("disabled"))
+	t.Cleanup(srv.approvals.Close)
+	handler := srv.handler()
+
+	for _, endpoint := range []string{"/v1/tool/exec", "/v1/preflight/exec"} {
+		for _, test := range []struct {
+			name   string
+			bearer string
+			status int
+		}{
+			{name: "eval token", bearer: evalToken, status: http.StatusOK},
+			{name: "local admin", bearer: "admin-token", status: http.StatusOK},
+			{name: "admin-only agent token", bearer: adminOnlyToken, status: http.StatusForbidden},
+			{name: "combined token", bearer: combinedToken, status: http.StatusOK},
+			{name: "invalid token", bearer: "invalid-token", status: http.StatusUnauthorized},
+			{name: "missing token", status: http.StatusUnauthorized},
+		} {
+			t.Run(endpoint+"/"+test.name, func(t *testing.T) {
+				body := `{"agent":"untrusted","session":"scope-test","params":{"command":"true"}}`
+				req := httptest.NewRequest(http.MethodPost, endpoint, strings.NewReader(body))
+				if test.bearer != "" {
+					req.Header.Set("Authorization", "Bearer "+test.bearer)
+				}
+				rr := httptest.NewRecorder()
+				handler.ServeHTTP(rr, req)
+				if rr.Code != test.status {
+					t.Fatalf("status = %d, want %d; body = %s", rr.Code, test.status, rr.Body.String())
+				}
+			})
+		}
+	}
+}
+
 func TestDecodeJSONBodyRejectsAdditionalValues(t *testing.T) {
 	for _, tt := range []struct {
 		name    string

--- a/internal/proxy/eval_handlers.go
+++ b/internal/proxy/eval_handlers.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (s *Server) handleToolCall(w http.ResponseWriter, r *http.Request) {
-	identity := s.checkAuthIdentity(w, r)
+	identity := s.checkEvalAuth(w, r)
 	if identity == nil {
 		return
 	}
@@ -554,7 +554,7 @@ func notificationActionMatches(configured, actual string) bool {
 // Returns the decision that would be made — agents use this to plan around
 // policy restrictions before attempting blocked actions.
 func (s *Server) handlePreflight(w http.ResponseWriter, r *http.Request) {
-	identity := s.checkAuthIdentity(w, r)
+	identity := s.checkEvalAuth(w, r)
 	if identity == nil {
 		return
 	}

--- a/internal/proxy/eval_handlers.go
+++ b/internal/proxy/eval_handlers.go
@@ -179,6 +179,10 @@ func (s *Server) handleToolCall(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if s.mode == "enforce" && (decision.Action == engine.ActionRequireApproval || decision.Action == engine.ActionAsk) {
+		ownerScope := ""
+		if identity.Token != nil {
+			ownerScope = identity.Token.Hash
+		}
 		if req.requestsHostedApproval() {
 			if identity.IsAdmin {
 				if err := req.validateTrustedHostedApproval(); err != nil {
@@ -217,7 +221,7 @@ func (s *Server) handleToolCall(w http.ResponseWriter, r *http.Request) {
 		// the host retries the identical run_id/tool_call_id and payload. The
 		// approval store atomically consumes the fingerprint-bound grant before
 		// this request is reported as allowed.
-		approved, consumed, consumeErr := s.approvals.ConsumeApproved(call)
+		approved, consumed, consumeErr := s.approvals.ConsumeApprovedFor(call, ownerScope)
 		if consumeErr != nil {
 			s.logger.Error("proxy: exact approval replay unavailable", "tool", toolName, "run_id", call.RunID, "tool_call_id", call.ToolCallID, "error", consumeErr)
 			writeError(w, http.StatusServiceUnavailable, "approval state is unavailable; refusing tool call")
@@ -272,7 +276,7 @@ func (s *Server) handleToolCall(w http.ResponseWriter, r *http.Request) {
 		// Check run-scoped authorization and enqueue atomically. This prevents a
 		// bulk cache publication from racing a stale check and leaving an orphan
 		// pending approval for a call that should have been auto-approved.
-		pending, autoApproved, createErr := s.approvals.CreateOrAutoApproved(call, decision)
+		pending, autoApproved, createErr := s.approvals.CreateOrAutoApproved(call, decision, ownerScope)
 		if createErr != nil {
 			s.logger.Error("proxy: approval store full", "error", createErr)
 			writeError(w, http.StatusServiceUnavailable, createErr.Error())

--- a/internal/proxy/server_test.go
+++ b/internal/proxy/server_test.go
@@ -169,6 +169,7 @@ func (s *createAutoRaceSink) Write(audit.Event) error {
 			request, autoApproved, err := s.store.CreateOrAutoApproved(
 				s.call,
 				engine.Decision{Action: engine.ActionRequireApproval, Message: "raced bulk publication"},
+				"",
 			)
 			s.result <- createAutoRaceResult{request: request, autoApproved: autoApproved, err: err}
 		}()
@@ -709,6 +710,82 @@ policies:
 	assert.Equal(t, "pending", secondResult["approval_status"])
 	assert.NotEqual(t, approvalID, secondResult["approval_id"], "the consumed grant must not authorize another replay")
 	require.Len(t, srv.approvals.List(), 1)
+}
+
+func TestToolCall_ExactReplayIsBoundToEvalToken(t *testing.T) {
+	srv, adminToken, _ := setupTestServer(t, `
+version: "1"
+default_action: allow
+policies:
+  - name: approve-deploy
+    match:
+      tool: exec
+    rules:
+      - action: ask
+        when:
+          command_matches: ["deploy prod"]
+`, "enforce")
+	tokenStore, err := token.NewStore(filepath.Join(t.TempDir(), "tokens.json"))
+	require.NoError(t, err)
+	owner, _, err := tokenStore.Create("codex", "", "", []string{token.ScopeEval}, nil)
+	require.NoError(t, err)
+	sibling, _, err := tokenStore.Create("codex", "", "", []string{token.ScopeEval}, nil)
+	require.NoError(t, err)
+	third, _, err := tokenStore.Create("codex", "", "", []string{token.ScopeEval}, nil)
+	require.NoError(t, err)
+	srv.tokenStore = tokenStore
+	handler := srv.handler()
+	body := `{"agent":"spoofed","session":"s1","run_id":"run-owner","tool_call_id":"call-owner","params":{"command":"deploy prod"}}`
+	post := func(bearer string) (int, map[string]any) {
+		req := httptest.NewRequest(http.MethodPost, "/v1/tool/exec", strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer "+bearer)
+		req.Header.Set("Content-Type", "application/json")
+		recorder := httptest.NewRecorder()
+		handler.ServeHTTP(recorder, req)
+		result := map[string]any{}
+		require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &result))
+		return recorder.Code, result
+	}
+	status, ownerPending := post(owner)
+	require.Equal(t, http.StatusAccepted, status)
+	status, siblingPending := post(sibling)
+	require.Equal(t, http.StatusAccepted, status)
+	ownerID := ownerPending["approval_id"].(string)
+	siblingID := siblingPending["approval_id"].(string)
+	require.NotEqual(t, ownerID, siblingID)
+
+	resolveReq := httptest.NewRequest(http.MethodPost, "/v1/approvals/"+ownerID+"/resolve",
+		strings.NewReader(`{"approved":true,"resolved_by":"operator"}`))
+	resolveReq.Header.Set("Authorization", "Bearer "+adminToken)
+	resolveReq.Header.Set("Content-Type", "application/json")
+	resolveRecorder := httptest.NewRecorder()
+	handler.ServeHTTP(resolveRecorder, resolveReq)
+	require.Equal(t, http.StatusOK, resolveRecorder.Code)
+
+	status, siblingRetry := post(sibling)
+	require.Equal(t, http.StatusAccepted, status)
+	assert.Equal(t, siblingID, siblingRetry["approval_id"])
+	status, ownerResult := post(owner)
+	require.Equal(t, http.StatusOK, status)
+	assert.Equal(t, true, ownerResult["allowed"])
+	assert.Equal(t, ownerID, ownerResult["approval_id"])
+
+	bulkReq := httptest.NewRequest(http.MethodPost, "/v1/approvals/bulk-resolve",
+		strings.NewReader(`{"agent":"codex","session":"s1","run_id":"run-owner","action":"approve"}`))
+	bulkReq.Header.Set("Authorization", "Bearer "+adminToken)
+	bulkReq.Header.Set("Content-Type", "application/json")
+	bulkRecorder := httptest.NewRecorder()
+	handler.ServeHTTP(bulkRecorder, bulkReq)
+	require.Equal(t, http.StatusOK, bulkRecorder.Code)
+
+	body = `{"agent":"spoofed","session":"s1","run_id":"run-owner","tool_call_id":"call-next","params":{"command":"deploy prod"}}`
+	status, thirdResult := post(third)
+	require.Equal(t, http.StatusAccepted, status, "a sibling token must not inherit the bulk run grant")
+	assert.Equal(t, "pending", thirdResult["approval_status"])
+	status, siblingResult := post(sibling)
+	require.Equal(t, http.StatusOK, status)
+	assert.Equal(t, true, siblingResult["allowed"])
+	assert.Equal(t, "auto-approved", siblingResult["policy"])
 }
 
 func TestToolCall_ResponseDeniedAndRedacted(t *testing.T) {

--- a/internal/token/store.go
+++ b/internal/token/store.go
@@ -44,7 +44,7 @@ const (
 	Prefix = "rampart_"
 
 	// ScopeEval allows tool-call evaluation and enforcement through the
-	// /v1/preflight/{tool} endpoint.
+	// /v1/tool/{tool} and /v1/preflight/{tool} endpoints.
 	// Audit reads, status checks, approvals, and rule management require ScopeAdmin.
 	ScopeEval = "eval"
 


### PR DESCRIPTION
## Summary
- bind pending approval deduplication, exact replay grants, and bulk run authorization to the originating eval token
- preserve same-token retries across restarts for the full pending lifetime
- domain-separate scoped persistence so older Rampart versions fail closed on rollback

## Validation
- full Go test suite and vet
- affected race suites and repeated owner-isolation probes
- real v1.6.2 rollback compatibility probe
- security assurance and independent adversarial review

This is intentionally stacked on PR #379, which adds positive eval-scope enforcement.