### PR TITLE
ci: add fast draft feedback lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, staging]
   pull_request:
     branches: [main, staging]
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
   workflow_call:
 
 permissions:
@@ -15,8 +16,44 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  draft:
+    name: Draft CI
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Go toolchain pins are synchronized
+        run: scripts/check-toolchain-sync.sh
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Module files are tidy
+        run: |
+          go mod tidy
+          git diff --exit-code -- go.mod go.sum
+
+      - name: Go files are formatted
+        run: test -z "$(gofmt -l .)"
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test
+        run: go test ./...
+
   test:
     name: test (${{ matrix.os }})
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     timeout-minutes: 15
     strategy:
       fail-fast: false
@@ -187,6 +224,7 @@ jobs:
 
   docker-smoke:
     name: docker smoke (amd64 runtime + arm64 build)
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -226,6 +264,7 @@ jobs:
 
   release-dry-run:
     name: goreleaser snapshot (cross-platform build check)
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -253,6 +292,7 @@ jobs:
 
   python-sdk:
     name: Python SDK (Python ${{ matrix.python-version }})
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -302,7 +342,7 @@ jobs:
 
   ci-gate:
     name: CI gate
-    if: always()
+    if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: [test, docker-smoke, release-dry-run, python-sdk]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   draft:
     name: Draft CI
-    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft }}
+    if: ${{ github.event_name == 'pull_request' && github.base_ref == 'staging' && github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -53,7 +53,7 @@ jobs:
 
   test:
     name: test (${{ matrix.os }})
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
+    if: ${{ github.event_name != 'pull_request' || github.base_ref != 'staging' || github.event.pull_request.draft == false }}
     timeout-minutes: 15
     strategy:
       fail-fast: false
@@ -224,7 +224,7 @@ jobs:
 
   docker-smoke:
     name: docker smoke (amd64 runtime + arm64 build)
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
+    if: ${{ github.event_name != 'pull_request' || github.base_ref != 'staging' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -264,7 +264,7 @@ jobs:
 
   release-dry-run:
     name: goreleaser snapshot (cross-platform build check)
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
+    if: ${{ github.event_name != 'pull_request' || github.base_ref != 'staging' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -292,7 +292,7 @@ jobs:
 
   python-sdk:
     name: Python SDK (Python ${{ matrix.python-version }})
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
+    if: ${{ github.event_name != 'pull_request' || github.base_ref != 'staging' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -342,7 +342,7 @@ jobs:
 
   ci-gate:
     name: CI gate
-    if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
+    if: ${{ always() && (github.event_name != 'pull_request' || github.base_ref != 'staging' || github.event.pull_request.draft == false) }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: [test, docker-smoke, release-dry-run, python-sdk]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,8 +51,11 @@ architecture diagram.
 3. Add or update only the tests and documentation needed for that behavior.
 4. Run checks proportional to the change, followed by the full source checks
    before requesting review.
-5. Open the pull request against `staging` and explain the user-visible result,
-   security impact, limitations, and validation performed.
+5. Open the pull request against `staging` as a draft while iterating. Drafts
+   receive a fast Linux source check; marking the pull request ready starts the
+   complete cross-platform, packaging, container, and SDK matrix.
+6. Explain the user-visible result, security impact, limitations, and
+   validation performed before requesting review.
 
 The `main` branch represents published releases. Release merges and tags are
 maintainer-managed.


### PR DESCRIPTION
## Outcome

Draft pull requests targeting `staging` run a single fast Linux source check during iteration. Marking a pull request ready triggers the existing complete Linux, macOS, Windows, container, release-snapshot, and Python SDK matrix. Pull requests targeting protected `main` always run the complete matrix, including while draft. Pushes to `main` and `staging`, reusable release validation, and release workflows remain unchanged.

## Why this shape

- keeps `staging` as the sole integration branch instead of adding a drift-prone `dev` branch
- preserves exact-head full validation before review and merge
- does not weaken the existing required `CI gate` on `main`
- cancels superseded runs through the existing concurrency policy
- adds no scripts, dependencies, private runner details, or lab artifacts

## Validation

- `scripts/maintain.sh local full`
- `actionlint` v1.7.12
- exact proposed draft sequence: toolchain sync, module tidy, formatting, vet, and `go test ./...`
- local warm-cache draft sequence: approximately 25 seconds
- live GitHub draft run: 56 seconds, with the full matrix skipped
- live draft-to-ready transition: the unchanged first commit automatically started all seven full matrix jobs
- final exact head `45f9cf2830a2`: 9/9 ready-state checks passed

## Deliberate boundary

The fast lane applies only to draft PRs targeting `staging`. GitHub treats skipped required checks as acceptable, so protected `main` intentionally keeps full validation for every PR state.