### PR TITLE
docs: align Hermes approval claims

### DIFF
--- a/docs-site/getting-started/support-matrix.md
+++ b/docs-site/getting-started/support-matrix.md
@@ -183,9 +183,10 @@ and the isolated latest-Hermes compatibility check for runtime evidence.
   memory, and delegated-agent calls; a real authenticated host proof is still
   pending, and this does not cover Antigravity
 - **Hermes Agent** → experimental plugin path with isolated latest-runtime
-  discovery, dispatch, deny/allow, and degraded-mode checks; `ask` decisions
-  block rather than resume until Hermes exposes a first-class plugin approval flow. Its built-in
-  status check remains static, so it is not included in `rampart verify --all`
+  discovery, dispatch, deny/allow, native approval/resume, and degraded-mode
+  checks. Older Hermes releases block `ask` with upgrade guidance. Its built-in
+  status check remains static, so it is not included in `rampart verify --all`,
+  and authenticated live-host proof remains pending
 
 ## Degraded behavior notes
 

--- a/docs-site/integrations/index.md
+++ b/docs-site/integrations/index.md
@@ -42,7 +42,7 @@ When a policy action is `ask`, behavior varies by integration:
 | **Cline** | Hook returns `{"cancel":true}` with approval message (no native ask) |
 | **MCP (Claude Desktop/Cursor)** | Proxy blocks, returns JSON-RPC error on deny |
 | **OpenClaw** | OpenClaw owns the visible approval UI; Rampart plugin supplies policy decisions |
-| **Hermes Agent** | Experimental plugin blocks `ask` with an approval-required message until Hermes owns a plugin approval/resume flow |
+| **Hermes Agent** | Current Hermes releases own the native approval prompt and resume the same call; older releases block with upgrade guidance |
 | **Shell Wrapper** | Shim blocks, command appears "hung" until resolved |
 | **LD_PRELOAD** | Library blocks exec call, process appears "hung" |
 | **HTTP API** | Returns `"decision":"ask"` with approval metadata when interactive review is required |


### PR DESCRIPTION
## Outcome

Correct the two remaining canonical docs that described Hermes `ask` behavior using the pre-native-approval limitation. Current Hermes releases own the native prompt and resume the same tool call; older releases continue to fail closed with upgrade guidance.

Hermes remains experimental because authenticated live-host proof, delegated-agent coverage, and complete host-failure behavior are not established.

## Scope

- no product behavior changes
- no support-tier promotion
- no private host evidence or dated lab artifacts
- no new tests or maintenance framework

## Validation

- canonical document wrapper check
- stale-claim repository search
- `mkdocs build --strict`
- `git diff --check`