### PR TITLE
security: preserve unowned service definitions

### DIFF
--- a/cmd/rampart/cli/serve_install.go
+++ b/cmd/rampart/cli/serve_install.go
@@ -323,6 +323,15 @@ func snapshotServiceToken() (string, privateFileSnapshot, error) {
 	return tokenPath, token, nil
 }
 
+func secureManagedServiceState(configPath string, config privateFileSnapshot) (string, privateFileSnapshot, error) {
+	if config.exists {
+		if err := secureFilePermissions(configPath); err != nil {
+			return "", privateFileSnapshot{}, fmt.Errorf("secure service definition: %w", err)
+		}
+	}
+	return snapshotServiceToken()
+}
+
 func rollbackServiceFiles(configPath string, config privateFileSnapshot, tokenPath string, token privateFileSnapshot) error {
 	return errors.Join(
 		restorePrivateFile(configPath, config),
@@ -505,14 +514,16 @@ func installDarwin(cmd *cobra.Command, cfg serviceConfig, force, generated bool,
 		if err := validateManagedLaunchdService(configBefore.data, path, plistLabel); err != nil {
 			return fmt.Errorf("refusing to overwrite service definition: %w", err)
 		}
+	}
+	tokenPath, tokenBefore, err := secureManagedServiceState(path, configBefore)
+	if err != nil {
+		return err
+	}
+	if configBefore.exists {
 		if !force {
 			fmt.Fprintf(cmd.ErrOrStderr(), "Service already installed at %s\nUse --force to overwrite.\n", path)
 			return nil
 		}
-	}
-	tokenPath, tokenBefore, err := snapshotServiceToken()
-	if err != nil {
-		return err
 	}
 	serviceExists := configBefore.exists
 	serviceWasLoaded := false
@@ -580,14 +591,16 @@ func installLinux(cmd *cobra.Command, cfg serviceConfig, force, generated bool, 
 		if err := validateManagedSystemdService(configBefore.data, path); err != nil {
 			return fmt.Errorf("refusing to overwrite service definition: %w", err)
 		}
+	}
+	tokenPath, tokenBefore, err := secureManagedServiceState(path, configBefore)
+	if err != nil {
+		return err
+	}
+	if configBefore.exists {
 		if !force {
 			fmt.Fprintf(cmd.ErrOrStderr(), "Service already installed at %s\nUse --force to overwrite.\n", path)
 			return nil
 		}
-	}
-	tokenPath, tokenBefore, err := snapshotServiceToken()
-	if err != nil {
-		return err
 	}
 	serviceExists := configBefore.exists
 	priorState := systemdServiceState{}

--- a/cmd/rampart/cli/serve_install.go
+++ b/cmd/rampart/cli/serve_install.go
@@ -303,20 +303,24 @@ func restorePrivateFile(path string, snapshot privateFileSnapshot) error {
 	return filetxn.SyncDir(dir)
 }
 
-func snapshotServiceFiles(configPath string) (privateFileSnapshot, string, privateFileSnapshot, error) {
-	config, err := snapshotPrivateFile(configPath)
+func snapshotServiceDefinition(configPath string) (privateFileSnapshot, error) {
+	configData, configExists, err := readRegularServiceFile(configPath)
 	if err != nil {
-		return privateFileSnapshot{}, "", privateFileSnapshot{}, fmt.Errorf("snapshot service definition: %w", err)
+		return privateFileSnapshot{}, fmt.Errorf("snapshot service definition: %w", err)
 	}
+	return privateFileSnapshot{exists: configExists, data: configData}, nil
+}
+
+func snapshotServiceToken() (string, privateFileSnapshot, error) {
 	tokenPath, err := tokenFilePath()
 	if err != nil {
-		return privateFileSnapshot{}, "", privateFileSnapshot{}, err
+		return "", privateFileSnapshot{}, err
 	}
 	token, err := snapshotPrivateFile(tokenPath)
 	if err != nil {
-		return privateFileSnapshot{}, "", privateFileSnapshot{}, fmt.Errorf("snapshot service token: %w", err)
+		return "", privateFileSnapshot{}, fmt.Errorf("snapshot service token: %w", err)
 	}
-	return config, tokenPath, token, nil
+	return tokenPath, token, nil
 }
 
 func rollbackServiceFiles(configPath string, config privateFileSnapshot, tokenPath string, token privateFileSnapshot) error {
@@ -493,13 +497,22 @@ func installDarwin(cmd *cobra.Command, cfg serviceConfig, force, generated bool,
 		return err
 	}
 
-	configBefore, tokenPath, tokenBefore, err := snapshotServiceFiles(path)
+	configBefore, err := snapshotServiceDefinition(path)
 	if err != nil {
 		return err
 	}
-	if configBefore.exists && !force {
-		fmt.Fprintf(cmd.ErrOrStderr(), "Service already installed at %s\nUse --force to overwrite.\n", path)
-		return nil
+	if configBefore.exists {
+		if err := validateManagedLaunchdService(configBefore.data, path, plistLabel); err != nil {
+			return fmt.Errorf("refusing to overwrite service definition: %w", err)
+		}
+		if !force {
+			fmt.Fprintf(cmd.ErrOrStderr(), "Service already installed at %s\nUse --force to overwrite.\n", path)
+			return nil
+		}
+	}
+	tokenPath, tokenBefore, err := snapshotServiceToken()
+	if err != nil {
+		return err
 	}
 	serviceExists := configBefore.exists
 	serviceWasLoaded := false
@@ -526,6 +539,9 @@ func installDarwin(cmd *cobra.Command, cfg serviceConfig, force, generated bool,
 	// The definition contains the bearer token. Publish it atomically from an
 	// owner-only temporary file so readers never observe partial or permissive
 	// content on any supported platform.
+	if err := requireUnchangedServiceFile(path, configBefore.exists, configBefore.data); err != nil {
+		return fmt.Errorf("service definition changed before replacement: %w", err)
+	}
 	if err := atomicWritePrivateFile(path, []byte(content)); err != nil {
 		return fmt.Errorf("write plist: %w", err)
 	}
@@ -556,13 +572,22 @@ func installLinux(cmd *cobra.Command, cfg serviceConfig, force, generated bool, 
 		return err
 	}
 
-	configBefore, tokenPath, tokenBefore, err := snapshotServiceFiles(path)
+	configBefore, err := snapshotServiceDefinition(path)
 	if err != nil {
 		return err
 	}
-	if configBefore.exists && !force {
-		fmt.Fprintf(cmd.ErrOrStderr(), "Service already installed at %s\nUse --force to overwrite.\n", path)
-		return nil
+	if configBefore.exists {
+		if err := validateManagedSystemdService(configBefore.data, path); err != nil {
+			return fmt.Errorf("refusing to overwrite service definition: %w", err)
+		}
+		if !force {
+			fmt.Fprintf(cmd.ErrOrStderr(), "Service already installed at %s\nUse --force to overwrite.\n", path)
+			return nil
+		}
+	}
+	tokenPath, tokenBefore, err := snapshotServiceToken()
+	if err != nil {
+		return err
 	}
 	serviceExists := configBefore.exists
 	priorState := systemdServiceState{}
@@ -582,6 +607,9 @@ func installLinux(cmd *cobra.Command, cfg serviceConfig, force, generated bool, 
 		return err
 	}
 
+	if err := requireUnchangedServiceFile(path, configBefore.exists, configBefore.data); err != nil {
+		return fmt.Errorf("service definition changed before replacement: %w", err)
+	}
 	if err := atomicWritePrivateFile(path, []byte(content)); err != nil {
 		return fmt.Errorf("write unit: %w", err)
 	}

--- a/cmd/rampart/cli/serve_install_test.go
+++ b/cmd/rampart/cli/serve_install_test.go
@@ -806,6 +806,101 @@ func TestServeLifecycleRefusesUnownedDefinition(t *testing.T) {
 	}
 }
 
+func TestInstallRepairsManagedServiceAndTokenPermissionsBeforeEarlyReturn(t *testing.T) {
+	skipOnWindows(t, "Unix service file permissions")
+	cases := []struct {
+		name    string
+		path    func() (string, error)
+		content func(*testing.T, string) string
+		install func(*cobra.Command, serviceConfig, bool, bool, int, commandRunner) error
+	}{
+		{name: "systemd", path: systemdUnitPath, content: managedSystemdFixture, install: installLinux},
+		{name: "launchd", path: plistPath, content: managedLaunchdFixture, install: installDarwin},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			testSetHome(t, home)
+			servicePath, err := tc.path()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.MkdirAll(filepath.Dir(servicePath), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(servicePath, []byte(tc.content(t, "old-token")), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			tokenPath, err := tokenFilePath()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.MkdirAll(filepath.Dir(tokenPath), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(tokenPath, []byte("old-token"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			var calls []string
+			cfg := serviceConfig{Binary: "/usr/local/bin/rampart", Token: "replacement-token", LogPath: filepath.Join(home, ".rampart", "serve.log")}
+			if err := tc.install(&cobra.Command{}, cfg, false, false, defaultServePort, mockRunner(&calls)); err != nil {
+				t.Fatal(err)
+			}
+			if len(calls) != 0 {
+				t.Fatalf("existing managed service triggered lifecycle commands: %v", calls)
+			}
+			for _, path := range []string{servicePath, tokenPath} {
+				info, err := os.Stat(path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if info.Mode().Perm() != 0o600 {
+					t.Fatalf("%s permissions = %04o, want 0600", path, info.Mode().Perm())
+				}
+			}
+		})
+	}
+}
+
+func TestInstallExistingManagedServiceRejectsSymlinkedToken(t *testing.T) {
+	skipOnWindows(t, "Unix symlink semantics")
+	home := t.TempDir()
+	testSetHome(t, home)
+	servicePath, err := systemdUnitPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(servicePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(servicePath, []byte(managedSystemdFixture(t, "old-token")), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	tokenPath, err := tokenFilePath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(tokenPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(home, "shared-token")
+	if err := os.WriteFile(target, []byte("keep me"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, tokenPath); err != nil {
+		t.Fatal(err)
+	}
+
+	err = installLinux(&cobra.Command{}, serviceConfig{}, false, false, defaultServePort, mockRunner(&[]string{}))
+	if err == nil || !strings.Contains(err.Error(), "symlinked") {
+		t.Fatalf("installLinux error = %v, want token symlink refusal", err)
+	}
+	if data, readErr := os.ReadFile(target); readErr != nil || string(data) != "keep me" {
+		t.Fatalf("token target changed: data=%q err=%v", data, readErr)
+	}
+}
+
 func TestRequireUnchangedServiceFileRejectsCreatedOrModifiedDefinition(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "rampart-serve.service")
 	if err := os.WriteFile(path, []byte("created"), 0o600); err != nil {

--- a/cmd/rampart/cli/serve_install_test.go
+++ b/cmd/rampart/cli/serve_install_test.go
@@ -354,6 +354,31 @@ func mockRunner(calls *[]string) commandRunner {
 	}
 }
 
+func managedSystemdFixture(t *testing.T, token string) string {
+	t.Helper()
+	content, err := generateSystemdUnit(serviceConfig{
+		Binary: "/usr/local/bin/rampart",
+		Token:  token,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return content
+}
+
+func managedLaunchdFixture(t *testing.T, token string) string {
+	t.Helper()
+	content, err := generatePlist(serviceConfig{
+		Binary:  "/usr/local/bin/rampart",
+		Token:   token,
+		LogPath: filepath.Join(t.TempDir(), "serve.log"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return content
+}
+
 func TestInstallLinuxRotatesTokenBetweenStopAndStart(t *testing.T) {
 	skipOnWindows(t, "Unix service runner")
 	home := t.TempDir()
@@ -368,7 +393,7 @@ func TestInstallLinuxRotatesTokenBetweenStopAndStart(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(unitPath), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(unitPath, []byte("old unit"), 0o600); err != nil {
+	if err := os.WriteFile(unitPath, []byte(managedSystemdFixture(t, "old-token")), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -411,7 +436,7 @@ func TestInstallLinuxRestoresDefinitionTokenAndServiceOnStartFailure(t *testing.
 	if err := os.MkdirAll(filepath.Dir(unitPath), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	const oldUnit = "old unit\n"
+	oldUnit := managedSystemdFixture(t, "old-token")
 	if err := os.WriteFile(unitPath, []byte(oldUnit), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -474,7 +499,7 @@ func TestInstallLinuxRollbackPreservesInactiveDisabledState(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(unitPath), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(unitPath, []byte("old unit\n"), 0o600); err != nil {
+	if err := os.WriteFile(unitPath, []byte(managedSystemdFixture(t, "old-token")), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -560,7 +585,7 @@ func TestInstallDarwinRotatesTokenBetweenUnloadAndLoad(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(path, []byte("old plist"), 0o600); err != nil {
+	if err := os.WriteFile(path, []byte(managedLaunchdFixture(t, "old-token")), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -625,7 +650,7 @@ func TestInstallDarwinAllowsExistingUnloadedService(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(path, []byte("old plist"), 0o600); err != nil {
+	if err := os.WriteFile(path, []byte(managedLaunchdFixture(t, "old-token")), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -675,7 +700,7 @@ func TestInstallDarwinRefusesTokenRotationOnUnknownListFailure(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(path, []byte("old plist"), 0o600); err != nil {
+	if err := os.WriteFile(path, []byte(managedLaunchdFixture(t, "old-token")), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -702,6 +727,98 @@ func TestInstallDarwinRefusesTokenRotationOnUnknownListFailure(t *testing.T) {
 	}
 	if token != "old-token" {
 		t.Fatalf("persisted token = %q, want old-token", token)
+	}
+}
+
+func TestServeLifecycleRefusesUnownedDefinition(t *testing.T) {
+	skipOnWindows(t, "Unix service file semantics")
+	cases := []struct {
+		name      string
+		path      func() (string, error)
+		content   string
+		wantError string
+		install   func(*cobra.Command, serviceConfig, bool, bool, int, commandRunner) error
+		uninstall func(*cobra.Command, commandRunner) error
+	}{
+		{
+			name:      "systemd",
+			path:      systemdUnitPath,
+			content:   "[Service]\nExecStart=/usr/bin/unrelated serve\n",
+			wantError: "unrecognized systemd service",
+			install:   installLinux,
+			uninstall: uninstallLinux,
+		},
+		{
+			name: "launchd",
+			path: plistPath,
+			content: `<?xml version="1.0"?><plist><dict>
+<key>Label</key><string>sh.rampart.serve</string>
+<key>ProgramArguments</key><array><string>/usr/bin/unrelated</string><string>serve</string></array>
+			</dict></plist>`,
+			wantError: "unrecognized LaunchAgent",
+			install:   installDarwin,
+			uninstall: uninstallDarwin,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			testSetHome(t, home)
+			path, err := tc.path()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(path, []byte(tc.content), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			beforeInfo, err := os.Stat(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var calls []string
+			runner := mockRunner(&calls)
+			cfg := serviceConfig{Binary: "/usr/local/bin/rampart", Token: "replacement-token", LogPath: filepath.Join(home, ".rampart", "serve.log")}
+			if err := tc.install(&cobra.Command{}, cfg, true, false, defaultServePort, runner); err == nil || !strings.Contains(err.Error(), tc.wantError) {
+				t.Fatalf("install error = %v, want ownership refusal", err)
+			}
+			if err := tc.uninstall(&cobra.Command{}, runner); err == nil || !strings.Contains(err.Error(), tc.wantError) {
+				t.Fatalf("uninstall error = %v, want ownership refusal", err)
+			}
+			if len(calls) != 0 {
+				t.Fatalf("unowned service triggered lifecycle commands: %v", calls)
+			}
+			data, err := os.ReadFile(path)
+			if err != nil || string(data) != tc.content {
+				t.Fatalf("unowned service changed: data=%q err=%v", data, err)
+			}
+			afterInfo, err := os.Stat(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if afterInfo.Mode().Perm() != beforeInfo.Mode().Perm() {
+				t.Fatalf("unowned service mode changed: before=%v after=%v", beforeInfo.Mode().Perm(), afterInfo.Mode().Perm())
+			}
+		})
+	}
+}
+
+func TestRequireUnchangedServiceFileRejectsCreatedOrModifiedDefinition(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "rampart-serve.service")
+	if err := os.WriteFile(path, []byte("created"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := requireUnchangedServiceFile(path, false, nil); err == nil {
+		t.Fatal("service created after an absent snapshot was accepted")
+	}
+	if err := requireUnchangedServiceFile(path, true, []byte("original")); err == nil {
+		t.Fatal("service modified after snapshot was accepted")
+	}
+	if err := requireUnchangedServiceFile(path, true, []byte("created")); err != nil {
+		t.Fatalf("unchanged service rejected: %v", err)
 	}
 }
 

--- a/cmd/rampart/cli/serve_uninstall.go
+++ b/cmd/rampart/cli/serve_uninstall.go
@@ -59,14 +59,24 @@ func uninstallDarwin(cmd *cobra.Command, runner commandRunner) error {
 		return err
 	}
 
-	if _, err := os.Stat(path); os.IsNotExist(err) {
+	definition, exists, err := readRegularServiceFile(path)
+	if err != nil {
+		return err
+	}
+	if !exists {
 		fmt.Fprintln(cmd.ErrOrStderr(), "Service is not installed.")
 		return nil
+	}
+	if err := validateManagedLaunchdService(definition, path, plistLabel); err != nil {
+		return err
 	}
 
 	// Best-effort unload; ignore errors (service may not be running).
 	_ = runner("launchctl", "unload", path).Run()
 
+	if err := requireUnchangedServiceFile(path, true, definition); err != nil {
+		return fmt.Errorf("service definition changed before removal: %w", err)
+	}
 	if err := os.Remove(path); err != nil {
 		return fmt.Errorf("remove plist: %w", err)
 	}
@@ -81,14 +91,24 @@ func uninstallLinux(cmd *cobra.Command, runner commandRunner) error {
 		return err
 	}
 
-	if _, err := os.Stat(path); os.IsNotExist(err) {
+	definition, exists, err := readRegularServiceFile(path)
+	if err != nil {
+		return err
+	}
+	if !exists {
 		fmt.Fprintln(cmd.ErrOrStderr(), "Service is not installed.")
 		return nil
+	}
+	if err := validateManagedSystemdService(definition, path); err != nil {
+		return err
 	}
 
 	// Best-effort stop+disable.
 	_ = runner("systemctl", "--user", "disable", "--now", "rampart-serve.service").Run()
 
+	if err := requireUnchangedServiceFile(path, true, definition); err != nil {
+		return fmt.Errorf("service definition changed before removal: %w", err)
+	}
 	if err := os.Remove(path); err != nil {
 		return fmt.Errorf("remove unit: %w", err)
 	}

--- a/cmd/rampart/cli/uninstall.go
+++ b/cmd/rampart/cli/uninstall.go
@@ -296,14 +296,21 @@ func managedLaunchdServiceFile(path, label string) (bool, error) {
 	if err != nil || !exists {
 		return false, err
 	}
-	actualLabel, args, err := launchdServiceIdentity(data)
-	if err != nil {
-		return false, fmt.Errorf("parse LaunchAgent %q: %w", path, err)
-	}
-	if actualLabel != label || !isRampartServeArguments(args) {
-		return false, fmt.Errorf("refusing to remove unrecognized LaunchAgent at %q", path)
+	if err := validateManagedLaunchdService(data, path, label); err != nil {
+		return false, err
 	}
 	return true, nil
+}
+
+func validateManagedLaunchdService(data []byte, path, label string) error {
+	actualLabel, args, err := launchdServiceIdentity(data)
+	if err != nil {
+		return fmt.Errorf("parse LaunchAgent %q: %w", path, err)
+	}
+	if actualLabel != label || !isRampartServeArguments(args) {
+		return fmt.Errorf("refusing to manage unrecognized LaunchAgent at %q", path)
+	}
+	return nil
 }
 
 func launchdServiceIdentity(data []byte) (label string, programArguments []string, err error) {
@@ -381,6 +388,13 @@ func managedSystemdServiceFile(path string) (bool, error) {
 	if err != nil || !exists {
 		return false, err
 	}
+	if err := validateManagedSystemdService(data, path); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func validateManagedSystemdService(data []byte, path string) error {
 	var execStarts []string
 	for _, line := range strings.Split(string(data), "\n") {
 		line = strings.TrimSpace(line)
@@ -389,13 +403,13 @@ func managedSystemdServiceFile(path string) (bool, error) {
 		}
 	}
 	if len(execStarts) != 1 {
-		return false, fmt.Errorf("refusing to remove systemd service with %d ExecStart directives at %q", len(execStarts), path)
+		return fmt.Errorf("refusing to manage systemd service with %d ExecStart directives at %q", len(execStarts), path)
 	}
 	binary, args, ok := splitServiceCommand(execStarts[0])
 	if !ok || !isRampartServeArguments(append([]string{binary}, args...)) {
-		return false, fmt.Errorf("refusing to remove unrecognized systemd service at %q", path)
+		return fmt.Errorf("refusing to manage unrecognized systemd service at %q", path)
 	}
-	return true, nil
+	return nil
 }
 
 func splitServiceCommand(command string) (binary string, args []string, ok bool) {
@@ -449,7 +463,7 @@ func readRegularServiceFile(path string) ([]byte, bool, error) {
 		return nil, false, fmt.Errorf("inspect service file %q: %w", path, err)
 	}
 	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
-		return nil, false, fmt.Errorf("refusing to remove non-regular service file at %q", path)
+		return nil, false, fmt.Errorf("refusing to manage non-regular or symlinked service file at %q", path)
 	}
 	if info.Size() > maxServiceStateFileBytes {
 		return nil, false, fmt.Errorf("refusing to read service file larger than %d bytes at %q", maxServiceStateFileBytes, path)
@@ -459,6 +473,20 @@ func readRegularServiceFile(path string) ([]byte, bool, error) {
 		return nil, false, fmt.Errorf("read service file %q: %w", path, err)
 	}
 	return data, true, nil
+}
+
+func requireUnchangedServiceFile(path string, existed bool, before []byte) error {
+	current, exists, err := readRegularServiceFile(path)
+	if err != nil {
+		return err
+	}
+	if exists != existed {
+		return fmt.Errorf("service definition existence changed")
+	}
+	if exists && !bytes.Equal(current, before) {
+		return fmt.Errorf("service definition changed")
+	}
+	return nil
 }
 
 // removeFromWindowsPath removes ~/.rampart/bin from the user PATH on Windows.


### PR DESCRIPTION
## Summary

- refuse to overwrite or remove unowned, symlinked, non-regular, oversized, or concurrently changed launchd/systemd service definitions
- preserve secure upgrade behavior by repairing owner-only permissions on recognized managed definitions and token state before an early "already installed" return
- retain transactional service/token rollback behavior and leave unrelated service definitions untouched

## Security properties

- ownership is proven before Rampart changes file permissions or service state
- managed service definitions and tokens are repaired to owner-only access
- unowned definitions trigger no lifecycle commands or mutations
- a changed definition is rejected immediately before replacement or removal

## Validation

- full private maintainer local gate on the exact branch head
- repeated focused lifecycle regressions and affected race tests
- Linux, macOS, Windows, packaging, container, and SDK coverage through GitHub CI

This branch temporarily includes PR #392 so CI evaluates it with Go 1.25.13. After #392 merges, only the focused lifecycle diff remains against `staging`.

No private lab material, host details, credentials, or dated validation evidence are included.
