### PR TITLE
build: update Go to 1.25.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # requested image platform so linux/arm64 releases don't depend on slow QEMU
 # emulation for the Go build itself.
 ARG BUILDPLATFORM
-FROM --platform=$BUILDPLATFORM golang:1.25.12-bookworm AS build
+FROM --platform=$BUILDPLATFORM golang:1.25.13-bookworm AS build
 WORKDIR /src
 
 ARG TARGETOS

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **A firewall for AI coding agents.**
 
-[![Go](https://img.shields.io/badge/Go-1.25.12+-00ADD8?style=flat&logo=go)](https://go.dev)
+[![Go](https://img.shields.io/badge/Go-1.25.13+-00ADD8?style=flat&logo=go)](https://go.dev)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![CI](https://github.com/peg/rampart/actions/workflows/ci.yml/badge.svg)](https://github.com/peg/rampart/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/peg/rampart?style=flat)](https://github.com/peg/rampart/releases)
@@ -33,7 +33,7 @@ brew install peg/tap/rampart
 # One-line install (no sudo required)
 curl -fsSL https://rampart.sh/install | bash
 
-# Go install (requires Go 1.25.12+)
+# Go install (requires Go 1.25.13+)
 go install github.com/peg/rampart/cmd/rampart@latest
 ```
 
@@ -823,7 +823,7 @@ go build -o rampart ./cmd/rampart
 go test ./...
 ```
 
-Requires Go 1.25.12+.
+Requires Go 1.25.13+.
 
 ---
 

--- a/docs-site/contributing.md
+++ b/docs-site/contributing.md
@@ -15,7 +15,7 @@ cd rampart
 go test ./...
 ```
 
-Requires Go 1.25.12+.
+Requires Go 1.25.13+.
 
 ## Workflow
 

--- a/docs-site/getting-started/installation.md
+++ b/docs-site/getting-started/installation.md
@@ -58,7 +58,7 @@ This installs the `rampart` binary.
 
 ## Go Install
 
-Requires Go 1.25.12+:
+Requires Go 1.25.13+:
 
 ```bash
 go install github.com/peg/rampart/cmd/rampart@latest

--- a/docs-site/getting-started/tutorial.md
+++ b/docs-site/getting-started/tutorial.md
@@ -18,7 +18,7 @@ Let's set it up.
 ## Prerequisites
 
 - **macOS or Linux** (Windows WSL works too)
-- **Go 1.25.12+** (recommended) or the install script for a no-Go option
+- **Go 1.25.13+** (recommended) or the install script for a no-Go option
 - **Claude Code, Codex, or Cline** — this guide uses Claude Code, but Rampart works with [many agents](../integrations/index.md)
 
 ---

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/peg/rampart
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/charmbracelet/bubbletea v1.3.10


### PR DESCRIPTION
## Summary

- update the coordinated Go release-build pin from 1.25.12 to 1.25.13
- keep `go.mod` and the Docker build image aligned
- update current source-build requirements in the README and documentation

## Why

Linux CI reported seven reachable standard-library vulnerabilities in Go 1.25.12. The official Go release history identifies 1.25.13 as the security release containing the relevant fixes.

## Validation

- full private maintainer local gate on the exact branch head
- full Go test suite, vet, and security assurance
- toolchain synchronization check
- the same `govulncheck ./...` scan used by Linux CI passes locally
- documentation no longer advertises the incompatible 1.25.12 minimum

This remains a focused toolchain and build-requirement patch.
