### PR TITLE
docs: finalize Rampart 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,67 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-08-14
+
+### Security
+
+- **Approval authority is bound to the requesting credential** — Evaluation
+  routes require the `eval` scope, pending requests and replay grants retain
+  token ownership across restarts, and older Rampart releases cannot consume
+  the new scoped state after a rollback.
+- **MCP correlation fails closed without changing monitor transparency** —
+  Canonical JSON-RPC identities, case-shadowed security arguments, cross-kind
+  collisions, unsolicited responses, replays, and response-before-forward
+  races are handled explicitly while monitor mode preserves raw traffic.
+- **Destructive command matching is operand-aware and bounded** — Restrictive
+  `rm` and `find` rules retain quoting and redirection meaning, evaluate each
+  target independently, recognize supported wrappers and traversal forms, and
+  cap ambiguous expansion work.
+- **Managed services preserve ownership and private state** — Install and
+  removal refuse unowned service definitions while existing Rampart-managed
+  definitions and tokens have private permissions repaired safely.
+- **OpenClaw bridge modes keep their authority boundaries** — Monitor mode no
+  longer consumes approval state or persists allow-always rules, and enforce
+  mode leaves host approval pending when required audit delivery fails.
+
+### Added
+
+- **Hermes can use its native approval flow** — Compatible Hermes installations
+  pause and resume the same tool call for `ask` decisions using an opaque,
+  action-bound identity; older or incomplete runtimes fail closed. The
+  integration remains experimental pending authenticated live-host proof.
+- **Diagnostics use the same canonical action shapes as enforcement** —
+  `rampart test --tool` and `policy explain` now populate command, path, URL,
+  domain, and parameter fields consistently with live requests.
+
 ### Changed
 
+- **Managed onboarding shares one protection lifecycle** — `protect` and the
+  compatibility `quickstart` path now share policy, service, integration, and
+  verification orchestration instead of maintaining duplicate flows.
 - **The bare interactive setup wizard is deprecated** — It remains functional
   throughout Rampart 1.x for compatibility, including `--force`, but managed
   onboarding now leads with `rampart protect`. Integration-specific
   `rampart setup <agent>` commands remain supported for advanced operations;
   removal of the bare wizard is planned for 2.0.
+- **Unsafe MCP policy generation is retired** — `rampart mcp scan` remains as a
+  non-executing compatibility stub that directs users to the reviewable static
+  MCP profile instead of trusting server-supplied discovery output.
+- **Contributor and CI paths are leaner** — Draft pull requests receive a fast
+  feedback lane, protected branches retain the full platform matrix, source
+  builds use Go 1.25.13, and contributor guidance focuses on durable public
+  work rather than private maintenance ceremony.
+- **The public site presents Rampart's authority boundary directly** — The
+  landing page and supporting copy now lead with visible policy, approval, and
+  audit control without overstating sandbox or integration guarantees.
+
+### Fixed
+
+- **Integration state is inspected through one registry** — Status,
+  verification targeting, assurance reporting, and detection no longer rely on
+  separate hand-maintained integration lists.
+- **Interactive setup failures return failure** — The compatibility wizard no
+  longer reports success after an integration setup error.
 
 ## [1.6.2] - 2026-08-11
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Experimental integrations are explicit opt-ins and stay outside bare
 `rampart protect` auto-detection:
 
 ```bash
-# Hermes Agent (experimental; native approval on current Hermes)
+# Hermes Agent (experimental; native approval on compatible Hermes)
 rampart setup hermes
 
 # Gemini CLI (experimental enterprise/API-key path; no authenticated host proof)
@@ -354,7 +354,7 @@ rampart setup hermes
 hermes plugins enable rampart
 ```
 
-The plugin registers a Hermes `pre_tool_call` hook and sends sanitized tool metadata to Rampart before execution. It defaults to `/v1/preflight/{tool}` with execution intent, so one-time grants and call counters are enforced without creating a second Rampart approval queue. On current Hermes releases, `ask` decisions use Hermes' native approval flow to pause and resume the same tool call. Older Hermes releases block with an upgrade message. Service outages deny every Hermes tool by default.
+The plugin registers a Hermes `pre_tool_call` hook and sends sanitized tool metadata to Rampart before execution. It defaults to `/v1/preflight/{tool}` with execution intent, so one-time grants and call counters are enforced without creating a second Rampart approval queue. When Hermes exposes its packaged plugin approval directive, `ask` decisions use Hermes' native approval flow to pause and resume the same tool call. Older or incomplete installations block with upgrade guidance. Service outages deny every Hermes tool by default.
 
 Hermes currently has a static installation check rather than a safe built-in
 host verifier. Use `rampart doctor` for local status, then the isolated Hermes
@@ -731,7 +731,7 @@ rampart verify copilot                       # Verify dual-host deny response + 
 # Experimental, explicit opt-in integrations
 rampart setup gemini                         # Enterprise/API-key Gemini CLI; no authenticated host proof
 rampart verify gemini                        # Verify generated hooks + adapter response
-rampart setup hermes                         # Experimental Hermes plugin; current Hermes uses native approval
+rampart setup hermes                         # Experimental Hermes plugin; compatible hosts use native approval
 rampart setup <agent> --remove               # Clean uninstall
 
 # Run

--- a/assurance/integrations.yaml
+++ b/assurance/integrations.yaml
@@ -1,6 +1,6 @@
 schema_version: rampart.assurance.v2
-baseline_release: v1.6.2
-reviewed_at: "2026-08-11"
+baseline_release: v1.7.0
+reviewed_at: "2026-08-14"
 
 # Version 2 uses the canonical Rampart command target as each integration id
 # and requires an explicit declaration of bare `rampart protect` eligibility.
@@ -228,10 +228,11 @@ integrations:
         proves: Tool normalization, redaction, allow, deny, native ask approval identity, malformed responses, unknown-tool fail-closed behavior, adapter exceptions, and service failure are tested.
       - path: scripts/compat-hermes-latest.py
         kind: upstream_latest
-        proves: Hermes' official latest stable GitHub release is resolved independently of PyPI, then discovery, native approval allow/deny resolution, dispatcher decisions, degraded mode, and multi-path deny-wins behavior are checked in isolation.
+        proves: Hermes' official latest stable GitHub release is resolved independently of PyPI and must pass packaged discovery, native approval allow/deny resolution, dispatcher decisions, degraded mode, and multi-path deny-wins behavior in isolation.
     limitations:
       - Hermes documents that a crashing plugin callback is skipped and the agent continues.
       - Native approval/resume requires a Hermes release that exposes the plugin approval directive; older releases block `ask` decisions with an upgrade message.
+      - A release that cannot load Hermes' packaged plugin manager fails the rolling compatibility gate and is not inferred compatible from its source tree.
       - Operators may explicitly weaken degraded behavior by configuring selected tools to fail open; the default denies every tool.
       - Hermes tools outside the plugin's typed map, including MCP and delegated-agent tools, fail closed but are not claimed as covered policy surfaces.
       - Delegated-agent and authenticated live-host E2E are not present.

--- a/cmd/rampart/cli/doctor.go
+++ b/cmd/rampart/cli/doctor.go
@@ -2105,7 +2105,7 @@ func doctorHermesIntegration(emit emitFn, serveURL, token string) (warnings int)
 			"Set endpoint_mode: preflight")
 		warnings++
 	} else {
-		emit("Hermes policy mode", "ok", "preflight mode; current Hermes releases use native approval for ask decisions, while older releases fail closed")
+		emit("Hermes policy mode", "ok", "preflight mode; compatible Hermes installations use native approval for ask decisions, while older or incomplete installs fail closed")
 	}
 
 	failOpenTools := hermesFailOpenTools(pluginConfig)
@@ -2135,7 +2135,7 @@ func doctorHermesIntegration(emit emitFn, serveURL, token string) (warnings int)
 		}
 	}
 
-	emit("Hermes support tier", "info", "experimental policy gate; native approval requires a current Hermes release, and authenticated live-host E2E remains unverified")
+	emit("Hermes support tier", "info", "experimental policy gate; native approval requires a compatible Hermes installation, and authenticated live-host E2E remains unverified")
 	return warnings
 }
 

--- a/cmd/rampart/cli/doctor_test.go
+++ b/cmd/rampart/cli/doctor_test.go
@@ -1004,7 +1004,7 @@ func TestDoctorHermesIntegrationReportsReadyExperimentalGate(t *testing.T) {
 	if !strings.Contains(out, "experimental policy gate configured") {
 		t.Fatalf("expected Hermes readiness message, got: %s", out)
 	}
-	if !strings.Contains(out, "native approval requires a current Hermes release") {
+	if !strings.Contains(out, "native approval requires a compatible Hermes installation") {
 		t.Fatalf("expected support-tier boundary, got: %s", out)
 	}
 }

--- a/cmd/rampart/cli/setup.go
+++ b/cmd/rampart/cli/setup.go
@@ -159,7 +159,7 @@ patching Hermes itself.
 
 The plugin uses Hermes' pre_tool_call hook, calls Rampart's policy API before
 sensitive tool calls execute, defaults to /v1/preflight/{tool}, routes ask
-responses through current Hermes releases' native approval/resume flow instead
+responses through compatible Hermes installations' native approval/resume flow instead
 of creating hidden approvals, and fails closed for every tool when Rampart serve
 is unavailable unless an operator explicitly opts a tool out. Older Hermes
 releases that lack the required approval contract block ask decisions.

--- a/docs-site/getting-started/support-matrix.md
+++ b/docs-site/getting-started/support-matrix.md
@@ -104,7 +104,7 @@ and the isolated latest-Hermes compatibility check for runtime evidence.
       <td data-label="Best path">Experimental user plugin<br><code>rampart setup hermes</code></td>
       <td data-label="Bare protect">No</td>
       <td data-label="rampart serve">Required</td>
-      <td data-label="Approval UX">Current Hermes native approval; older releases block <code>ask</code></td>
+      <td data-label="Approval UX">Compatible Hermes native approval; older or incomplete installs block <code>ask</code></td>
       <td data-label="Support tier"><strong>Experimental</strong><br>latest-runtime compatibility; authenticated live-host proof pending</td>
     </tr>
     <tr class="tier-supported">

--- a/docs-site/getting-started/support-matrix.md
+++ b/docs-site/getting-started/support-matrix.md
@@ -105,7 +105,7 @@ and the isolated latest-Hermes compatibility check for runtime evidence.
       <td data-label="Bare protect">No</td>
       <td data-label="rampart serve">Required</td>
       <td data-label="Approval UX">Compatible Hermes native approval; older or incomplete installs block <code>ask</code></td>
-      <td data-label="Support tier"><strong>Experimental</strong><br>latest-runtime compatibility; authenticated live-host proof pending</td>
+      <td data-label="Support tier"><strong>Experimental</strong><br>credential-free package/runtime gate; authenticated live-host proof pending</td>
     </tr>
     <tr class="tier-supported">
       <td data-label="Surface"><strong>OpenClaw 2026.4.29 - 2026.5.1</strong></td>

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -233,10 +233,10 @@ verify -> outcomes.approval
 
 ## Current release
 
-Rampart v1.6.2 hardens audit secrecy, compound-command and self-protection
-enforcement, and MCP/HTTP protocol boundaries. It also corrects plugin
-freshness and Hermes status reporting while grounding public support claims in
-reproducible, credential-free evidence. See the
+Rampart v1.7.0 binds approvals to their requesting identity, hardens MCP and
+compound-command enforcement, unifies managed protection, and adds native
+Hermes approval support for compatible installations. It also reduces the
+repository and CI maintenance footprint while refreshing the public site. See the
 [release notes](https://github.com/peg/rampart/releases/latest) for the concise
 upgrade summary or the repository
 [changelog](https://github.com/peg/rampart/blob/main/CHANGELOG.md) for history.

--- a/docs-site/integrations/hermes.md
+++ b/docs-site/integrations/hermes.md
@@ -8,7 +8,7 @@ description: "Experimental Rampart integration for Hermes Agent using a user plu
 Rampart can protect Hermes Agent through an **experimental user plugin**. The plugin registers a Hermes `pre_tool_call` hook, sends a sanitized policy check to Rampart before selected tools execute, passes Hermes' top-level `tool_call_id` for audit correlation, and blocks the tool call when policy denies it.
 
 !!! warning "Experimental integration"
-    This integration is intentionally conservative. It does not patch Hermes or create a hidden Rampart approval queue. Current Hermes releases own the `ask` prompt and resume the same tool call; older releases fail closed with an upgrade message. It remains experimental because authenticated live-host proof and full host-failure behavior are not yet established.
+    This integration is intentionally conservative. It does not patch Hermes or create a hidden Rampart approval queue. Compatible Hermes installations own the `ask` prompt and resume the same tool call; older or incomplete installations fail closed with upgrade guidance. It remains experimental because authenticated live-host proof and full host-failure behavior are not yet established.
 
 ## What it covers
 
@@ -91,10 +91,10 @@ plugins:
 | --- | --- |
 | `allow`, `watch`, `log` | Tool call continues. |
 | `deny` | Tool call is blocked with the policy reason. |
-| `ask` | Current Hermes releases show Hermes' native approval and resume the same tool call when approved. Older releases block with an upgrade message. No hidden Rampart approval is created. When Rampart returns an `audit_id`, the prompt message includes it for correlation. |
+| `ask` | Compatible Hermes installations show Hermes' native approval and resume the same tool call when approved. Older or incomplete installations block with upgrade guidance. No hidden Rampart approval is created. When Rampart returns an `audit_id`, the prompt message includes it for correlation. |
 | Rampart unavailable | Every tool fails closed by default. Advanced operators can explicitly configure selected tools to fail open. |
 
-The default endpoint mode is `preflight`, which calls `POST /v1/preflight/{tool}` with `enforce: true`. This consumes one-time grants and records call-count state at Hermes' actual pre-execution boundary without creating pending Rampart approvals. A current Hermes host owns the approval UI and resumes the same call after approval. Rampart records the evaluation audit ID, and the plugin sends Hermes' top-level `tool_call_id` when Hermes provides one.
+The default endpoint mode is `preflight`, which calls `POST /v1/preflight/{tool}` with `enforce: true`. This consumes one-time grants and records call-count state at Hermes' actual pre-execution boundary without creating pending Rampart approvals. A compatible Hermes host owns the approval UI and resumes the same call after approval. Rampart records the evaluation audit ID, and the plugin sends Hermes' top-level `tool_call_id` when Hermes provides one.
 
 For session or `always` choices, the plugin supplies Hermes an opaque, token-keyed
 identity of both the original call and its resolved policy paths. This prevents
@@ -137,8 +137,9 @@ The harness creates a temporary Hermes state, installs the Rampart plugin there,
 By default it resolves Hermes' official latest stable GitHub release and uses
 an isolated editable checkout of that exact tag, the development install path
 Hermes permits. `--package` is an explicit maintainer override; it is not the
-definition of the latest supported Hermes release. The check does not use
-provider credentials or invoke a model.
+definition of the latest supported Hermes release. Package discovery failures
+fail the gate rather than treating a source-tree import as compatibility. The
+check does not use provider credentials or invoke a model.
 
 !!! warning "Why this remains experimental"
     Hermes currently documents that a plugin callback which fails outside

--- a/docs-site/integrations/index.md
+++ b/docs-site/integrations/index.md
@@ -42,7 +42,7 @@ When a policy action is `ask`, behavior varies by integration:
 | **Cline** | Hook returns `{"cancel":true}` with approval message (no native ask) |
 | **MCP (Claude Desktop/Cursor)** | Proxy blocks, returns JSON-RPC error on deny |
 | **OpenClaw** | OpenClaw owns the visible approval UI; Rampart plugin supplies policy decisions |
-| **Hermes Agent** | Current Hermes releases own the native approval prompt and resume the same call; older releases block with upgrade guidance |
+| **Hermes Agent** | Compatible Hermes installations own the native approval prompt and resume the same call; older or incomplete installs block with upgrade guidance |
 | **Shell Wrapper** | Shim blocks, command appears "hung" until resolved |
 | **LD_PRELOAD** | Library blocks exec call, process appears "hung" |
 | **HTTP API** | Returns `"decision":"ask"` with approval metadata when interactive review is required |

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -1,6 +1,6 @@
 # Threat Model
 
-> Last reviewed: 2026-08-11 | Applies to: v1.6.2+
+> Last reviewed: 2026-08-14 | Applies to: v1.7.0+
 
 Rampart is a policy engine for AI agents — not a sandbox, not a hypervisor, not a full isolation boundary. This document describes what Rampart protects against, what it doesn't, and why.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -28,7 +28,7 @@
       "url": "https://rampart.sh",
       "applicationCategory": "SecurityApplication",
       "operatingSystem": "Linux, macOS, Windows",
-      "softwareVersion": "1.6.2",
+      "softwareVersion": "1.7.0",
       "license": "https://opensource.org/licenses/Apache-2.0",
       "codeRepository": "https://github.com/peg/rampart"
     }
@@ -974,7 +974,7 @@
     <section class="hero" aria-labelledby="hero-title">
         <div class="hero-grid">
             <div class="hero-copy">
-                <p class="eyebrow">v1.6.2 · Open-source control for AI agents</p>
+                <p class="eyebrow">v1.7.0 · Open-source control for AI agents</p>
                 <h1 id="hero-title">
                     <span class="first-line">Let agents move fast.</span>
                     <span class="final-line">Keep the final say.</span>

--- a/internal/plugin/hermes/__init__.py
+++ b/internal/plugin/hermes/__init__.py
@@ -10,7 +10,7 @@ The plugin is intentionally conservative:
   hidden approval queue alongside Hermes' native approval UI.
 * It passes Hermes' native ``tool_call_id`` as top-level Rampart metadata so
   Rampart audit IDs can be correlated with the exact Hermes tool call.
-* On current Hermes releases, ``ask`` / ``require_approval`` decisions return
+* On compatible Hermes installations, ``ask`` / ``require_approval`` decisions return
   Hermes' native ``approve`` directive so the host pauses and resumes the exact
   tool call. Older hosts that lack that directive fail closed with an upgrade
   message instead of silently executing the call.


### PR DESCRIPTION
## Summary

- publish the complete Rampart 1.7.0 changelog and release metadata
- align the assurance baseline, threat model, docs landing page, and website version
- qualify Hermes native approval support by the packaged runtime capability instead of assuming every new upstream tag is compatible

No product behavior or private test material is added.

## Validation

- full local Rampart maintainer gate
- Hermes adapter unit suite
- canonical documentation wrapper check
- diff and public-boundary review
