### PR TITLE
fix: make future run approval explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Bulk approval no longer grants hidden future authority** — Dashboard and
+  API pending-scope actions resolve only the exact approval IDs the operator
+  reviewed. API callers must name that scope explicitly. Future calls require
+  a separate, time-bounded run grant bound to one credential owner and the
+  disclosed agent/session/run identity (default: 2 minutes). Run grants require
+  every approval already pending for that owner at validation; calls arriving
+  after that snapshot are reported separately as race-covered IDs. A raced
+  denial, expiry, deletion, or external approval aborts future authority.
+- **Run-approval audit fields now separate intent from publication** — Audit
+  consumers should migrate from the deprecated `request.auto_approve` and
+  `request.auto_approve_ttl_seconds` aliases to `approval_scope`,
+  `future_calls_requested`, `run_approval_publication_authorized`, and
+  millisecond TTL/expiry fields. The aliases remain in `rampart.audit.v1` for
+  1.x compatibility. Only a successful API response reports
+  `future_calls_authorized: true`.
+- **Approval state has one live service owner** — A second `rampart serve`
+  process using the same Rampart data directory now fails at startup, even on
+  a different port. This prevents independent in-memory run grants from
+  disagreeing with shared durable approval state.
+
 ## [1.7.0] - 2026-08-14
 
 ### Security

--- a/cmd/rampart/cli/serve.go
+++ b/cmd/rampart/cli/serve.go
@@ -240,6 +240,19 @@ func newServeCmd(opts *rootOptions, deps *serveDeps) *cobra.Command {
 			if listenAddr != "" && net.ParseIP(listenAddr) == nil {
 				return fmt.Errorf("serve: invalid --addr %q (must be a valid IP address, e.g. 127.0.0.1 or ::1)", listenAddr)
 			}
+			if port > 0 && rampartDir != "" {
+				if err := os.MkdirAll(rampartDir, 0o700); err != nil {
+					return fmt.Errorf("serve: create approval-state directory: %w", err)
+				}
+				instanceLock, lockErr := filetxn.AcquireLock(rampartDir)
+				if lockErr != nil {
+					if errors.Is(lockErr, filetxn.ErrLockHeld) {
+						return fmt.Errorf("serve: another Rampart serve process already owns approval state in %s", rampartDir)
+					}
+					return fmt.Errorf("serve: acquire approval-state ownership: %w", lockErr)
+				}
+				defer func() { _ = instanceLock.Close() }()
+			}
 
 			// Validate TLS flags.
 			if (tlsCert == "") != (tlsKey == "") {

--- a/cmd/rampart/cli/serve_test.go
+++ b/cmd/rampart/cli/serve_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/fsnotify/fsnotify"
 	"github.com/peg/rampart/internal/engine"
 	"github.com/peg/rampart/policies"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNotifyRequiresSignedApprovalLinks(t *testing.T) {
@@ -70,6 +71,83 @@ policies: []
 	}
 	if !loaderCalled {
 		t.Fatal("serve did not attempt to load the approval signing key")
+	}
+}
+
+func TestServeRejectsSecondApprovalStateOwner(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+	configPath := filepath.Join(home, "rampart.yaml")
+	content, err := policies.FS.ReadFile("standard.yaml")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(configPath, content, 0o600))
+
+	freePort := func() int {
+		listener, listenErr := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, listenErr)
+		port := listener.Addr().(*net.TCPAddr).Port
+		require.NoError(t, listener.Close())
+		return port
+	}
+	firstPort, secondPort := freePort(), freePort()
+	for secondPort == firstPort {
+		secondPort = freePort()
+	}
+
+	signalCh := make(chan os.Signal, 1)
+	deps := &serveDeps{
+		notifyContext: func(parent context.Context, _ ...os.Signal) (context.Context, context.CancelFunc) {
+			ctx, cancel := context.WithCancel(parent)
+			go func() {
+				select {
+				case <-ctx.Done():
+				case <-signalCh:
+					cancel()
+				}
+			}()
+			return ctx, cancel
+		},
+	}
+
+	first := newServeCmd(&rootOptions{configPath: configPath}, deps)
+	first.SetOut(&bytes.Buffer{})
+	first.SetErr(&bytes.Buffer{})
+	first.SetContext(context.Background())
+	first.SetArgs([]string{"--addr", "127.0.0.1", "--port", fmt.Sprintf("%d", firstPort), "--audit-dir", filepath.Join(home, "audit")})
+	firstErr := make(chan error, 1)
+	go func() { firstErr <- first.Execute() }()
+
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		conn, dialErr := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", firstPort), 50*time.Millisecond)
+		if dialErr == nil {
+			_ = conn.Close()
+			break
+		}
+		select {
+		case serveErr := <-firstErr:
+			t.Fatalf("first serve exited before readiness: %v", serveErr)
+		default:
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("first serve did not become ready")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	second := newServeCmd(&rootOptions{configPath: configPath}, nil)
+	second.SetOut(&bytes.Buffer{})
+	second.SetErr(&bytes.Buffer{})
+	second.SetArgs([]string{"--addr", "127.0.0.1", "--port", fmt.Sprintf("%d", secondPort), "--audit-dir", filepath.Join(home, "audit")})
+	secondErr := second.Execute()
+	require.ErrorContains(t, secondErr, "another Rampart serve process already owns approval state")
+
+	signalCh <- os.Interrupt
+	select {
+	case serveErr := <-firstErr:
+		require.NoError(t, serveErr)
+	case <-time.After(3 * time.Second):
+		t.Fatal("first serve did not shut down")
 	}
 }
 

--- a/docs-site/features/agent-teams.md
+++ b/docs-site/features/agent-teams.md
@@ -5,7 +5,11 @@ description: "Rampart groups sub-agent approvals by shared run ID so you can sup
 
 # Agent Team Oversight
 
-When you run Claude Code with multiple sub-agents — or any orchestrator spawning parallel workers — every agent in the session shares the same **run ID**. Rampart groups their pending approvals together so you can review and approve the whole team in one click.
+When you run Claude Code with multiple sub-agents — or any orchestrator spawning
+parallel workers — every agent in the session shares the same **run ID**.
+Rampart groups their pending approvals so you can decide the current calls
+together and separately choose whether later calls receive a time-bounded
+grant.
 
 !!! info "Available since v0.4.0"
 
@@ -23,48 +27,64 @@ You don't configure anything. If you already use Rampart, agent team grouping ju
 
 ## Dashboard View
 
-When 2 or more pending approvals share a run ID, the dashboard's **Active** tab groups them into a cluster card:
+When 2 or more pending approvals share the same agent, session, run ID, and
+credential owner, the dashboard's **Active** tab groups them into a cluster
+card:
 
 ```
 ┌─────────────────────────────────────────────────────────┐
-│  Run: a1b2c3d4…  (3 pending)                ▼           │
+│  Run: a1b2c3d4…  credential-3fa87c…  (3 pending)    ▼   │
 ├─────────────────────────────────────────────────────────┤
 │  exec  kubectl apply -f deploy.yaml    claude-code      │
 │  exec  kubectl delete pod old-pod      claude-code      │
 │  exec  kubectl rollout restart app     claude-code      │
 ├─────────────────────────────────────────────────────────┤
-│              [✓ Approve All]  [✗ Deny All]              │
+│ [✓ Approve Pending] [Allow Future (2m)] [✗ Deny Pending]│
 └─────────────────────────────────────────────────────────┘
 ```
 
-**Approve All** resolves every pending approval in the same agent/session/run
-scope and caches that exact scope for the remainder of the approval timeout
-(default: 1 hour). A different agent or session that happens to reuse the run
-ID remains isolated.
+**Approve Pending** resolves only the calls that are pending now. Later calls
+from the same run still require approval.
 
-**Deny All** blocks all pending requests. The agents get a denial response and can try a different approach.
+**Allow Future** is a separate, explicit grant. It approves the pending calls
+and authorizes later calls from the exact same agent/session/run and credential
+owner for the duration shown on the button (default: 2 minutes). Calls that
+are already pending for that owner must all appear in the reviewed request.
+The window begins at Rampart's validation snapshot; resolving raced calls does
+not restart or extend it.
+Calls that arrive after Rampart's validation snapshot while it closes the
+create-versus-grant race are covered by that future authority and reported
+separately from the reviewed IDs. If one of those calls is denied, expires, is
+deleted, or is approved by another resolver first, Rampart aborts the future
+grant and requires a refresh rather than overriding the intervening decision.
+
+**Deny Pending** blocks only the currently pending requests. The agents get a
+denial response and can try a different approach.
 
 Solo approvals (no run ID, or unique run ID) render exactly as before — no UI change for single-agent users.
 
 ---
 
-## Auto-Approve Cache
+## Explicit Run Grants
 
-After you click **Approve All**, Rampart caches the complete agent, session, and
-run identity. New tool calls in that exact scope are allowed immediately — the
-agent doesn't wait and no approval card is created.
+After you confirm **Allow Future**, Rampart caches the complete agent, session,
+run, and credential-owner identity. New tool calls in that exact scope are
+allowed immediately — the agent doesn't wait and no approval card is created.
 
-The cache expires after the configured `--approval-timeout` (default 1 hour). After expiry, the next call from that run will queue for approval again.
+The grant expires after the configured `--approval-timeout` (default: 2
+minutes). The confirmation names the exact scope and duration before authority
+is granted. This window begins when Rampart validates the reviewed snapshot,
+not when the last raced call settles. After expiry, the next call from that run
+queues for approval again.
 
-To disable the cache for a specific run, use the API directly:
+Run grants currently expire by timeout or when the server restarts; the bulk
+endpoint does not yet revoke a live grant early. A `deny` request affects
+pending calls only.
 
-```bash
-# Deny a run, preventing future auto-approvals
-curl -X POST http://localhost:9090/v1/approvals/bulk-resolve \
-  -H "Authorization: Bearer $RAMPART_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"agent":"YOUR_AGENT","session":"YOUR_SESSION","run_id":"YOUR_RUN_ID","action":"deny"}'
-```
+Only one live `rampart serve` process may own approval state in a Rampart data
+directory. A second process using the same directory fails at startup rather
+than creating an independent in-memory grant view. Use one service endpoint per
+data directory.
 
 ---
 
@@ -74,7 +94,7 @@ curl -X POST http://localhost:9090/v1/approvals/bulk-resolve \
 
 ```http
 POST /v1/approvals/bulk-resolve
-Authorization: Bearer <token>
+Authorization: Bearer <admin-scoped-token>
 Content-Type: application/json
 
 {
@@ -82,6 +102,8 @@ Content-Type: application/json
   "session": "repo/main",
   "run_id": "SESSION_ID_HERE",
   "action": "approve",
+  "scope": "pending",
+  "ids": ["01KHT3...", "01KHT4...", "01KHT5..."],
   "resolved_by": "dashboard"
 }
 ```
@@ -91,18 +113,35 @@ Response:
 ```json
 {
   "resolved": 3,
-  "ids": ["01KHT3...", "01KHT4...", "01KHT5..."]
+  "ids": ["01KHT3...", "01KHT4...", "01KHT5..."],
+  "reviewed_ids": ["01KHT3...", "01KHT4...", "01KHT5..."],
+  "race_covered_ids": [],
+  "scope": "pending",
+  "future_calls_authorized": false
 }
 ```
 
-`agent`, `session`, and `run_id` are required. Missing or empty scope fields
-return `400`; Rampart refuses to infer an authorization scope from a run ID.
+`agent`, `session`, and `run_id` are required. Missing or empty identity fields
+return `400`; Rampart refuses to infer an authorization identity from a run ID.
+`scope` and `ids` are also required. The IDs must be the exact pending
+approvals the operator reviewed. IDs already stale during initial validation
+return `409` before this request resolves a listed call. If another resolver or
+expiry races after validation, Rampart returns `503`; exact resolutions already
+committed are named in `ids`, unresolved reviewed calls are named in
+`unresolved_reviewed_ids`, and no future-call grant is published. A `503` also
+sets `refresh_required: true`; refresh and reconcile instead of replaying the
+same request blindly. Use `scope: "run"` only when you intend to grant future-call
+authority. All IDs in a run-scoped request must share one credential owner. A
+run-scoped request must also include every approval already pending for that
+owner at initial validation; omission returns `409` without resolving a listed
+call. A successful response then includes `future_calls_authorized: true`,
+`grant_ttl_ms`, and `grant_expires_at`.
 
 ### List approvals with run groups
 
 ```http
 GET /v1/approvals
-Authorization: Bearer <token>
+Authorization: Bearer <admin-scoped-token>
 ```
 
 Response includes both the flat `approvals` array and a `run_groups` array:
@@ -110,11 +149,13 @@ Response includes both the flat `approvals` array and a `run_groups` array:
 ```json
 {
   "approvals": [...],
+  "run_grant_ttl_ms": 120000,
   "run_groups": [
     {
       "agent": "claude-code",
       "session": "repo/main",
       "run_id": "abc123...",
+      "credential_owner": "credential-3fa87c921e10",
       "count": 3,
       "earliest_created_at": "2026-02-19T04:30:00Z",
       "items": [...]
@@ -124,7 +165,9 @@ Response includes both the flat `approvals` array and a `run_groups` array:
 ```
 
 `run_groups` only includes groups with 2+ pending items in the same exact
-agent/session/run scope, sorted by `earliest_created_at`.
+agent/session/run and credential-owner scope, sorted by
+`earliest_created_at`. The credential-owner value is an opaque, shortened
+store identifier; it is not a bearer credential.
 
 ---
 
@@ -159,6 +202,16 @@ Every audit event includes `run_id` when present:
   "decision": { "action": "approved" }
 }
 ```
+
+Each bulk-resolution audit event records `approval_scope`, the exact approval
+ID, and `future_calls_requested`. A separate
+`run_approval_publication_authorized` event is required immediately before a
+run grant can become observable and distinguishes reviewed IDs from any
+race-covered approvals, along with credential owner, millisecond TTL, and
+candidate expiry. It records authorization intent, not successful publication,
+so a sink failure cannot leave evidence that overclaims active authority. The
+API response's `future_calls_authorized` field confirms that Rampart published
+the future-call grant.
 
 This means you can trace the full activity of an agent team run across the entire audit log — filter by `run_id` to see everything that run touched.
 

--- a/docs-site/features/dashboard.md
+++ b/docs-site/features/dashboard.md
@@ -31,19 +31,26 @@ serve: full token: <generated-64-character-token>
 
 Enter this token in the dashboard's token field. It's stored in your browser's `localStorage` — never sent to any external service.
 
-### Admin Token vs. Per-Agent Tokens
+### Admin Scope vs. Eval Scope
 
-Rampart has two distinct token types:
+Rampart credentials carry explicit scopes:
 
-- **Admin token** — generated at startup, printed to stdout, and stored in `~/.rampart/token`. Full access to all dashboard APIs.
-- **Per-agent tokens** — created with `rampart token create <name>`. Scoped to specific policy profiles; useful for restricting what a particular agent can approve or query.
+- **Bootstrap admin token** — generated at startup, printed to stdout, and
+  stored in `~/.rampart/token`. It carries admin scope and can access all
+  dashboard APIs.
+- **Named tokens** — created with `rampart token create <name>`. They can carry
+  eval scope, admin scope, or both, plus optional policy profiles.
 
-Both token types can authenticate to the dashboard and the `/v1/approvals` API. The difference is scope: per-agent tokens may be restricted to a subset of policies (e.g., a `codex` token that can only operate within the `standard` profile). Use per-agent tokens when running multiple agents with different trust levels.
+Only a credential carrying admin scope can read or resolve dashboard
+approvals. Eval-only credentials are rejected by the approval and other admin
+APIs; they cannot turn an agent's own request into operator authorization.
 
 ## Features
 
 - **Pending approvals**: See all approval-gated decisions waiting for human input
-- **Approve / Deny**: Click to resolve approvals directly from the browser
+- **Approve / Deny**: Resolve only the exact pending approvals shown in the confirmation
+- **Explicit run grants**: Separately authorize future calls for the exact
+  agent/session/run and credential-owner scope for the duration shown in the confirmation
 - **History**: View past decisions with timestamps, agents, commands, and who resolved them
 - **Auto-refresh**: Dashboard polls for new approvals automatically
 
@@ -52,8 +59,9 @@ Both token types can authenticate to the dashboard and the `/v1/approvals` API. 
 | Component | Auth Required? | Notes |
 |-----------|---------------|-------|
 | Dashboard HTML/CSS/JS | No | Static files, no embedded secrets |
-| `GET /v1/approvals` | Yes (Bearer token) | Lists pending and resolved approvals |
-| `POST /v1/approvals/{id}/resolve` | Yes (Bearer OR signed URL) | Resolves a pending approval |
+| `GET /v1/approvals` | Yes (admin-scoped Bearer) | Lists pending approvals and safe run groupings |
+| `POST /v1/approvals/{id}/resolve` | Yes (admin-scoped Bearer or signed URL) | Resolves one pending approval |
+| `POST /v1/approvals/bulk-resolve` | Yes (admin-scoped Bearer) | Requires exact reviewed IDs and an explicit scope; `scope: "run"` grants future-call authority |
 
 **Signed URLs**: When webhooks fire for approval-gated decisions, the notification includes a self-authenticating signed URL. Recipients can approve/deny by clicking the link without needing the Bearer token.
 

--- a/docs-site/getting-started/tutorial.md
+++ b/docs-site/getting-started/tutorial.md
@@ -144,8 +144,10 @@ Approve it → Claude continues. Deny it → Claude gets an explanation and trie
 
 !!! tip "Working with an agent team?"
     Pending approvals are grouped only when the calls report the same agent,
-    session, and run ID. One click can then **Approve All** for that exact team
-    run without authorizing a colliding run ID from another agent or session.
+    session, run ID, and credential owner. **Approve Pending** affects only the
+    calls shown; **Allow Future** separately grants time-bounded authority for
+    that exact team run without authorizing a colliding run ID or another
+    credential.
 
 ---
 

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -32,7 +32,11 @@ Notes:
 - `GET /healthz` does not require authentication.
 - `POST /v1/tool/*` and `POST /v1/preflight/*` require either the local admin
   token or a per-agent token carrying `eval` scope.
-- `GET /v1/events/stream` accepts either bearer auth or `?token=<token>` query parameter.
+- Approval, rule, audit, policy/status/test, SSE, and metrics endpoints require
+  a credential carrying `admin` scope. A valid eval-only credential receives
+  `403 Forbidden`.
+- `GET /v1/events/stream` accepts an admin-scoped bearer credential either in
+  the header or as a `?token=<token>` query parameter.
 - `POST /v1/approvals/{id}/resolve` may also be authorized by signed URL query params (`sig`, `exp`) when server-side signing is enabled.
 
 ## API Conventions
@@ -254,7 +258,8 @@ result is returned as an effective allow with the observed result in
 `policy_decision`.
 
 ### Request Headers
-- `Authorization: Bearer <token>`
+- `Authorization: Bearer <token>` (admin or an evaluation-scoped agent token;
+  agent tokens without `eval` scope are rejected)
 - `Content-Type: application/json`
 
 ### Request Body Schema
@@ -314,7 +319,7 @@ curl -X POST "http://127.0.0.1:9090/v1/preflight/exec" \
 Creates an external/manual approval request.
 
 ### Request Headers
-- `Authorization: Bearer <admin-token>` (admin scope required; agent evaluation tokens are rejected)
+- `Authorization: Bearer <admin-scoped-token>` (eval-only credentials are rejected)
 - `Content-Type: application/json`
 
 ### Request Body Schema
@@ -349,7 +354,7 @@ Created (`201`):
 }
 ```
 
-Auto-approved (`200`, when run is bulk-approved):
+Auto-approved (`200`, when an explicit owner-bound run grant is active):
 
 ```json
 {
@@ -362,9 +367,11 @@ Auto-approved (`200`, when run is bulk-approved):
 
 ### Status Codes
 - `201 Created` approval created
-- `200 OK` auto-approved by the exact agent/session/run cache
+- `200 OK` auto-approved by an active grant for the exact
+  agent/session/run/credential-owner scope
 - `400 Bad Request` invalid JSON
 - `401 Unauthorized`
+- `403 Forbidden` valid credential without admin scope
 - `503 Service Unavailable` approval queue full
 
 ### curl
@@ -377,18 +384,19 @@ curl -X POST "http://127.0.0.1:9090/v1/approvals" \
 
 ## GET /v1/approvals
 Lists pending approvals plus groups keyed by the complete
-`agent`/`session`/`run_id` scope. A caller-selected run ID is not assumed to be
-globally unique.
+`agent`/`session`/`run_id` and credential-owner scope. A caller-selected run ID
+is not assumed to be globally unique, and distinct credentials are never
+co-grouped for future authorization.
 
 ### Request Headers
-- `Authorization: Bearer <admin-token>` (admin scope required; agent evaluation tokens are rejected)
+- `Authorization: Bearer <admin-scoped-token>` (eval-only credentials are rejected)
 
 ### Response Body Schema
 
 ```json
 {
   "type": "object",
-  "required": ["approvals", "run_groups"],
+  "required": ["approvals", "run_groups", "run_grant_ttl_ms"],
   "properties": {
     "approvals": {
       "type": "array",
@@ -400,6 +408,7 @@ globally unique.
           "command": { "type": "string" },
           "agent": { "type": "string" },
           "session": { "type": "string" },
+          "credential_owner": { "type": "string" },
           "message": { "type": "string" },
           "status": { "type": "string" },
           "run_id": { "type": "string" },
@@ -416,11 +425,16 @@ globally unique.
           "agent": { "type": "string" },
           "session": { "type": "string" },
           "run_id": { "type": "string" },
+          "credential_owner": { "type": "string" },
           "count": { "type": "integer" },
           "earliest_created_at": { "type": "string", "format": "date-time" },
           "items": { "type": "array" }
         }
       }
+    },
+    "run_grant_ttl_ms": {
+      "type": "integer",
+      "description": "Configured lifetime in milliseconds for an explicit future-call run grant; positive sub-millisecond values round up"
     }
   }
 }
@@ -429,6 +443,7 @@ globally unique.
 ### Status Codes
 - `200 OK`
 - `401 Unauthorized`
+- `403 Forbidden` valid credential without admin scope
 
 ### curl
 ```bash
@@ -440,7 +455,7 @@ curl -H "Authorization: Bearer $TOKEN" \
 Returns one approval by ID.
 
 ### Request Headers
-- `Authorization: Bearer <admin-token>` (admin scope required; agent evaluation tokens are rejected)
+- `Authorization: Bearer <admin-scoped-token>` (eval-only credentials are rejected)
 
 ### Response Body Schema
 
@@ -467,6 +482,7 @@ Returns one approval by ID.
 ### Status Codes
 - `200 OK`
 - `401 Unauthorized`
+- `403 Forbidden` valid credential without admin scope
 - `404 Not Found`
 
 ### curl
@@ -490,7 +506,7 @@ Unsupported tool types return `400` and leave the approval pending so the
 operator can approve once or author an explicit policy.
 
 ### Request Headers
-- `Authorization: Bearer <admin-token>` (admin scope required), or a valid
+- `Authorization: Bearer <admin-scoped-token>`, or a valid
   server-generated `sig` + `exp` query pair scoped to this approval ID
 - `Content-Type: application/json`
 
@@ -530,6 +546,7 @@ Signed URLs may approve or deny this one request, but cannot use
 - `200 OK`
 - `400 Bad Request` invalid JSON
 - `401 Unauthorized` invalid token/signature
+- `403 Forbidden` valid bearer credential without admin scope
 - `404 Not Found` unknown approval ID
 - `410 Gone` approval already resolved (replay attempt)
 - `503 Service Unavailable` durable exact-replay state could not be committed;
@@ -545,11 +562,27 @@ curl -X POST "http://127.0.0.1:9090/v1/approvals/01J.../resolve" \
 
 ## POST /v1/approvals/bulk-resolve
 Bulk approves or denies pending approvals for one exact
-`agent`/`session`/`run_id` scope. An approved scope is cached for subsequent
-calls in that same scope only.
+`agent`/`session`/`run_id` identity. The caller must supply both an explicit
+scope and the exact pending approval IDs the operator reviewed. `pending`
+scope resolves only those IDs. `run` scope is valid only with `approve`; it
+also authorizes future calls in that exact identity and one credential-owner
+scope until the configured approval timeout expires. That authorization window
+starts at the initial validation snapshot and is never restarted while raced
+calls are resolved. A run-scoped request must
+include every approval already pending for that owner-bound scope at Rampart's
+initial validation snapshot. Calls that arrive after that snapshot while
+Rampart closes the create-versus-publication race are covered by the explicit
+future-call authority and reported separately from reviewed IDs. If a
+post-snapshot call is denied, expires, is deleted, or is approved by another
+resolver before publication, Rampart aborts the future grant instead of
+overriding that transition.
+
+The contract changed in 1.8: omitted `scope` or `ids` now returns `400` instead
+of inferring authority. Existing clients must send `"scope":"pending"` with
+reviewed IDs, or opt in to `"scope":"run"` for future-call authority.
 
 ### Request Headers
-- `Authorization: Bearer <admin-token>` (admin scope required; agent evaluation tokens are rejected)
+- `Authorization: Bearer <admin-scoped-token>` (eval-only credentials are rejected)
 - `Content-Type: application/json`
 
 ### Request Body Schema
@@ -557,12 +590,19 @@ calls in that same scope only.
 ```json
 {
   "type": "object",
-  "required": ["agent", "session", "run_id", "action"],
+  "required": ["agent", "session", "run_id", "action", "scope", "ids"],
   "properties": {
     "agent": { "type": "string" },
     "session": { "type": "string" },
     "run_id": { "type": "string" },
     "action": { "type": "string", "enum": ["approve", "deny"] },
+    "scope": { "type": "string", "enum": ["pending", "run"] },
+    "ids": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "type": "string", "minLength": 1 }
+    },
     "resolved_by": { "type": "string" }
   }
 }
@@ -573,32 +613,101 @@ calls in that same scope only.
 ```json
 {
   "type": "object",
-  "required": ["resolved", "ids"],
+  "required": ["resolved", "ids", "reviewed_ids", "race_covered_ids", "scope", "future_calls_authorized"],
   "properties": {
     "resolved": { "type": "integer" },
-    "ids": { "type": "array", "items": { "type": "string" } }
+    "ids": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Every approval this request committed, including any run-scope race-covered calls"
+    },
+    "reviewed_ids": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Normalized exact IDs supplied by the caller"
+    },
+    "race_covered_ids": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Run-scope calls that arrived after the initial validation snapshot while the future grant was being published; always empty for pending scope"
+    },
+    "scope": { "type": "string", "enum": ["pending", "run"] },
+    "future_calls_authorized": { "type": "boolean" },
+    "grant_ttl_ms": {
+      "type": "integer",
+      "description": "Configured authorization window beginning at the validation snapshot; present only when future_calls_authorized is true"
+    },
+    "grant_expires_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Present only when future_calls_authorized is true"
+    }
   }
 }
 ```
 
+A `503` response uses the same core fields and additionally includes
+`unresolved_reviewed_ids` and `refresh_required: true`. Its `ids` list is the
+authoritative set committed by this request before the failure. Do not replay
+the original body blindly: refresh, reconcile those IDs, and present any
+remaining calls for review again.
+
 ### Status Codes
 - `200 OK`
-- `400 Bad Request` missing/empty `agent`, `session`, or `run_id`, or invalid `action`
+- `400 Bad Request` missing/empty `agent`, `session`, or `run_id`; invalid
+  `action`, `scope`, or `ids`; mismatched or duplicate IDs; multiple credential
+  owners in run scope; or `scope:"run"` used with `deny`
 - `401 Unauthorized`
+- `403 Forbidden` valid credential without admin scope
+- `409 Conflict` one or more reviewed IDs were already not pending during
+  initial validation, or run scope omitted an approval already pending for the
+  selected credential owner; this request has not resolved a listed approval
+- `503 Service Unavailable` a required resolution or run-grant audit could not
+  be committed; a listed approval changed concurrently; or the owner-bound run
+  recorded a denial, expiry, deletion, or approval by another resolver after
+  validation. Exact per-ID resolutions already committed remain valid, but no
+  unaudited or conflicting future-call grant is published. Refresh and
+  reconcile the returned approval list before retrying.
+
+### Audit field migration in 1.8
+
+SIEM consumers of bulk-approval events should migrate from the action-specific
+`request.auto_approve` and `request.auto_approve_ttl_seconds` fields. They
+remain as deprecated aliases in `rampart.audit.v1`: `auto_approve` mirrors
+`future_calls_requested`, and the seconds TTL remains present for run scope.
+Resolution events now use `approval_scope`, `future_calls_requested`, and
+`grant_ttl_ms` as the authoritative fields.
+A separate `run_approval_publication_authorized` event records reviewed and
+race-covered IDs plus the candidate expiry without claiming successful
+publication. Only the successful bulk API response sets
+`future_calls_authorized: true`.
 
 ### curl
 ```bash
 curl -X POST "http://127.0.0.1:9090/v1/approvals/bulk-resolve" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"agent":"claude-code","session":"repo/main","run_id":"run_01J...","action":"approve","resolved_by":"api"}'
+  -d '{"agent":"claude-code","session":"repo/main","run_id":"run_01J...","action":"approve","scope":"pending","ids":["01KHT3...","01KHT4..."],"resolved_by":"api"}'
 ```
+
+To approve current and future calls for the disclosed timeout, opt in to run
+scope explicitly:
+
+```bash
+curl -X POST "http://127.0.0.1:9090/v1/approvals/bulk-resolve" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"agent":"claude-code","session":"repo/main","run_id":"run_01J...","action":"approve","scope":"run","ids":["01KHT3...","01KHT4..."],"resolved_by":"api"}'
+```
+
+Get the IDs and their `credential_owner` grouping from `GET /v1/approvals`
+immediately before presenting the decision to the operator.
 
 ## GET /v1/rules/auto-allowed
 Returns user auto-allow rules persisted in `~/.rampart/policies/auto-allowed.yaml`.
 
 ### Request Headers
-- `Authorization: Bearer <token>`
+- `Authorization: Bearer <admin-scoped-token>` (eval-only credentials are rejected)
 
 ### Response Body Schema
 
@@ -628,6 +737,7 @@ Returns user auto-allow rules persisted in `~/.rampart/policies/auto-allowed.yam
 ### Status Codes
 - `200 OK`
 - `401 Unauthorized`
+- `403 Forbidden` valid credential without admin scope
 - `500 Internal Server Error`
 
 ### curl
@@ -640,7 +750,7 @@ curl -H "Authorization: Bearer $TOKEN" \
 Writes a permanent, exact allow rule to `~/.rampart/policies/user-overrides.yaml`. Used by the OpenClaw plugin for "Always Allow" writeback. Rampart preserves the full approved command or file path and escapes literal glob metacharacters rather than generalizing it. Automatic persistence supports `exec`, `read`, `write`, and `edit`; use an explicit policy for tools whose complete input cannot yet be represented exactly. Rate-limited to ~5 writes/sec.
 
 ### Request Headers
-- `Authorization: Bearer <token>` (admin scope required)
+- `Authorization: Bearer <admin-scoped-token>` (eval-only credentials are rejected)
 - `Content-Type: application/json`
 
 ### Request Body Schema
@@ -676,6 +786,7 @@ Writes a permanent, exact allow rule to `~/.rampart/policies/user-overrides.yaml
 - `409 Conflict` — rule already exists (returns existing pattern)
 - `400 Bad Request` — invalid request body or decision value
 - `401 Unauthorized`
+- `403 Forbidden` valid credential without admin scope
 - `429 Too Many Requests` — rate limited
 
 ### curl
@@ -686,11 +797,12 @@ curl -X POST -H "Authorization: Bearer $TOKEN" \
   "http://127.0.0.1:9090/v1/rules/learn"
 ```
 
-## DELETE /v1/rules/auto-allowed/{index}
-Deletes one auto-allowed rule by index and reloads policy engine.
+## DELETE /v1/rules/auto-allowed/{name}
+Deletes one auto-allowed rule by its exact URL-encoded rule name and reloads
+the policy engine.
 
 ### Request Headers
-- `Authorization: Bearer <token>`
+- `Authorization: Bearer <admin-scoped-token>` (eval-only credentials are rejected)
 
 ### Response Body Schema
 
@@ -706,22 +818,23 @@ Deletes one auto-allowed rule by index and reloads policy engine.
 
 ### Status Codes
 - `200 OK`
-- `400 Bad Request` invalid index
+- `400 Bad Request` empty rule name
 - `401 Unauthorized`
-- `404 Not Found` file missing or index out of range
+- `403 Forbidden` valid credential without admin scope
+- `404 Not Found` file missing or rule name not found
 - `500 Internal Server Error`
 
 ### curl
 ```bash
 curl -X DELETE -H "Authorization: Bearer $TOKEN" \
-  "http://127.0.0.1:9090/v1/rules/auto-allowed/0"
+  "http://127.0.0.1:9090/v1/rules/auto-allowed/user-allow-a3f2b1c4"
 ```
 
 ## GET /v1/audit/events
 Queries audit events for a date, with filtering and pagination.
 
 ### Request Headers
-- `Authorization: Bearer <token>`
+- `Authorization: Bearer <admin-scoped-token>` (eval-only credentials are rejected)
 
 ### Query Parameters
 - `date` (`YYYY-MM-DD`, optional, default: current UTC date)
@@ -777,6 +890,7 @@ Queries audit events for a date, with filtering and pagination.
 - `200 OK`
 - `400 Bad Request` invalid date format
 - `401 Unauthorized`
+- `403 Forbidden` valid credential without admin scope
 - `503 Service Unavailable` audit directory not configured
 
 ### curl
@@ -789,7 +903,7 @@ curl -H "Authorization: Bearer $TOKEN" \
 Lists available audit dates.
 
 ### Request Headers
-- `Authorization: Bearer <token>`
+- `Authorization: Bearer <admin-scoped-token>` (eval-only credentials are rejected)
 
 ### Response Body Schema
 
@@ -807,6 +921,7 @@ Lists available audit dates.
 ### Status Codes
 - `200 OK`
 - `401 Unauthorized`
+- `403 Forbidden` valid credential without admin scope
 - `500 Internal Server Error`
 - `503 Service Unavailable` audit directory not configured
 
@@ -820,7 +935,7 @@ curl -H "Authorization: Bearer $TOKEN" \
 Downloads a day of audit logs as JSONL.
 
 ### Request Headers
-- `Authorization: Bearer <token>`
+- `Authorization: Bearer <admin-scoped-token>` (eval-only credentials are rejected)
 
 ### Query Parameters
 - `date` (required, `YYYY-MM-DD`)
@@ -833,6 +948,7 @@ Downloads a day of audit logs as JSONL.
 - `200 OK`
 - `400 Bad Request` missing/invalid `date`
 - `401 Unauthorized`
+- `403 Forbidden` valid credential without admin scope
 - `404 Not Found` no log for requested date
 - `503 Service Unavailable` audit directory not configured
 
@@ -847,7 +963,7 @@ curl -H "Authorization: Bearer $TOKEN" \
 Aggregated audit statistics for a date range.
 
 ### Request Headers
-- `Authorization: Bearer <token>`
+- `Authorization: Bearer <admin-scoped-token>` (eval-only credentials are rejected)
 
 ### Query Parameters
 - `from` (`YYYY-MM-DD`, optional, default current UTC date)
@@ -873,6 +989,7 @@ Aggregated audit statistics for a date range.
 - `200 OK`
 - `400 Bad Request` invalid dates or `to < from`
 - `401 Unauthorized`
+- `403 Forbidden` valid credential without admin scope
 - `503 Service Unavailable` audit directory not configured
 
 ### curl
@@ -888,8 +1005,8 @@ Note: the route is `/v1/events/stream` (not `/v1/events`).
 
 ### Authentication
 Either:
-- `Authorization: Bearer <token>` header, or
-- `?token=<token>` query parameter
+- `Authorization: Bearer <admin-scoped-token>` header, or
+- `?token=<admin-scoped-token>` query parameter
 
 ### Response Headers
 - `Content-Type: text/event-stream`
@@ -916,6 +1033,7 @@ Observed server-emitted event types:
 ### Status Codes
 - `200 OK` stream established
 - `401 Unauthorized`
+- `403 Forbidden` valid credential without admin scope
 - `500 Internal Server Error` streaming unsupported by writer
 
 ### curl
@@ -930,11 +1048,11 @@ Query-token variant:
 curl -N "http://127.0.0.1:9090/v1/events/stream?token=$TOKEN"
 ```
 
-## GET /v1/policy
-Alias of `/v1/status`. Returns active runtime policy/config summary.
+## GET /v1/status
+Returns current runtime status and active policy/config counts.
 
 ### Request Headers
-- `Authorization: Bearer <token>`
+- `Authorization: Bearer <admin-scoped-token>` (eval-only credentials are rejected)
 
 ### Response Body Schema
 
@@ -956,25 +1074,7 @@ Alias of `/v1/status`. Returns active runtime policy/config summary.
 ### Status Codes
 - `200 OK`
 - `401 Unauthorized`
-
-### curl
-```bash
-curl -H "Authorization: Bearer $TOKEN" \
-  "http://127.0.0.1:9090/v1/policy"
-```
-
-## GET /v1/status
-Returns current runtime status and policy counts.
-
-### Request Headers
-- `Authorization: Bearer <token>`
-
-### Response
-Same schema as `GET /v1/policy`.
-
-### Status Codes
-- `200 OK`
-- `401 Unauthorized`
+- `403 Forbidden` valid credential without admin scope
 
 ### curl
 ```bash
@@ -986,7 +1086,7 @@ curl -H "Authorization: Bearer $TOKEN" \
 Returns transparency-oriented rule summary.
 
 ### Request Headers
-- `Authorization: Bearer <token>`
+- `Authorization: Bearer <admin-scoped-token>` (eval-only credentials are rejected)
 
 ### Response Body Schema
 
@@ -1015,6 +1115,7 @@ Returns transparency-oriented rule summary.
 ### Status Codes
 - `200 OK`
 - `401 Unauthorized`
+- `403 Forbidden` valid credential without admin scope
 
 ### curl
 ```bash
@@ -1026,7 +1127,7 @@ curl -H "Authorization: Bearer $TOKEN" \
 Forces immediate policy reload.
 
 ### Request Headers
-- `Authorization: Bearer <token>`
+- `Authorization: Bearer <admin-scoped-token>` (eval-only credentials are rejected)
 
 ### Request Body
 - No body required.
@@ -1059,6 +1160,7 @@ Failure (`500`):
 ### Status Codes
 - `200 OK`
 - `401 Unauthorized`
+- `403 Forbidden` valid credential without admin scope
 - `429 Too Many Requests` rate-limited (<1s since previous reload)
 - `500 Internal Server Error` reload failed
 - `503 Service Unavailable` policy engine not initialized
@@ -1073,7 +1175,7 @@ curl -X POST -H "Authorization: Bearer $TOKEN" \
 Policy REPL endpoint for evaluating a hypothetical command.
 
 ### Request Headers
-- `Authorization: Bearer <token>`
+- `Authorization: Bearer <admin-scoped-token>` (eval-only credentials are rejected)
 - `Content-Type: application/json`
 
 ### Request Body Schema
@@ -1112,6 +1214,7 @@ Policy REPL endpoint for evaluating a hypothetical command.
 - `200 OK`
 - `400 Bad Request` invalid JSON or missing `command`
 - `401 Unauthorized`
+- `403 Forbidden` valid credential without admin scope
 - `503 Service Unavailable` policy engine not initialized
 
 ### curl
@@ -1155,7 +1258,7 @@ curl "http://127.0.0.1:9090/healthz"
 Prometheus metrics endpoint. Available only when server starts with metrics enabled.
 
 ### Request Headers
-- `Authorization: Bearer <token>`
+- `Authorization: Bearer <admin-scoped-token>` (eval-only credentials are rejected)
 
 ### Response
 - `Content-Type`: Prometheus text exposition format
@@ -1172,6 +1275,7 @@ Primary Rampart metrics:
 ### Status Codes
 - `200 OK`
 - `401 Unauthorized`
+- `403 Forbidden` valid credential without admin scope
 - `404 Not Found` when metrics endpoint is disabled
 
 ### curl

--- a/internal/approval/store.go
+++ b/internal/approval/store.go
@@ -40,9 +40,16 @@ import (
 	"github.com/peg/rampart/internal/securefile"
 )
 
-// approvedReplayWindow is intentionally short: an allow-once approval is only
-// useful for the host's immediate retry of the exact tool call.
-const approvedReplayWindow = 60 * time.Second
+const (
+	// DefaultTimeout is how long a pending approval remains open when the
+	// server does not configure an explicit timeout. Explicit run grants use
+	// the same default so the displayed and enforced durations do not diverge.
+	DefaultTimeout = 2 * time.Minute
+
+	// approvedReplayWindow is intentionally short: an allow-once approval is
+	// only useful for the host's immediate retry of the exact tool call.
+	approvedReplayWindow = 60 * time.Second
+)
 
 // Approval requests originate from the 1 MiB HTTP API but may contain both
 // normalized params and structured input. Keep recovery bounded while leaving
@@ -120,6 +127,12 @@ type Request struct {
 	// ownerScope is a one-way digest binding token-originated approvals.
 	ownerScope string
 
+	// runScope is the immutable owner-bound run identity captured at creation.
+	// Never recompute authorization scope from the exported Call snapshot,
+	// which callers may retain after Create returns.
+	runScope    autoApproveScope
+	hasRunScope bool
+
 	// done is closed when the approval is resolved.
 	done chan struct{}
 }
@@ -151,6 +164,48 @@ type autoApproveScope struct {
 	Session    string
 	RunID      string
 	OwnerScope string
+}
+
+type runScopeMutationKind uint8
+
+const (
+	runScopeCreated runScopeMutationKind = iota + 1
+	runScopeApproved
+	runScopeDenied
+	runScopeExpired
+	runScopeDeleted
+)
+
+const (
+	maxRunScopeSnapshotMutations = maxPendingApprovals * 8
+	maxActiveRunScopeSnapshots   = 64
+)
+
+type runScopeMutation struct {
+	kind  runScopeMutationKind
+	id    string
+	actor *RunScopeSnapshot
+}
+
+// RunScopeSnapshot is a store-bound, single-use authorization transaction for
+// one immutable agent/session/run/credential-owner scope. Pending contains
+// copies safe for callers to inspect; all security state remains unexported.
+type RunScopeSnapshot struct {
+	Pending []*Request
+
+	store     *Store
+	scope     autoApproveScope
+	reviewed  map[string]struct{}
+	mutations []runScopeMutation
+	expiresAt time.Time
+	invalid   bool
+	consumed  bool
+}
+
+// RunApprovalCommit is proof that this snapshot, rather than another
+// resolver, committed one approval transition in the Store.
+type RunApprovalCommit struct {
+	ID string
 }
 
 // persistRecord is the on-disk representation of an approval request.
@@ -186,6 +241,7 @@ type Store struct {
 	pending         map[string]*Request
 	approvedOnce    map[string]replayGrant // exact call/owner key -> one-shot grant
 	autoApproveRuns map[autoApproveScope]time.Time
+	activeRunScopes map[autoApproveScope]*RunScopeSnapshot
 	timeout         time.Duration
 	onExpire        func(*Request)
 	stop            chan struct{}
@@ -236,7 +292,8 @@ func NewStore(opts ...Option) *Store {
 		pending:         make(map[string]*Request),
 		approvedOnce:    make(map[string]replayGrant),
 		autoApproveRuns: make(map[autoApproveScope]time.Time),
-		timeout:         2 * time.Minute,
+		activeRunScopes: make(map[autoApproveScope]*RunScopeSnapshot),
+		timeout:         DefaultTimeout,
 		stop:            make(chan struct{}),
 		logger:          slog.Default(),
 	}
@@ -390,15 +447,28 @@ func (s *Store) Create(call engine.ToolCall, decision engine.Decision) (*Request
 // racing a stale IsAutoApproved check and leaving an orphan pending request.
 // A non-empty owner scope binds pending and replay state to that caller.
 func (s *Store) CreateOrAutoApproved(call engine.ToolCall, decision engine.Decision, ownerScope string) (*Request, bool, error) {
+	req, _, autoApproved, err := s.CreateOrAutoApprovedWithExpiry(call, decision, ownerScope)
+	return req, autoApproved, err
+}
+
+// CreateOrAutoApprovedWithExpiry is CreateOrAutoApproved plus the exact expiry
+// of a run grant observed by this call. The expiry is zero when the request is
+// enqueued instead. Callers that disclose grant lifetime must use this value
+// rather than reconstructing a fresh timeout after the cache lookup.
+func (s *Store) CreateOrAutoApprovedWithExpiry(
+	call engine.ToolCall,
+	decision engine.Decision,
+	ownerScope string,
+) (*Request, time.Time, bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	ownerScope = ownerScopeDigest(ownerScope)
-	if s.isAutoApprovedLocked(call, ownerScope) {
-		return nil, true, nil
+	if expiresAt, ok := s.autoApprovalExpiryLocked(call, ownerScope); ok {
+		return nil, expiresAt, true, nil
 	}
 	req, err := s.createLocked(call, decision, ownerScope)
-	return req, false, err
+	return req, time.Time{}, false, err
 }
 
 // createLocked enqueues one request. The caller must hold s.mu.
@@ -440,6 +510,10 @@ func (s *Store) createLocked(call engine.ToolCall, decision engine.Decision, own
 		ownerScope: ownerScope,
 		done:       make(chan struct{}),
 	}
+	if scope, valid := autoApproveScopeFor(call, ownerScope); valid {
+		req.runScope = scope
+		req.hasRunScope = true
+	}
 
 	s.pending[req.ID] = req
 
@@ -450,6 +524,7 @@ func (s *Store) createLocked(call engine.ToolCall, decision engine.Decision, own
 			return nil, fmt.Errorf("approval: persist new approval: %w", err)
 		}
 	}
+	s.recordRunScopeMutationLocked(req, runScopeCreated, nil)
 
 	// Start expiry timer.
 	s.startWorker(func() { s.watchExpiry(req) })
@@ -481,6 +556,50 @@ func (s *Store) ResolveBeforePublish(
 ) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	return s.resolveBeforePublishLocked(id, approved, resolvedBy, beforePublish, nil)
+}
+
+// ResolveBeforePublishForRunScopeSnapshot commits one approval through the
+// active store-bound run snapshot and returns a commit receipt for API/audit
+// reporting. Grant publication trusts the Store's internal actor-tagged
+// mutation log, never caller-supplied IDs.
+func (s *Store) ResolveBeforePublishForRunScopeSnapshot(
+	snapshot *RunScopeSnapshot,
+	id string,
+	resolvedBy string,
+	beforePublish func(*Request) error,
+) (*RunApprovalCommit, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.runScopeSnapshotActiveLocked(snapshot) {
+		return nil, fmt.Errorf("approval: run-scope snapshot is stale, consumed, or belongs to another store")
+	}
+	if !time.Now().Before(snapshot.expiresAt) {
+		return nil, fmt.Errorf("approval: run-scope snapshot authorization window expired")
+	}
+	req, ok := s.pending[id]
+	if !ok || !req.hasRunScope || req.runScope != snapshot.scope {
+		return nil, fmt.Errorf("approval: %q does not belong to the active run-scope snapshot", id)
+	}
+	if !time.Now().Before(req.ExpiresAt) {
+		return nil, fmt.Errorf("approval: %q expired before resolution publication", id)
+	}
+	if err := s.resolveBeforePublishLocked(id, true, resolvedBy, beforePublish, snapshot); err != nil {
+		return nil, err
+	}
+	return &RunApprovalCommit{ID: id}, nil
+}
+
+// resolveBeforePublishLocked implements the durable transition and observable
+// publication boundary. The caller must hold s.mu. actor is non-nil only for
+// an approval committed by the matching active run-scope transaction.
+func (s *Store) resolveBeforePublishLocked(
+	id string,
+	approved bool,
+	resolvedBy string,
+	beforePublish func(*Request) error,
+	actor *RunScopeSnapshot,
+) error {
 
 	req, ok := s.pending[id]
 	if !ok {
@@ -489,6 +608,9 @@ func (s *Store) ResolveBeforePublish(
 
 	if req.Status != StatusPending {
 		return fmt.Errorf("approval: %s is already %s", id, req.Status)
+	}
+	if !time.Now().Before(req.ExpiresAt) {
+		return fmt.Errorf("approval: %s expired before resolution publication", id)
 	}
 	if s.persistFile != "" {
 		if err := secureExistingApprovalFile(s.persistFile); err != nil {
@@ -533,6 +655,12 @@ func (s *Store) ResolveBeforePublish(
 			return rollbackPending(fmt.Errorf("approval: required pre-publication step: %w", err))
 		}
 	}
+	if actor != nil && !time.Now().Before(actor.expiresAt) {
+		return rollbackPending(fmt.Errorf("approval: run-scope snapshot authorization window expired before resolution publication"))
+	}
+	if !time.Now().Before(req.ExpiresAt) {
+		return rollbackPending(fmt.Errorf("approval: %s expired before resolution publication", id))
+	}
 
 	var grant replayGrant
 	grantKey := ""
@@ -546,6 +674,9 @@ func (s *Store) ResolveBeforePublish(
 				ResolvedBy:  resolvedBy,
 				ResolvedAt:  now,
 				ExpiresAt:   now.Add(approvedReplayWindow),
+			}
+			if actor != nil && actor.expiresAt.Before(grant.ExpiresAt) {
+				grant.ExpiresAt = actor.expiresAt
 			}
 			if s.persistFile != "" {
 				if err := s.publishReplayGrant(grant); err != nil {
@@ -563,6 +694,11 @@ func (s *Store) ResolveBeforePublish(
 	req.Persisted = resolved.Persisted
 	if grantKey != "" {
 		s.approvedOnce[grantKey] = grant
+	}
+	if approved {
+		s.recordRunScopeMutationLocked(req, runScopeApproved, actor)
+	} else {
+		s.recordRunScopeMutationLocked(req, runScopeDenied, actor)
 	}
 	close(req.done)
 
@@ -674,6 +810,138 @@ func (s *Store) List() []*Request {
 	return result
 }
 
+// BeginRunScopeSnapshot atomically validates and captures every currently
+// pending approval for one exact owner-bound run. Mutations committed after
+// this boundary are recorded on the returned store-bound token until it is
+// either published or aborted.
+func (s *Store) BeginRunScopeSnapshot(call engine.ToolCall, reviewedIDs []string, ttl time.Duration) (*RunScopeSnapshot, error) {
+	if len(reviewedIDs) == 0 {
+		return nil, fmt.Errorf("approval: run scope requires reviewed approval ids")
+	}
+	if ttl <= 0 {
+		return nil, fmt.Errorf("approval: run scope requires a positive authorization window")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := time.Now()
+	s.pruneExpiredRunScopeSnapshotsLocked(now)
+
+	reviewed := make(map[string]struct{}, len(reviewedIDs))
+	matching := make([]*Request, 0, len(reviewedIDs))
+	var scope autoApproveScope
+	for index, rawID := range reviewedIDs {
+		id := strings.TrimSpace(rawID)
+		if id == "" {
+			return nil, fmt.Errorf("approval: run scope contains an empty approval id")
+		}
+		if _, duplicate := reviewed[id]; duplicate {
+			return nil, fmt.Errorf("approval: run scope contains duplicate approval id %q", id)
+		}
+		reviewed[id] = struct{}{}
+
+		req, ok := s.pending[id]
+		if !ok || req.Status != StatusPending || !now.Before(req.ExpiresAt) {
+			return nil, fmt.Errorf("approval: %q is no longer pending", id)
+		}
+		if !req.hasRunScope {
+			return nil, fmt.Errorf("approval: %q has incomplete run identity", id)
+		}
+		if index == 0 {
+			scope = req.runScope
+			if scope.Agent != strings.TrimSpace(call.Agent) ||
+				scope.Session != strings.TrimSpace(call.Session) ||
+				scope.RunID != strings.TrimSpace(call.RunID) {
+				return nil, fmt.Errorf("approval: %q does not belong to the requested run identity", id)
+			}
+		} else if req.runScope != scope {
+			return nil, fmt.Errorf("approval: run scope ids span multiple identities or credential owners")
+		}
+		cp := *req
+		matching = append(matching, &cp)
+	}
+
+	for _, req := range s.pending {
+		if req.Status != StatusPending || !req.hasRunScope || req.runScope != scope {
+			continue
+		}
+		if !now.Before(req.ExpiresAt) {
+			return nil, fmt.Errorf("approval: run scope contains expired pending approval %q", req.ID)
+		}
+		if _, selected := reviewed[req.ID]; !selected {
+			return nil, fmt.Errorf("approval: run scope omitted pending approval %q", req.ID)
+		}
+	}
+	if active := s.activeRunScopes[scope]; active != nil {
+		return nil, fmt.Errorf("approval: another run-scope authorization is already in progress")
+	}
+	if expiry, exists := s.autoApproveRuns[scope]; exists {
+		if time.Now().Before(expiry) {
+			return nil, fmt.Errorf("approval: run scope already has active future-call authority")
+		}
+		delete(s.autoApproveRuns, scope)
+	}
+	if len(s.activeRunScopes) >= maxActiveRunScopeSnapshots {
+		return nil, fmt.Errorf("approval: too many run-scope authorizations are already in progress")
+	}
+
+	snapshot := &RunScopeSnapshot{
+		Pending:   matching,
+		store:     s,
+		scope:     scope,
+		reviewed:  reviewed,
+		expiresAt: now.Add(ttl),
+	}
+	s.activeRunScopes[scope] = snapshot
+	return snapshot, nil
+}
+
+// AbortRunScopeSnapshot releases an unpublished snapshot. It is idempotent;
+// successful publication consumes and releases the token first.
+func (s *Store) AbortRunScopeSnapshot(snapshot *RunScopeSnapshot) {
+	if snapshot == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if snapshot.store != s || snapshot.consumed || s.activeRunScopes[snapshot.scope] != snapshot {
+		return
+	}
+	delete(s.activeRunScopes, snapshot.scope)
+	snapshot.consumed = true
+}
+
+func (s *Store) runScopeSnapshotActiveLocked(snapshot *RunScopeSnapshot) bool {
+	return snapshot != nil && snapshot.store == s && !snapshot.consumed && s.activeRunScopes[snapshot.scope] == snapshot
+}
+
+func (s *Store) pruneExpiredRunScopeSnapshotsLocked(now time.Time) {
+	for scope, snapshot := range s.activeRunScopes {
+		if snapshot != nil && !snapshot.consumed && now.Before(snapshot.expiresAt) {
+			continue
+		}
+		delete(s.activeRunScopes, scope)
+		if snapshot != nil {
+			snapshot.consumed = true
+		}
+	}
+}
+
+func (s *Store) recordRunScopeMutationLocked(req *Request, kind runScopeMutationKind, actor *RunScopeSnapshot) {
+	if req == nil || !req.hasRunScope {
+		return
+	}
+	snapshot := s.activeRunScopes[req.runScope]
+	if snapshot == nil || snapshot.invalid {
+		return
+	}
+	if len(snapshot.mutations) >= maxRunScopeSnapshotMutations {
+		snapshot.invalid = true
+		return
+	}
+	snapshot.mutations = append(snapshot.mutations, runScopeMutation{kind: kind, id: req.ID, actor: actor})
+}
+
 // Done returns a channel that's closed when the request is resolved.
 func (r *Request) Done() <-chan struct{} {
 	return r.done
@@ -696,6 +964,7 @@ func (s *Store) Cleanup(olderThan time.Duration) int {
 
 	for id, req := range s.pending {
 		if req.Status != StatusPending && req.ResolvedAt.Before(cutoff) {
+			s.recordRunScopeMutationLocked(req, runScopeDeleted, nil)
 			delete(s.pending, id)
 			removed++
 		}
@@ -759,25 +1028,144 @@ func (s *Store) AutoApproveRunIfNoPending(call engine.ToolCall, ttl time.Duratio
 // AutoApproveRunIfNoPendingForRequest installs only the owner scope carried by
 // a request the operator explicitly selected for bulk resolution.
 func (s *Store) AutoApproveRunIfNoPendingForRequest(call engine.ToolCall, source *Request, ttl time.Duration) ([]*Request, bool) {
-	if source == nil {
-		return nil, false
-	}
-	return s.autoApproveRunIfNoPending(call, source.ownerScope, ttl)
+	pending, _, installed, _ := s.AutoApproveRunBeforePublishForRequest(call, source, ttl, nil)
+	return pending, installed
 }
 
-func (s *Store) autoApproveRunIfNoPending(call engine.ToolCall, ownerScope string, ttl time.Duration) ([]*Request, bool) {
-	scope, ok := autoApproveScopeFor(call, ownerScope)
-	if !ok || ttl <= 0 {
-		return nil, false
+// AutoApproveRunBeforePublishForRunScopeSnapshot publishes future authority
+// only when every mutation since BeginRunScopeSnapshot is accounted for. New
+// pending requests are returned for caller review/audit; any denial, expiry,
+// deletion, or approval by another resolver invalidates publication.
+func (s *Store) AutoApproveRunBeforePublishForRunScopeSnapshot(
+	snapshot *RunScopeSnapshot,
+	beforePublish func(time.Time) error,
+) ([]*Request, time.Time, bool, error) {
+	if snapshot == nil {
+		return nil, time.Time{}, false, fmt.Errorf("approval: invalid run-scope publication request")
 	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if !s.runScopeSnapshotActiveLocked(snapshot) {
+		return nil, time.Time{}, false, fmt.Errorf("approval: run-scope snapshot is stale, consumed, or belongs to another store")
+	}
+	if snapshot.invalid {
+		return nil, time.Time{}, false, fmt.Errorf("approval: run-scope mutation log exceeded its safety bound")
+	}
+	if !time.Now().Before(snapshot.expiresAt) {
+		return nil, time.Time{}, false, fmt.Errorf("approval: run-scope snapshot authorization window expired")
+	}
+
+	created := make(map[string]struct{})
+	committed := make(map[string]struct{})
+	for _, mutation := range snapshot.mutations {
+		switch mutation.kind {
+		case runScopeCreated:
+			created[mutation.id] = struct{}{}
+		case runScopeApproved:
+			if mutation.actor != snapshot {
+				return nil, time.Time{}, false, fmt.Errorf("approval: %q was approved outside the active run-scope transaction", mutation.id)
+			}
+			committed[mutation.id] = struct{}{}
+		case runScopeDenied:
+			return nil, time.Time{}, false, fmt.Errorf("approval: %q was denied after the run-scope snapshot", mutation.id)
+		case runScopeExpired:
+			return nil, time.Time{}, false, fmt.Errorf("approval: %q expired after the run-scope snapshot", mutation.id)
+		case runScopeDeleted:
+			return nil, time.Time{}, false, fmt.Errorf("approval: %q was deleted after the run-scope snapshot", mutation.id)
+		default:
+			return nil, time.Time{}, false, fmt.Errorf("approval: unknown run-scope mutation")
+		}
+	}
+	for id := range snapshot.reviewed {
+		if _, ok := committed[id]; !ok {
+			if req, exists := s.pending[id]; exists && req.Status == StatusPending && req.hasRunScope && req.runScope == snapshot.scope {
+				continue
+			}
+			return nil, time.Time{}, false, fmt.Errorf("approval: reviewed approval %q was not committed by the active run-scope transaction", id)
+		}
+	}
 
 	pending := make([]*Request, 0)
 	for _, req := range s.pending {
-		requestScope, valid := autoApproveScopeFor(req.Call, req.ownerScope)
-		if req.Status != StatusPending || !valid || requestScope != scope {
+		if req.Status != StatusPending || !req.hasRunScope || req.runScope != snapshot.scope {
+			continue
+		}
+		if _, reviewed := snapshot.reviewed[req.ID]; !reviewed {
+			if _, arrivedAfterSnapshot := created[req.ID]; !arrivedAfterSnapshot {
+				return nil, time.Time{}, false, fmt.Errorf("approval: unaccounted pending approval %q in run scope", req.ID)
+			}
+		}
+		cp := *req
+		pending = append(pending, &cp)
+	}
+	if len(pending) > 0 {
+		sort.Slice(pending, func(i, j int) bool {
+			if pending[i].CreatedAt.Equal(pending[j].CreatedAt) {
+				return pending[i].ID < pending[j].ID
+			}
+			return pending[i].CreatedAt.Before(pending[j].CreatedAt)
+		})
+		return pending, time.Time{}, false, nil
+	}
+
+	expiresAt := snapshot.expiresAt
+	if beforePublish != nil {
+		if err := beforePublish(expiresAt); err != nil {
+			return nil, time.Time{}, false, fmt.Errorf("approval: required run-grant pre-publication step: %w", err)
+		}
+	}
+	if !time.Now().Before(expiresAt) {
+		return nil, time.Time{}, false, fmt.Errorf("approval: run grant expired before publication")
+	}
+	s.autoApproveRuns[snapshot.scope] = expiresAt
+
+	delete(s.activeRunScopes, snapshot.scope)
+	snapshot.consumed = true
+	return nil, expiresAt, true, nil
+}
+
+// AutoApproveRunBeforePublishForRequest installs only the owner scope carried
+// by a request the operator explicitly selected. The callback runs under the
+// Store lock before the cache entry is installed, so callers can require a
+// durable audit record without opening a create/publication race.
+func (s *Store) AutoApproveRunBeforePublishForRequest(
+	call engine.ToolCall,
+	source *Request,
+	ttl time.Duration,
+	beforePublish func(time.Time) error,
+) ([]*Request, time.Time, bool, error) {
+	if source == nil {
+		return nil, time.Time{}, false, nil
+	}
+	return s.autoApproveRunBeforePublish(call, source.ownerScope, ttl, beforePublish)
+}
+
+func (s *Store) autoApproveRunIfNoPending(call engine.ToolCall, ownerScope string, ttl time.Duration) ([]*Request, bool) {
+	pending, _, installed, _ := s.autoApproveRunBeforePublish(call, ownerScope, ttl, nil)
+	return pending, installed
+}
+
+func (s *Store) autoApproveRunBeforePublish(
+	call engine.ToolCall,
+	ownerScope string,
+	ttl time.Duration,
+	beforePublish func(time.Time) error,
+) ([]*Request, time.Time, bool, error) {
+	scope, ok := autoApproveScopeFor(call, ownerScope)
+	if !ok || ttl <= 0 {
+		return nil, time.Time{}, false, nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.activeRunScopes[scope] != nil {
+		return nil, time.Time{}, false, fmt.Errorf("approval: run-scope authorization is already in progress")
+	}
+
+	pending := make([]*Request, 0)
+	for _, req := range s.pending {
+		if req.Status != StatusPending || !req.hasRunScope || req.runScope != scope {
 			continue
 		}
 		cp := *req
@@ -790,11 +1178,20 @@ func (s *Store) autoApproveRunIfNoPending(call engine.ToolCall, ownerScope strin
 			}
 			return pending[i].CreatedAt.Before(pending[j].CreatedAt)
 		})
-		return pending, false
+		return pending, time.Time{}, false, nil
 	}
 
-	s.autoApproveRuns[scope] = time.Now().Add(ttl)
-	return nil, true
+	expiresAt := time.Now().Add(ttl)
+	if beforePublish != nil {
+		if err := beforePublish(expiresAt); err != nil {
+			return nil, time.Time{}, false, fmt.Errorf("approval: required run-grant pre-publication step: %w", err)
+		}
+	}
+	if !time.Now().Before(expiresAt) {
+		return nil, time.Time{}, false, fmt.Errorf("approval: run grant expired before publication")
+	}
+	s.autoApproveRuns[scope] = expiresAt
+	return nil, expiresAt, true, nil
 }
 
 // IsAutoApproved reports whether this exact agent/session/run scope has been
@@ -807,12 +1204,24 @@ func (s *Store) IsAutoApproved(call engine.ToolCall) bool {
 
 // isAutoApprovedLocked checks one call. The caller must hold s.mu.
 func (s *Store) isAutoApprovedLocked(call engine.ToolCall, ownerScope string) bool {
+	_, ok := s.autoApprovalExpiryLocked(call, ownerScope)
+	return ok
+}
+
+func (s *Store) autoApprovalExpiryLocked(call engine.ToolCall, ownerScope string) (time.Time, bool) {
 	scope, ok := autoApproveScopeFor(call, ownerScope)
 	if !ok {
-		return false
+		return time.Time{}, false
 	}
 	expiry, exists := s.autoApproveRuns[scope]
-	return exists && time.Now().Before(expiry)
+	if !exists {
+		return time.Time{}, false
+	}
+	if !time.Now().Before(expiry) {
+		delete(s.autoApproveRuns, scope)
+		return time.Time{}, false
+	}
+	return expiry, true
 }
 
 // cleanAutoApproveCache removes expired run_id entries from the cache.
@@ -841,6 +1250,7 @@ func (s *Store) watchExpiry(req *Request) {
 			req.Status = StatusExpired
 			req.ResolvedAt = time.Now()
 			req.ResolvedBy = "timeout"
+			s.recordRunScopeMutationLocked(req, runScopeExpired, nil)
 			close(req.done)
 
 			if s.onExpire != nil {
@@ -1196,6 +1606,10 @@ func fromRecord(rec persistRecord) (*Request, bool) {
 		ownerScope: rec.OwnerScope,
 		done:       make(chan struct{}),
 	}
+	if scope, valid := autoApproveScopeFor(call, rec.OwnerScope); valid {
+		req.runScope = scope
+		req.hasRunScope = true
+	}
 	return req, true
 }
 
@@ -1339,6 +1753,7 @@ func (s *Store) loadFromDisk() {
 			}
 		}
 		s.pending[req.ID] = req
+		s.recordRunScopeMutationLocked(req, runScopeCreated, nil)
 		s.startWorker(func() { s.watchExpiry(req) })
 		restored++
 	}

--- a/internal/approval/store_test.go
+++ b/internal/approval/store_test.go
@@ -850,6 +850,423 @@ func TestRunAutoApprovalIsBoundToResolvedOwner(t *testing.T) {
 	assert.NotNil(t, sibling)
 }
 
+func TestRunAutoApprovalRequiresPrePublicationStep(t *testing.T) {
+	store := NewStore()
+	defer store.Close()
+	call := testCall()
+	request, err := store.Create(call, testDecision())
+	require.NoError(t, err)
+	require.NoError(t, store.Resolve(request.ID, true, "operator"))
+
+	called := false
+	pending, expiresAt, installed, err := store.AutoApproveRunBeforePublishForRequest(
+		call,
+		request,
+		time.Minute,
+		func(expiry time.Time) error {
+			called = true
+			assert.WithinDuration(t, time.Now().Add(time.Minute), expiry, time.Second)
+			return fmt.Errorf("audit unavailable")
+		},
+	)
+	require.Error(t, err)
+	assert.True(t, called)
+	assert.Empty(t, pending)
+	assert.True(t, expiresAt.IsZero())
+	assert.False(t, installed)
+	assert.False(t, store.IsAutoApproved(call))
+
+	pending, expiresAt, installed, err = store.AutoApproveRunBeforePublishForRequest(
+		call,
+		request,
+		time.Minute,
+		func(time.Time) error { return nil },
+	)
+	require.NoError(t, err)
+	assert.Empty(t, pending)
+	assert.False(t, expiresAt.IsZero())
+	assert.True(t, installed)
+	assert.True(t, store.IsAutoApproved(call))
+}
+
+func TestRunAutoApprovalRejectsGrantExpiredDuringPublication(t *testing.T) {
+	store := NewStore()
+	defer store.Close()
+	call := testCall()
+	request, err := store.Create(call, testDecision())
+	require.NoError(t, err)
+	require.NoError(t, store.Resolve(request.ID, true, "operator"))
+
+	pending, expiresAt, installed, err := store.AutoApproveRunBeforePublishForRequest(
+		call,
+		request,
+		time.Nanosecond,
+		func(time.Time) error {
+			time.Sleep(time.Millisecond)
+			return nil
+		},
+	)
+	require.ErrorContains(t, err, "expired before publication")
+	assert.Empty(t, pending)
+	assert.True(t, expiresAt.IsZero())
+	assert.False(t, installed)
+	assert.False(t, store.IsAutoApproved(call))
+}
+
+func TestRunScopeSnapshotRejectsPostSnapshotDenial(t *testing.T) {
+	store := NewStore()
+	t.Cleanup(store.Close)
+	call := testCall()
+	initial, err := store.Create(call, testDecision())
+	require.NoError(t, err)
+	snapshot, err := store.BeginRunScopeSnapshot(call, []string{initial.ID}, time.Minute)
+	require.NoError(t, err)
+	t.Cleanup(func() { store.AbortRunScopeSnapshot(snapshot) })
+
+	commit, err := store.ResolveBeforePublishForRunScopeSnapshot(snapshot, initial.ID, "operator", nil)
+	require.NoError(t, err)
+	assert.Equal(t, initial.ID, commit.ID)
+
+	racedCall := call
+	racedCall.ToolCallID = "post-snapshot-denied"
+	racedCall.Params = map[string]any{"command": "deploy denied"}
+	raced, autoApproved, err := store.CreateOrAutoApproved(racedCall, testDecision(), "")
+	require.NoError(t, err)
+	require.False(t, autoApproved)
+	require.NotNil(t, raced)
+	require.NoError(t, store.Resolve(raced.ID, false, "other-operator"))
+
+	pending, expiresAt, installed, err := store.AutoApproveRunBeforePublishForRunScopeSnapshot(snapshot, nil)
+	require.ErrorContains(t, err, "was denied after the run-scope snapshot")
+	assert.Empty(t, pending)
+	assert.True(t, expiresAt.IsZero())
+	assert.False(t, installed)
+	assert.False(t, store.IsAutoApproved(call))
+
+	retry := racedCall
+	retryRequest, retryAutoApproved, err := store.CreateOrAutoApproved(retry, testDecision(), "")
+	require.NoError(t, err)
+	assert.False(t, retryAutoApproved, "a denied post-snapshot call gained future authority")
+	assert.NotNil(t, retryRequest)
+}
+
+func TestRunScopeSnapshotRejectsPostSnapshotExternalApprovalAndExpiry(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		timeout time.Duration
+		settle  func(*testing.T, *Store, *Request)
+		want    string
+	}{
+		{
+			name:    "external approval",
+			timeout: time.Minute,
+			settle: func(t *testing.T, store *Store, request *Request) {
+				require.NoError(t, store.Resolve(request.ID, true, "other-operator"))
+			},
+			want: "approved outside the active run-scope transaction",
+		},
+		{
+			name:    "expiry",
+			timeout: 100 * time.Millisecond,
+			settle: func(t *testing.T, _ *Store, request *Request) {
+				select {
+				case <-request.Done():
+				case <-time.After(2 * time.Second):
+					t.Fatal("post-snapshot approval did not expire")
+				}
+			},
+			want: "expired after the run-scope snapshot",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			store := NewStore(WithTimeout(test.timeout))
+			t.Cleanup(store.Close)
+			call := testCall()
+			initial, err := store.Create(call, testDecision())
+			require.NoError(t, err)
+			snapshot, err := store.BeginRunScopeSnapshot(call, []string{initial.ID}, time.Minute)
+			require.NoError(t, err)
+			t.Cleanup(func() { store.AbortRunScopeSnapshot(snapshot) })
+			_, err = store.ResolveBeforePublishForRunScopeSnapshot(snapshot, initial.ID, "operator", nil)
+			require.NoError(t, err)
+
+			racedCall := call
+			racedCall.ToolCallID = "post-snapshot-" + strings.ReplaceAll(test.name, " ", "-")
+			raced, autoApproved, err := store.CreateOrAutoApproved(racedCall, testDecision(), "")
+			require.NoError(t, err)
+			require.False(t, autoApproved)
+			require.NotNil(t, raced)
+			test.settle(t, store, raced)
+
+			_, _, installed, err := store.AutoApproveRunBeforePublishForRunScopeSnapshot(snapshot, nil)
+			require.ErrorContains(t, err, test.want)
+			assert.False(t, installed)
+			assert.False(t, store.IsAutoApproved(call))
+		})
+	}
+}
+
+func TestRunScopeSnapshotUsesImmutableCreationScope(t *testing.T) {
+	store := NewStore()
+	t.Cleanup(store.Close)
+	call := testCall()
+	request, err := store.Create(call, testDecision())
+	require.NoError(t, err)
+	request.Call.Agent = "mutated-agent"
+	request.Call.Session = "mutated-session"
+	request.Call.RunID = "mutated-run"
+
+	snapshot, err := store.BeginRunScopeSnapshot(call, []string{request.ID}, time.Minute)
+	require.NoError(t, err)
+	t.Cleanup(func() { store.AbortRunScopeSnapshot(snapshot) })
+	_, err = store.ResolveBeforePublishForRunScopeSnapshot(snapshot, request.ID, "operator", nil)
+	require.NoError(t, err)
+	_, _, installed, err := store.AutoApproveRunBeforePublishForRunScopeSnapshot(snapshot, nil)
+	require.NoError(t, err)
+	assert.True(t, installed)
+	assert.True(t, store.IsAutoApproved(call))
+}
+
+func TestRunScopeSnapshotReturnsAndCommitsPendingRace(t *testing.T) {
+	store := NewStore()
+	t.Cleanup(store.Close)
+	call := testCall()
+	initial, err := store.Create(call, testDecision())
+	require.NoError(t, err)
+	snapshot, err := store.BeginRunScopeSnapshot(call, []string{initial.ID}, time.Minute)
+	require.NoError(t, err)
+	t.Cleanup(func() { store.AbortRunScopeSnapshot(snapshot) })
+	_, err = store.ResolveBeforePublishForRunScopeSnapshot(snapshot, initial.ID, "operator", nil)
+	require.NoError(t, err)
+
+	racedCall := call
+	racedCall.ToolCallID = "post-snapshot-pending"
+	racedCall.Params = map[string]any{"command": "deploy raced"}
+	raced, autoApproved, err := store.CreateOrAutoApproved(racedCall, testDecision(), "")
+	require.NoError(t, err)
+	require.False(t, autoApproved)
+	require.NotNil(t, raced)
+
+	pending, _, installed, err := store.AutoApproveRunBeforePublishForRunScopeSnapshot(snapshot, nil)
+	require.NoError(t, err)
+	require.False(t, installed)
+	require.Len(t, pending, 1)
+	assert.Equal(t, raced.ID, pending[0].ID)
+	_, err = store.ResolveBeforePublishForRunScopeSnapshot(snapshot, raced.ID, "operator", nil)
+	require.NoError(t, err)
+	store.mu.Lock()
+	racedGrant, replayPublished := store.approvedOnce[ownerBoundKey(replayKey(racedCall), "")]
+	store.mu.Unlock()
+	require.True(t, replayPublished)
+	assert.False(t, racedGrant.ExpiresAt.After(snapshot.expiresAt), "exact replay grant outlived run-scope authorization window")
+
+	pending, expiresAt, installed, err := store.AutoApproveRunBeforePublishForRunScopeSnapshot(snapshot, nil)
+	require.NoError(t, err)
+	assert.Empty(t, pending)
+	assert.False(t, expiresAt.IsZero())
+	assert.True(t, installed)
+	assert.True(t, store.IsAutoApproved(racedCall))
+
+	_, _, installed, err = store.AutoApproveRunBeforePublishForRunScopeSnapshot(snapshot, nil)
+	require.ErrorContains(t, err, "stale, consumed, or belongs to another store")
+	assert.False(t, installed)
+}
+
+func TestRunScopeSnapshotIgnoresUnrelatedScopeAndRejectsForeignStore(t *testing.T) {
+	store := NewStore()
+	t.Cleanup(store.Close)
+	otherStore := NewStore()
+	t.Cleanup(otherStore.Close)
+	call := testCall()
+	initial, err := store.Create(call, testDecision())
+	require.NoError(t, err)
+	snapshot, err := store.BeginRunScopeSnapshot(call, []string{initial.ID}, time.Minute)
+	require.NoError(t, err)
+	t.Cleanup(func() { store.AbortRunScopeSnapshot(snapshot) })
+
+	_, _, installed, err := otherStore.AutoApproveRunBeforePublishForRunScopeSnapshot(snapshot, nil)
+	require.ErrorContains(t, err, "another store")
+	assert.False(t, installed)
+
+	otherCall := call
+	otherCall.RunID = "unrelated-run"
+	otherCall.ToolCallID = "unrelated-call"
+	other, err := store.Create(otherCall, testDecision())
+	require.NoError(t, err)
+	require.NoError(t, store.Resolve(other.ID, false, "other-operator"))
+	_, err = store.ResolveBeforePublishForRunScopeSnapshot(snapshot, initial.ID, "operator", nil)
+	require.NoError(t, err)
+	_, _, installed, err = store.AutoApproveRunBeforePublishForRunScopeSnapshot(snapshot, nil)
+	require.NoError(t, err)
+	assert.True(t, installed)
+}
+
+func TestRunScopeSnapshotDeadlineCannotBeExtendedByRacedCalls(t *testing.T) {
+	store := NewStore()
+	t.Cleanup(store.Close)
+	call := testCall()
+	initial, err := store.Create(call, testDecision())
+	require.NoError(t, err)
+	snapshot, err := store.BeginRunScopeSnapshot(call, []string{initial.ID}, 20*time.Millisecond)
+	require.NoError(t, err)
+	t.Cleanup(func() { store.AbortRunScopeSnapshot(snapshot) })
+	_, err = store.ResolveBeforePublishForRunScopeSnapshot(snapshot, initial.ID, "operator", nil)
+	require.NoError(t, err)
+
+	var raced *Request
+	for index := 0; time.Now().Before(snapshot.expiresAt); index++ {
+		racedCall := call
+		racedCall.ToolCallID = fmt.Sprintf("deadline-race-%d", index)
+		racedCall.Params = map[string]any{"command": racedCall.ToolCallID}
+		var autoApproved bool
+		raced, autoApproved, err = store.CreateOrAutoApproved(racedCall, testDecision(), "")
+		require.NoError(t, err)
+		require.False(t, autoApproved)
+		time.Sleep(time.Millisecond)
+	}
+	require.NotNil(t, raced)
+
+	_, err = store.ResolveBeforePublishForRunScopeSnapshot(snapshot, raced.ID, "operator", nil)
+	require.ErrorContains(t, err, "authorization window expired")
+	_, _, installed, err := store.AutoApproveRunBeforePublishForRunScopeSnapshot(snapshot, nil)
+	require.ErrorContains(t, err, "authorization window expired")
+	assert.False(t, installed)
+	assert.False(t, store.IsAutoApproved(call))
+}
+
+func TestRunScopeSnapshotDeadlineCannotPassDuringResolutionAudit(t *testing.T) {
+	store := NewStore(WithTimeout(time.Minute))
+	t.Cleanup(store.Close)
+	call := testCall()
+	initial, err := store.Create(call, testDecision())
+	require.NoError(t, err)
+	snapshot, err := store.BeginRunScopeSnapshot(call, []string{initial.ID}, 100*time.Millisecond)
+	require.NoError(t, err)
+	t.Cleanup(func() { store.AbortRunScopeSnapshot(snapshot) })
+	_, err = store.ResolveBeforePublishForRunScopeSnapshot(snapshot, initial.ID, "operator", nil)
+	require.NoError(t, err)
+
+	racedCall := call
+	racedCall.ToolCallID = "resolution-audit-deadline-race"
+	racedCall.Params = map[string]any{"command": "echo deadline"}
+	raced, autoApproved, err := store.CreateOrAutoApproved(racedCall, testDecision(), "")
+	require.NoError(t, err)
+	require.False(t, autoApproved)
+
+	callbackRan := false
+	_, err = store.ResolveBeforePublishForRunScopeSnapshot(snapshot, raced.ID, "operator", func(*Request) error {
+		callbackRan = true
+		time.Sleep(time.Until(snapshot.expiresAt) + 10*time.Millisecond)
+		return nil
+	})
+	require.True(t, callbackRan)
+	require.ErrorContains(t, err, "authorization window expired")
+
+	current, ok := store.Get(raced.ID)
+	require.True(t, ok)
+	assert.Equal(t, StatusPending, current.Status)
+	select {
+	case <-raced.Done():
+		t.Fatal("raced approval waiter was published after the snapshot deadline")
+	default:
+	}
+	grant, consumed, consumeErr := store.ConsumeApproved(racedCall)
+	require.NoError(t, consumeErr)
+	assert.False(t, consumed)
+	assert.Nil(t, grant)
+	assert.False(t, store.IsAutoApproved(call))
+}
+
+func TestRunScopeSnapshotAuditPanicCannotPublishGrant(t *testing.T) {
+	store := NewStore()
+	t.Cleanup(store.Close)
+	call := testCall()
+	request, err := store.Create(call, testDecision())
+	require.NoError(t, err)
+	snapshot, err := store.BeginRunScopeSnapshot(call, []string{request.ID}, time.Minute)
+	require.NoError(t, err)
+	t.Cleanup(func() { store.AbortRunScopeSnapshot(snapshot) })
+	_, err = store.ResolveBeforePublishForRunScopeSnapshot(snapshot, request.ID, "operator", nil)
+	require.NoError(t, err)
+
+	func() {
+		defer func() {
+			assert.Equal(t, "audit panic", recover())
+		}()
+		_, _, _, _ = store.AutoApproveRunBeforePublishForRunScopeSnapshot(snapshot, func(time.Time) error {
+			panic("audit panic")
+		})
+	}()
+	assert.False(t, store.IsAutoApproved(call))
+}
+
+func TestRunGrantAuditPanicPreservesPreviousState(t *testing.T) {
+	store := NewStore()
+	t.Cleanup(store.Close)
+	call := testCall()
+	request, err := store.Create(call, testDecision())
+	require.NoError(t, err)
+	require.NoError(t, store.Resolve(request.ID, true, "operator"))
+
+	func() {
+		defer func() {
+			assert.Equal(t, "audit panic", recover())
+		}()
+		_, _, _, _ = store.AutoApproveRunBeforePublishForRequest(call, request, time.Minute, func(time.Time) error {
+			panic("audit panic")
+		})
+	}()
+	assert.False(t, store.IsAutoApproved(call))
+}
+
+func TestResolveRejectsWallClockExpiredPendingRequest(t *testing.T) {
+	store := NewStore(WithTimeout(5 * time.Millisecond))
+	t.Cleanup(store.Close)
+	request, err := store.Create(testCall(), testDecision())
+	require.NoError(t, err)
+	time.Sleep(10 * time.Millisecond)
+
+	err = store.Resolve(request.ID, true, "operator")
+	require.Error(t, err)
+	current, ok := store.Get(request.ID)
+	require.True(t, ok)
+	assert.NotEqual(t, StatusApproved, current.Status)
+}
+
+func TestBeginRunScopeSnapshotPrunesExpiredAbandonedTokens(t *testing.T) {
+	store := NewStore()
+	t.Cleanup(store.Close)
+	snapshots := make([]*RunScopeSnapshot, 0, maxActiveRunScopeSnapshots)
+
+	for index := 0; index < maxActiveRunScopeSnapshots; index++ {
+		call := testCall()
+		call.RunID = fmt.Sprintf("abandoned-run-%d", index)
+		call.ToolCallID = fmt.Sprintf("abandoned-call-%d", index)
+		request, err := store.Create(call, testDecision())
+		require.NoError(t, err)
+		snapshot, err := store.BeginRunScopeSnapshot(call, []string{request.ID}, time.Minute)
+		require.NoError(t, err)
+		snapshots = append(snapshots, snapshot)
+	}
+	require.Len(t, store.activeRunScopes, maxActiveRunScopeSnapshots)
+	for _, snapshot := range snapshots {
+		snapshot.expiresAt = time.Now().Add(-time.Second)
+	}
+
+	call := testCall()
+	call.RunID = "replacement-run"
+	call.ToolCallID = "replacement-call"
+	request, err := store.Create(call, testDecision())
+	require.NoError(t, err)
+	replacement, err := store.BeginRunScopeSnapshot(call, []string{request.ID}, time.Minute)
+	require.NoError(t, err)
+	t.Cleanup(func() { store.AbortRunScopeSnapshot(replacement) })
+	assert.Len(t, store.activeRunScopes, 1)
+	for _, snapshot := range snapshots {
+		assert.True(t, snapshot.consumed)
+	}
+}
+
 func TestPersistentApprovalAuthorizationFilesAreOwnerOnly(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Windows DACL behavior is covered by internal/securefile tests")

--- a/internal/dashboard/handler_test.go
+++ b/internal/dashboard/handler_test.go
@@ -16,6 +16,7 @@ package dashboard
 import (
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -101,6 +102,20 @@ func TestHandlerNonceInHTML(t *testing.T) {
 	}
 }
 
+func TestHandlerHasNoCSPBlockedInlineAttributes(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rr := httptest.NewRecorder()
+	Handler().ServeHTTP(rr, req)
+
+	// A nonce authorizes the style and script elements, but it does not
+	// authorize style attributes or inline event handlers. Keep those out of
+	// both the static markup and dynamically rendered HTML templates.
+	inlineAttribute := regexp.MustCompile(`(?i)\s(?:style|on[a-z][a-z0-9_-]*)\s*=`)
+	if match := inlineAttribute.FindString(rr.Body.String()); match != "" {
+		t.Fatalf("dashboard contains CSP-blocked inline attribute %q", match)
+	}
+}
+
 func TestHandlerIncludesAuthUXForApprovalsAPI(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rr := httptest.NewRecorder()
@@ -117,5 +132,79 @@ func TestHandlerIncludesAuthUXForApprovalsAPI(t *testing.T) {
 	}
 	if !strings.Contains(body, "rampart serve") {
 		t.Fatalf("response does not include serve guidance message")
+	}
+}
+
+func TestHandlerSeparatesPendingApprovalFromFutureRunAuthority(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rr := httptest.NewRecorder()
+
+	Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, rr.Code)
+	}
+
+	body := rr.Body.String()
+	for _, want := range []string{
+		"Approve Pending",
+		"Allow Future",
+		"Approve Selected",
+		"Future calls will still require approval.",
+		`aria-expanded="true"`,
+		"Admin scope required",
+		"Invalid or expired token",
+		"function handleAuthFailure(status)",
+		"function resetProtectedState()",
+		"function assertAuthEpoch(epoch)",
+		"handleAPIControlError",
+		"assertAuthEpoch(requestEpoch)",
+		"const generation=++pollGeneration",
+		"if(generation!==pollGeneration)return",
+		"const operationEpoch=authEpoch",
+		"if(operationEpoch===authEpoch)",
+		"policyTestButton.disabled=false",
+		"clearTimeout(denialRefreshTimer)",
+		"if(connected&&requestEpoch===authEpoch)loadRecentDenials()",
+		"if(streamEpoch!==authEpoch)return",
+		"if(handleAuthFailure(r.status))return",
+		"switchTab('active')",
+		"document.getElementById('main-content').classList.remove('visible')",
+		"Approvals changed",
+		"action,scope,ids,resolved_by:'dashboard'",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("response does not contain explicit approval-scope UX %q", want)
+		}
+	}
+	if strings.Contains(body, "__auth__") || strings.Contains(body, "__admin__") {
+		t.Fatal("response exposes internal authentication sentinels")
+	}
+}
+
+func TestHandlerIncludesDashboardRuntimeSafetyContracts(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rr := httptest.NewRecorder()
+	Handler().ServeHTTP(rr, req)
+	body := rr.Body.String()
+
+	for _, want := range []string{
+		"async function bulkAction(action)",
+		"if(operationEpoch!==authEpoch)return",
+		"document.getElementById('decision-bar').innerHTML=''",
+		"document.getElementById('heatmap-bars').innerHTML=''",
+		"document.getElementById('rules-empty').style.display='block'",
+		"reloadHint.textContent='';reloadHint.classList.remove('visible')",
+		`document.querySelector('.tab-btn[data-tab="history"]')`,
+		"api('/v1/status')",
+		"data-rule-name=",
+		"encodeURIComponent(ruleName)",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("response does not contain dashboard runtime contract %q", want)
+		}
+	}
+	if strings.Contains(body, "api('/v1/policy')") {
+		t.Fatal("policy card calls removed /v1/policy route instead of /v1/status")
 	}
 }

--- a/internal/dashboard/static/index.html
+++ b/internal/dashboard/static/index.html
@@ -35,6 +35,7 @@ body{font-family:'Inter',system-ui,sans-serif;font-size:13px;line-height:1.4;bac
 #token-input::placeholder{color:#52525b}
 #connect-btn{background:var(--accent);color:#fff;border:none;padding:6px 14px;border-radius:var(--radius);font-size:12px;font-weight:600;cursor:pointer}
 #connect-btn:hover{background:var(--accent-dim)}
+#token-show-btn{background:none;border:none;color:var(--text-dim);cursor:pointer;font-size:14px;padding:0 4px}
 #theme-toggle{background:var(--surface);border:1px solid var(--border);color:var(--text-bright);padding:4px 8px;border-radius:var(--radius);font-size:14px;cursor:pointer;line-height:1}
 #theme-toggle:hover{border-color:var(--accent)}
 /* Connected state — replaces input+button after auth */
@@ -48,6 +49,28 @@ body{font-family:'Inter',system-ui,sans-serif;font-size:13px;line-height:1.4;bac
 /* Error banner */
 #error-banner{display:none;background:rgba(239,68,68,.12);border:1px solid rgba(239,68,68,.3);color:var(--red);padding:8px 16px;border-radius:var(--radius);margin:8px 0;font-size:12px;align-items:center;gap:8px}
 #error-banner button{background:var(--red);color:#fff;border:none;padding:3px 10px;border-radius:var(--radius);cursor:pointer;font-size:11px}
+
+/* Static states and utility presentation. Keep presentation out of element
+   attributes so the nonce-only CSP applies without unsafe-inline. */
+#auth-prompt{display:none;border:1px solid var(--border);border-radius:var(--radius);padding:14px 16px;margin:10px 0;font-size:12px;line-height:1.7}
+.auth-prompt-title{color:var(--text-bright);font-size:13px}
+.auth-prompt-help,.empty-secondary{color:#52525b;font-size:12px}
+.empty-secondary{margin-top:4px}
+#badge-active,#denials-badge,#decision-bar-wrap,#policy-heatmap,#hist-empty,#hist-loading,#policy-test-result{display:none}
+.recent-denials-divider{margin-top:24px}
+.view-all-btn{margin-left:auto;background:none;border:none;color:var(--text-dim);font-size:11px;cursor:pointer;text-decoration:underline}
+.hist-loading{text-align:center;padding:24px;color:var(--text-dim);font-size:12px}
+.hist-more-cell{text-align:center;padding:8px;color:#52525b;font-size:11px}
+.cell-time{font-size:11px;white-space:nowrap}
+.cell-session,.cell-created{font-size:11px}
+.cell-actions{text-align:right}
+.col-w-time,.col-w-agent{width:80px}
+.col-w-session{width:100px}
+.col-w-tool{width:60px}
+.col-w-outcome{width:110px}
+.col-w-rules-tool{width:70px}
+.col-w-created{width:150px}
+.col-w-actions{width:80px;text-align:right}
 
 /* Tabs */
 .tabs{display:flex;gap:0;border-bottom:1px solid var(--border);margin-top:2px}
@@ -199,6 +222,9 @@ body{font-family:'Inter',system-ui,sans-serif;font-size:13px;line-height:1.4;bac
 .heatmap-count{width:36px;text-align:right;color:var(--text-dim);font-size:11px;font-family:'JetBrains Mono',monospace}
 .decision-bar-legend{display:flex;gap:12px;margin-top:4px;font-size:11px;color:var(--text-secondary)}
 .decision-bar-legend .swatch{display:inline-block;width:8px;height:8px;border-radius:2px;margin-right:3px;vertical-align:middle}
+.decision-bar-legend .swatch.allow{background:#34d399}
+.decision-bar-legend .swatch.pending{background:#fbbf24}
+.decision-bar-legend .swatch.deny{background:#f87171}
 
 /* Filter pills */
 .filter-pills{display:flex;gap:4px;padding:6px 0 10px;flex-wrap:wrap}
@@ -250,12 +276,15 @@ body{font-family:'Inter',system-ui,sans-serif;font-size:13px;line-height:1.4;bac
 
 /* Run cluster — grouped approvals sharing a run_id */
 .run-cluster{border:1px solid var(--border);border-radius:var(--radius);margin:8px 0;overflow:hidden}
-.run-cluster-header{display:flex;align-items:center;gap:10px;padding:9px 12px;background:var(--surface);border-bottom:1px solid var(--border);cursor:pointer;user-select:none}
+.run-cluster-header{display:flex;align-items:center;gap:10px;padding:9px 12px;background:var(--surface);border-bottom:1px solid var(--border);user-select:none}
+.run-cluster-toggle{display:flex;align-items:center;gap:10px;flex:1;min-width:0;padding:0;border:0;background:none;color:inherit;font:inherit;text-align:left;cursor:pointer}
+.run-cluster-toggle:focus-visible{outline:2px solid var(--accent);outline-offset:3px;border-radius:3px}
 .run-cluster-chevron{font-size:10px;color:var(--text-dim);transition:transform .2s;flex-shrink:0}
 .run-cluster.collapsed .run-cluster-chevron{transform:rotate(-90deg)}
 .run-cluster-label{font-family:'JetBrains Mono',monospace;font-size:12px;font-weight:600;color:var(--text-bright);flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.run-cluster-owner{font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--text-dim);flex-shrink:0}
 .run-cluster-count{font-size:10px;color:var(--text-dim);background:var(--surface-3);padding:1px 7px;border-radius:10px;flex-shrink:0}
-.run-cluster-actions{display:flex;gap:5px;flex-shrink:0}
+.run-cluster-actions{display:flex;gap:5px;flex-shrink:0;flex-wrap:wrap;justify-content:flex-end}
 .run-cluster-body{display:block}
 .run-cluster.collapsed .run-cluster-body{display:none}
 /* Items inside a cluster get a subtle left inset */
@@ -272,6 +301,10 @@ body{font-family:'Inter',system-ui,sans-serif;font-size:13px;line-height:1.4;bac
   .tbl td.cmd-col{max-width:none;white-space:normal;word-break:break-all}
   #token-input{width:160px}
   .stat:nth-child(n+4){display:none}
+  .run-cluster-header{flex-wrap:wrap}
+  .run-cluster-toggle{flex:1 1 120px}
+  .run-cluster-owner{max-width:140px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .run-cluster-actions{flex:1 0 100%;justify-content:flex-start}
 }
 @media(max-width:480px){
   #auth-bar{gap:6px;padding:8px 0}
@@ -305,7 +338,7 @@ body{font-family:'Inter',system-ui,sans-serif;font-size:13px;line-height:1.4;bac
     <button id="theme-toggle" title="Toggle theme">🌙</button>
     <!-- Pre-auth -->
     <input type="password" id="token-input" placeholder="API token" autocomplete="off">
-    <button id="token-show-btn" title="Show/hide token" onclick="toggleTokenVis()" style="background:none;border:none;color:var(--text-dim);cursor:pointer;font-size:14px;padding:0 4px">👁</button>
+    <button id="token-show-btn" title="Show/hide token">👁</button>
     <button id="connect-btn">Connect</button>
     <!-- Post-auth (shown after connect) -->
     <div id="auth-connected">
@@ -315,19 +348,19 @@ body{font-family:'Inter',system-ui,sans-serif;font-size:13px;line-height:1.4;bac
     </div>
   </div>
   <div id="auth-help">
-    <div id="auth-prompt" style="display:none;border:1px solid var(--border);border-radius:var(--radius);padding:14px 16px;margin:10px 0;font-size:12px;line-height:1.7">
-      <b style="color:var(--text-bright);font-size:13px">Connect to Rampart</b><br>
+    <div id="auth-prompt">
+      <b class="auth-prompt-title">Connect to Rampart</b><br>
       Paste the token from <code>rampart serve</code> output above, then click <b>Connect</b>.<br>
-      <span style="color:#52525b">Don't have it? Run <code>rampart serve install</code> and check the output, or run <code>rampart serve</code> directly to see the token printed on startup.</span>
+      <span class="auth-prompt-help">Don't have it? Run <code>rampart serve install</code> and check the output, or run <code>rampart serve</code> directly to see the token printed on startup.</span>
     </div>
   </div>
 
-  <div id="error-banner"><span id="error-msg"></span><button onclick="reconnect()">Retry</button></div>
+  <div id="error-banner"><span id="error-msg"></span><button id="reconnect-btn">Retry</button></div>
 
 <div id="main-content">
   <!-- Tabs -->
   <div class="tabs">
-    <button class="tab-btn active" data-tab="active">Active<span class="tab-badge" id="badge-active" style="display:none">0</span></button>
+    <button class="tab-btn active" data-tab="active">Active<span class="tab-badge" id="badge-active">0</span></button>
     <button class="tab-btn" data-tab="history">History</button>
     <button class="tab-btn" data-tab="policy">Policy</button>
   </div>
@@ -341,14 +374,14 @@ body{font-family:'Inter',system-ui,sans-serif;font-size:13px;line-height:1.4;bac
     <div class="empty" id="pending-empty">
       <div class="icon"><svg width="28" height="28" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M12 2L3 12l9 10 9-10L12 2z" fill="var(--accent)" opacity="0.15" stroke="var(--accent)" stroke-width="1.5" stroke-linejoin="round"/><path d="M12 7v6m0 2.5v.5" stroke="var(--accent)" stroke-width="1.5" stroke-linecap="round"/></svg></div>
       <div>All quiet — no pending approvals</div>
-      <div style="color:var(--text-dim);font-size:12px;margin-top:4px">Approvals appear here when agents request them</div>
+      <div class="empty-secondary">Approvals appear here when agents request them</div>
     </div>
 
     <!-- Recent Denials feed -->
-    <div class="section-divider" style="margin-top:24px">
+    <div class="section-divider recent-denials-divider">
       <span class="section-title">Recent Denials</span>
-      <span class="count-badge" id="denials-badge" style="display:none"></span>
-      <button onclick="switchTab('history')" style="margin-left:auto;background:none;border:none;color:var(--text-dim);font-size:11px;cursor:pointer;text-decoration:underline">View all →</button>
+      <span class="count-badge" id="denials-badge"></span>
+      <button id="view-history-btn" class="view-all-btn">View all →</button>
     </div>
     <div id="denials-feed"></div>
     <div class="empty" id="denials-empty">
@@ -365,11 +398,11 @@ body{font-family:'Inter',system-ui,sans-serif;font-size:13px;line-height:1.4;bac
       <div class="stat"><span class="dot denied"></span> <b id="hs-denied">—</b> denied</div>
       <div class="stat"><span class="dot pending"></span> <b id="hs-blocked">—</b> blocked</div>
     </div>
-    <div class="decision-bar-wrap" id="decision-bar-wrap" style="display:none">
+    <div class="decision-bar-wrap" id="decision-bar-wrap">
       <div class="decision-bar" id="decision-bar"></div>
     </div>
 
-    <div class="policy-heatmap" id="policy-heatmap" style="display:none">
+    <div class="policy-heatmap" id="policy-heatmap">
       <div class="heatmap-title">Top Policies</div>
       <div class="heatmap-bars" id="heatmap-bars"></div>
     </div>
@@ -377,8 +410,8 @@ body{font-family:'Inter',system-ui,sans-serif;font-size:13px;line-height:1.4;bac
     <div class="hist-controls">
       <input type="search" id="hist-search" placeholder="Filter by command…">
       <input type="date" id="hist-date">
-      <button onclick="loadHistoryTab(true)">Load</button>
-      <button onclick="exportHistoryAudit()">Export</button>
+      <button id="history-load-btn">Load</button>
+      <button id="history-export-btn">Export</button>
     </div>
 
     <div class="filter-pills" id="filter-pills">
@@ -392,23 +425,23 @@ body{font-family:'Inter',system-ui,sans-serif;font-size:13px;line-height:1.4;bac
     <div class="tbl-scroll" id="hist-scroll-wrap">
       <table class="tbl" id="hist-table">
         <thead><tr>
-          <th style="width:80px">Time</th>
-          <th class="col-agent" style="width:80px">Agent</th>
-          <th style="width:100px">Session</th>
-          <th class="col-tool" style="width:60px">Tool</th>
+          <th class="col-w-time">Time</th>
+          <th class="col-agent col-w-agent">Agent</th>
+          <th class="col-w-session">Session</th>
+          <th class="col-tool col-w-tool">Tool</th>
           <th class="cmd-col">Command</th>
 
-          <th style="width:110px">Outcome</th>
+          <th class="col-w-outcome">Outcome</th>
         </tr></thead>
         <tbody id="hist-body"></tbody>
       </table>
-      <div class="empty" id="hist-empty" style="display:none">
+      <div class="empty" id="hist-empty">
         <div class="icon">📭</div>
         <div>No events for this date</div>
-        <div style="color:var(--text-dim);font-size:12px;margin-top:4px">Try selecting a different date</div>
+        <div class="empty-secondary">Try selecting a different date</div>
       </div>
-      <div id="hist-loading" style="display:none;text-align:center;padding:24px;color:var(--text-dim);font-size:12px">Loading history…</div>
-      <div id="hist-sentinel" style="height:4px"></div>
+      <div id="hist-loading" class="hist-loading">Loading history…</div>
+      <div id="hist-sentinel"></div>
     </div>
   </div>
 
@@ -427,7 +460,7 @@ body{font-family:'Inter',system-ui,sans-serif;font-size:13px;line-height:1.4;bac
         </select>
         <button id="policy-test-btn" class="policy-test-btn">Test</button>
       </div>
-      <div id="policy-test-result" class="policy-test-result" style="display:none"></div>
+      <div id="policy-test-result" class="policy-test-result"></div>
     </div>
     <!-- Policy info card (reload button lives inside) -->
     <div class="policy-card" id="policy-card">
@@ -442,9 +475,9 @@ body{font-family:'Inter',system-ui,sans-serif;font-size:13px;line-height:1.4;bac
     <table class="tbl" id="rules-table">
       <thead><tr>
         <th class="cmd-col">Command Pattern</th>
-        <th class="col-tool" style="width:70px">Tool</th>
-        <th style="width:150px">Created</th>
-        <th style="width:80px;text-align:right">Actions</th>
+        <th class="col-tool col-w-rules-tool">Tool</th>
+        <th class="col-w-created">Created</th>
+        <th class="col-w-actions">Actions</th>
       </tr></thead>
       <tbody id="rules-body"></tbody>
     </table>
@@ -459,8 +492,8 @@ body{font-family:'Inter',system-ui,sans-serif;font-size:13px;line-height:1.4;bac
 <!-- Bulk action bar -->
 <div id="bulk-bar">
   <span class="bulk-count" id="bulk-count">0 selected</span>
-  <button class="act-btn approve" onclick="bulkAction('approve')">✓ Approve All</button>
-  <button class="act-btn deny" onclick="bulkAction('deny')">✗ Deny All</button>
+  <button class="act-btn approve" data-bulk-action="approve">✓ Approve Selected</button>
+  <button class="act-btn deny" data-bulk-action="deny">✗ Deny Selected</button>
 </div>
 
 <script>
@@ -468,10 +501,11 @@ body{font-family:'Inter',system-ui,sans-serif;font-size:13px;line-height:1.4;bac
 const DANGEROUS=[/^rm\s/,/^chmod\s/,/^chown\s/,/^kill\s/,/^killall\s/,/^pkill\s/,/^dd\s/,/^mkfs/,/^fdisk/,/^reboot/,/^shutdown/,/^halt/,/^systemctl\s+(stop|disable|restart)/,/\bsudo\b/,/\brm\s+-rf\b/,/^ssh\b.*\breboot\b/,/^curl\b.*\|\s*(ba)?sh/];
 function isDangerous(cmd){return DANGEROUS.some(r=>r.test(cmd||''))}
 
-let token='',pollTimer=null,connected=false,expandedId=null,initialPoll=true,evtSource=null;
+let token='',pollTimer=null,connected=false,expandedId=null,initialPoll=true,evtSource=null,authEpoch=0,pollGeneration=0;
 const pendingMap=new Map();
 const selectedIds=new Set();
 let runGroupsData=[];
+let runGrantTTLMS=120000;
 
 // ── Theme ──────────────────────────────────────────────────────────────────
 function initTheme(){
@@ -531,26 +565,16 @@ function initResizeHandles(){
   if(token){connect()}else{const p=document.getElementById('auth-prompt');if(p)p.style.display='block'}
 
   document.getElementById('theme-toggle').addEventListener('click',toggleTheme);
+  document.getElementById('token-show-btn').addEventListener('click',toggleTokenVis);
   document.getElementById('connect-btn').addEventListener('click',connect);
+  document.getElementById('reconnect-btn').addEventListener('click',reconnect);
   document.getElementById('token-input').addEventListener('keydown',e=>{if(e.key==='Enter')connect()});
   document.getElementById('disconnect-btn').addEventListener('click',()=>{
-    clearTimeout(pollTimer);clearTimeout(denialsTimer);
-    if(evtSource){evtSource.close();evtSource=null;}
-    connected=false;token='';_denialsStarted=false;
-    histEvents=[];histOffset=0;histFiltered=[];
-    pendingMap.clear();selectedIds.clear();
+    authEpoch++;
+    token='';
     localStorage.removeItem('rampart_token');
-    setConnected(false);hideError();
     document.getElementById('token-input').value='';
-    document.getElementById('main-content').classList.remove('visible');
-    document.getElementById('pending-body').innerHTML='';
-    document.getElementById('denials-feed').innerHTML='';
-    document.getElementById('hist-body').innerHTML='';
-    document.getElementById('badge-active').style.display='none';
-    document.getElementById('pending-empty').style.display='block';
-    document.getElementById('denials-empty').style.display='block';
-    const p=document.getElementById('auth-prompt');if(p)p.style.display='block';
-    document.getElementById('auth-help').style.display='';
+    resetProtectedState();hideError();
   });
 
   // Tab switching
@@ -561,6 +585,10 @@ function initResizeHandles(){
 
   // Pending table events (including run-cluster bulk buttons)
   document.getElementById('pending-body').addEventListener('click',handlePendingClick);
+  document.getElementById('bulk-bar').addEventListener('click',e=>{
+    const btn=e.target.closest('[data-bulk-action]');if(!btn)return;
+    bulkAction(btn.dataset.bulkAction);
+  });
 
   // Select-all
   document.getElementById('select-all').addEventListener('change',function(e){
@@ -583,6 +611,18 @@ function initResizeHandles(){
   // History: search
   document.getElementById('hist-search').addEventListener('input',function(){
     histSearch=this.value.trim().toLowerCase();applyHistFilters();
+  });
+  document.getElementById('view-history-btn').addEventListener('click',()=>switchTab('history'));
+  document.getElementById('history-load-btn').addEventListener('click',()=>loadHistoryTab(true));
+  document.getElementById('history-export-btn').addEventListener('click',exportHistoryAudit);
+
+  // Policy content is rendered dynamically, so its actions use delegation.
+  document.getElementById('policy-card').addEventListener('click',e=>{
+    if(e.target.closest('#reload-btn'))reloadPolicy();
+  });
+  document.getElementById('rules-body').addEventListener('click',e=>{
+    const btn=e.target.closest('[data-rule-name]');if(!btn)return;
+    revokeRule(btn.dataset.ruleName);
   });
 
   // History table: expand on click
@@ -627,11 +667,95 @@ function setDot(cls){
 function showError(msg){const b=document.getElementById('error-banner');b.style.display='flex';document.getElementById('error-msg').textContent=msg}
 function hideError(){document.getElementById('error-banner').style.display='none'}
 function toast(msg){const t=document.getElementById('toast');t.textContent=msg;t.classList.add('show');setTimeout(()=>t.classList.remove('show'),2000)}
+function resetProtectedState(){
+  pollGeneration++;
+  clearTimeout(pollTimer);clearTimeout(denialsTimer);clearTimeout(denialRefreshTimer);
+  pollTimer=null;denialsTimer=null;denialRefreshTimer=null;
+  if(evtSource){evtSource.close();evtSource=null;}
+  connected=false;_denialsStarted=false;initialPoll=true;expandedId=null;
+  pendingMap.clear();selectedIds.clear();runGroupsData=[];
+  histEvents=[];histFiltered=[];histOffset=0;histHasMore=false;histLoading=false;
+  histSeenIds=new Set();histTabLoaded=false;histActiveFilter='all';histSearch='';rulesCache=[];
+  if(histObserver){histObserver.disconnect();histObserver=null;}
+  switchTab('active');
+  setConnected(false);
+  document.getElementById('main-content').classList.remove('visible');
+  document.getElementById('pending-body').innerHTML='';
+  document.getElementById('denials-feed').innerHTML='';
+  document.getElementById('hist-body').innerHTML='';
+  document.getElementById('hist-loading').style.display='none';
+  document.getElementById('hist-empty').style.display='none';
+  document.getElementById('hist-search').value='';
+  document.getElementById('hist-date').value='';
+  document.querySelectorAll('#filter-pills .pill').forEach(p=>p.classList.toggle('active',p.dataset.filter==='all'));
+  for(const id of ['hs-total','hs-approved','hs-denied','hs-blocked'])document.getElementById(id).textContent='—';
+  document.getElementById('decision-bar').innerHTML='';
+  const decisionBarWrap=document.getElementById('decision-bar-wrap');
+  decisionBarWrap.style.display='none';
+  decisionBarWrap.querySelector('.decision-bar-legend')?.remove();
+  document.getElementById('heatmap-bars').innerHTML='';
+  document.getElementById('policy-heatmap').style.display='none';
+  document.getElementById('rules-body').innerHTML='';
+  document.getElementById('rules-empty').style.display='block';
+  document.getElementById('policy-card').innerHTML='<div class="policy-unavail">Loading policy info…</div>';
+  const reloadHint=document.getElementById('reload-hint');
+  reloadHint.textContent='';reloadHint.classList.remove('visible');
+  const policyTestResult=document.getElementById('policy-test-result');
+  policyTestResult.textContent='';policyTestResult.className='policy-test-result';policyTestResult.style.display='none';
+  const policyTestInput=document.getElementById('policy-test-input');
+  policyTestInput.value='';policyTestInput.placeholder=policyTestPlaceholders.exec;
+  document.getElementById('policy-test-tool').value='exec';
+  const policyTestButton=document.getElementById('policy-test-btn');
+  policyTestButton.disabled=false;policyTestButton.textContent='Test';
+  const activeBadge=document.getElementById('badge-active');activeBadge.textContent='0';activeBadge.style.display='none';
+  const denialsBadge=document.getElementById('denials-badge');denialsBadge.textContent='';denialsBadge.style.display='none';
+  document.getElementById('pending-empty').style.display='block';
+  document.getElementById('denials-empty').style.display='block';
+  document.getElementById('bulk-bar').style.display='none';
+  document.getElementById('bulk-count').textContent='0 selected';
+  document.getElementById('select-all').checked=false;
+  const prompt=document.getElementById('auth-prompt');if(prompt)prompt.style.display='block';
+  document.getElementById('auth-help').style.display='';
+}
+function handleAuthFailure(status){
+  if(status!==401&&status!==403)return false;
+  authEpoch++;
+  resetProtectedState();
+  showError(status===403
+    ?'Admin scope required — eval-only tokens cannot access dashboard controls.'
+    :'Invalid or expired token — paste a current admin-scoped token and click Connect.');
+  return true;
+}
+function handleAuthError(error){return handleAuthFailure(error&&error.status)}
+function supersededRequestError(){const e=new Error('Superseded authentication request');e.stale=true;return e}
+function assertAuthEpoch(epoch){if(epoch!==authEpoch)throw supersededRequestError()}
+function handleAPIControlError(error){return Boolean(error&&error.stale)||handleAuthError(error)}
 async function api(path,opts={}){
-  const r=await fetch(path,{...opts,headers:{'Authorization':'Bearer '+token,...(opts.headers||{})}});
-  if(r.status===401||r.status===403){throw new Error('__auth__')}
-  if(!r.ok)throw new Error(r.status+' '+r.statusText);
-  return r;
+  const requestEpoch=authEpoch;
+  let r;
+  try{
+    r=await fetch(path,{...opts,headers:{'Authorization':'Bearer '+token,...(opts.headers||{})}});
+  }catch(error){assertAuthEpoch(requestEpoch);throw error}
+  assertAuthEpoch(requestEpoch);
+  if(r.status===401){const e=new Error('Invalid or expired token');e.status=401;throw e}
+  if(r.status===403){const e=new Error('Admin scope required');e.status=403;throw e}
+  if(!r.ok){
+    let message=r.status+' '+r.statusText;
+    let details=null;
+    try{details=await r.clone().json();assertAuthEpoch(requestEpoch);if(details&&details.error)message=details.error}catch(error){if(error&&error.stale)throw error}
+    assertAuthEpoch(requestEpoch);
+    const e=new Error(message);e.status=r.status;e.details=details;throw e;
+  }
+  const guardedRead=async reader=>{
+    try{const value=await reader();assertAuthEpoch(requestEpoch);return value}
+    catch(error){assertAuthEpoch(requestEpoch);throw error}
+  };
+  return{
+    status:r.status,
+    assertCurrent:()=>assertAuthEpoch(requestEpoch),
+    json:()=>guardedRead(()=>r.json()),
+    blob:()=>guardedRead(()=>r.blob()),
+  };
 }
 
 // ── Tab switching ──────────────────────────────────────────────────────────
@@ -649,6 +773,8 @@ function switchTab(name){
 // ── Connection / Poll ──────────────────────────────────────────────────────
 function connect(){
   token=document.getElementById('token-input').value.trim();if(!token)return;
+  authEpoch++;
+  pollGeneration++;
   if(evtSource){evtSource.close();evtSource=null;}
   localStorage.setItem('rampart_token',token);
   const p=document.getElementById('auth-prompt');if(p)p.style.display='none';
@@ -663,18 +789,19 @@ function startSSE(){
   if(evtSource)evtSource.close();
   // EventSource can't expose HTTP status codes — probe first so auth errors
   // show a useful message instead of generic "Cannot reach Rampart".
+  const requestEpoch=authEpoch;
   fetch('/v1/events/stream',{headers:{'Authorization':'Bearer '+token},method:'HEAD'}).then(r=>{
-    if(r.status===401||r.status===403){
-      showError('Dashboard requires an admin token. Agent-scoped tokens cannot access the event stream.');
-      return;
-    }
+    if(requestEpoch!==authEpoch)return;
+    if(handleAuthFailure(r.status))return;
     _startSSEInner();
-  }).catch(()=>_startSSEInner());
+  }).catch(()=>{if(requestEpoch===authEpoch)_startSSEInner()});
 }
 function _startSSEInner(){
   if(evtSource)evtSource.close();
+  const streamEpoch=authEpoch;
   evtSource=new EventSource(`/v1/events/stream?token=${encodeURIComponent(token)}`);
   evtSource.onmessage=function(e){
+    if(streamEpoch!==authEpoch)return;
     try{
       const msg=JSON.parse(e.data);
       if(msg.type==="connected")return;
@@ -686,7 +813,8 @@ function _startSSEInner(){
         // Bulk-resolve produced multiple audit events — reload History rather
         // than flooding SSE with N individual events.
         histTabLoaded=false;
-        if(document.getElementById('tab-history').classList.contains('active')){
+        const historyTab=document.querySelector('.tab-btn[data-tab="history"]');
+        if(historyTab&&historyTab.classList.contains('active')){
           loadHistoryTab();
         }
       }
@@ -696,6 +824,7 @@ function _startSSEInner(){
     }catch(_){}
   };
   evtSource.onerror=function(){
+    if(streamEpoch!==authEpoch)return;
     setDot('wait');
     if(pollTimer)clearTimeout(pollTimer);
     pollTimer=setTimeout(poll,5000);
@@ -703,9 +832,11 @@ function _startSSEInner(){
 }
 
 async function poll(){
+  const generation=++pollGeneration;
   clearTimeout(pollTimer);
   try{
-    const r=await api('/v1/approvals');const data=await r.json();
+    const r=await api('/v1/approvals');const data=await r.json();r.assertCurrent();
+    if(generation!==pollGeneration)return;
     initialPoll=false;
     if(!connected){
       connected=true;setConnected(true);hideError();
@@ -713,21 +844,18 @@ async function poll(){
       startSSE();
       if(!_denialsStarted){_denialsStarted=true;loadRecentDenials()}
     }
+    if(Number.isFinite(data.run_grant_ttl_ms)&&data.run_grant_ttl_ms>0){
+      runGrantTTLMS=data.run_grant_ttl_ms;
+    }
     updatePending(data.approvals||[],data.run_groups||[]);
     const delay=15000;
-    if(!document.hidden)pollTimer=setTimeout(poll,delay);
+    if(generation===pollGeneration&&!document.hidden)pollTimer=setTimeout(poll,delay);
   }catch(e){
-    if(e.message==='__auth__'){
-      if(evtSource){evtSource.close();evtSource=null;}
-      connected=false;setConnected(false);
-      showError('Invalid token — paste the token from rampart serve output and click Connect.');
-      return; // don't retry on auth failure
-    }
+    if(generation!==pollGeneration)return;
+    if(handleAPIControlError(e))return; // don't retry stale or auth-failed requests
     if(initialPoll){initialPoll=false;pollTimer=setTimeout(poll,15000);return}
-    connected=false;_denialsStarted=false;
-    if(evtSource){evtSource.close();evtSource=null;}
-    setConnected(false);
-    document.getElementById('main-content').classList.remove('visible');
+    authEpoch++;
+    resetProtectedState();
     showError('Cannot reach Rampart — is rampart serve running on this machine?');
     pollTimer=setTimeout(poll,10000);
   }
@@ -834,19 +962,24 @@ function createRunCluster(g,groupItems,newIds){
 
   const header=document.createElement('div');
   header.className='run-cluster-header';
+  const grantTTL=formatDurationMS(runGrantTTLMS);
+  const reviewedIDs=JSON.stringify(groupItems.map(item=>item.id));
   header.innerHTML=`
-    <span class="run-cluster-chevron">▾</span>
-    <span class="run-cluster-label" title="${esc(g.run_id)}">Run: ${esc(shortId)}…</span>
+    <button type="button" class="run-cluster-toggle" aria-expanded="true" title="Expand or collapse this run">
+      <span class="run-cluster-chevron" aria-hidden="true">▾</span>
+      <span class="run-cluster-label" title="${esc(g.run_id)}">Run: ${esc(shortId)}…</span>
+    </button>
+    <span class="run-cluster-owner" title="Credential owner">${esc(g.credential_owner||'server/admin')}</span>
     <span class="run-cluster-count">${count} pending</span>
     <div class="run-cluster-actions">
-      <button class="act-btn approve run-approve-all" data-agent="${esc(g.agent)}" data-session="${esc(g.session)}" data-run-id="${esc(g.run_id)}" data-count="${count}" title="Approve all pending calls from this agent session and run">✓ Approve All</button>
-      <button class="act-btn deny run-deny-all" data-agent="${esc(g.agent)}" data-session="${esc(g.session)}" data-run-id="${esc(g.run_id)}" data-count="${count}" title="Deny all pending calls from this agent session and run">✗ Deny All</button>
+      <button class="act-btn approve run-approve-pending" data-agent="${esc(g.agent)}" data-session="${esc(g.session)}" data-run-id="${esc(g.run_id)}" data-owner="${esc(g.credential_owner||'server/admin')}" data-ids="${esc(reviewedIDs)}" data-count="${count}" title="Approve only these reviewed pending calls">✓ Approve Pending</button>
+      <button class="act-btn always run-allow-future" data-agent="${esc(g.agent)}" data-session="${esc(g.session)}" data-run-id="${esc(g.run_id)}" data-owner="${esc(g.credential_owner||'server/admin')}" data-ids="${esc(reviewedIDs)}" data-count="${count}" title="Approve reviewed and future calls from this exact run and credential owner for ${grantTTL}">Allow Future (${grantTTL})</button>
+      <button class="act-btn deny run-deny-pending" data-agent="${esc(g.agent)}" data-session="${esc(g.session)}" data-run-id="${esc(g.run_id)}" data-owner="${esc(g.credential_owner||'server/admin')}" data-ids="${esc(reviewedIDs)}" data-count="${count}" title="Deny only these reviewed pending calls">✗ Deny Pending</button>
     </div>`;
-  // Toggle collapse on header click (but not button clicks)
-  header.addEventListener('click',e=>{
-    if(e.target.closest('button'))return;
+  const toggle=header.querySelector('.run-cluster-toggle');
+  toggle.addEventListener('click',()=>{
     cluster.classList.toggle('collapsed');
-    header.querySelector('.run-cluster-chevron').textContent=cluster.classList.contains('collapsed')?'▸':'▾';
+    toggle.setAttribute('aria-expanded',String(!cluster.classList.contains('collapsed')));
   });
   cluster.appendChild(header);
 
@@ -865,20 +998,53 @@ function createRunCluster(g,groupItems,newIds){
   return cluster;
 }
 
-async function bulkResolveRun(agent,session,runId,action,count){
-  const actionVerb=action==='approve'?'Approve':'Deny';
-  const pastTense=action==='approve'?'Approved':'Denied';
-  if(!confirm(`${actionVerb} all ${count} pending call${count===1?'':'s'} from this run?`))return;
+function formatDurationMS(totalMS){
+  let remaining=Math.max(0,Math.ceil(totalMS));
+  const h=Math.floor(remaining/3600000);remaining%=3600000;
+  const m=Math.floor(remaining/60000);remaining%=60000;
+  const s=Math.floor(remaining/1000),ms=remaining%1000;
+  return [h?h+'h':'',m?m+'m':'',s?s+'s':'',ms?ms+'ms':''].filter(Boolean).join(' ')||'0ms';
+}
+
+async function bulkResolveRun(agent,session,runId,owner,ids,action,scope,count){
+  let prompt;
+  if(scope==='run'){
+    prompt=`Allow these ${count} reviewed call${count===1?'':'s'}, plus future calls from this exact run and credential owner for ${formatDurationMS(runGrantTTLMS)}?\n\nAgent: ${agent}\nSession: ${session}\nRun: ${runId}\nCredential owner: ${owner}`;
+  }else if(action==='approve'){
+    prompt=`Approve only these ${count} reviewed pending call${count===1?'':'s'}?\n\nFuture calls will still require approval.`;
+  }else{
+    prompt=`Deny only these ${count} reviewed pending call${count===1?'':'s'}?`;
+  }
+  if(!confirm(prompt))return;
   try{
-    await api('/v1/approvals/bulk-resolve',{
+    const r=await api('/v1/approvals/bulk-resolve',{
       method:'POST',
       headers:{'Content-Type':'application/json'},
-      body:JSON.stringify({agent,session,run_id:runId,action})
+      body:JSON.stringify({agent,session,run_id:runId,action,scope,ids,resolved_by:'dashboard'})
     });
-    toast(`${pastTense} run ${runId.slice(0,8)}…`);
+    const result=await r.json();r.assertCurrent();
+    if(result.future_calls_authorized){
+      toast(`Allowed future calls for ${formatDurationMS(result.grant_ttl_ms)} — ${runId.slice(0,8)}…`);
+    }else{
+      toast(`${action==='approve'?'Approved':'Denied'} ${result.resolved} pending call${result.resolved===1?'':'s'}`);
+    }
     // Re-poll immediately to update the dashboard
     clearTimeout(pollTimer);poll();
   }catch(e){
+    if(handleAPIControlError(e))return;
+    if(e.status===409){
+      toast('Approvals changed — refresh and review again.');
+      clearTimeout(pollTimer);poll();
+      return;
+    }
+    if(e.status===503&&e.details&&e.details.refresh_required){
+      const n=Number(e.details.resolved)||0;
+      toast(n>0
+        ?`${n} approval${n===1?' was':'s were'} committed — refreshed; review before retrying.`
+        :'Bulk action was not completed — refreshed; review before retrying.');
+      clearTimeout(pollTimer);poll();
+      return;
+    }
     toast('Error: '+e.message);
   }
 }
@@ -925,17 +1091,23 @@ function createPendingRow(a){
 }
 
 function handlePendingClick(e){
-  // Run cluster: Approve All / Deny All buttons
-  const runApprove=e.target.closest('.run-approve-all');
-  if(runApprove){
+  // Run cluster: pending-only decisions and explicit future authority.
+  const approvePending=e.target.closest('.run-approve-pending');
+  if(approvePending){
     e.stopPropagation();
-    bulkResolveRun(runApprove.dataset.agent,runApprove.dataset.session,runApprove.dataset.runId,'approve',parseInt(runApprove.dataset.count,10));
+    bulkResolveRun(approvePending.dataset.agent,approvePending.dataset.session,approvePending.dataset.runId,approvePending.dataset.owner,JSON.parse(approvePending.dataset.ids),'approve','pending',parseInt(approvePending.dataset.count,10));
     return;
   }
-  const runDeny=e.target.closest('.run-deny-all');
-  if(runDeny){
+  const allowFuture=e.target.closest('.run-allow-future');
+  if(allowFuture){
     e.stopPropagation();
-    bulkResolveRun(runDeny.dataset.agent,runDeny.dataset.session,runDeny.dataset.runId,'deny',parseInt(runDeny.dataset.count,10));
+    bulkResolveRun(allowFuture.dataset.agent,allowFuture.dataset.session,allowFuture.dataset.runId,allowFuture.dataset.owner,JSON.parse(allowFuture.dataset.ids),'approve','run',parseInt(allowFuture.dataset.count,10));
+    return;
+  }
+  const denyPending=e.target.closest('.run-deny-pending');
+  if(denyPending){
+    e.stopPropagation();
+    bulkResolveRun(denyPending.dataset.agent,denyPending.dataset.session,denyPending.dataset.runId,denyPending.dataset.owner,JSON.parse(denyPending.dataset.ids),'deny','pending',parseInt(denyPending.dataset.count,10));
     return;
   }
   if(e.target.classList.contains('row-chk')){
@@ -974,26 +1146,39 @@ function updateBulkBar(){
 
 async function bulkAction(action){
   const ids=[...selectedIds];if(!ids.length)return;
+  const operationEpoch=authEpoch;
   if(!confirm(`${action==='approve'?'Approve':'Deny'} ${ids.length} pending approval(s)?`))return;
-  for(const id of ids){try{await resolveApproval(id,action)}catch(e){}}
+  for(const id of ids){
+    if(operationEpoch!==authEpoch)return;
+    try{await resolveApproval(id,action)}catch(e){}
+    if(operationEpoch!==authEpoch)return;
+  }
   selectedIds.clear();updateBulkBar();
 }
 
 async function resolveApproval(id,action){
   const approved=action!=='deny';const persist=action==='always';
+  const requestEpoch=authEpoch;
   const row=document.getElementById('row-'+id);
   if(row)row.classList.add(approved?'flash-green':'flash-red');
   try{
-    await api('/v1/approvals/'+id+'/resolve',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({approved,resolved_by:'dashboard',persist})});
+    const response=await api('/v1/approvals/'+id+'/resolve',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({approved,resolved_by:'dashboard',persist})});
+    response.assertCurrent();
     setTimeout(()=>{
+      if(requestEpoch!==authEpoch)return;
       pendingMap.delete(id);selectedIds.delete(id);
       renderPending(new Set());
       updateBulkBar();
       // If denied, quietly refresh the denials feed after a short delay
-      if(!approved)setTimeout(loadRecentDenials,600);
+      if(!approved){
+        clearTimeout(denialRefreshTimer);
+        denialRefreshTimer=setTimeout(()=>{
+          if(connected&&requestEpoch===authEpoch)loadRecentDenials();
+        },600);
+      }
     },400);
     if(persist)toast('Rule saved — always allowed');
-  }catch(e){toast('Error: '+e.message)}
+  }catch(e){if(handleAPIControlError(e))return;toast('Error: '+e.message)}
 }
 
 // ── Timers ─────────────────────────────────────────────────────────────────
@@ -1011,7 +1196,7 @@ function updateTimerCell(a){
 }
 
 // ── Recent Denials ─────────────────────────────────────────────────────────
-let denialsTimer=null;
+let denialsTimer=null,denialRefreshTimer=null;
 
 async function loadRecentDenials(){
   clearTimeout(denialsTimer);
@@ -1021,7 +1206,12 @@ async function loadRecentDenials(){
       api('/v1/audit/events?action=deny&limit=10'),
     ]);
     const e1=r1.status==='fulfilled'?(await r1.value.json()).events||[]:[];
+    if(r1.status==='fulfilled')r1.value.assertCurrent();
     const e2=r2.status==='fulfilled'?(await r2.value.json()).events||[]:[];
+    if(r2.status==='fulfilled')r2.value.assertCurrent();
+    for(const result of [r1,r2]){
+      if(result.status==='rejected'&&handleAPIControlError(result.reason))return;
+    }
     const seen=new Set();
     const combined=[...e1,...e2].filter(ev=>{
       const k=ev.id||(ev.timestamp+extractCmd(ev));
@@ -1031,7 +1221,7 @@ async function loadRecentDenials(){
       return a==='denied'||a==='deny'||a==='blocked';
     }).sort((a,b)=>(b.timestamp||'').localeCompare(a.timestamp||'')).slice(0,10);
     renderDenials(combined);
-  }catch(e){/* silently ignore */}
+  }catch(e){if(handleAPIControlError(e))return/* silently ignore other failures */}
   denialsTimer=setTimeout(loadRecentDenials,30000);
 }
 
@@ -1078,6 +1268,7 @@ function onHistoryTabOpen(){
 
 async function loadHistoryTab(reset){
   if(histLoading)return;histLoading=true;
+  const operationEpoch=authEpoch;
   const loading=document.getElementById('hist-loading');
   if(loading)loading.style.display='block';
   if(reset){
@@ -1087,7 +1278,7 @@ async function loadHistoryTab(reset){
   const date=document.getElementById('hist-date').value||todayStr();
   try{
     const r=await api(`/v1/audit/events?date=${date}&limit=${HIST_PAGE}&offset=${histOffset}`);
-    const data=await r.json();
+    const data=await r.json();r.assertCurrent();
     const evs=data.events||[];
     // Deduplicate: SSE may have already added some events.
     const fresh=evs.filter(ev=>!histSeenIds.has(ev.id));
@@ -1101,17 +1292,19 @@ async function loadHistoryTab(reset){
     applyHistFilters();
     renderPolicyHeatmap();
     await loadHistStats(date);
-  }catch(e){toast('History error: '+e.message)}
+  }catch(e){if(handleAPIControlError(e))return;toast('History error: '+e.message)}
   finally{
-    if(loading)loading.style.display='none';
+    if(operationEpoch===authEpoch){
+      if(loading)loading.style.display='none';
+      histLoading=false;
+    }
   }
-  histLoading=false;
 }
 
 async function loadHistStats(date){
   try{
     const r=await api(`/v1/audit/stats?from=${date}&to=${date}`);
-    const s=await r.json();
+    const s=await r.json();r.assertCurrent();
     const ba=s.by_action||{};
     const approved=(ba.approved||0)+(ba.allow||0);
     const denied=(ba.denied||0);
@@ -1121,7 +1314,7 @@ async function loadHistStats(date){
     document.getElementById('hs-denied').textContent=denied;
     document.getElementById('hs-blocked').textContent=blocked;
     renderDecisionBar(approved,denied,blocked);
-  }catch(e){/* silently ignore if stats endpoint unavailable */}
+  }catch(e){if(handleAPIControlError(e))return/* silently ignore if stats endpoint unavailable */}
 }
 
 function renderDecisionBar(approved,denied,blocked){
@@ -1133,17 +1326,25 @@ function renderDecisionBar(approved,denied,blocked){
   const pA=((approved/total)*100).toFixed(1);
   const pD=((denied/total)*100).toFixed(1);
   const pB=((blocked/total)*100).toFixed(1);
-  bar.innerHTML=
-    (approved?`<div class="seg seg-allow" style="width:${pA}%" title="Allowed: ${approved} (${pA}%)"></div>`:'')+
-    (blocked?`<div class="seg seg-pending" style="width:${pB}%" title="Blocked (awaiting approval): ${blocked} (${pB}%)"></div>`:'')+
-    (denied?`<div class="seg seg-deny" style="width:${pD}%" title="Denied by policy: ${denied} (${pD}%)"></div>`:'');
+  bar.innerHTML='';
+  const addSegment=(count,cls,pct,label)=>{
+    if(!count)return;
+    const segment=document.createElement('div');
+    segment.className='seg '+cls;
+    segment.style.width=pct+'%';
+    segment.title=`${label}: ${count} (${pct}%)`;
+    bar.appendChild(segment);
+  };
+  addSegment(approved,'seg-allow',pA,'Allowed');
+  addSegment(blocked,'seg-pending',pB,'Blocked (awaiting approval)');
+  addSegment(denied,'seg-deny',pD,'Denied by policy');
   // Add or update legend below bar
   let legend=wrap.querySelector('.decision-bar-legend');
   if(!legend){legend=document.createElement('div');legend.className='decision-bar-legend';wrap.appendChild(legend)}
   legend.innerHTML=
-    `<span><span class="swatch" style="background:#34d399"></span>Allowed ${pA}%</span>`+
-    `<span><span class="swatch" style="background:#fbbf24"></span>Blocked ${pB}%</span>`+
-    `<span><span class="swatch" style="background:#f87171"></span>Denied ${pD}%</span>`;
+    `<span><span class="swatch allow"></span>Allowed ${pA}%</span>`+
+    `<span><span class="swatch pending"></span>Blocked ${pB}%</span>`+
+    `<span><span class="swatch deny"></span>Denied ${pD}%</span>`;
 }
 
 function renderPolicyHeatmap(){
@@ -1164,15 +1365,18 @@ function renderPolicyHeatmap(){
   if(!entries.length){wrap.style.display='none';return}
   wrap.style.display='block';
   const maxCount=entries[0][1].total;
-  container.innerHTML=entries.map(([name,c])=>{
+  container.innerHTML='';
+  entries.forEach(([name,c])=>{
     const pct=((c.total/maxCount)*100).toFixed(1);
     const cls=c.deny===0?'allow':c.allow===0?'deny':'mixed';
-    return `<div class="heatmap-row">
+    const row=document.createElement('div');row.className='heatmap-row';
+    row.innerHTML=`
       <span class="heatmap-label" title="${esc(name)}">${esc(name)}</span>
-      <div class="heatmap-bar-track"><div class="heatmap-bar-fill ${cls}" style="width:${pct}%"></div></div>
-      <span class="heatmap-count">${c.total}</span>
-    </div>`;
-  }).join('');
+      <div class="heatmap-bar-track"><div class="heatmap-bar-fill ${cls}"></div></div>
+      <span class="heatmap-count">${c.total}</span>`;
+    row.querySelector('.heatmap-bar-fill').style.width=pct+'%';
+    container.appendChild(row);
+  });
 }
 
 function applyHistFilters(){
@@ -1208,7 +1412,7 @@ function renderHistEvents(){
   // Sentinel for infinite scroll
   if(histHasMore){
     const sentinel=document.createElement('tr');sentinel.id='hist-sentinel-row';
-    sentinel.innerHTML='<td colspan="6" style="text-align:center;padding:8px;color:#52525b;font-size:11px">Loading more…</td>';
+    sentinel.innerHTML='<td colspan="6" class="hist-more-cell">Loading more…</td>';
     tbody.append(sentinel);
     if(histObserver)histObserver.disconnect();
     const wrapper=document.getElementById('hist-scroll-wrap');
@@ -1231,9 +1435,9 @@ function appendHistRow(ev,tbody){
   const normAction=action==='log'?'watch':action==='ask'?'require_approval':action==='blocked'?'deny':action==='denied'?'deny':action||'';
   const actionLabel=normAction==='deny'?'blocked':normAction==='allow'?'allow':normAction==='approved'?'approved':normAction==='watch'?'watch':normAction==='require_approval'?'pending':normAction||'—';
   const badgeCls=normAction==='allow'?'allow':normAction==='deny'?'deny':normAction==='approved'?'approved':normAction==='require_approval'?'require_approval':normAction==='watch'?'watch':'';
-  tr.innerHTML=`<td style="font-size:11px;white-space:nowrap">${esc(t)}</td>
+  tr.innerHTML=`<td class="cell-time">${esc(t)}</td>
     <td class="col-agent">${esc(ev.agent||'—')}</td>
-    <td style="font-size:11px">${esc(ev.session||'—')}</td>
+    <td class="cell-session">${esc(ev.session||'—')}</td>
     <td class="col-tool">${esc(ev.tool==='unknown'&&ev.request&&ev.request.raw_error?'parse-err':ev.tool||'—')}</td>
     <td class="cmd-col mono"><span class="cmd-text" title="${esc(cmd)}">${esc(cmd||ev.decision&&ev.decision.message||'—')}</span></td>
     <td><span class="badge ${badgeCls}" title="${esc(ev.decision&&ev.decision.message||'')}">${esc(actionLabel)}</span></td>`;
@@ -1279,9 +1483,9 @@ function prependAuditEvent(ev){
 async function exportHistoryAudit(){
   const date=document.getElementById('hist-date').value||todayStr();
   try{
-    const r=await api(`/v1/audit/export?date=${date}`);const blob=await r.blob();
+    const r=await api(`/v1/audit/export?date=${date}`);const blob=await r.blob();r.assertCurrent();
     const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download=`audit-${date}.jsonl`;a.click();
-  }catch(e){toast('Export error: '+e.message)}
+  }catch(e){if(handleAPIControlError(e))return;toast('Export error: '+e.message)}
 }
 
 // ── Policy Tab ─────────────────────────────────────────────────────────────
@@ -1308,17 +1512,20 @@ async function runPolicyTest(){
   if(!cmd) return;
   const tool = document.getElementById('policy-test-tool').value;
   const btn = document.getElementById('policy-test-btn');
+  if(btn.disabled) return;
+  const operationEpoch = authEpoch;
   btn.disabled = true; btn.textContent = 'Testing...';
   const isPath = tool === 'write' || tool === 'read';
   const payload = isPath
     ? {command: cmd, tool: tool, path: cmd}
     : {command: cmd, tool: 'exec'};
   try {
-    const data = await (await api('/v1/test', {
+    const response = await api('/v1/test', {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify(payload)
-    })).json();
+    });
+    const data = await response.json();response.assertCurrent();
     const action = data.action || 'allow';
     const icons = {allow:'✓', deny:'✗', ask:'⏸', require_approval:'⏸', watch:'○'};
     const labels = {allow:'Allow', deny:'Deny', ask:'Ask', require_approval:'Require Approval', watch:'Watch'};
@@ -1331,11 +1538,15 @@ async function runPolicyTest(){
     result.textContent = text;
     result.style.display = 'block';
   } catch(e) {
+    if(handleAPIControlError(e)){
+      if(operationEpoch===authEpoch)result.style.display='none';
+      return;
+    }
     result.className = 'policy-test-result deny';
     result.textContent = 'Error: ' + e.message;
     result.style.display = 'block';
   } finally {
-    btn.disabled = false; btn.textContent = 'Test';
+    if(operationEpoch===authEpoch){btn.disabled = false; btn.textContent = 'Test';}
   }
 }
 
@@ -1348,12 +1559,12 @@ async function loadPolicyInfo(){
   const card=document.getElementById('policy-card');
   card.innerHTML='<div class="policy-unavail">Loading policy info…</div>';
   try{
-    const r=await api('/v1/policy');
+    const r=await api('/v1/status');
     if(r.status===404){throw new Error('not implemented')}
-    const p=await r.json();
+    const p=await r.json();r.assertCurrent();
     const path=p.config_path||'embedded:standard';
     card.innerHTML=`
-      <button class="policy-reload-btn" id="reload-btn" onclick="reloadPolicy()" title="Reload policy files">
+      <button class="policy-reload-btn" id="reload-btn" title="Reload policy files">
         <svg width="11" height="11" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><path d="M10 6A4 4 0 1 1 8.5 2.5"/><polyline points="10 1 10 4 7 4"/></svg>
         Reload
       </button>
@@ -1365,6 +1576,7 @@ async function loadPolicyInfo(){
         <div class="policy-kv"><span class="pk-label">Rules</span><span class="pk-value">${esc(String(p.rule_count??'—'))}</span></div>
       </div>`;
   }catch(e){
+    if(handleAPIControlError(e))return;
     card.innerHTML='<div class="policy-unavail">Policy info unavailable — endpoint not yet implemented.</div>';
   }
 }
@@ -1374,11 +1586,12 @@ async function reloadPolicy(){
   const btn=document.getElementById('reload-btn');
   if(btn)btn.classList.add('spinning');
   try{
-    await api('/v1/policy/reload',{method:'POST'});
+    const response=await api('/v1/policy/reload',{method:'POST'});response.assertCurrent();
     toast('Policy reloaded');
     if(hint){hint.textContent='';hint.classList.remove('visible')}
     loadPolicyInfo();
   }catch(e){
+    if(handleAPIControlError(e))return;
     if(hint){
       hint.textContent=e.message.includes('404')||e.message.includes('405')?'Restart serve to pick up changes':'Reload failed: '+e.message;
       hint.classList.add('visible');
@@ -1391,9 +1604,9 @@ async function reloadPolicy(){
 async function loadRules(){
   try{
     const r=await api('/v1/rules/auto-allowed');
-    const data=await r.json();
+    const data=await r.json();r.assertCurrent();
     rulesCache=data.rules||[];renderRules(rulesCache);
-  }catch(e){toast('Rules error: '+e.message)}
+  }catch(e){if(handleAPIControlError(e))return;toast('Rules error: '+e.message)}
 }
 
 function renderRules(rules){
@@ -1405,18 +1618,18 @@ function renderRules(rules){
     const created=r.created?new Date(r.created).toLocaleString():'—';
     tr.innerHTML=`<td class="cmd-col mono" title="${esc(pattern)}">${esc(pattern)}</td>
       <td class="col-tool">${esc(r.tool||'')}</td>
-      <td style="font-size:11px">${esc(created)}</td>
-      <td style="text-align:right"><button class="act-btn revoke" onclick="revokeRule(${parseInt(r.index,10)})">Revoke</button></td>`;
+      <td class="cell-created">${esc(created)}</td>
+      <td class="cell-actions"><button class="act-btn revoke" data-rule-name="${esc(r.name||'')}">Revoke</button></td>`;
     tbody.append(tr);
   });
 }
 
-async function revokeRule(index){
+async function revokeRule(ruleName){
   if(!confirm('Revoke this auto-allowed rule?'))return;
   try{
-    await api('/v1/rules/auto-allowed/'+index,{method:'DELETE'});
+    const response=await api('/v1/rules/auto-allowed/'+encodeURIComponent(ruleName),{method:'DELETE'});response.assertCurrent();
     toast('Rule revoked');loadRules();
-  }catch(e){toast('Revoke error: '+e.message)}
+  }catch(e){if(handleAPIControlError(e))return;toast('Revoke error: '+e.message)}
 }
 </script>
 </body>

--- a/internal/filetxn/filetxn.go
+++ b/internal/filetxn/filetxn.go
@@ -6,11 +6,26 @@
 package filetxn
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
 )
+
+// ErrLockHeld reports that AcquireLock found another live owner. Anchor files
+// may remain on disk after exit; ownership is determined by the OS lock, not
+// by file existence.
+var ErrLockHeld = errors.New("file transaction: lock is already held")
+
+// Lock is a process- and OS-bound advisory lock held until Close.
+type Lock struct {
+	file          *os.File
+	unlockFile    func() error
+	unlockProcess func()
+	once          sync.Once
+	err           error
+}
 
 type pathMutex struct {
 	mu   sync.Mutex
@@ -47,6 +62,84 @@ func WithLock(path string, fn func() error) error {
 	return fn()
 }
 
+// AcquireLock takes a non-blocking lifetime lock for an existing data
+// directory. The platform helper anchors ownership outside that directory so
+// replacing the state-directory pathname cannot create a second owner. The
+// caller must Close the returned lock. It returns ErrLockHeld when another
+// goroutine or process owns it.
+func AcquireLock(path string) (*Lock, error) {
+	canonical, err := CanonicalPath(path)
+	if err != nil {
+		return nil, fmt.Errorf("file transaction: canonicalize lock path: %w", err)
+	}
+	targetBefore, err := os.Lstat(canonical)
+	if err != nil {
+		return nil, fmt.Errorf("file transaction: inspect lifetime-lock directory: %w", err)
+	}
+	if targetBefore.Mode()&os.ModeSymlink != 0 || !targetBefore.IsDir() {
+		return nil, fmt.Errorf("file transaction: refusing non-directory or symlinked lifetime-lock target %s", canonical)
+	}
+
+	processKey := lifetimeLockProcessKey(canonical)
+	unlockProcess, acquired := tryLockProcessPath(processKey)
+	if !acquired {
+		return nil, ErrLockHeld
+	}
+
+	lockFile, unlockFile, acquired, err := acquireLifetimeLock(canonical)
+	if err != nil {
+		if lockFile != nil {
+			_ = lockFile.Close()
+		}
+		unlockProcess()
+		return nil, fmt.Errorf("file transaction: acquire lifetime lock: %w", err)
+	}
+	if !acquired {
+		if lockFile != nil {
+			_ = lockFile.Close()
+		}
+		unlockProcess()
+		return nil, ErrLockHeld
+	}
+	targetAfter, err := os.Lstat(canonical)
+	if err != nil || targetAfter.Mode()&os.ModeSymlink != 0 || !targetAfter.IsDir() || !os.SameFile(targetBefore, targetAfter) {
+		if unlockFile != nil {
+			_ = unlockFile()
+		}
+		if lockFile != nil {
+			_ = lockFile.Close()
+		}
+		unlockProcess()
+		if err != nil {
+			return nil, fmt.Errorf("file transaction: reinspect lifetime-lock directory: %w", err)
+		}
+		return nil, fmt.Errorf("file transaction: lifetime-lock directory changed during acquisition: %s", canonical)
+	}
+
+	return &Lock{file: lockFile, unlockFile: unlockFile, unlockProcess: unlockProcess}, nil
+}
+
+// Close releases the lifetime lock. It is safe to call more than once.
+func (l *Lock) Close() error {
+	if l == nil {
+		return nil
+	}
+	l.once.Do(func() {
+		if l.unlockFile != nil {
+			l.err = l.unlockFile()
+		}
+		if l.file != nil {
+			if err := l.file.Close(); l.err == nil {
+				l.err = err
+			}
+		}
+		if l.unlockProcess != nil {
+			l.unlockProcess()
+		}
+	})
+	return l.err
+}
+
 func lockProcessPath(canonical string) func() {
 	processLocks.Lock()
 	lock := processLocks.byPath[canonical]
@@ -58,6 +151,32 @@ func lockProcessPath(canonical string) func() {
 	processLocks.Unlock()
 
 	lock.mu.Lock()
+	return processPathUnlock(canonical, lock)
+}
+
+func tryLockProcessPath(canonical string) (func(), bool) {
+	processLocks.Lock()
+	lock := processLocks.byPath[canonical]
+	if lock == nil {
+		lock = &pathMutex{}
+		processLocks.byPath[canonical] = lock
+	}
+	lock.refs++
+	processLocks.Unlock()
+
+	if !lock.mu.TryLock() {
+		processLocks.Lock()
+		lock.refs--
+		if lock.refs == 0 {
+			delete(processLocks.byPath, canonical)
+		}
+		processLocks.Unlock()
+		return nil, false
+	}
+	return processPathUnlock(canonical, lock), true
+}
+
+func processPathUnlock(canonical string, lock *pathMutex) func() {
 	return func() {
 		lock.mu.Unlock()
 		processLocks.Lock()

--- a/internal/filetxn/filetxn_test.go
+++ b/internal/filetxn/filetxn_test.go
@@ -6,6 +6,7 @@ package filetxn
 import (
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"sync"
@@ -77,6 +78,122 @@ func TestWithLockReturnsCallbackError(t *testing.T) {
 	err := WithLock(filepath.Join(t.TempDir(), "state.json"), func() error { return want })
 	if !errors.Is(err, want) {
 		t.Fatalf("WithLock error = %v, want %v", err, want)
+	}
+}
+
+func TestAcquireLockExcludesProcessesAndReleases(t *testing.T) {
+	const helperEnv = "RAMPART_FILETXN_LOCK_HELPER"
+	if path := os.Getenv(helperEnv); path != "" {
+		lock, err := AcquireLock(path)
+		if lock != nil {
+			_ = lock.Close()
+			t.Fatal("helper unexpectedly acquired parent lock")
+		}
+		if !errors.Is(err, ErrLockHeld) {
+			t.Fatalf("helper AcquireLock error = %v, want ErrLockHeld", err)
+		}
+		return
+	}
+
+	path := filepath.Join(t.TempDir(), "lifetime")
+	if err := os.Mkdir(path, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	lock, err := AcquireLock(path)
+	if err != nil {
+		t.Fatalf("AcquireLock: %v", err)
+	}
+	if _, err := AcquireLock(path); !errors.Is(err, ErrLockHeld) {
+		t.Fatalf("same-process AcquireLock error = %v, want ErrLockHeld", err)
+	}
+
+	// On Unix the lifetime lock is held on the stable parent directory, so an
+	// unlinked/replaced legacy sidecar cannot create a second lock inode. On
+	// Windows the exclusive anchor handle must prevent the replacement itself.
+	anchorPath := path + ".rampart.lock"
+	if runtime.GOOS == "windows" {
+		if err := os.Remove(anchorPath); err == nil {
+			t.Fatal("removed Windows lifetime-lock anchor while its no-share handle was open")
+		}
+		if err := os.Rename(anchorPath, anchorPath+".moved"); err == nil {
+			t.Fatal("renamed Windows lifetime-lock anchor while its no-share handle was open")
+		}
+	} else {
+		if err := os.WriteFile(anchorPath, []byte("old anchor\n"), 0o600); err != nil {
+			t.Fatalf("write replaceable sidecar: %v", err)
+		}
+		if err := os.Remove(anchorPath); err != nil {
+			t.Fatalf("remove replaceable sidecar: %v", err)
+		}
+		if err := os.WriteFile(anchorPath, []byte("replacement anchor\n"), 0o600); err != nil {
+			t.Fatalf("replace sidecar: %v", err)
+		}
+	}
+
+	// The lifetime primitive is anchored outside the state directory. Even if
+	// a non-cooperating process renames and recreates that directory, another
+	// Rampart process must still observe the existing owner.
+	movedPath := path + ".moved"
+	if err := os.Rename(path, movedPath); err != nil {
+		t.Fatalf("rename locked data directory: %v", err)
+	}
+	if err := os.Mkdir(path, 0o700); err != nil {
+		t.Fatalf("recreate locked data directory path: %v", err)
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestAcquireLockExcludesProcessesAndReleases$")
+	cmd.Env = append(os.Environ(), helperEnv+"="+path)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("cross-process lock helper: %v\n%s", err, output)
+	}
+
+	if err := lock.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := lock.Close(); err != nil {
+		t.Fatalf("idempotent Close: %v", err)
+	}
+	reacquired, err := AcquireLock(path)
+	if err != nil {
+		t.Fatalf("AcquireLock after release: %v", err)
+	}
+	if err := reacquired.Close(); err != nil {
+		t.Fatalf("reacquired Close: %v", err)
+	}
+}
+
+func TestAcquireLockRejectsSymlinkDirectory(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "target")
+	link := filepath.Join(root, "state")
+	if err := os.Mkdir(target, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	lock, err := AcquireLock(link)
+	if lock != nil {
+		_ = lock.Close()
+		t.Fatal("AcquireLock unexpectedly accepted a symlinked data directory")
+	}
+	if err == nil {
+		t.Fatal("AcquireLock unexpectedly accepted a symlinked data directory")
+	}
+}
+
+func TestAcquireLockRejectsNonDirectoryTarget(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(path, []byte("file\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	lock, err := AcquireLock(path)
+	if lock != nil {
+		_ = lock.Close()
+		t.Fatal("AcquireLock unexpectedly accepted a non-directory target")
+	}
+	if err == nil || errors.Is(err, ErrLockHeld) {
+		t.Fatalf("AcquireLock error = %v, want invalid target error", err)
 	}
 }
 

--- a/internal/filetxn/filetxn_windows_test.go
+++ b/internal/filetxn/filetxn_windows_test.go
@@ -1,0 +1,80 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0
+
+//go:build windows
+
+package filetxn
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAcquireLockRejectsSymlinkAnchor(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "lifetime")
+	if err := os.Mkdir(path, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(dir, "target")
+	if err := os.WriteFile(target, []byte("target\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, path+".rampart.lock"); err != nil {
+		t.Skipf("creating symlink requires Windows developer mode or privilege: %v", err)
+	}
+
+	lock, err := AcquireLock(path)
+	if lock != nil {
+		_ = lock.Close()
+		t.Fatal("AcquireLock unexpectedly followed a symlinked anchor")
+	}
+	if err == nil {
+		t.Fatal("AcquireLock unexpectedly accepted a symlinked anchor")
+	}
+}
+
+func TestAcquireLockRejectsDirectoryAnchor(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "lifetime")
+	if err := os.Mkdir(path, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(path+".rampart.lock", 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	lock, err := AcquireLock(path)
+	if lock != nil {
+		_ = lock.Close()
+		t.Fatal("AcquireLock unexpectedly accepted a directory anchor")
+	}
+	if err == nil {
+		t.Fatal("AcquireLock unexpectedly accepted a directory anchor")
+	}
+}
+
+func TestAcquireLockRejectsHardLinkedAnchor(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "lifetime")
+	if err := os.Mkdir(path, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(dir, "target")
+	if err := os.WriteFile(target, []byte("target\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Link(target, path+".rampart.lock"); err != nil {
+		t.Skipf("creating a hard link is unavailable: %v", err)
+	}
+
+	lock, err := AcquireLock(path)
+	if lock != nil {
+		_ = lock.Close()
+		t.Fatal("AcquireLock unexpectedly accepted a hard-linked anchor")
+	}
+	if err == nil {
+		t.Fatal("AcquireLock unexpectedly accepted a hard-linked anchor")
+	}
+}

--- a/internal/filetxn/lock_unix.go
+++ b/internal/filetxn/lock_unix.go
@@ -6,7 +6,9 @@
 package filetxn
 
 import (
+	"fmt"
 	"os"
+	"path/filepath"
 
 	"golang.org/x/sys/unix"
 )
@@ -16,4 +18,61 @@ func lockFileExclusive(file *os.File) (func() error, error) {
 		return nil, err
 	}
 	return func() error { return unix.Flock(int(file.Fd()), unix.LOCK_UN) }, nil
+}
+
+func tryLockFileExclusive(file *os.File) (func() error, bool, error) {
+	err := unix.Flock(int(file.Fd()), unix.LOCK_EX|unix.LOCK_NB)
+	if err == unix.EWOULDBLOCK || err == unix.EAGAIN {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	return func() error { return unix.Flock(int(file.Fd()), unix.LOCK_UN) }, true, nil
+}
+
+// Lifetime locks use the canonical state directory's parent rather than a
+// sidecar inside the replaceable state directory. Rampart uses one data
+// directory per home, so parent-directory granularity is intentional.
+func lifetimeLockProcessKey(canonical string) string {
+	return "lifetime-directory:" + filepath.Dir(canonical)
+}
+
+func acquireLifetimeLock(canonical string) (*os.File, func() error, bool, error) {
+	directoryPath := filepath.Dir(canonical)
+	before, err := os.Lstat(directoryPath)
+	if err != nil {
+		return nil, nil, false, fmt.Errorf("inspect lock directory: %w", err)
+	}
+	if before.Mode()&os.ModeSymlink != 0 || !before.IsDir() {
+		return nil, nil, false, fmt.Errorf("refusing non-directory or symlinked lifetime-lock parent %s", directoryPath)
+	}
+
+	directory, err := os.Open(directoryPath)
+	if err != nil {
+		return nil, nil, false, fmt.Errorf("open lock directory: %w", err)
+	}
+	opened, err := directory.Stat()
+	if err != nil {
+		_ = directory.Close()
+		return nil, nil, false, fmt.Errorf("inspect opened lock directory: %w", err)
+	}
+	if !opened.IsDir() || !os.SameFile(before, opened) {
+		_ = directory.Close()
+		return nil, nil, false, fmt.Errorf("lifetime-lock parent changed while opening: %s", directoryPath)
+	}
+
+	unlock, acquired, err := tryLockFileExclusive(directory)
+	if err != nil || !acquired {
+		return directory, nil, acquired, err
+	}
+	after, err := os.Lstat(directoryPath)
+	if err != nil || after.Mode()&os.ModeSymlink != 0 || !after.IsDir() || !os.SameFile(opened, after) {
+		_ = unlock()
+		if err != nil {
+			return directory, nil, false, fmt.Errorf("reinspect lock directory: %w", err)
+		}
+		return directory, nil, false, fmt.Errorf("lifetime-lock parent changed during acquisition: %s", directoryPath)
+	}
+	return directory, unlock, true, nil
 }

--- a/internal/filetxn/lock_windows.go
+++ b/internal/filetxn/lock_windows.go
@@ -6,6 +6,8 @@
 package filetxn
 
 import (
+	"errors"
+	"fmt"
 	"os"
 
 	"golang.org/x/sys/windows"
@@ -18,4 +20,84 @@ func lockFileExclusive(file *os.File) (func() error, error) {
 		return nil, err
 	}
 	return func() error { return windows.UnlockFileEx(handle, 0, 1, 0, overlapped) }, nil
+}
+
+func tryLockFileExclusive(file *os.File) (func() error, bool, error) {
+	overlapped := &windows.Overlapped{}
+	handle := windows.Handle(file.Fd())
+	err := windows.LockFileEx(handle, windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY, 0, 1, 0, overlapped)
+	if err == windows.ERROR_LOCK_VIOLATION {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	return func() error { return windows.UnlockFileEx(handle, 0, 1, 0, overlapped) }, true, nil
+}
+
+func lifetimeLockProcessKey(canonical string) string {
+	return "lifetime-anchor:" + canonical + ".rampart.lock"
+}
+
+// acquireLifetimeLock opens a sibling anchor without any share permissions.
+// Keeping it outside the replaceable state directory means Windows refuses a
+// second owner even if that directory is renamed or recreated. The reparse
+// flag lets us inspect and reject a symlink or other reparse point without
+// following it.
+func acquireLifetimeLock(canonical string) (*os.File, func() error, bool, error) {
+	anchorPath := canonical + ".rampart.lock"
+	name, err := windows.UTF16PtrFromString(anchorPath)
+	if err != nil {
+		return nil, nil, false, fmt.Errorf("encode lock anchor path: %w", err)
+	}
+	handle, err := windows.CreateFile(
+		name,
+		windows.GENERIC_READ|windows.GENERIC_WRITE,
+		0, // No sharing: in particular, do not permit delete or replacement.
+		nil,
+		windows.OPEN_ALWAYS,
+		windows.FILE_ATTRIBUTE_NORMAL|windows.FILE_FLAG_OPEN_REPARSE_POINT,
+		0,
+	)
+	if err != nil {
+		if errors.Is(err, windows.ERROR_SHARING_VIOLATION) || errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
+			return nil, nil, false, nil
+		}
+		return nil, nil, false, fmt.Errorf("open exclusive lock anchor: %w", err)
+	}
+	closeHandle := func() { _ = windows.CloseHandle(handle) }
+
+	var info windows.ByHandleFileInformation
+	if err := windows.GetFileInformationByHandle(handle, &info); err != nil {
+		closeHandle()
+		return nil, nil, false, fmt.Errorf("inspect lock anchor: %w", err)
+	}
+	if info.FileAttributes&(windows.FILE_ATTRIBUTE_DIRECTORY|windows.FILE_ATTRIBUTE_REPARSE_POINT) != 0 {
+		closeHandle()
+		return nil, nil, false, fmt.Errorf("refusing directory or reparse-point lifetime-lock anchor %s", anchorPath)
+	}
+	if info.NumberOfLinks != 1 {
+		closeHandle()
+		return nil, nil, false, fmt.Errorf("refusing hard-linked lifetime-lock anchor %s", anchorPath)
+	}
+	fileType, err := windows.GetFileType(handle)
+	if err != nil {
+		closeHandle()
+		return nil, nil, false, fmt.Errorf("inspect lock anchor type: %w", err)
+	}
+	if fileType != windows.FILE_TYPE_DISK {
+		closeHandle()
+		return nil, nil, false, fmt.Errorf("refusing non-disk lifetime-lock anchor %s", anchorPath)
+	}
+
+	file := os.NewFile(uintptr(handle), anchorPath)
+	if file == nil {
+		closeHandle()
+		return nil, nil, false, fmt.Errorf("wrap lifetime-lock anchor handle")
+	}
+	unlock, acquired, err := tryLockFileExclusive(file)
+	if err != nil || !acquired {
+		return file, nil, acquired, err
+	}
+	return file, unlock, true, nil
 }

--- a/internal/proxy/approval_handlers.go
+++ b/internal/proxy/approval_handlers.go
@@ -54,7 +54,7 @@ func (s *Server) handleCreateApproval(w http.ResponseWriter, r *http.Request) {
 	// Check run-scoped authorization and enqueue atomically. A bulk cache
 	// publication can never slip between a stale check and Create, leaving an
 	// orphan pending request for a call that should have been auto-approved.
-	pending, autoApproved, err := s.approvals.CreateOrAutoApproved(call, decision, "")
+	pending, grantExpiresAt, autoApproved, err := s.approvals.CreateOrAutoApprovedWithExpiry(call, decision, "")
 	if err != nil {
 		s.logger.Error("proxy: approval store full", "error", err)
 		writeError(w, http.StatusServiceUnavailable, err.Error())
@@ -62,15 +62,11 @@ func (s *Server) handleCreateApproval(w http.ResponseWriter, r *http.Request) {
 	}
 	if autoApproved {
 		s.logger.Debug("proxy: run auto-approved (hook), bypassing approval queue", "tool", req.Tool, "run_id", call.RunID)
-		ttl := s.approvalTimeout
-		if ttl <= 0 {
-			ttl = time.Hour
-		}
 		writeJSON(w, http.StatusOK, map[string]any{
 			"id":         audit.NewEventID(),
 			"status":     "approved",
 			"message":    "auto-approved by bulk-resolve",
-			"expires_at": time.Now().Add(ttl).Format(time.RFC3339),
+			"expires_at": grantExpiresAt.UTC().Format(time.RFC3339Nano),
 		})
 		return
 	}
@@ -95,6 +91,17 @@ func (s *Server) handleCreateApproval(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+func approvalOwnerLabel(ownerScope string) string {
+	if ownerScope == "" {
+		return "server/admin"
+	}
+	const visiblePrefix = 12
+	if len(ownerScope) > visiblePrefix {
+		ownerScope = ownerScope[:visiblePrefix]
+	}
+	return "credential-" + ownerScope
+}
+
 func (s *Server) handleListApprovals(w http.ResponseWriter, r *http.Request) {
 	if !s.checkAdminAuth(w, r) {
 		return
@@ -106,9 +113,10 @@ func (s *Server) handleListApprovals(w http.ResponseWriter, r *http.Request) {
 	// A run ID is caller-selected and not globally unique. Group approvals by
 	// the complete identity used by bulk authorization.
 	type runScope struct {
-		agent   string
-		session string
-		runID   string
+		agent      string
+		session    string
+		runID      string
+		ownerScope string
 	}
 	type runGroupEntry struct {
 		minCreatedAt time.Time
@@ -117,23 +125,26 @@ func (s *Server) handleListApprovals(w http.ResponseWriter, r *http.Request) {
 	runGroupMap := make(map[runScope]*runGroupEntry)
 
 	for _, req := range pending {
+		credentialOwner := approvalOwnerLabel(req.OwnerScopeID())
 		item := map[string]any{
-			"id":         req.ID,
-			"tool":       req.Call.Tool,
-			"command":    req.Call.Command(),
-			"agent":      req.Call.Agent,
-			"session":    req.Call.Session,
-			"message":    req.Decision.Message,
-			"status":     req.Status.String(),
-			"created_at": req.CreatedAt.Format(time.RFC3339),
-			"expires_at": req.ExpiresAt.Format(time.RFC3339),
+			"id":               req.ID,
+			"tool":             req.Call.Tool,
+			"command":          req.Call.Command(),
+			"agent":            req.Call.Agent,
+			"session":          req.Call.Session,
+			"credential_owner": credentialOwner,
+			"message":          req.Decision.Message,
+			"status":           req.Status.String(),
+			"created_at":       req.CreatedAt.Format(time.RFC3339),
+			"expires_at":       req.ExpiresAt.Format(time.RFC3339),
 		}
 		if req.Call.RunID != "" {
 			item["run_id"] = req.Call.RunID
 			scope := runScope{
-				agent:   strings.TrimSpace(req.Call.Agent),
-				session: strings.TrimSpace(req.Call.Session),
-				runID:   strings.TrimSpace(req.Call.RunID),
+				agent:      strings.TrimSpace(req.Call.Agent),
+				session:    strings.TrimSpace(req.Call.Session),
+				runID:      strings.TrimSpace(req.Call.RunID),
+				ownerScope: req.OwnerScopeID(),
 			}
 			// Incomplete identity cannot safely support a bulk authorization
 			// operation, so leave that approval in the flat/solo view.
@@ -180,6 +191,7 @@ func (s *Server) handleListApprovals(w http.ResponseWriter, r *http.Request) {
 			"agent":               g.scope.agent,
 			"session":             g.scope.session,
 			"run_id":              g.scope.runID,
+			"credential_owner":    approvalOwnerLabel(g.scope.ownerScope),
 			"count":               len(g.items),
 			"earliest_created_at": g.minCreatedAt.Format(time.RFC3339),
 			"items":               g.items,
@@ -187,8 +199,9 @@ func (s *Server) handleListApprovals(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, map[string]any{
-		"approvals":  items,
-		"run_groups": runGroupsJSON,
+		"approvals":        items,
+		"run_groups":       runGroupsJSON,
+		"run_grant_ttl_ms": durationMilliseconds(s.effectiveApprovalTimeout()),
 	})
 }
 
@@ -434,9 +447,46 @@ authorized:
 	})
 }
 
-// handleBulkResolve resolves all pending approvals for an exact
-// agent/session/run scope. Incomplete scopes are rejected to prevent
-// inadvertent cross-agent authorization.
+func runApprovalAuthorizationEvent(
+	call engine.ToolCall,
+	owner *approval.Request,
+	resolvedApprovalIDs []string,
+	reviewedApprovalIDs []string,
+	raceCoveredApprovalIDs []string,
+	resolvedBy string,
+	ttl time.Duration,
+	expiresAt time.Time,
+) audit.Event {
+	return audit.Event{
+		ID:        audit.NewEventID(),
+		Timestamp: time.Now().UTC(),
+		Agent:     call.Agent,
+		Session:   call.Session,
+		RunID:     call.RunID,
+		Tool:      "approval",
+		Request: map[string]any{
+			"action":                 "run_approval_publication_authorized",
+			"approval_scope":         "run",
+			"approval_ids":           append([]string(nil), resolvedApprovalIDs...),
+			"reviewed_approval_ids":  append([]string(nil), reviewedApprovalIDs...),
+			"race_covered_ids":       append([]string(nil), raceCoveredApprovalIDs...),
+			"credential_owner":       approvalOwnerLabel(owner.OwnerScopeID()),
+			"future_calls_requested": true,
+			"publication_authorized": true,
+			"grant_ttl_ms":           durationMilliseconds(ttl),
+			"grant_expires_at":       expiresAt.UTC().Format(time.RFC3339Nano),
+			"resolved_by":            resolvedBy,
+		},
+		Decision: audit.EventDecision{
+			Action:  "authorized",
+			Message: fmt.Sprintf("future-call grant publication authorized by %s", resolvedBy),
+		},
+	}
+}
+
+// handleBulkResolve resolves an exact operator-reviewed approval set for one
+// agent/session/run identity. Incomplete identities, omitted authority scope,
+// and stale or mismatched approval IDs are rejected before any resolution.
 func (s *Server) handleBulkResolve(w http.ResponseWriter, r *http.Request) {
 	if !s.checkAdminAuth(w, r) {
 		return
@@ -463,41 +513,123 @@ func (s *Server) handleBulkResolve(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	approved := action == "approve"
+	scope := strings.ToLower(strings.TrimSpace(req.Scope))
+	if scope == "" {
+		writeError(w, http.StatusBadRequest, "scope is required and must be \"pending\" or \"run\"")
+		return
+	}
+	if scope != "pending" && scope != "run" {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("scope must be \"pending\" or \"run\", got %q", req.Scope))
+		return
+	}
+	if !approved && scope == "run" {
+		writeError(w, http.StatusBadRequest, "scope \"run\" is only valid when action is \"approve\"")
+		return
+	}
+	authorizeFutureCalls := approved && scope == "run"
+	if len(req.IDs) == 0 {
+		writeError(w, http.StatusBadRequest, "ids must contain the exact pending approvals reviewed by the operator")
+		return
+	}
 
 	resolvedBy := req.ResolvedBy
 	if resolvedBy == "" {
 		resolvedBy = "api"
 	}
 
-	// Collect all pending approvals that belong to this run.
+	// Resolve only the IDs the operator reviewed. New same-run calls that arrive
+	// after the dashboard poll are not pulled into a pending-scope decision.
 	pending := s.approvals.List()
-	matching := make([]*approval.Request, 0)
+	pendingByID := make(map[string]*approval.Request, len(pending))
 	for _, ap := range pending {
-		if strings.TrimSpace(ap.Call.Agent) == req.Agent &&
-			strings.TrimSpace(ap.Call.Session) == req.Session &&
-			strings.TrimSpace(ap.Call.RunID) == req.RunID {
-			matching = append(matching, ap)
+		pendingByID[ap.ID] = ap
+	}
+	matching := make([]*approval.Request, 0, len(req.IDs))
+	reviewedIDs := make([]string, 0, len(req.IDs))
+	seenIDs := make(map[string]struct{}, len(req.IDs))
+	for _, rawID := range req.IDs {
+		id := strings.TrimSpace(rawID)
+		if id == "" {
+			writeError(w, http.StatusBadRequest, "ids must not contain empty values")
+			return
 		}
+		if _, seen := seenIDs[id]; seen {
+			writeError(w, http.StatusBadRequest, fmt.Sprintf("duplicate approval id %q", id))
+			return
+		}
+		seenIDs[id] = struct{}{}
+		reviewedIDs = append(reviewedIDs, id)
+		ap, ok := pendingByID[id]
+		if !ok {
+			writeError(w, http.StatusConflict, fmt.Sprintf("approval %q is no longer pending; refresh and retry", id))
+			return
+		}
+		if strings.TrimSpace(ap.Call.Agent) != req.Agent ||
+			strings.TrimSpace(ap.Call.Session) != req.Session ||
+			strings.TrimSpace(ap.Call.RunID) != req.RunID {
+			writeError(w, http.StatusBadRequest, fmt.Sprintf("approval %q does not belong to the requested agent/session/run identity", id))
+			return
+		}
+		matching = append(matching, ap)
+	}
+
+	grantOwner := matching[0]
+	var runScopeSnapshot *approval.RunScopeSnapshot
+	scopeCall := engine.ToolCall{Agent: req.Agent, Session: req.Session, RunID: req.RunID}
+	autoApproveTTL := s.effectiveApprovalTimeout()
+	if authorizeFutureCalls {
+		for _, ap := range matching[1:] {
+			if ap.OwnerScopeID() != grantOwner.OwnerScopeID() {
+				writeError(w, http.StatusBadRequest, "scope \"run\" requires all approval ids to share one credential owner")
+				return
+			}
+		}
+		// Future authority covers the entire owner-bound run scope. Require the
+		// caller to review every request already pending in that scope at this
+		// server snapshot; only requests created after the snapshot may be
+		// reported as race-covered while the grant is published.
+		for _, ap := range pending {
+			if strings.TrimSpace(ap.Call.Agent) != req.Agent ||
+				strings.TrimSpace(ap.Call.Session) != req.Session ||
+				strings.TrimSpace(ap.Call.RunID) != req.RunID ||
+				ap.OwnerScopeID() != grantOwner.OwnerScopeID() {
+				continue
+			}
+			if _, reviewed := seenIDs[ap.ID]; !reviewed {
+				writeError(w, http.StatusConflict, fmt.Sprintf("scope \"run\" omitted pending approval %q for the selected credential owner; refresh and review the complete scope", ap.ID))
+				return
+			}
+		}
+		var beginErr error
+		runScopeSnapshot, beginErr = s.approvals.BeginRunScopeSnapshot(scopeCall, reviewedIDs, autoApproveTTL)
+		if beginErr != nil {
+			writeError(w, http.StatusConflict, fmt.Sprintf("run approval scope changed during validation; refresh and review again: %v", beginErr))
+			return
+		}
+		defer s.approvals.AbortRunScopeSnapshot(runScopeSnapshot)
+		matching = runScopeSnapshot.Pending
+		grantOwner = matching[0]
 	}
 
 	var resolved int
-	var ids []string
+	ids := make([]string, 0, len(matching))
+	raceCoveredIDs := make([]string, 0)
 	var resolveErr error
-	autoApproveTTL := s.approvalTimeout
-	if autoApproveTTL <= 0 {
-		autoApproveTTL = time.Hour
-	}
-
-	resolveBatch := func(batch []*approval.Request) {
+	resolveBatch := func(batch []*approval.Request, raceCovered bool) {
 		for _, ap := range batch {
-			err := s.approvals.ResolveBeforePublish(ap.ID, approved, resolvedBy, func(candidate *approval.Request) error {
+			beforeResolvePublish := func(candidate *approval.Request) error {
 				if s.sink == nil {
 					return nil
 				}
 				event := approvalResolutionEvent(candidate, approved, false, resolvedBy)
 				event.Request["bulk"] = true
-				event.Request["auto_approve"] = approved
-				if approved {
+				event.Request["approval_scope"] = scope
+				event.Request["future_calls_requested"] = authorizeFutureCalls
+				// Deprecated rampart.audit.v1 aliases retained for 1.x SIEM
+				// consumers. New integrations should use the explicit fields above.
+				event.Request["auto_approve"] = authorizeFutureCalls
+				if authorizeFutureCalls {
+					event.Request["grant_ttl_ms"] = durationMilliseconds(autoApproveTTL)
 					event.Request["auto_approve_ttl_seconds"] = int64(autoApproveTTL / time.Second)
 				}
 				event.Decision.Message = fmt.Sprintf("bulk %s by %s", event.Decision.Action, resolvedBy)
@@ -505,18 +637,37 @@ func (s *Server) handleBulkResolve(w http.ResponseWriter, r *http.Request) {
 					return fmt.Errorf("write bulk approval resolution audit: %w", writeErr)
 				}
 				return nil
-			})
+			}
+			committedID := ap.ID
+			var err error
+			if authorizeFutureCalls {
+				var commit *approval.RunApprovalCommit
+				commit, err = s.approvals.ResolveBeforePublishForRunScopeSnapshot(
+					runScopeSnapshot,
+					ap.ID,
+					resolvedBy,
+					beforeResolvePublish,
+				)
+				if commit != nil {
+					committedID = commit.ID
+				}
+			} else {
+				err = s.approvals.ResolveBeforePublish(ap.ID, approved, resolvedBy, beforeResolvePublish)
+			}
 			if err != nil {
 				resolveErr = err
 				s.logger.Warn("proxy: bulk-resolve stopped before publishing approval", "id", ap.ID, "error", err)
 				return
 			}
 			resolved++
-			ids = append(ids, ap.ID)
+			ids = append(ids, committedID)
+			if raceCovered {
+				raceCoveredIDs = append(raceCoveredIDs, committedID)
+			}
 			// Individual audit SSE events intentionally remain batched below.
 		}
 	}
-	resolveBatch(matching)
+	resolveBatch(matching, false)
 
 	// The run-scoped cache is authorization state in its own right. Install it
 	// only after every approval selected by this bulk request has a durable
@@ -524,34 +675,50 @@ func (s *Server) handleBulkResolve(w http.ResponseWriter, r *http.Request) {
 	// creation use the same Store lock. If creation wins their race, this loop
 	// receives and resolves that new request before trying publication again;
 	// if publication wins, the creator observes auto-approved state atomically.
-	if approved && resolveErr == nil && len(matching) > 0 {
-		scopeCall := engine.ToolCall{Agent: req.Agent, Session: req.Session, RunID: req.RunID}
-		owners := make([]*approval.Request, 0, len(matching))
-		seenOwners := make(map[string]struct{}, len(matching))
-		for _, ap := range matching {
-			if _, seen := seenOwners[ap.OwnerScopeID()]; !seen {
-				seenOwners[ap.OwnerScopeID()] = struct{}{}
-				owners = append(owners, ap)
+	futureCallsAuthorized := false
+	grantExpiresAt := time.Time{}
+	if authorizeFutureCalls && resolveErr == nil {
+		for resolveErr == nil {
+			if err := r.Context().Err(); err != nil {
+				resolveErr = fmt.Errorf("bulk approval request cancelled before cache publication: %w", err)
+				break
 			}
-		}
-		for _, owner := range owners {
-			for resolveErr == nil {
-				select {
-				case <-r.Context().Done():
-					resolveErr = fmt.Errorf("bulk approval request cancelled before cache publication: %w", r.Context().Err())
-					continue
-				default:
-				}
-				raced, installed := s.approvals.AutoApproveRunIfNoPendingForRequest(scopeCall, owner, autoApproveTTL)
-				if installed {
-					break
-				}
-				if len(raced) == 0 {
-					resolveErr = fmt.Errorf("bulk approval scope could not be installed")
-					break
-				}
-				resolveBatch(raced)
+			raced, expiresAt, installed, publishErr := s.approvals.AutoApproveRunBeforePublishForRunScopeSnapshot(
+				runScopeSnapshot,
+				func(candidateExpiry time.Time) error {
+					if s.sink == nil {
+						return nil
+					}
+					event := runApprovalAuthorizationEvent(
+						scopeCall,
+						grantOwner,
+						ids,
+						reviewedIDs,
+						raceCoveredIDs,
+						resolvedBy,
+						autoApproveTTL,
+						candidateExpiry,
+					)
+					if err := s.sink.Write(event); err != nil {
+						return fmt.Errorf("write run approval authorization audit: %w", err)
+					}
+					return nil
+				},
+			)
+			if publishErr != nil {
+				resolveErr = publishErr
+				break
 			}
+			if installed {
+				grantExpiresAt = expiresAt
+				futureCallsAuthorized = true
+				break
+			}
+			if len(raced) == 0 {
+				resolveErr = fmt.Errorf("bulk approval scope could not be installed")
+				break
+			}
+			resolveBatch(raced, true)
 		}
 		if resolveErr != nil {
 			s.logger.Error("proxy: bulk-resolve could not install auto-approval scope",
@@ -568,26 +735,58 @@ func (s *Server) handleBulkResolve(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	s.logger.Info("proxy: bulk-resolve completed",
+	logFields := []any{
 		"agent", req.Agent,
 		"session", req.Session,
 		"run_id", req.RunID,
 		"action", req.Action,
+		"scope", scope,
 		"resolved", resolved,
+		"future_calls_authorized", futureCallsAuthorized,
 		"resolved_by", resolvedBy,
-	)
+	}
+	if authorizeFutureCalls {
+		logFields = append(logFields, "credential_owner", approvalOwnerLabel(grantOwner.OwnerScopeID()))
+	}
+	s.logger.Info("proxy: bulk-resolve completed", logFields...)
 	if resolveErr != nil {
-		writeError(w, http.StatusServiceUnavailable, "bulk resolution stopped before unaudited authorization could be published")
+		resolvedSet := make(map[string]struct{}, len(ids))
+		for _, id := range ids {
+			resolvedSet[id] = struct{}{}
+		}
+		unresolvedReviewedIDs := make([]string, 0, len(reviewedIDs))
+		for _, id := range reviewedIDs {
+			if _, ok := resolvedSet[id]; !ok {
+				unresolvedReviewedIDs = append(unresolvedReviewedIDs, id)
+			}
+		}
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{
+			"error":                   "bulk resolution stopped before every requested transition and grant could be published; refresh before retrying",
+			"resolved":                resolved,
+			"ids":                     ids,
+			"reviewed_ids":            reviewedIDs,
+			"unresolved_reviewed_ids": unresolvedReviewedIDs,
+			"race_covered_ids":        raceCoveredIDs,
+			"scope":                   scope,
+			"future_calls_authorized": false,
+			"refresh_required":        true,
+		})
 		return
 	}
 
-	if ids == nil {
-		ids = []string{}
+	response := map[string]any{
+		"resolved":                resolved,
+		"ids":                     ids,
+		"reviewed_ids":            reviewedIDs,
+		"race_covered_ids":        raceCoveredIDs,
+		"scope":                   scope,
+		"future_calls_authorized": futureCallsAuthorized,
 	}
-	writeJSON(w, http.StatusOK, map[string]any{
-		"resolved": resolved,
-		"ids":      ids,
-	})
+	if futureCallsAuthorized {
+		response["grant_ttl_ms"] = durationMilliseconds(autoApproveTTL)
+		response["grant_expires_at"] = grantExpiresAt.UTC().Format(time.RFC3339Nano)
+	}
+	writeJSON(w, http.StatusOK, response)
 }
 
 func (s *Server) handleResolveHostedApproval(w http.ResponseWriter, r *http.Request) {

--- a/internal/proxy/auth.go
+++ b/internal/proxy/auth.go
@@ -144,7 +144,7 @@ func (s *Server) checkAdminAuth(w http.ResponseWriter, r *http.Request) bool {
 		return false
 	}
 	if !id.HasScope(token.ScopeAdmin) {
-		writeError(w, http.StatusForbidden, "this endpoint requires admin scope — agent tokens cannot perform mutations")
+		writeError(w, http.StatusForbidden, "this endpoint requires admin scope")
 		return false
 	}
 	return true

--- a/internal/proxy/eval_handlers.go
+++ b/internal/proxy/eval_handlers.go
@@ -507,10 +507,7 @@ func (s *Server) writeAuditRecord(
 }
 
 func (s *Server) hostedApprovalDescriptor(req toolRequest, decision engine.Decision) map[string]any {
-	timeout := s.approvalTimeout
-	if timeout <= 0 {
-		timeout = 2 * time.Minute
-	}
+	timeout := s.effectiveApprovalTimeout()
 	scopeOptions := []string{"once", "session"}
 	allowAlways := req.ApprovalOwner != nil && req.ApprovalOwner.SupportsAllowAlways
 	if allowAlways {

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -149,6 +149,27 @@ func WithApprovalTimeout(d time.Duration) Option {
 	}
 }
 
+// effectiveApprovalTimeout returns the timeout enforced by the approval
+// store, including its default when serve did not configure one explicitly.
+// Explicit run-scoped grants use this same duration.
+func (s *Server) effectiveApprovalTimeout() time.Duration {
+	if s.approvalTimeout > 0 {
+		return s.approvalTimeout
+	}
+	return approval.DefaultTimeout
+}
+
+func durationMilliseconds(d time.Duration) int64 {
+	if d <= 0 {
+		return 0
+	}
+	milliseconds := d / time.Millisecond
+	if d%time.Millisecond != 0 {
+		milliseconds++
+	}
+	return int64(milliseconds)
+}
+
 // WithApprovalPersistenceFile sets the path for the JSONL file used to persist
 // pending approvals across server restarts. If empty, persistence is disabled.
 func WithApprovalPersistenceFile(path string) Option {
@@ -568,11 +589,13 @@ type hostedApprovalResolveRequest struct {
 
 // bulkResolveRequest is the JSON body for POST /v1/approvals/bulk-resolve.
 type bulkResolveRequest struct {
-	Agent      string `json:"agent"`
-	Session    string `json:"session"`
-	RunID      string `json:"run_id"`
-	Action     string `json:"action"`      // "approve" or "deny"
-	ResolvedBy string `json:"resolved_by"` // e.g. "api", "cli"
+	Agent      string   `json:"agent"`
+	Session    string   `json:"session"`
+	RunID      string   `json:"run_id"`
+	Action     string   `json:"action"`      // "approve" or "deny"
+	Scope      string   `json:"scope"`       // "pending" or "run"
+	IDs        []string `json:"ids"`         // exact approvals reviewed by the operator
+	ResolvedBy string   `json:"resolved_by"` // e.g. "api", "cli"
 }
 
 // Approvals returns the approval store for external CLI access.

--- a/internal/proxy/server_test.go
+++ b/internal/proxy/server_test.go
@@ -771,7 +771,7 @@ policies:
 	assert.Equal(t, ownerID, ownerResult["approval_id"])
 
 	bulkReq := httptest.NewRequest(http.MethodPost, "/v1/approvals/bulk-resolve",
-		strings.NewReader(`{"agent":"codex","session":"s1","run_id":"run-owner","action":"approve"}`))
+		strings.NewReader(fmt.Sprintf(`{"agent":"codex","session":"s1","run_id":"run-owner","action":"approve","scope":"run","ids":[%q]}`, siblingID)))
 	bulkReq.Header.Set("Authorization", "Bearer "+adminToken)
 	bulkReq.Header.Set("Content-Type", "application/json")
 	bulkRecorder := httptest.NewRecorder()
@@ -1060,6 +1060,62 @@ policies:
 	})
 }
 
+func TestDurationMillisecondsRoundsPositiveFractionsUp(t *testing.T) {
+	assert.Equal(t, int64(0), durationMilliseconds(0))
+	assert.Equal(t, int64(0), durationMilliseconds(-time.Second))
+	assert.Equal(t, int64(1), durationMilliseconds(500*time.Microsecond))
+	assert.Equal(t, int64(1500), durationMilliseconds(1500*time.Millisecond))
+}
+
+func TestRunGrantDisclosesConfiguredMillisecondTTL(t *testing.T) {
+	const configuredTTL = 1500 * time.Millisecond
+	eng := buildApprovalEngine(t)
+	sink := &mockSink{}
+	srv := New(
+		eng,
+		sink,
+		WithToken("tok"),
+		WithMode("enforce"),
+		WithApprovalTimeout(configuredTTL),
+		WithLogger(slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil))),
+	)
+	call := engine.ToolCall{
+		Tool: "exec", Params: map[string]any{"command": "deploy"},
+		Agent: "claude", Session: "s1", RunID: "run-millisecond-ttl", ToolCallID: "call-one",
+	}
+	pending, err := srv.approvals.Create(call, engine.Decision{Action: engine.ActionRequireApproval})
+	require.NoError(t, err)
+
+	startedAt := time.Now()
+	req := httptest.NewRequest(http.MethodPost, "/v1/approvals/bulk-resolve",
+		strings.NewReader(fmt.Sprintf(
+			`{"agent":"claude","session":"s1","run_id":"run-millisecond-ttl","action":"approve","scope":"run","ids":[%q]}`,
+			pending.ID,
+		)))
+	req.Header.Set("Authorization", "Bearer tok")
+	req.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	srv.handler().ServeHTTP(recorder, req)
+	require.Equal(t, http.StatusOK, recorder.Code)
+
+	var response map[string]any
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+	assert.Equal(t, float64(configuredTTL/time.Millisecond), response["grant_ttl_ms"])
+	expiresAt, err := time.Parse(time.RFC3339Nano, response["grant_expires_at"].(string))
+	require.NoError(t, err)
+	assert.WithinDuration(t, startedAt.Add(configuredTTL), expiresAt, 100*time.Millisecond)
+	assert.True(t, srv.approvals.IsAutoApproved(call))
+
+	listReq := httptest.NewRequest(http.MethodGet, "/v1/approvals", nil)
+	listReq.Header.Set("Authorization", "Bearer tok")
+	listRecorder := httptest.NewRecorder()
+	srv.handler().ServeHTTP(listRecorder, listReq)
+	require.Equal(t, http.StatusOK, listRecorder.Code)
+	response = map[string]any{}
+	require.NoError(t, json.Unmarshal(listRecorder.Body.Bytes(), &response))
+	assert.Equal(t, float64(configuredTTL/time.Millisecond), response["run_grant_ttl_ms"])
+}
+
 func TestServerTimeouts(t *testing.T) {
 	srv, _, _ := setupTestServer(t, testPolicyYAML, "enforce")
 
@@ -1184,6 +1240,46 @@ func TestAutoAllowedRuleCreatedSupportsLegacyAndHashedNames(t *testing.T) {
 	assert.Equal(t, want, autoAllowedRuleCreated("auto-allow-git-push-20260728T123456Z"))
 	assert.Equal(t, want, autoAllowedRuleCreated("auto-allow-git-push-20260728T123456Z-0123456789abcdef01234567"))
 	assert.Empty(t, autoAllowedRuleCreated("auto-allow-git-push-no-time"))
+}
+
+func TestDeleteAutoAllowedRouteUsesExactRuleName(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	policyPath := engine.DefaultAutoAllowedPath()
+	require.NoError(t, os.MkdirAll(filepath.Dir(policyPath), 0o755))
+	const ruleName = "auto allow exact & named rule"
+	require.NoError(t, os.WriteFile(policyPath, []byte(`version: "1"
+policies:
+  - name: "auto allow exact & named rule"
+    match:
+      tool: [exec]
+    rules:
+      - action: allow
+        when:
+          command_matches: ["echo safe"]
+`), 0o600))
+
+	srv, token, _ := setupTestServerWithHome(t, testPolicyYAML, "enforce", home)
+	handler := srv.handler()
+
+	// Array positions are display metadata, not revocation authority.
+	indexRequest := httptest.NewRequest(http.MethodDelete, "/v1/rules/auto-allowed/0", nil)
+	indexRequest.Header.Set("Authorization", "Bearer "+token)
+	indexResponse := httptest.NewRecorder()
+	handler.ServeHTTP(indexResponse, indexRequest)
+	require.Equal(t, http.StatusNotFound, indexResponse.Code)
+
+	request := httptest.NewRequest(http.MethodDelete,
+		"/v1/rules/auto-allowed/"+url.PathEscape(ruleName), nil)
+	request.Header.Set("Authorization", "Bearer "+token)
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	require.Equal(t, http.StatusOK, response.Code, response.Body.String())
+	assert.JSONEq(t, `{"deleted":true}`, response.Body.String())
+
+	_, err := os.Stat(policyPath)
+	assert.True(t, os.IsNotExist(err), "exactly named final rule should be removed")
 }
 
 func TestApprovalResolveURL_SignedWhenSignerConfigured(t *testing.T) {
@@ -1930,13 +2026,23 @@ func TestBulkResolve_AuditFailureDoesNotInstallAutoApproval(t *testing.T) {
 	}
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/approvals/bulk-resolve",
-		strings.NewReader(`{"agent":"claude","session":"s1","run_id":"run-bulk","action":"approve","resolved_by":"dashboard"}`))
+		strings.NewReader(fmt.Sprintf(
+			`{"agent":"claude","session":"s1","run_id":"run-bulk","action":"approve","scope":"run","ids":[%q,%q],"resolved_by":"dashboard"}`,
+			requests[0].ID, requests[1].ID,
+		)))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer tok")
 	recorder := httptest.NewRecorder()
 	srv.handler().ServeHTTP(recorder, req)
 
 	assert.Equal(t, http.StatusServiceUnavailable, recorder.Code)
+	var response map[string]any
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+	assert.Equal(t, float64(1), response["resolved"])
+	assert.Equal(t, false, response["future_calls_authorized"])
+	assert.Equal(t, true, response["refresh_required"])
+	assert.Equal(t, []any{requests[0].ID}, response["ids"])
+	assert.Equal(t, []any{requests[1].ID}, response["unresolved_reviewed_ids"])
 	assert.Equal(t, 2, failing.count())
 	approvedCount := 0
 	pendingCount := 0
@@ -1955,6 +2061,43 @@ func TestBulkResolve_AuditFailureDoesNotInstallAutoApproval(t *testing.T) {
 	assert.False(t, srv.approvals.IsAutoApproved(calls[0]), "partial bulk resolution installed future authorization")
 }
 
+func TestBulkResolve_RunGrantAuditFailureDoesNotPublishAuthority(t *testing.T) {
+	eng := buildApprovalEngine(t)
+	failing := &failOnWriteSink{failAt: 2}
+	srv := New(eng, failing, WithToken("tok"), WithMode("enforce"),
+		WithLogger(slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil))))
+	call := engine.ToolCall{
+		Tool: "exec", Params: map[string]any{"command": "deploy one"},
+		Agent: "claude", Session: "s1", RunID: "run-grant-audit", ToolCallID: "call-one",
+	}
+	pending, err := srv.approvals.Create(call, engine.Decision{Action: engine.ActionRequireApproval})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/approvals/bulk-resolve",
+		strings.NewReader(fmt.Sprintf(
+			`{"agent":"claude","session":"s1","run_id":"run-grant-audit","action":"approve","scope":"run","ids":[%q],"resolved_by":"dashboard"}`,
+			pending.ID,
+		)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer tok")
+	recorder := httptest.NewRecorder()
+	srv.handler().ServeHTTP(recorder, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, recorder.Code)
+	var response map[string]any
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+	assert.Equal(t, float64(1), response["resolved"])
+	assert.Equal(t, []any{pending.ID}, response["ids"])
+	assert.Empty(t, response["unresolved_reviewed_ids"])
+	assert.Equal(t, false, response["future_calls_authorized"])
+	assert.Equal(t, true, response["refresh_required"])
+	assert.Equal(t, 2, failing.count(), "resolution audit should pass before the required grant audit fails")
+	assert.False(t, srv.approvals.IsAutoApproved(call))
+	resolved, ok := srv.approvals.Get(pending.ID)
+	require.True(t, ok)
+	assert.Equal(t, approval.StatusApproved, resolved.Status, "the separately audited exact approval remains valid")
+}
+
 func TestBulkResolve_ConcurrentCreateCannotLeaveOrphanPending(t *testing.T) {
 	eng := buildApprovalEngine(t)
 	srv := New(eng, nil, WithToken("tok"), WithMode("enforce"),
@@ -1967,7 +2110,7 @@ func TestBulkResolve_ConcurrentCreateCannotLeaveOrphanPending(t *testing.T) {
 		RunID:      "run-create-race",
 		ToolCallID: "call-initial",
 	}
-	_, err := srv.approvals.Create(initial, engine.Decision{Action: engine.ActionRequireApproval})
+	initialRequest, err := srv.approvals.Create(initial, engine.Decision{Action: engine.ActionRequireApproval})
 	require.NoError(t, err)
 
 	racedCall := initial
@@ -1981,7 +2124,70 @@ func TestBulkResolve_ConcurrentCreateCannotLeaveOrphanPending(t *testing.T) {
 	srv.sink = tracingSink
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/approvals/bulk-resolve",
-		strings.NewReader(`{"agent":"claude","session":"s1","run_id":"run-create-race","action":"approve","resolved_by":"dashboard"}`))
+		strings.NewReader(fmt.Sprintf(
+			`{"agent":"claude","session":"s1","run_id":"run-create-race","action":"approve","scope":"run","ids":[%q],"resolved_by":"dashboard"}`,
+			initialRequest.ID,
+		)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer tok")
+	recorder := httptest.NewRecorder()
+	srv.handler().ServeHTTP(recorder, req)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	var response map[string]any
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+	assert.Equal(t, []any{initialRequest.ID}, response["reviewed_ids"])
+	var raced createAutoRaceResult
+	select {
+	case raced = <-tracingSink.result:
+	case <-time.After(2 * time.Second):
+		t.Fatal("concurrent create did not complete")
+	}
+	require.NoError(t, raced.err)
+	if raced.autoApproved {
+		assert.Nil(t, raced.request)
+		assert.Empty(t, response["race_covered_ids"])
+	} else {
+		require.NotNil(t, raced.request)
+		assert.Equal(t, []any{raced.request.ID}, response["race_covered_ids"])
+		resolved, ok := srv.approvals.Get(raced.request.ID)
+		require.True(t, ok)
+		assert.Equal(t, approval.StatusApproved, resolved.Status, "creation won the race but bulk publication did not catch it")
+	}
+	assert.Empty(t, srv.approvals.List(), "bulk publication left an orphan same-scope approval pending")
+	assert.True(t, srv.approvals.IsAutoApproved(racedCall))
+}
+
+func TestBulkResolve_ConcurrentCreateRemainsPendingAtExplicitPendingScope(t *testing.T) {
+	eng := buildApprovalEngine(t)
+	srv := New(eng, nil, WithToken("tok"), WithMode("enforce"),
+		WithLogger(slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil))))
+	initial := engine.ToolCall{
+		Tool:       "exec",
+		Params:     map[string]any{"command": "deploy initial"},
+		Agent:      "claude",
+		Session:    "s1",
+		RunID:      "run-pending-race",
+		ToolCallID: "call-initial",
+	}
+	initialRequest, err := srv.approvals.Create(initial, engine.Decision{Action: engine.ActionRequireApproval})
+	require.NoError(t, err)
+
+	racedCall := initial
+	racedCall.Params = map[string]any{"command": "deploy raced"}
+	racedCall.ToolCallID = "call-raced"
+	tracingSink := &createAutoRaceSink{
+		store:  srv.approvals,
+		call:   racedCall,
+		result: make(chan createAutoRaceResult, 1),
+	}
+	srv.sink = tracingSink
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/approvals/bulk-resolve",
+		strings.NewReader(fmt.Sprintf(
+			`{"agent":"claude","session":"s1","run_id":"run-pending-race","action":"approve","scope":"pending","ids":[%q],"resolved_by":"dashboard"}`,
+			initialRequest.ID,
+		)))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer tok")
 	recorder := httptest.NewRecorder()
@@ -1995,16 +2201,12 @@ func TestBulkResolve_ConcurrentCreateCannotLeaveOrphanPending(t *testing.T) {
 		t.Fatal("concurrent create did not complete")
 	}
 	require.NoError(t, raced.err)
-	if raced.autoApproved {
-		assert.Nil(t, raced.request)
-	} else {
-		require.NotNil(t, raced.request)
-		resolved, ok := srv.approvals.Get(raced.request.ID)
-		require.True(t, ok)
-		assert.Equal(t, approval.StatusApproved, resolved.Status, "creation won the race but bulk publication did not catch it")
-	}
-	assert.Empty(t, srv.approvals.List(), "bulk publication left an orphan same-scope approval pending")
-	assert.True(t, srv.approvals.IsAutoApproved(racedCall))
+	require.False(t, raced.autoApproved)
+	require.NotNil(t, raced.request)
+	current, ok := srv.approvals.Get(raced.request.ID)
+	require.True(t, ok)
+	assert.Equal(t, approval.StatusPending, current.Status)
+	assert.False(t, srv.approvals.IsAutoApproved(racedCall))
 }
 
 // TestGetPolicy is removed — GET /v1/policy was removed in v0.9.9.
@@ -2183,7 +2385,7 @@ func TestHandleTest_HTTP(t *testing.T) {
 
 // ── W2: Bulk resolve + auto-approve cache ──────────────────────────────────
 
-func TestBulkResolve_ApprovesAllInRun(t *testing.T) {
+func TestBulkResolve_ApprovesOnlyReviewedIDs(t *testing.T) {
 	configYAML := `version: "1"
 default_action: allow
 policies: []`
@@ -2211,10 +2413,14 @@ policies: []`
 
 	id1 := createApproval("claude-code", "rm -rf /tmp/a")
 	id2 := createApproval("claude-code", "rm -rf /tmp/b")
+	unreviewedID := createApproval("claude-code", "rm -rf /tmp/unreviewed")
 	collidingID := createApproval("codex", "rm -rf /tmp/c")
 
-	// Bulk-resolve: approve the run.
-	bulkBody := fmt.Sprintf(`{"agent":"claude-code","session":"hook","run_id":%q,"action":"approve","resolved_by":"test"}`, runID)
+	// Pending scope resolves only the exact IDs the operator reviewed.
+	bulkBody := fmt.Sprintf(
+		`{"agent":"claude-code","session":"hook","run_id":%q,"action":"approve","scope":"pending","ids":[%q,%q],"resolved_by":"test"}`,
+		runID, id1, id2,
+	)
 	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/approvals/bulk-resolve", strings.NewReader(bulkBody))
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Content-Type", "application/json")
@@ -2226,6 +2432,10 @@ policies: []`
 	var bulkResult map[string]any
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&bulkResult))
 	assert.Equal(t, float64(2), bulkResult["resolved"])
+	assert.Equal(t, "pending", bulkResult["scope"])
+	assert.Equal(t, false, bulkResult["future_calls_authorized"])
+	assert.Equal(t, []any{id1, id2}, bulkResult["reviewed_ids"])
+	assert.Empty(t, bulkResult["race_covered_ids"])
 
 	ids, ok := bulkResult["ids"].([]any)
 	require.True(t, ok)
@@ -2250,13 +2460,19 @@ policies: []`
 	}
 	assert.Equal(t, "approved", getStatus(id1))
 	assert.Equal(t, "approved", getStatus(id2))
+	assert.Equal(t, "pending", getStatus(unreviewedID), "an unseen same-run call must not be resolved")
 	assert.Equal(t, "pending", getStatus(collidingID), "same run_id in another agent scope must remain pending")
+	subsequentID := createApproval("claude-code", "rm -rf /tmp/later")
+	assert.Equal(t, "pending", getStatus(subsequentID), "pending-only approval must not authorize later calls")
 	events := sink.snapshot()
 	require.Len(t, events, 2)
 	for _, event := range events {
 		assert.Equal(t, true, event.Request["bulk"])
-		assert.Equal(t, true, event.Request["auto_approve"])
-		assert.NotZero(t, event.Request["auto_approve_ttl_seconds"])
+		assert.Equal(t, "pending", event.Request["approval_scope"])
+		assert.Equal(t, false, event.Request["future_calls_requested"])
+		assert.Equal(t, false, event.Request["auto_approve"])
+		assert.NotContains(t, event.Request, "auto_approve_ttl_seconds")
+		assert.NotContains(t, event.Request, "grant_ttl_ms")
 		assert.Equal(t, runID, event.RunID)
 	}
 }
@@ -2273,11 +2489,58 @@ policies: []`
 	// Every identity field is required — never batch-resolve a caller-selected
 	// run ID across agents or sessions.
 	for _, body := range []string{
-		`{"agent":"","session":"hook","run_id":"run","action":"approve"}`,
-		`{"agent":"claude-code","session":"","run_id":"run","action":"approve"}`,
-		`{"agent":"claude-code","session":"hook","run_id":"","action":"approve"}`,
-		`{"agent":"claude-code","session":"hook","run_id":"   ","action":"approve"}`,
-		`{"action":"approve"}`,
+		`{"agent":"","session":"hook","run_id":"run","action":"approve","scope":"pending","ids":["id"]}`,
+		`{"agent":"claude-code","session":"","run_id":"run","action":"approve","scope":"pending","ids":["id"]}`,
+		`{"agent":"claude-code","session":"hook","run_id":"","action":"approve","scope":"pending","ids":["id"]}`,
+		`{"agent":"claude-code","session":"hook","run_id":"   ","action":"approve","scope":"pending","ids":["id"]}`,
+		`{"action":"approve","scope":"pending","ids":["id"]}`,
+	} {
+		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/approvals/bulk-resolve", strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		resp.Body.Close()
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "body: %s", body)
+	}
+}
+
+func TestBulkResolve_InvalidScopeRejected(t *testing.T) {
+	configYAML := `version: "1"
+default_action: allow
+policies: []`
+
+	srv, token, _ := setupTestServer(t, configYAML, "enforce")
+	ts := httptest.NewServer(srv.handler())
+	defer ts.Close()
+
+	for _, body := range []string{
+		`{"agent":"claude-code","session":"hook","run_id":"run","action":"approve","scope":"session","ids":["id"]}`,
+		`{"agent":"claude-code","session":"hook","run_id":"run","action":"deny","scope":"run","ids":["id"]}`,
+	} {
+		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/approvals/bulk-resolve", strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		resp.Body.Close()
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "body: %s", body)
+	}
+}
+
+func TestBulkResolve_ScopeAndIDsRequired(t *testing.T) {
+	configYAML := `version: "1"
+default_action: allow
+policies: []`
+
+	srv, token, _ := setupTestServer(t, configYAML, "enforce")
+	ts := httptest.NewServer(srv.handler())
+	defer ts.Close()
+
+	for _, body := range []string{
+		`{"agent":"claude-code","session":"hook","run_id":"run","action":"approve","ids":["id"]}`,
+		`{"agent":"claude-code","session":"hook","run_id":"run","action":"approve","scope":"pending"}`,
+		`{"agent":"claude-code","session":"hook","run_id":"run","action":"approve","scope":"pending","ids":[]}`,
 	} {
 		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/approvals/bulk-resolve", strings.NewReader(body))
 		req.Header.Set("Authorization", "Bearer "+token)
@@ -2307,7 +2570,7 @@ policies: []`
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 }
 
-func TestBulkResolve_ZeroResolved_WhenNoPendingForRun(t *testing.T) {
+func TestBulkResolve_StaleApprovalIDRejected(t *testing.T) {
 	configYAML := `version: "1"
 default_action: allow
 policies: []`
@@ -2316,8 +2579,7 @@ policies: []`
 	ts := httptest.NewServer(srv.handler())
 	defer ts.Close()
 
-	// Bulk-resolve a run that has no pending approvals.
-	body := `{"agent":"claude-code","session":"hook","run_id":"run-nonexistent","action":"approve"}`
+	body := `{"agent":"claude-code","session":"hook","run_id":"run-nonexistent","action":"approve","scope":"pending","ids":["missing"]}`
 	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/approvals/bulk-resolve", strings.NewReader(body))
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Content-Type", "application/json")
@@ -2325,14 +2587,110 @@ policies: []`
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	var result map[string]any
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
-	assert.Equal(t, float64(0), result["resolved"])
-	// ids should be an empty array, not null.
-	ids, ok := result["ids"].([]any)
-	assert.True(t, ok, "ids should be a JSON array")
-	assert.Empty(t, ids)
+	assert.Equal(t, http.StatusConflict, resp.StatusCode)
+}
+
+func TestBulkResolve_ValidatesEveryIDBeforeResolving(t *testing.T) {
+	configYAML := `version: "1"
+default_action: allow
+policies: []`
+
+	srv, token, _ := setupTestServer(t, configYAML, "enforce")
+	call := engine.ToolCall{
+		Tool: "exec", Params: map[string]any{"command": "deploy"},
+		Agent: "claude-code", Session: "hook", RunID: "run-validate-all", ToolCallID: "call-one",
+	}
+	pending, err := srv.approvals.Create(call, engine.Decision{Action: engine.ActionRequireApproval})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/approvals/bulk-resolve",
+		strings.NewReader(fmt.Sprintf(
+			`{"agent":"claude-code","session":"hook","run_id":"run-validate-all","action":"approve","scope":"pending","ids":[%q,"missing"]}`,
+			pending.ID,
+		)))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	srv.handler().ServeHTTP(recorder, req)
+
+	assert.Equal(t, http.StatusConflict, recorder.Code)
+	current, ok := srv.approvals.Get(pending.ID)
+	require.True(t, ok)
+	assert.Equal(t, approval.StatusPending, current.Status)
+}
+
+func TestBulkResolve_RunScopeRejectsMultipleCredentialOwners(t *testing.T) {
+	configYAML := `version: "1"
+default_action: allow
+policies: []`
+
+	srv, token, _ := setupTestServer(t, configYAML, "enforce")
+	call := engine.ToolCall{
+		Tool: "exec", Params: map[string]any{"command": "deploy"},
+		Agent: "claude-code", Session: "hook", RunID: "run-owner-split", ToolCallID: "call-a",
+	}
+	first, autoApproved, err := srv.approvals.CreateOrAutoApproved(call, engine.Decision{Action: engine.ActionRequireApproval}, strings.Repeat("a", 64))
+	require.NoError(t, err)
+	require.False(t, autoApproved)
+	call.ToolCallID = "call-b"
+	second, autoApproved, err := srv.approvals.CreateOrAutoApproved(call, engine.Decision{Action: engine.ActionRequireApproval}, strings.Repeat("b", 64))
+	require.NoError(t, err)
+	require.False(t, autoApproved)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/approvals/bulk-resolve",
+		strings.NewReader(fmt.Sprintf(
+			`{"agent":"claude-code","session":"hook","run_id":"run-owner-split","action":"approve","scope":"run","ids":[%q,%q]}`,
+			first.ID, second.ID,
+		)))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	srv.handler().ServeHTTP(recorder, req)
+
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+	firstCurrent, ok := srv.approvals.Get(first.ID)
+	require.True(t, ok)
+	secondCurrent, ok := srv.approvals.Get(second.ID)
+	require.True(t, ok)
+	assert.Equal(t, approval.StatusPending, firstCurrent.Status)
+	assert.Equal(t, approval.StatusPending, secondCurrent.Status)
+}
+
+func TestBulkResolve_RunScopeRejectsOmittedPendingApprovalForOwner(t *testing.T) {
+	configYAML := `version: "1"
+default_action: allow
+policies: []`
+
+	srv, token, sink := setupTestServer(t, configYAML, "enforce")
+	call := engine.ToolCall{
+		Tool: "exec", Params: map[string]any{"command": "deploy first"},
+		Agent: "claude-code", Session: "hook", RunID: "run-owner-complete", ToolCallID: "call-a",
+	}
+	first, err := srv.approvals.Create(call, engine.Decision{Action: engine.ActionRequireApproval})
+	require.NoError(t, err)
+	call.Params = map[string]any{"command": "deploy omitted"}
+	call.ToolCallID = "call-b"
+	omitted, err := srv.approvals.Create(call, engine.Decision{Action: engine.ActionRequireApproval})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/approvals/bulk-resolve",
+		strings.NewReader(fmt.Sprintf(
+			`{"agent":"claude-code","session":"hook","run_id":"run-owner-complete","action":"approve","scope":"run","ids":[%q]}`,
+			first.ID,
+		)))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	srv.handler().ServeHTTP(recorder, req)
+
+	assert.Equal(t, http.StatusConflict, recorder.Code)
+	for _, id := range []string{first.ID, omitted.ID} {
+		current, ok := srv.approvals.Get(id)
+		require.True(t, ok)
+		assert.Equal(t, approval.StatusPending, current.Status)
+	}
+	assert.Empty(t, sink.snapshot(), "rejected incomplete run scope must not publish audit transitions")
+	assert.False(t, srv.approvals.IsAutoApproved(call))
 }
 
 func TestAutoApproveCache_SubsequentCallsSkipQueue(t *testing.T) {
@@ -2340,28 +2698,59 @@ func TestAutoApproveCache_SubsequentCallsSkipQueue(t *testing.T) {
 default_action: allow
 policies: []`
 
-	srv, token, _ := setupTestServer(t, configYAML, "enforce")
+	srv, token, sink := setupTestServer(t, configYAML, "enforce")
 	ts := httptest.NewServer(srv.handler())
 	defer ts.Close()
 
 	runID := "run-auto-approve-test"
 
 	// Create and bulk-approve two approvals to seed the auto-approve cache.
+	createdIDs := make([]string, 0, 2)
 	for _, cmd := range []string{"rm /tmp/x", "rm /tmp/y"} {
 		body := fmt.Sprintf(`{"tool":"exec","command":%q,"agent":"claude-code","run_id":%q,"message":"needs approval"}`, cmd, runID)
 		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/approvals", strings.NewReader(body))
 		req.Header.Set("Authorization", "Bearer "+token)
 		req.Header.Set("Content-Type", "application/json")
 		resp, _ := http.DefaultClient.Do(req)
+		result := decodeBody(t, resp)
+		createdIDs = append(createdIDs, result["id"].(string))
 		resp.Body.Close()
 	}
 
-	bulkBody := fmt.Sprintf(`{"agent":"claude-code","session":"hook","run_id":%q,"action":"approve"}`, runID)
+	bulkBody := fmt.Sprintf(
+		`{"agent":"claude-code","session":"hook","run_id":%q,"action":"approve","scope":"run","ids":[%q,%q]}`,
+		runID, createdIDs[0], createdIDs[1],
+	)
 	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/approvals/bulk-resolve", strings.NewReader(bulkBody))
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Content-Type", "application/json")
-	resp, _ := http.DefaultClient.Do(req)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	bulkResult := decodeBody(t, resp)
 	resp.Body.Close()
+	assert.Equal(t, "run", bulkResult["scope"])
+	assert.Equal(t, true, bulkResult["future_calls_authorized"])
+	assert.Equal(t, []any{createdIDs[0], createdIDs[1]}, bulkResult["reviewed_ids"])
+	assert.Empty(t, bulkResult["race_covered_ids"])
+	assert.Equal(t, float64(approval.DefaultTimeout/time.Millisecond), bulkResult["grant_ttl_ms"])
+	assert.NotEmpty(t, bulkResult["grant_expires_at"])
+	events := sink.snapshot()
+	require.Len(t, events, 3)
+	for _, event := range events[:2] {
+		assert.Equal(t, "run", event.Request["approval_scope"])
+		assert.Equal(t, true, event.Request["future_calls_requested"])
+		assert.Equal(t, true, event.Request["auto_approve"])
+		assert.Equal(t, int64(approval.DefaultTimeout/time.Second), event.Request["auto_approve_ttl_seconds"])
+		assert.Equal(t, int64(approval.DefaultTimeout/time.Millisecond), event.Request["grant_ttl_ms"])
+	}
+	grantEvent := events[2]
+	assert.Equal(t, "run_approval_publication_authorized", grantEvent.Request["action"])
+	assert.Equal(t, true, grantEvent.Request["future_calls_requested"])
+	assert.Equal(t, true, grantEvent.Request["publication_authorized"])
+	assert.NotContains(t, grantEvent.Request, "future_calls_authorized")
+	assert.Equal(t, int64(approval.DefaultTimeout/time.Millisecond), grantEvent.Request["grant_ttl_ms"])
+	assert.NotEmpty(t, grantEvent.Request["grant_expires_at"])
 
 	// Now a NEW approval from the same run should be auto-approved (status="approved", not "pending").
 	newBody := fmt.Sprintf(`{"tool":"exec","command":"rm /tmp/z","agent":"claude-code","run_id":%q,"message":"new call"}`, runID)
@@ -2376,6 +2765,7 @@ policies: []`
 	var result map[string]any
 	require.NoError(t, json.NewDecoder(resp2.Body).Decode(&result))
 	assert.Equal(t, "approved", result["status"], "subsequent call from auto-approved run should be auto-approved")
+	assert.Equal(t, bulkResult["grant_expires_at"], result["expires_at"], "auto-approved responses must preserve the stored grant expiry")
 
 	// A run ID is caller-selected and may collide across agents. The cached
 	// approval must not authorize a different identity using the same value.
@@ -2431,6 +2821,7 @@ policies: []`
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	var result map[string]any
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
+	assert.Equal(t, float64(approval.DefaultTimeout/time.Millisecond), result["run_grant_ttl_ms"])
 
 	// run_groups must be present.
 	runGroups, ok := result["run_groups"].([]any)
@@ -2466,6 +2857,51 @@ policies: []`
 	approvals, ok := result["approvals"].([]any)
 	require.True(t, ok)
 	assert.Len(t, approvals, 4)
+}
+
+func TestListApprovals_RunGroupsAreSplitByCredentialOwner(t *testing.T) {
+	configYAML := `version: "1"
+default_action: allow
+policies: []`
+
+	srv, token, _ := setupTestServer(t, configYAML, "enforce")
+	base := engine.ToolCall{
+		Tool: "exec", Params: map[string]any{"command": "deploy"},
+		Agent: "claude-code", Session: "hook", RunID: "run-owner-groups",
+	}
+	for ownerIndex, owner := range []string{strings.Repeat("a", 64), strings.Repeat("b", 64)} {
+		for callIndex := range 2 {
+			call := base
+			call.ToolCallID = fmt.Sprintf("call-%d-%d", ownerIndex, callIndex)
+			_, autoApproved, err := srv.approvals.CreateOrAutoApproved(
+				call, engine.Decision{Action: engine.ActionRequireApproval}, owner,
+			)
+			require.NoError(t, err)
+			require.False(t, autoApproved)
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/approvals", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	recorder := httptest.NewRecorder()
+	srv.handler().ServeHTTP(recorder, req)
+	require.Equal(t, http.StatusOK, recorder.Code)
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &result))
+	runGroups, ok := result["run_groups"].([]any)
+	require.True(t, ok)
+	require.Len(t, runGroups, 2)
+	owners := map[string]bool{}
+	for _, rawGroup := range runGroups {
+		group := rawGroup.(map[string]any)
+		assert.Equal(t, float64(2), group["count"])
+		owner, ok := group["credential_owner"].(string)
+		require.True(t, ok)
+		assert.True(t, strings.HasPrefix(owner, "credential-"))
+		owners[owner] = true
+	}
+	assert.Len(t, owners, 2)
 }
 
 func TestListApprovals_RunGroupsSortedByEarliestCreatedAt(t *testing.T) {


### PR DESCRIPTION
## Summary

- require callers to choose `pending` or `run` scope and submit the exact approval IDs the operator reviewed
- keep pending-scope actions exact; publish future run authority only through a time-bounded, credential-owner-bound transaction that closes create/resolve/expiry races
- make partial failures, reviewed IDs, race-covered IDs, grant expiry, and authorization state explicit in API and audit output while retaining `rampart.audit.v1` aliases
- split the dashboard into Approve Pending and Allow Future flows, harden auth/reconnect behavior, and remove CSP-blocked inline handlers/styles
- enforce one live approval-service owner per Rampart data directory so independent in-memory run grants cannot disagree

## Why

The staging dashboard currently labels its bulk action as approving pending calls while the API also grants future authority for that run. Operators cannot safely distinguish the two intents. Error responses can also hide partial commits, and two service processes sharing approval state can disagree about in-memory grants.

This is the first focused 1.8 slice: make approval authority explicit, bounded, owner-aware, and auditable before adding broader roadmap features.

## API and compatibility

- `POST /v1/approvals/bulk-resolve` now requires non-empty `ids` and explicit `scope`.
- `pending` resolves only reviewed IDs and never grants future authority.
- `run` is approve-only, requires every approval already pending for the exact owner-bound run snapshot, reports post-snapshot race-covered IDs separately, and uses one absolute deadline from validation through publication.
- partial `503` responses identify committed and unresolved IDs and require refresh rather than blind retry.
- deprecated `request.auto_approve` and `request.auto_approve_ttl_seconds` remain as audit-v1 aliases; new fields separate requested intent from successfully published authority.
- a second `rampart serve` using the same data directory now fails before serving, including on a different port.

## Validation

- maintainer `local full` gate
- `go test -race -count=20 -run '^TestAcquireLock' ./internal/filetxn`
- `go test -race -count=10 -run '^TestServeRejectsSecondApprovalStateOwner$' ./cmd/rampart/cli`
- Windows amd64 cross-compiles for `internal/filetxn` and `cmd/rampart/cli`
- `sh scripts/check-api-reference.sh`
- real-handler browser smoke under the served nonce CSP: connect, disconnect, reconnect, Active, History, Policy, and invalid-auth reset; no CSP/runtime console errors
- `git diff --check`

## Follow-up roadmap

This PR intentionally does not implement decision-rule provenance, a canonical policy snapshot/resolver, policy impact replay, canonical audit reporting, or Cursor support. Those should remain separate reviewable 1.8 slices; Cursor work is already proposed independently in #397.
