### PR TITLE
fix(hermes): support v0.20.2 native approval resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   calls, preserves Cursor's own permissions on allow, and keeps Cloud Agent,
   Tab, project, team, and enterprise deployment claims separate.
 
+### Fixed
+
+- **Hermes v0.20.2 native approvals remain action-bound** — Rampart recognizes
+  Hermes' reviewed shared approval-resolver path while retaining fail-closed
+  capability detection for unknown host implementations.
+
 ## [1.7.0] - 2026-08-14
 
 ### Security

--- a/internal/plugin/hermes/__init__.py
+++ b/internal/plugin/hermes/__init__.py
@@ -39,7 +39,7 @@ from pathlib import Path
 from typing import Any, Callable, Mapping
 from urllib.parse import quote, urlsplit
 
-VERSION = "1.7.0"
+VERSION = "1.7.1"
 
 DEFAULT_SERVE_URL = "http://127.0.0.1:9090"
 DEFAULT_TIMEOUT_MS = 3000
@@ -809,6 +809,7 @@ def _hermes_supports_native_approval() -> bool:
         hermes_plugins, "_get_pre_tool_call_directive_details", None
     )
     resolver = getattr(hermes_plugins, "resolve_pre_tool_block", None)
+    resolution_helper = getattr(hermes_plugins, "_resolve_block_from_details", None)
     if not (
         callable(public_getter)
         and callable(details_getter)
@@ -818,11 +819,14 @@ def _hermes_supports_native_approval() -> bool:
         return False
 
     # A field on the directive alone is not a capability guarantee. Prove the
-    # two released-v2026.8.3 data-flow legs from installed source: the private
+    # released data-flow legs from installed source: the private
     # dispatcher copies the hook's ``result["rule_key"]`` into the directive,
-    # and the resolver supplies ``details.rule_key`` to the approval gate. If
-    # source is unavailable or a future host delegates this differently, fail
-    # closed until that contract is reviewed instead of guessing from names.
+    # and the resolver supplies ``details.rule_key`` to the approval gate.
+    # Hermes v0.20.2 moved the gate into ``_resolve_block_from_details``; for
+    # that shape, also prove that the resolver passes the same directive into
+    # the helper. If source is unavailable or a future host delegates this
+    # differently, fail closed until that contract is reviewed instead of
+    # guessing from names.
     try:
         details_tree = ast.parse(textwrap.dedent(inspect.getsource(details_getter)))
         resolver_tree = ast.parse(textwrap.dedent(inspect.getsource(resolver)))
@@ -874,6 +878,22 @@ def _hermes_supports_native_approval() -> bool:
         and call_name(node.value) == "_get_pre_tool_call_directive_details"
         for node in ast.walk(resolver_tree)
     )
+    resolver_delegates_same_details = callable(resolution_helper) and any(
+        isinstance(node, ast.Call)
+        and call_name(node) == "_resolve_block_from_details"
+        and node.args
+        and isinstance(node.args[0], ast.Name)
+        and node.args[0].id == "details"
+        for node in ast.walk(resolver_tree)
+    )
+    gate_tree = resolver_tree
+    if resolver_delegates_same_details:
+        try:
+            gate_tree = ast.parse(
+                textwrap.dedent(inspect.getsource(resolution_helper))
+            )
+        except (OSError, TypeError, SyntaxError, IndentationError):
+            return False
     details_rule_key_reaches_gate = any(
         isinstance(node, ast.Call)
         and call_name(node) == "request_tool_approval"
@@ -888,7 +908,7 @@ def _hermes_supports_native_approval() -> bool:
             )
             for keyword in node.keywords
         )
-        for node in ast.walk(resolver_tree)
+        for node in ast.walk(gate_tree)
     )
     return (
         result_rule_key_is_captured

--- a/internal/plugin/hermes/embed_test.go
+++ b/internal/plugin/hermes/embed_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestVersionReadsManifest(t *testing.T) {
-	if got, want := Version(), "1.7.0"; got != want {
+	if got, want := Version(), "1.7.1"; got != want {
 		t.Fatalf("Version() = %q, want %q", got, want)
 	}
 }
@@ -97,7 +97,7 @@ func TestExtractRollsBackManagedPluginOnActivationFailure(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	oldManifest = bytes.Replace(oldManifest, []byte("version: 1.7.0"), []byte("version: 1.6.0"), 1)
+	oldManifest = bytes.Replace(oldManifest, []byte("version: 1.7.1"), []byte("version: 1.6.0"), 1)
 	if err := os.WriteFile(manifestPath, oldManifest, 0o600); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/plugin/hermes/plugin.yaml
+++ b/internal/plugin/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: rampart
-version: 1.7.0
+version: 1.7.1
 description: Experimental Rampart policy gate for Hermes Agent pre_tool_call hooks
 author: peg
 provides_hooks:

--- a/internal/plugin/hermes/test_hermes_plugin.py
+++ b/internal/plugin/hermes/test_hermes_plugin.py
@@ -50,8 +50,12 @@ class HermesPluginTests(unittest.TestCase):
         def resolve_pre_tool_block(*_):
             return None
 
+        def resolve_block_from_details(*_):
+            return None
+
         hermes_plugins._get_pre_tool_call_directive_details = details_getter
         hermes_plugins.resolve_pre_tool_block = resolve_pre_tool_block
+        hermes_plugins._resolve_block_from_details = resolve_block_from_details
         directive_type = type(
             "_PreToolCallDirective",
             (),
@@ -77,6 +81,13 @@ class HermesPluginTests(unittest.TestCase):
                         rule_key=details.rule_key or tool_name,
                     )
             """,
+            resolve_block_from_details: """
+                def _resolve_block_from_details(details, tool_name):
+                    return request_tool_approval(
+                        tool_name, details.message or "",
+                        rule_key=details.rule_key or tool_name,
+                    )
+            """,
         }
 
         with (
@@ -92,6 +103,21 @@ class HermesPluginTests(unittest.TestCase):
                 def resolve_pre_tool_block(tool_name, args):
                     details = _get_pre_tool_call_directive_details(tool_name, args)
                     return request_tool_approval(tool_name, details.message, rule_key=tool_name)
+            """
+            self.assertFalse(plugin._hermes_supports_native_approval())
+
+            sources[resolve_pre_tool_block] = """
+                def resolve_pre_tool_block(tool_name, args):
+                    details = _get_pre_tool_call_directive_details(tool_name, args)
+                    return _resolve_block_from_details(details, tool_name)
+            """
+            self.assertTrue(plugin._hermes_supports_native_approval())
+
+            sources[resolve_block_from_details] = """
+                def _resolve_block_from_details(details, tool_name):
+                    return request_tool_approval(
+                        tool_name, details.message or "", rule_key=tool_name
+                    )
             """
             self.assertFalse(plugin._hermes_supports_native_approval())
 


### PR DESCRIPTION
## Summary

- recognize Hermes v0.20.2's reviewed shared native-approval resolver
- preserve exact action-bound rule-key proof and fail closed for unknown implementations
- bump the bundled Hermes plugin to 1.7.1

## Validation

- full local maintainer gate
- focused Python plugin suite
- focused Go race test
- exact Agent02 latest-Hermes gate passed on commit 16a02662dbf10b2cbb4600a1672c15efee499d14
- zero model calls

The full Agent02 upstream matrix remains blocked only by the existing Cline CPU incompatibility; Copilot and both OpenClaw gates passed. No private lab material is included.