### PR TITLE
docs: finalize v1.8.0 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.0] - 2026-08-17
+
 ### Security
 
 - **Bulk approval no longer grants hidden future authority** — Dashboard and

--- a/assurance/integrations.yaml
+++ b/assurance/integrations.yaml
@@ -1,6 +1,6 @@
 schema_version: rampart.assurance.v2
-baseline_release: v1.7.0
-reviewed_at: "2026-08-14"
+baseline_release: v1.8.0
+reviewed_at: "2026-08-17"
 
 # Version 2 uses the canonical Rampart command target as each integration id
 # and requires an explicit declaration of bare `rampart protect` eligibility.

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -234,10 +234,10 @@ verify -> outcomes.approval
 
 ## Current release
 
-Rampart v1.7.0 binds approvals to their requesting identity, hardens MCP and
-compound-command enforcement, unifies managed protection, and adds native
-Hermes approval support for compatible installations. It also reduces the
-repository and CI maintenance footprint while refreshing the public site. See the
-[release notes](https://github.com/peg/rampart/releases/latest) for the concise
-upgrade summary or the repository
+Rampart v1.8.0 adds a fail-closed native hook for local Cursor Agent and Cmd+K
+tool calls, makes future run approval explicit and credential-bound, and keeps
+native approvals compatible with Hermes v0.20.2. Cursor Cloud Agent remains
+outside the local hook boundary. See the [release
+notes](https://github.com/peg/rampart/releases/latest) for the concise upgrade
+summary or the repository
 [changelog](https://github.com/peg/rampart/blob/main/CHANGELOG.md) for history.

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -1,6 +1,6 @@
 # Threat Model
 
-> Last reviewed: 2026-08-14 | Applies to: v1.7.0+
+> Last reviewed: 2026-08-17 | Applies to: v1.8.0+
 
 Rampart is a policy engine for AI agents — not a sandbox, not a hypervisor, not a full isolation boundary. This document describes what Rampart protects against, what it doesn't, and why.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -28,7 +28,7 @@
       "url": "https://rampart.sh",
       "applicationCategory": "SecurityApplication",
       "operatingSystem": "Linux, macOS, Windows",
-      "softwareVersion": "1.7.0",
+      "softwareVersion": "1.8.0",
       "license": "https://opensource.org/licenses/Apache-2.0",
       "codeRepository": "https://github.com/peg/rampart"
     }
@@ -974,7 +974,7 @@
     <section class="hero" aria-labelledby="hero-title">
         <div class="hero-grid">
             <div class="hero-copy">
-                <p class="eyebrow">v1.7.0 · Open-source control for AI agents</p>
+                <p class="eyebrow">v1.8.0 · Open-source control for AI agents</p>
                 <h1 id="hero-title">
                     <span class="first-line">Let agents move fast.</span>
                     <span class="final-line">Keep the final say.</span>


### PR DESCRIPTION
## Summary

- publish the staged changes under the 1.8.0 changelog section dated 2026-08-17
- advance the integration assurance baseline and threat-model review metadata
- update the docs homepage and public site from 1.7.0 to 1.8.0 with conservative Cursor, approval, and Hermes wording

## Validation

- full local maintainer gate
- strict MkDocs build using pinned documentation requirements
- canonical documentation wrapper check
- git diff --check

This PR changes release metadata and public copy only; it does not change product behavior.