### PR TITLE
build: move to supported Go 1.26 line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Source and release builds now use Go 1.26.7** — Rampart's module baseline,
+- **Source and release builds now use Go 1.26.8** — Rampart's module baseline,
   container build, and public source-build requirements now use the supported
   Go 1.26 line after Go 1.27 ended upstream support for Go 1.25.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Source and release builds now use Go 1.26.7** — Rampart's module baseline,
+  container build, and public source-build requirements now use the supported
+  Go 1.26 line after Go 1.27 ended upstream support for Go 1.25.
+
 ## [1.8.0] - 2026-08-17
 
 ### Security

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # requested image platform so linux/arm64 releases don't depend on slow QEMU
 # emulation for the Go build itself.
 ARG BUILDPLATFORM
-FROM --platform=$BUILDPLATFORM golang:1.25.13-bookworm AS build
+FROM --platform=$BUILDPLATFORM golang:1.26.7-bookworm AS build
 WORKDIR /src
 
 ARG TARGETOS

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # requested image platform so linux/arm64 releases don't depend on slow QEMU
 # emulation for the Go build itself.
 ARG BUILDPLATFORM
-FROM --platform=$BUILDPLATFORM golang:1.26.7-bookworm AS build
+FROM --platform=$BUILDPLATFORM golang:1.26.8-bookworm AS build
 WORKDIR /src
 
 ARG TARGETOS

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <img src="docs/og-authority-visible.png" alt="Rampart — Let agents move fast. Keep the final say." width="100%">
 
-[![Go](https://img.shields.io/badge/Go-1.26.7+-00ADD8?style=flat&logo=go)](https://go.dev)
+[![Go](https://img.shields.io/badge/Go-1.26.8+-00ADD8?style=flat&logo=go)](https://go.dev)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![CI](https://github.com/peg/rampart/actions/workflows/ci.yml/badge.svg)](https://github.com/peg/rampart/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/peg/rampart?style=flat)](https://github.com/peg/rampart/releases)
@@ -86,7 +86,7 @@ irm https://rampart.sh/install.ps1 | iex
 go install github.com/peg/rampart/cmd/rampart@latest
 ```
 
-Source builds require Go 1.26.7 or newer. Windows upgrades use the PowerShell
+Source builds require Go 1.26.8 or newer. Windows upgrades use the PowerShell
 installer; binary self-upgrade is intentionally disabled there.
 
 </details>

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <img src="docs/og-authority-visible.png" alt="Rampart — Let agents move fast. Keep the final say." width="100%">
 
-[![Go](https://img.shields.io/badge/Go-1.25.13+-00ADD8?style=flat&logo=go)](https://go.dev)
+[![Go](https://img.shields.io/badge/Go-1.26.7+-00ADD8?style=flat&logo=go)](https://go.dev)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![CI](https://github.com/peg/rampart/actions/workflows/ci.yml/badge.svg)](https://github.com/peg/rampart/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/peg/rampart?style=flat)](https://github.com/peg/rampart/releases)
@@ -86,7 +86,7 @@ irm https://rampart.sh/install.ps1 | iex
 go install github.com/peg/rampart/cmd/rampart@latest
 ```
 
-Source builds require Go 1.25.13 or newer. Windows upgrades use the PowerShell
+Source builds require Go 1.26.7 or newer. Windows upgrades use the PowerShell
 installer; binary self-upgrade is intentionally disabled there.
 
 </details>

--- a/docs-site/getting-started/installation.md
+++ b/docs-site/getting-started/installation.md
@@ -58,7 +58,7 @@ This installs the `rampart` binary.
 
 ## Go Install
 
-Requires Go 1.26.7+:
+Requires Go 1.26.8+:
 
 ```bash
 go install github.com/peg/rampart/cmd/rampart@latest

--- a/docs-site/getting-started/installation.md
+++ b/docs-site/getting-started/installation.md
@@ -58,7 +58,7 @@ This installs the `rampart` binary.
 
 ## Go Install
 
-Requires Go 1.25.13+:
+Requires Go 1.26.7+:
 
 ```bash
 go install github.com/peg/rampart/cmd/rampart@latest

--- a/docs-site/getting-started/tutorial.md
+++ b/docs-site/getting-started/tutorial.md
@@ -18,7 +18,7 @@ Let's set it up.
 ## Prerequisites
 
 - **macOS or Linux** (Windows WSL works too)
-- **Go 1.25.13+** (recommended) or the install script for a no-Go option
+- **Go 1.26.7+** (recommended) or the install script for a no-Go option
 - **Claude Code, Codex, or Cline** — this guide uses Claude Code, but Rampart works with [many agents](../integrations/index.md)
 
 ---

--- a/docs-site/getting-started/tutorial.md
+++ b/docs-site/getting-started/tutorial.md
@@ -18,7 +18,7 @@ Let's set it up.
 ## Prerequisites
 
 - **macOS or Linux** (Windows WSL works too)
-- **Go 1.26.7+** (recommended) or the install script for a no-Go option
+- **Go 1.26.8+** (recommended) or the install script for a no-Go option
 - **Claude Code, Codex, or Cline** — this guide uses Claude Code, but Rampart works with [many agents](../integrations/index.md)
 
 ---

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/peg/rampart
 
-go 1.26.7
+go 1.26.8
 
 require (
 	github.com/charmbracelet/bubbletea v1.3.10

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/peg/rampart
 
-go 1.25.13
+go 1.26.7
 
 require (
 	github.com/charmbracelet/bubbletea v1.3.10


### PR DESCRIPTION
Go 1.25 is outside upstream's supported release window. Move Rampart's source and container builds to Go 1.26.8 and keep the public source-build requirements synchronized. CI continues to derive its Go version from go.mod.

Go 1.26.8 is the current patch of the older supported line, avoiding an unnecessary move to Go 1.27 in this maintenance change. See the [official Go release history](https://go.dev/doc/devel/release).

Validation: `go test ./...`, `go vet ./...`, `make security-assurance`, `git diff --check`, and the toolchain synchronization check passed using Go 1.26.8. The new head must pass the full required CI checks before merge.
