### PR TITLE
docs: correct release support and audit integrity claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,12 +280,12 @@ setuid, direct-syscall, and SIP-protected paths remain outside that boundary.
 [Any CLI agent →](https://docs.rampart.sh/integrations/any-cli-agent/) ·
 [Threat model →](docs/THREAT-MODEL.md)
 
-## What changed in 1.7
+## What changed in 1.8
 
-Rampart 1.7 binds approval state to the requesting credential, hardens MCP
-correlation and destructive-command matching, unifies managed onboarding,
-repairs owned service state safely, adds compatible Hermes native approval,
-and reduces duplicated repository and CI maintenance surface.
+Rampart 1.8 adds a native local Cursor hook, separates approval of reviewed
+pending calls from explicit grants for future calls, and binds those grants
+to the requesting credential and run. It also gives approval state one live
+service owner and keeps native approvals compatible with Hermes v0.20.2.
 
 Read the [changelog](CHANGELOG.md) for the full release notes.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,8 @@
 
 | Version | Supported |
 | --- | --- |
-| 1.7.x | ✅ Current release |
-| 1.6.x | ⚠️ Critical fixes only |
+| 1.8.x | ✅ Current release |
+| 1.6.x–1.7.x | ⚠️ Critical fixes only |
 | < 1.6 | ❌ No longer supported |
 
 ## Reporting a Vulnerability
@@ -44,7 +44,9 @@ Rampart's threat model is documented in [`docs/THREAT-MODEL.md`](docs/THREAT-MOD
   dependency; explicitly configured notification, decision-webhook, semantic
   verification, and SIEM integrations send their documented data to the
   operator-selected endpoint
-- **Hash-chained audit** — tamper-evident append-only trail with SIEM export
+- **Hash-chained audit** — local records and checkpoints detect inconsistent
+  hashes and links; independent retention is needed to detect a complete
+  rewrite by an identity that can replace the audit directory
 
 The machine-readable integration guarantees, evidence paths, known limitations,
 and shared adversarial corpus live in [`assurance/`](assurance/README.md).

--- a/docs-site/features/audit-trail.md
+++ b/docs-site/features/audit-trail.md
@@ -1,15 +1,22 @@
 ---
 title: Audit Trail
-description: "Rampart logs every AI agent action to a hash-chained audit trail. Verify integrity, stream events live, and prove what commands were allowed or blocked."
+description: "Inspect Rampart policy decisions in a local hash-chained audit trail. Verify retained history, stream events, and understand the limits of local evidence."
 ---
 
 # Audit Trail
 
-Every tool call Rampart evaluates is logged to a hash-chained JSONL audit trail. Each entry includes a SHA-256 hash of the previous entry — tamper with any record and the chain breaks.
+Rampart records evaluated tool calls in a local hash-chained JSONL audit trail.
+Each entry includes a SHA-256 hash of the previous entry. The trail records
+decisions at the configured integration boundary; it does not prove that an
+allowed process executed exactly as intended or expose actions outside that
+boundary.
 
 ## Why Hash-Chained?
 
-In regulated environments, you need to prove what your AI agent did. A hash chain means no one can edit history without detection. Each record cryptographically depends on the one before it.
+A hash chain makes inconsistent event hashes and broken links detectable.
+An identity that can replace all local records and checkpoints can still
+construct a different valid history. Independent retention is needed to
+detect that rewrite; hashing alone does not make files immutable.
 
 ## Viewing the Audit Trail
 
@@ -84,7 +91,7 @@ redaction cannot be confused. These events set `request.rampart_phase` to
 - **Format:** JSONL (one JSON object per line)
 - **Rotation:** Daily files with chain continuity across files
 - **IDs:** ULID (time-ordered, sortable)
-- **Integrity:** External anchor every 100 events
+- **Integrity:** Local `audit-anchor.json` checkpoint every 100 events by default, stored beside the logs
 - **Durability:** long-running service writes use `fsync`; short-lived native hooks use the same cross-process chain lock and a validated tail checkpoint, then rely on normal OS flush behavior to avoid adding an `fsync` delay to every agent tool call
 
 ## HTML Reports
@@ -97,7 +104,10 @@ rampart report
 
 ## Tamper Detection
 
-The hash chain detects **partial tampering** — editing, inserting, or deleting individual records breaks the chain. A complete rewrite with a new valid chain is not detectable from the log alone.
+Verification checks retained event hashes, links, and local checkpoints. A
+complete rewrite with a new valid chain is not detectable from the local
+history alone. Neither is deletion of a valid suffix beyond the retained
+checkpoint. Verification also cannot establish that every action was logged.
 
 `rampart serve` verifies the complete chain when it starts. One-shot native
 hooks validate the current checkpoint, file size, and tail record before
@@ -108,5 +118,8 @@ integrity check.
 For stronger guarantees:
 
 - For centralized HTTP/SDK deployments, run `rampart serve` as a [separate user](../deployment/user-separation.md) so the agent cannot access service-owned audit files; native hooks need an external sink for an independent trust boundary
-- Enable [SIEM export](siem-integration.md) for an external trust anchor
-- Use [webhook notifications](webhooks.md) for real-time alerts to an external system
+- Configure [SIEM export](siem-integration.md) to a separately controlled
+  collector with suitable retention and access controls. Export is best effort;
+  the local verifier does not retrieve or validate remote evidence.
+- Use [webhook notifications](webhooks.md) for selected alerts to an external
+  system, rather than as a complete copy of the audit trail.

--- a/docs-site/features/siem-integration.md
+++ b/docs-site/features/siem-integration.md
@@ -37,7 +37,13 @@ Send Rampart audit events to your existing security stack. Three output formats,
 
     When you don't have a syslog collector. Works on all platforms.
 
-All outputs run alongside the default JSONL audit trail — you don't lose anything by enabling SIEM output.
+SIEM outputs supplement the default local JSONL audit trail. Delivery is best
+effort: the bounded secondary queue can drop exported events when full, and
+`--syslog` uses UDP without an authenticated delivery receipt. A local CEF file
+does not create a separate trust boundary. Configure a separately controlled
+collector and its retention/access policy when independent evidence is needed;
+export alone does not make stored events immutable. `rampart audit verify`
+checks local history and checkpoints, not remote SIEM evidence.
 
 ## Wazuh Integration
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -48,10 +48,13 @@ Policies hot-reload via fsnotify. Edit the YAML, Rampart picks it up.
 
 ### Audit Sink (`internal/audit/`)
 
-Append-only JSONL with hash chaining. Each event includes SHA-256 of the previous event's hash — tamper with any record and the chain breaks.
+JSONL records are written in append mode and linked by SHA-256 hashes.
+Verification detects inconsistent hashes and broken links in retained history;
+the local files remain writable by their owner.
 
 - ULID event IDs (time-ordered, sortable)
-- External anchor every 100 events for independent integrity checkpoints
+- Local `audit-anchor.json` checkpoint every 100 events by default; independent
+  evidence requires retention outside the agent's write authority
 - Validated local chain state avoids full-history scans in one-shot native hooks
 - fsync on long-running service writes; native hooks avoid per-call fsync latency
 - Log rotation with chain continuity across files

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -77,7 +77,11 @@ Rampart sees and evaluates `python3 script.py` — but cannot inspect what
 
 ### 2. Audit Log Rewrite
 
-The hash-chained audit trail detects **partial tampering** — editing, inserting, or deleting individual records breaks the chain. However, a complete rewrite from scratch with a new valid chain is not detectable from the log file alone.
+The hash-chained audit trail detects inconsistent event hashes and broken
+links between retained records. It cannot prove that every action was logged.
+A complete rewrite with a new valid chain, or deletion of a valid suffix
+beyond the retained checkpoint, is not detectable from the remaining local
+history alone.
 
 Rampart v1.6 also validates older logs containing chronological chain epochs
 created by legacy service restarts. Recovery verifies every event hash,
@@ -95,11 +99,21 @@ content, so operators must continue to protect audit storage and exports.
 
 **Mitigations:**
 - Run `rampart serve` as a [separate user](https://docs.rampart.sh/deployment/user-separation/) so the agent can't access audit files
-- Enable SIEM export (`--syslog` or `--cef`) to send events to an external immutable system
-- Webhook notifications send real-time alerts to Discord/Slack — a separate record
-- External chain anchors every 100 events provide additional integrity checkpoints
+- Configure SIEM export (`--syslog` or `--cef`) and a separately controlled
+  collector to retain received events outside the agent's write authority.
+  Export is best effort; the transport and collector determine delivery and
+  retention guarantees.
+- Webhook notifications can retain selected alerts in a separate system;
+  they are not a complete audit trail.
+- `audit-anchor.json` is a local checkpoint beside the audit files, updated
+  every 100 events by default. Verification checks it against retained events,
+  but an identity that can replace both logs and checkpoint can rewrite them
+  consistently. Append-mode files are not immutable storage.
 
-**For compliance environments:** Pair with external immutable logging (CloudTrail, Wazuh, etc.) for an independent trust anchor. See the [SIEM integration guide](https://docs.rampart.sh/features/siem-integration/).
+For independently retained evidence, configure collection, access control,
+and retention outside the agent's authority. Rampart's local verifier does
+not retrieve or validate remote SIEM evidence. See the
+[SIEM integration guide](https://docs.rampart.sh/features/siem-integration/).
 
 ### 3. Token Exposure in Wrap Mode
 


### PR DESCRIPTION
Correct the release summary and security documentation to describe the current 1.8 series and its actual audit guarantees. Local checkpoints detect inconsistent records; detecting a complete rewrite requires independently retained evidence. The SIEM guide now distinguishes best-effort delivery from proof of remote receipt.

Validation: required local source tests, vet, security assurance, strict MkDocs build, canonical document wrappers, and whitespace checks pass on the refreshed staging base. This changes documentation only and adds no enforcement or external-witness feature.
