### PR TITLE
feat(site): add architectural scroll narrative and complete setup journey

### DIFF
--- a/docs/assets/landing.css
+++ b/docs/assets/landing.css
@@ -1,0 +1,71 @@
+/* The architectural scene follows native scroll. All narrative content remains
+   in document order when scripting or motion is unavailable. */
+.hero, .hero-grid { min-height: auto; }
+.hero-grid { align-items: start; grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.hero-copy { display: contents; }
+.hero-copy::before { display: none; }
+.story-intro { grid-column: 1; grid-row: 1; min-height: 710px; padding: 150px 58px 60px 0; }
+.hero-intro { font-size: 1.05rem; }
+.hero-facts { font-size: .8rem; }
+.hero-facts li { padding-right: 15px; }
+.eyebrow { font-size: .78rem; }
+.hero-actions a { font-size: .9rem; }
+.threshold { grid-column: 2; grid-row: 1 / 4; position: sticky; top: 90px; height: min(720px, calc(100svh - 100px)); min-height: 450px; align-self: start; overflow: visible; }
+.threshold::before, .threshold::after { display: none; }
+.threshold-figure { inset: 0 -70px 0 -45px; overflow: visible; background: radial-gradient(ellipse at 50% 57%, #351b2a66, transparent 64%); }
+.boundary-canvas { display: none; width: 100%; height: 100%; }
+.scene-ready .boundary-canvas { display: block; }
+.scene-ready .architecture { display: none; }
+.boundary-note { left: 32px; bottom: 20px; max-width: 260px; font-size: .78rem; line-height: 1.6; color: #b9a9b1; }
+.story-chapter { grid-column: 1; padding: 62px 30px 78px 0; max-width: 490px; min-height: 430px; }
+#boundary-scope { grid-row: 2; }
+#boundary-record { grid-row: 3; }
+.chapter-index { color: var(--pink-soft); text-transform: uppercase; letter-spacing: .12em; font-family: var(--mono); font-size: .75rem; margin: 0 0 22px; }
+.story-chapter h2 { font: 400 clamp(2.6rem,4.5vw,4rem)/.97 var(--display); letter-spacing: -.04em; margin: 0 0 25px; }
+.story-chapter > p:not(.chapter-index) { color: #beb4ad; font-size: 1rem; line-height: 1.8; }
+.request-example { border-top: 1px solid var(--line); padding-top: 18px; margin-top: 26px; }
+.request-example > span { font-size: .75rem; color: var(--muted); }
+.request-example code { display: block; color: var(--pink-soft); font: .875rem/1.8 var(--mono); overflow-wrap: anywhere; margin-top: 7px; }
+.request-example p code { display: inline; margin: 0; font-size: .8125rem; }
+.request-example p { font-size: .875rem; color: #a99c96; line-height: 1.6; }
+.decision-example { display: grid; grid-template-columns: 1fr auto; gap: 12px 18px; border-block: 1px solid var(--line); padding: 20px 0; margin-top: 26px; font-size: .875rem; }
+.decision-example span:nth-child(even) { text-align: right; color: #c6bbb5; }
+.decision-example span.decision-deny { color: var(--pink-soft); }
+.decision-example code { font: .75rem/1.6 var(--mono); overflow-wrap: anywhere; text-align: right; color: var(--pink-soft); }
+.scene-legend { display: none; }
+.story-chapter > p.story-scope { font-size: .8125rem; line-height: 1.7; margin-top: 18px; }
+.premise-copy p.supporting { color: #bfb4ad; }
+.outcome-name { font-size: .8125rem; }
+.outcome-copy { font-size: .875rem; color: #b1a59f; }
+@media (min-width: 960px) and (min-height: 760px) {
+  .story-intro { min-height: 77svh; }
+  .story-chapter { min-height: 58svh; }
+}
+@media (max-width: 1120px) and (min-width: 960px) {
+  .story-intro { padding-right: 34px; }
+  .threshold-figure { inset-inline: -25px -40px; }
+}
+@media (max-width: 959px) {
+  .hero-grid { display: grid; grid-template-columns: 1fr; }
+  .story-intro { min-height: 0; padding: 125px 0 38px; }
+  .story-chapter { min-height: 0; padding: 45px 0; max-width: 600px; }
+  .hero-copy::before { display: none; }
+  .threshold { position: relative; top: auto; height: 350px; min-height: 0; grid-column: 1; grid-row: 2; }
+  #boundary-scope { grid-row: 3; }
+  #boundary-record { grid-row: 4; }
+  .threshold-figure { inset: 0; }
+  .boundary-note { bottom: 10px; left: 0; max-width: 270px; font-size: .75rem; }
+  .scene-legend { display: flex; justify-content: center; gap: 12px; margin: 0; position: absolute; inset: 0 0 auto; font-size: .8125rem; color: #dbc4cf; }
+  .scene-legend span { color: var(--pink-soft); }
+  .story-chapter h2 { font-size: clamp(2.7rem,8vw,3.8rem); }
+}
+@media (max-width: 460px) {
+  .story-intro { padding-top: 115px; }
+  .hero-facts { font-size: .75rem; }
+  .hero-facts li { padding-inline: 8px; }
+  .hero-facts li:first-child { padding-left: 0; }
+  .threshold { height: 300px; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .threshold { position: relative; top: 70px; }
+}

--- a/docs/assets/landing.css
+++ b/docs/assets/landing.css
@@ -1,3 +1,895 @@
+:root {
+    color-scheme: dark;
+    --obsidian: #0b0a0a;
+    --charcoal: #141212;
+    --graphite: #1d1a1b;
+    --bone: #f1ede7;
+    --muted: #a49d98;
+    --quiet: #77716e;
+    --line: rgba(241, 237, 231, 0.14);
+    --line-quiet: rgba(241, 237, 231, 0.075);
+    --pink: #ff4f9a;
+    --pink-soft: #ff8dbb;
+    --sans: "Manrope", "Helvetica Neue", Arial, sans-serif;
+    --display: "Newsreader", Georgia, serif;
+    --mono: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+    --gutter: clamp(18px, 2.6vw, 40px);
+    --page: min(calc(100% - (var(--gutter) + var(--gutter))), 1480px);
+}
+
+* { box-sizing: border-box; }
+
+html {
+    background: var(--obsidian);
+    scroll-behavior: smooth;
+}
+
+body {
+    margin: 0;
+    background: var(--obsidian);
+    color: var(--bone);
+    font-family: var(--sans);
+    font-size: 16px;
+    line-height: 1.55;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+}
+
+a { color: inherit; }
+
+button { font: inherit; }
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+a:focus-visible,
+button:focus-visible {
+    outline: 2px solid var(--pink);
+    outline-offset: 5px;
+}
+
+.skip-link {
+    position: fixed;
+    top: 14px;
+    left: 14px;
+    z-index: 100;
+    padding: 10px 14px;
+    background: var(--bone);
+    color: var(--obsidian);
+    font-size: 0.78rem;
+    font-weight: 600;
+    text-decoration: none;
+    transform: translateY(-180%);
+}
+
+.skip-link:focus { transform: translateY(0); }
+
+.site-header {
+    position: absolute;
+    inset: 0 0 auto;
+    z-index: 20;
+    padding-top: 24px;
+    isolation: isolate;
+}
+
+.site-header::before {
+    content: "";
+    position: absolute;
+    inset: 0 0 auto;
+    z-index: 0;
+    height: 92px;
+    border-bottom: 1px solid var(--line-quiet);
+    background: var(--obsidian);
+    pointer-events: none;
+}
+
+.nav {
+    position: relative;
+    z-index: 1;
+    width: var(--page);
+    margin: 0 auto;
+    display: grid;
+    grid-template-columns: minmax(180px, 1fr) auto minmax(180px, 1fr);
+    align-items: center;
+    gap: 32px;
+}
+
+.brand {
+    display: inline-flex;
+    align-items: center;
+    justify-self: start;
+    min-height: 44px;
+    gap: 12px;
+    font-size: 0.9rem;
+    font-weight: 600;
+    letter-spacing: -0.02em;
+    text-decoration: none;
+}
+
+.brand-mark {
+    width: 20px;
+    height: 23px;
+    color: var(--pink);
+}
+
+.nav-links,
+.nav-actions {
+    display: flex;
+    align-items: center;
+    gap: 28px;
+}
+
+.nav-links a,
+.github-link {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    min-height: 44px;
+    color: #c3bdb8;
+    font-size: 0.74rem;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+    text-decoration: none;
+    transition: color 160ms ease;
+}
+
+.nav-links a::after,
+.github-link::after {
+    content: "";
+    position: absolute;
+    right: 0;
+    bottom: 5px;
+    left: 0;
+    height: 1px;
+    color: var(--pink);
+    background: currentColor;
+    opacity: 0.8;
+    transform: scaleX(0);
+    transform-origin: left;
+    transition: transform 160ms ease;
+}
+
+.nav-links a:hover,
+.github-link:hover { color: var(--bone); }
+
+.nav-links a:hover::after,
+.nav-links a:focus-visible::after,
+.github-link:hover::after,
+.github-link:focus-visible::after {
+    color: var(--pink);
+    transform: scaleX(1);
+}
+
+.nav-actions { justify-self: end; }
+
+.nav-toggle,
+.mobile-nav { display: none; }
+
+.nav-install {
+    display: inline-flex;
+    align-items: center;
+    min-height: 44px;
+    padding: 0 17px;
+    border: 1px solid var(--bone);
+    background: var(--bone);
+    color: var(--obsidian);
+    font-size: 0.73rem;
+    font-weight: 600;
+    text-decoration: none;
+    transition: background 160ms ease, border-color 160ms ease;
+}
+
+.nav-install:hover {
+    border-color: var(--pink);
+    background: var(--pink);
+}
+
+main { overflow: clip; }
+
+.hero {
+    position: relative;
+    min-height: 680px;
+    min-height: clamp(680px, 88svh, 800px);
+    isolation: isolate;
+    border-bottom: 1px solid var(--line-quiet);
+}
+
+.hero::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: -3;
+    background:
+        linear-gradient(104deg, #100e0e 0 50%, #090909 50% 100%),
+        var(--obsidian);
+}
+
+.hero::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: -2;
+    background:
+        radial-gradient(ellipse at 70% 48%, rgba(255,255,255,0.026), transparent 38%),
+        linear-gradient(180deg, rgba(255,255,255,0.018), transparent 22%);
+    pointer-events: none;
+}
+
+.hero-grid {
+    width: var(--page);
+    min-height: 680px;
+    min-height: clamp(680px, 88svh, 800px);
+    margin: 0 auto;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-items: stretch;
+}
+
+.hero-copy {
+    position: relative;
+    z-index: 3;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    padding: 140px clamp(36px, 4.8vw, 76px) 62px 0;
+}
+
+.eyebrow {
+    margin: 0 0 28px;
+    color: #c4bdb8;
+    font-family: var(--mono);
+    font-size: 0.64rem;
+    line-height: 1;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+}
+
+h1,
+h2,
+p { margin-top: 0; }
+
+h1 {
+    max-width: 760px;
+    margin-bottom: 30px;
+    font-family: var(--display);
+    font-size: clamp(3.7rem, 5.9vw, 6.65rem);
+    font-weight: 300;
+    letter-spacing: -0.055em;
+    line-height: 0.86;
+}
+
+h1 .first-line,
+h1 .final-line { display: block; }
+
+h1 .first-line {
+    color: #a39c97;
+    font-size: 0.72em;
+    font-style: italic;
+    letter-spacing: -0.045em;
+    line-height: 1.05;
+}
+
+h1 .final-line { white-space: nowrap; }
+
+.hero-intro {
+    max-width: 570px;
+    margin-bottom: 34px;
+    color: #bbb4af;
+    font-size: clamp(1rem, 1.25vw, 1.16rem);
+    line-height: 1.7;
+}
+
+.hero-actions {
+    display: flex;
+    align-items: center;
+    gap: 24px;
+}
+
+.primary-action,
+.secondary-action,
+.text-action {
+    display: inline-flex;
+    align-items: center;
+    text-decoration: none;
+}
+
+.primary-action {
+    min-height: 50px;
+    padding: 0 22px;
+    background: var(--bone);
+    color: var(--obsidian);
+    font-size: 0.76rem;
+    font-weight: 600;
+    transition: background 160ms ease;
+}
+
+.primary-action:hover { background: var(--pink); }
+
+.secondary-action,
+.text-action {
+    gap: 11px;
+    color: #d3cdc7;
+    font-size: 0.76rem;
+    font-weight: 500;
+}
+
+.secondary-action { min-height: 44px; }
+
+.secondary-action::after,
+.text-action::after {
+    content: "";
+    width: 22px;
+    height: 1px;
+    background: var(--pink);
+    transition: width 160ms ease;
+}
+
+.secondary-action:hover::after,
+.secondary-action:focus-visible::after,
+.text-action:hover::after,
+.text-action:focus-visible::after {
+    width: 32px;
+}
+
+.hero-facts {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    max-width: 610px;
+    margin: 48px 0 0;
+    padding: 15px 0;
+    border-top: 1px solid var(--line);
+    border-bottom: 1px solid var(--line-quiet);
+    list-style: none;
+    color: #9b9490;
+    font-family: var(--mono);
+    font-size: 0.64rem;
+    line-height: 1.45;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.hero-facts li {
+    padding: 0 14px;
+    border-left: 1px solid var(--line-quiet);
+}
+
+.hero-facts li:first-child {
+    padding-left: 0;
+    border-left: 0;
+}
+
+.threshold {
+    position: relative;
+    min-height: 100%;
+    z-index: 2;
+}
+
+.threshold::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: 1px;
+    background: var(--pink);
+    box-shadow: 0 0 16px rgba(255,79,154,0.1);
+}
+
+.threshold::after {
+    content: "";
+    position: absolute;
+    inset: 0 -18vw 0 1px;
+    z-index: -1;
+    background:
+        linear-gradient(114deg, rgba(255,255,255,0.022) 0 38%, transparent 38.15%),
+        linear-gradient(90deg, rgba(255,79,154,0.024), transparent 15%);
+    -webkit-mask-image: linear-gradient(90deg, #000, rgba(0,0,0,0.7) 68%, transparent 100%);
+    mask-image: linear-gradient(90deg, #000, rgba(0,0,0,0.7) 68%, transparent 100%);
+}
+
+.threshold-figure {
+    position: absolute;
+    inset: 13% 0 0 3%;
+    margin: 0;
+}
+
+.architecture {
+    width: 100%;
+    height: 100%;
+    color: rgba(241,237,231,0.2);
+    overflow: hidden;
+    shape-rendering: geometricPrecision;
+}
+
+.architecture .mass {
+    fill: rgba(255,255,255,0.036);
+    stroke: rgba(241,237,231,0.18);
+    vector-effect: non-scaling-stroke;
+}
+
+.architecture .plane-top { fill: rgba(255,255,255,0.085); }
+.architecture .plane-side { fill: rgba(255,255,255,0.018); }
+
+.architecture .cut {
+    fill: #090909;
+    stroke: rgba(241,237,231,0.3);
+    vector-effect: non-scaling-stroke;
+}
+
+.architecture .reveal,
+.architecture .datum,
+.architecture .route-in,
+.architecture .route-out {
+    fill: none;
+    stroke-linecap: square;
+    stroke-linejoin: miter;
+    vector-effect: non-scaling-stroke;
+}
+
+.architecture .reveal,
+.architecture .datum { stroke: rgba(241,237,231,0.1); }
+
+.architecture .route-in { stroke: rgba(241,237,231,0.23); }
+.architecture .route-out { stroke: rgba(241,237,231,0.5); }
+
+.architecture .decision-gate {
+    fill: none;
+    stroke: var(--pink);
+    stroke-width: 1.25;
+    vector-effect: non-scaling-stroke;
+}
+
+.boundary-note {
+    position: absolute;
+    left: 26px;
+    bottom: 40px;
+    max-width: 180px;
+    margin: 0;
+    color: #938c87;
+    font-family: var(--mono);
+    font-size: 0.63rem;
+    line-height: 1.55;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+}
+
+.boundary-note::before {
+    content: "";
+    display: block;
+    width: 22px;
+    height: 1px;
+    margin-bottom: 12px;
+    background: var(--pink);
+}
+
+.premise {
+    position: relative;
+    background: var(--charcoal);
+}
+
+.premise::before {
+    content: "";
+    position: absolute;
+    top: -1px;
+    left: 50%;
+    width: 1px;
+    height: 112px;
+    background: var(--pink);
+}
+
+.premise-inner {
+    width: var(--page);
+    min-height: 600px;
+    margin: 0 auto;
+    padding: 112px 0 88px;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-rows: auto 1fr auto;
+    column-gap: 0;
+}
+
+.premise-index {
+    grid-column: 1;
+    grid-row: 1;
+    margin: 0 0 56px;
+    color: #938c87;
+    font-family: var(--mono);
+    font-size: 0.66rem;
+    line-height: 1.5;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+}
+
+.premise-title {
+    grid-column: 1;
+    grid-row: 2;
+    min-width: 0;
+    margin: 0;
+    padding-right: clamp(42px, 5vw, 80px);
+    font-family: var(--display);
+    font-size: clamp(4rem, 6.6vw, 6.8rem);
+    font-weight: 300;
+    letter-spacing: -0.055em;
+    line-height: 0.9;
+}
+
+.premise-copy {
+    grid-column: 2;
+    grid-row: 2;
+    min-width: 0;
+    align-self: start;
+    padding: 4px 0 0 clamp(42px, 5vw, 80px);
+}
+
+.premise-copy p {
+    max-width: 440px;
+    margin-bottom: 22px;
+    color: #bbb4af;
+    font-size: 1.02rem;
+    line-height: 1.75;
+}
+
+.premise-copy .supporting {
+    margin: 35px 0 0;
+    padding-top: 22px;
+    border-top: 1px solid var(--line);
+    color: var(--bone);
+    font-family: var(--display);
+    font-size: 1.34rem;
+    font-style: italic;
+    line-height: 1.35;
+}
+
+.scope-note {
+    grid-column: 2;
+    grid-row: 3;
+    align-self: end;
+    max-width: 440px;
+    margin: 62px 0 0 clamp(42px, 5vw, 80px);
+    padding: 22px 0 0;
+    border-top: 1px solid var(--line);
+    color: #9d9691;
+    font-size: 0.84rem;
+    line-height: 1.7;
+}
+
+.scope-note strong {
+    color: #b9b1ac;
+    font-weight: 500;
+}
+
+.scope-note .text-action {
+    width: max-content;
+    min-height: 44px;
+    margin-top: 10px;
+}
+
+.outcome-rail {
+    grid-column: 1 / -1;
+    grid-row: 4;
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    margin-top: 76px;
+    border-top: 1px solid var(--line);
+    border-bottom: 1px solid var(--line-quiet);
+}
+
+.outcome {
+    position: relative;
+    min-width: 0;
+    padding: 19px 24px 22px;
+    border-left: 1px solid var(--line-quiet);
+}
+
+.outcome:first-child {
+    padding-left: 0;
+    border-left: 0;
+}
+
+.outcome:nth-child(2)::before {
+    content: "";
+    position: absolute;
+    top: -1px;
+    left: 24px;
+    width: 28px;
+    height: 1px;
+    background: var(--pink);
+}
+
+.outcome-name {
+    margin: 0 0 8px;
+    color: var(--bone);
+    font-family: var(--mono);
+    font-size: 0.67rem;
+    letter-spacing: 0.13em;
+}
+
+.outcome-copy {
+    margin: 0;
+    color: #938c87;
+    font-size: 0.78rem;
+    line-height: 1.55;
+}
+
+@media (max-width: 1120px) {
+    .nav { gap: 20px; }
+    .nav-links { gap: 18px; }
+    .nav-links a,
+    .github-link { font-size: 0.69rem; }
+    .hero-copy { padding-right: 36px; }
+}
+
+@media (max-width: 959px) {
+    .site-header { padding-top: 18px; }
+    .site-header::before { height: 74px; }
+    .nav { grid-template-columns: 1fr 44px auto; gap: 10px; }
+    .nav-links { display: none; }
+    .nav-actions { gap: 12px; }
+    .nav-actions .github-link { display: none; }
+    .nav-install { padding: 0 13px; }
+
+    .nav-toggle {
+        position: relative;
+        display: grid;
+        place-items: center;
+        width: 44px;
+        height: 44px;
+        padding: 0;
+        border: 1px solid var(--line);
+        background: transparent;
+        color: var(--bone);
+        cursor: pointer;
+    }
+
+    .nav-toggle-lines,
+    .nav-toggle-lines::before {
+        display: block;
+        width: 16px;
+        height: 1px;
+        background: currentColor;
+        transition: transform 160ms ease;
+    }
+
+    .nav-toggle-lines::before {
+        content: "";
+        transform: translateY(-5px);
+    }
+
+    .nav-toggle[aria-expanded="true"] .nav-toggle-lines { transform: rotate(45deg); }
+    .nav-toggle[aria-expanded="true"] .nav-toggle-lines::before { transform: rotate(-90deg); }
+
+    .mobile-nav:not([hidden]) {
+        position: absolute;
+        z-index: 1;
+        top: 74px;
+        left: 50%;
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        width: var(--page);
+        padding: 10px 0;
+        border-top: 1px solid var(--pink);
+        border-bottom: 1px solid var(--line);
+        background: var(--obsidian);
+        box-shadow: 0 24px 54px rgba(0,0,0,0.35);
+        transform: translateX(-50%);
+    }
+
+    .mobile-nav a {
+        display: flex;
+        align-items: center;
+        min-height: 48px;
+        padding: 0 16px;
+        border-left: 1px solid var(--line-quiet);
+        color: #d3cdc7;
+        font-size: 0.75rem;
+        text-decoration: none;
+        transition: background 160ms ease, color 160ms ease;
+    }
+
+    .mobile-nav a:hover,
+    .mobile-nav a:focus-visible {
+        background: rgba(255,79,154,0.06);
+        color: var(--bone);
+    }
+
+    .mobile-nav a:nth-child(odd) { border-left: 0; }
+    .mobile-nav a:last-child { grid-column: 1 / -1; border-top: 1px solid var(--line-quiet); }
+
+    .hero,
+    .hero-grid { min-height: auto; }
+
+    .hero::before { background: #090909; }
+
+    .hero-grid {
+        display: flex;
+        flex-direction: column;
+    }
+
+    .hero-copy {
+        min-height: 650px;
+        justify-content: flex-start;
+        padding: 128px 0 64px;
+    }
+
+    .hero-copy::before {
+        content: "";
+        position: absolute;
+        inset: 0 calc(50% - 50vw);
+        z-index: -1;
+        background: linear-gradient(168deg, #100e0e 0 84%, #0d0c0c 84% 100%);
+        pointer-events: none;
+    }
+
+    .eyebrow { margin-bottom: 26px; }
+
+    h1 {
+        max-width: 530px;
+        margin-bottom: 28px;
+        font-size: clamp(3.55rem, 10.5vw, 5rem);
+        line-height: 0.89;
+    }
+
+    h1 .first-line { font-size: 0.66em; }
+    h1 .final-line { white-space: normal; }
+
+    .hero-intro {
+        max-width: 500px;
+        font-size: 0.98rem;
+        line-height: 1.65;
+    }
+
+    .hero-actions { gap: 18px; }
+    .hero-facts { margin-top: 42px; }
+
+    .threshold {
+        min-height: clamp(310px, 55vw, 420px);
+        overflow: hidden;
+    }
+
+    .threshold::before { left: 0; }
+    .threshold::after { inset: 0 calc(0px - var(--gutter)) 0 1px; }
+    .threshold-figure { inset: 0; }
+    .architecture { transform: scale(1.1); transform-origin: center bottom; }
+    .boundary-note { bottom: 26px; left: 18px; }
+
+    .premise::before {
+        left: var(--gutter);
+        height: 74px;
+    }
+
+    .premise-inner {
+        min-height: auto;
+        padding: 94px 0 82px;
+        display: block;
+    }
+
+    .premise-index { margin: 0 0 46px; }
+    .premise-title {
+        max-width: 610px;
+        margin: 0 0 56px;
+        padding: 0;
+        font-size: clamp(3.7rem, 12vw, 5.4rem);
+    }
+    .premise-copy { max-width: 540px; padding: 0; }
+    .scope-note {
+        max-width: 540px;
+        margin: 60px 0 0;
+        padding: 22px 0 0;
+    }
+
+    .outcome-rail { margin-top: 60px; }
+}
+
+@media (max-width: 460px) {
+    .brand { gap: 9px; font-size: 0.84rem; }
+    .brand-mark { width: 18px; height: 21px; }
+    .hero-copy { min-height: 0; padding-bottom: 54px; }
+    h1 { font-size: clamp(3rem, 15vw, 3.75rem); }
+    .hero-actions { align-items: flex-start; flex-direction: column; }
+    .primary-action { width: 100%; justify-content: center; }
+    .hero-facts {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        font-size: 0.62rem;
+    }
+    .hero-facts li { min-height: 34px; padding: 0 10px; }
+    .hero-facts li:nth-child(3) {
+        grid-column: 1 / -1;
+        min-height: 40px;
+        margin-top: 10px;
+        padding: 10px 0 0;
+        border-top: 1px solid var(--line-quiet);
+        border-left: 0;
+    }
+    .boundary-note { max-width: 150px; font-size: 0.61rem; }
+    .premise-title {
+        margin-bottom: 44px;
+        font-size: clamp(2.9rem, 14vw, 3.5rem);
+        line-height: 0.94;
+    }
+    .premise-copy p { font-size: 1rem; }
+    .scope-note { font-size: 0.86rem; }
+    .outcome-rail { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    .outcome { padding: 18px 14px 20px; }
+    .outcome:nth-child(odd) { padding-left: 0; border-left: 0; }
+    .outcome:nth-child(n + 3) { border-top: 1px solid var(--line-quiet); }
+    .outcome:nth-child(2)::before { left: 14px; }
+}
+
+@media (max-width: 959px) and (max-height: 600px) and (orientation: landscape) {
+    .hero,
+    .hero-grid { min-height: 520px; }
+
+    .hero-grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .hero-copy {
+        min-height: 520px;
+        padding: 92px 28px 34px 0;
+    }
+
+    h1 {
+        margin-bottom: 18px;
+        font-size: clamp(2.8rem, 6vw, 3.4rem);
+    }
+
+    .hero-intro {
+        margin-bottom: 18px;
+        font-size: 0.88rem;
+        line-height: 1.5;
+    }
+
+    .eyebrow { line-height: 1.5; }
+    .hero-actions { flex-flow: row wrap; gap: 14px; }
+    .primary-action { width: auto; }
+    .hero-facts { display: none; }
+    .threshold { min-height: 520px; }
+    .boundary-note { top: 310px; bottom: auto; }
+
+    .premise::before { left: 50%; height: 90px; }
+    .premise-inner {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        grid-template-rows: auto auto auto auto;
+        padding: 90px 0 60px;
+    }
+    .premise-index { grid-column: 1; grid-row: 1; margin: 0 0 34px; }
+    .premise-title {
+        grid-column: 1;
+        grid-row: 2;
+        margin: 0;
+        padding-right: 32px;
+        font-size: clamp(3.1rem, 6vw, 4rem);
+    }
+    .premise-copy {
+        grid-column: 2;
+        grid-row: 2;
+        max-width: none;
+        padding: 0 0 0 32px;
+    }
+    .scope-note {
+        grid-column: 2;
+        grid-row: 3;
+        margin: 40px 0 0 32px;
+    }
+    .outcome-rail { grid-column: 1 / -1; grid-row: 4; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    html { scroll-behavior: auto; }
+    *, *::before, *::after { transition: none !important; }
+}
+
 /* The architectural scene follows native scroll. All narrative content remains
    in document order when scripting or motion is unavailable. */
 .hero, .hero-grid { min-height: auto; }
@@ -68,4 +960,78 @@
 }
 @media (prefers-reduced-motion: reduce) {
   .threshold { position: relative; top: 70px; }
+}
+
+.section-shell { width: var(--page); margin-inline: auto; }
+.section-heading { display: grid; grid-template-columns: 1fr 1fr; column-gap: 8%; align-items: end; margin-bottom: 55px; }
+.section-heading .chapter-index { grid-column: 1 / -1; }
+.section-heading h2, .boundary-summary h2, .closing h2 { font: 400 clamp(2.8rem,5vw,5.2rem)/.97 var(--display); letter-spacing: -.035em; margin: 0; }
+.section-heading > p:last-child { max-width: 490px; margin: 0; line-height: 1.8; color: #bfb4ad; }
+.workflow { background: var(--bone); color: #1d1a1b; padding: 100px 0 72px; }
+.workflow .chapter-index { color: #9b2356; }
+.workflow .section-heading > p:last-child { color: #51494b; }
+.workflow-steps { list-style: none; padding: 0; margin: 0; display: grid; grid-template-columns: repeat(3,minmax(0,1fr)); gap: 35px; }
+.workflow-steps li { border-top: 1px solid #29202940; padding-top: 22px; min-width: 0; }
+.step-number { font: .8rem var(--mono); color: #8f2a54; }
+.workflow h3 { font: 400 2.5rem var(--display); margin: 22px 0 14px; }
+.workflow-steps p { min-height: 72px; color: #51494b; line-height: 1.7; }
+.command-block { min-height: 112px; padding: 18px; background: #e2ddd6; display: flex; align-items: start; flex-direction: column; gap: 16px; }
+.command-block code { font: .875rem/1.6 var(--mono); overflow-wrap: anywhere; }
+.copy-command { color: #4e4348; border: 1px solid #796970; background: transparent; padding: 4px 9px; font-size: .75rem; cursor: pointer; }
+.copy-command:hover { background: #d3c9cc; }
+.workflow .text-action { color: #5c1d39; font-size: .875rem; margin-top: 22px; }
+.workflow-note { margin: 35px 0 0; padding-top: 24px; border-top: 1px solid #29202940; max-width: 100%; font-size: .875rem; color: #51494b; }
+.workflow a:focus-visible, .workflow button:focus-visible { outline-color: #9b2356; }
+.integration-section { padding-block: 110px 70px; }
+.integration-grid { display: grid; grid-template-columns: repeat(2,minmax(0,1fr)); gap: 30px; }
+.integration-card { border: 1px solid var(--line); padding: 36px; background: linear-gradient(135deg,#21171c,#121011 80%); }
+.integration-kind { color: var(--pink-soft); text-transform: uppercase; letter-spacing: .08em; font: .75rem/1.8 var(--mono); }
+.integration-card h3 { margin: 28px 0 20px; font: 400 3rem var(--display); }
+.integration-card > p:not(.integration-kind) { color: #bfb4ad; max-width: 520px; min-height: 90px; line-height: 1.8; }
+.integration-card code { display: block; margin: 25px 0; font: .875rem/1.7 var(--mono); overflow-wrap: anywhere; color: #f1d7e2; }
+.integration-card .text-action, .integration-more .text-action { font-size: .875rem; }
+.integration-more { display: flex; justify-content: space-between; align-items: center; gap: 40px; padding: 30px 0; border-bottom: 1px solid var(--line); }
+.integration-more p { font-size: 1rem; line-height: 1.9; }
+.integration-more span { color: #bfb4ad; font-size: .875rem; }
+.boundary-summary { display: grid; grid-template-columns: 1fr 1fr; gap: 8%; padding-block: 60px 100px; }
+.boundary-details article + article { border-top: 1px solid var(--line); padding-top: 28px; margin-top: 30px; }
+.boundary-details h3 { font: 400 2rem var(--display); margin: 0 0 15px; }
+.boundary-details p { line-height: 1.8; color: #bfb4ad; }
+.boundary-details .text-action { font-size: .875rem; }
+.closing { padding-block: 80px 100px; text-align: center; border-top: 1px solid var(--line); background: radial-gradient(ellipse at 50% 100%,#36142366,transparent 68%); }
+.closing-actions { display: flex; flex-wrap: wrap; justify-content: center; align-items: center; gap: 30px; margin-top: 38px; }
+.closing-actions .text-action { font-size: .875rem; }
+.site-footer { padding-block: 35px; border-top: 1px solid var(--line); display: flex; align-items: center; justify-content: space-between; gap: 35px; }
+.footer-brand { text-decoration: none; font-size: 1.1rem; }
+.footer-brand span { display: block; font-size: .75rem; color: var(--muted); margin-top: 8px; }
+.site-footer nav { display: flex; flex-wrap: wrap; gap: 22px; font-size: .8rem; }
+.site-footer nav a { text-decoration: none; }
+.site-footer nav a:hover { color: var(--pink-soft); }
+@media (max-width: 959px) {
+  .threshold { height: 370px; top: auto; }
+  .threshold-figure { bottom: 60px; }
+  .boundary-note { bottom: 0; top: auto; }
+  .section-heading { display: block; margin-bottom: 35px; }
+  .section-heading > p:last-child { margin-top: 25px; }
+  .workflow, .integration-section { padding-block: 65px; }
+  .workflow-steps { gap: 25px; grid-template-columns: 1fr; }
+  .workflow-steps li { display: grid; grid-template-columns: 1fr 1fr; column-gap: 25px; }
+  .workflow-steps h3 { margin-top: 14px; }
+  .workflow-steps p { grid-column: 1; min-height: 0; }
+  .workflow-steps .command-block { grid-column: 2; grid-row: 2 / 4; }
+  .workflow-steps .text-action { grid-column: 1 / -1; }
+  .integration-card { padding: 25px; }
+  .integration-card > p:not(.integration-kind) { min-height: 0; }
+  .integration-more, .site-footer { align-items: start; flex-direction: column; gap: 15px; }
+  .boundary-summary { gap: 40px; padding-block: 10px 65px; }
+  .closing { padding-block: 60px; }
+  .site-footer nav { gap: 18px 24px; }
+  html:not(.navigation-ready) .nav-toggle { display: none; }
+  html:not(.navigation-ready) .nav-install { display: inline-flex; }
+}
+@media (max-width: 600px) {
+  .threshold { height: 340px; }
+  .integration-grid, .boundary-summary { grid-template-columns: 1fr; }
+  .workflow-steps li { display: block; }
+  .workflow-steps .command-block { min-height: 100px; }
 }

--- a/docs/assets/landing.js
+++ b/docs/assets/landing.js
@@ -1,0 +1,117 @@
+(() => {
+  'use strict';
+  const canvas = document.querySelector('.boundary-canvas');
+  const scene = document.querySelector('.threshold-figure');
+  const journey = document.querySelector('.hero');
+  if (!canvas || !scene || !journey) return;
+  const context = canvas.getContext('2d');
+  if (!context) return;
+  const reduced = matchMedia('(prefers-reduced-motion: reduce)');
+  const narrow = matchMedia('(max-width: 959px)');
+  let width = 0, height = 0, progress = 0, frame = 0, visible = true;
+  const clamp = value => Math.max(0, Math.min(1, value));
+  const smooth = value => { const t = clamp(value); return t * t * (3 - 2 * t); };
+
+  function draw() {
+    context.clearRect(0, 0, width, height);
+    const unfold = smooth(progress * 1.6);
+    const align = smooth((progress - .55) / .45);
+    const yaw = (.55 - unfold * .28 + align * .18);
+    const pitch = .31 + unfold * .13;
+    const scale = Math.min(width / 480, height / 440);
+    const project = (x, y, z) => [
+      width * .51 + (x * Math.cos(yaw) - z * Math.sin(yaw)) * scale,
+      height * .66 + (-y * Math.cos(pitch) + (z * Math.cos(yaw) + x * Math.sin(yaw)) * Math.sin(pitch)) * scale
+    ];
+    const path = (points, fill, stroke, weight = .8) => {
+      context.beginPath();
+      points.forEach((point, index) => {
+        const screen = project(...point);
+        if (index) context.lineTo(...screen); else context.moveTo(...screen);
+      });
+      context.closePath();
+      if (fill) { context.fillStyle = fill; context.fill(); }
+      if (stroke) { context.strokeStyle = stroke; context.lineWidth = weight; context.stroke(); }
+    };
+    const faces = [];
+    const face = (points, color, edge = '#ac819744') => {
+      const depth = points.reduce((sum, point) => sum + (point[2] * Math.cos(yaw) + point[0] * Math.sin(yaw)) * Math.cos(pitch) + point[1] * Math.sin(pitch), 0) / points.length;
+      faces.push({ points, color, edge, depth });
+    };
+    const box = (x1, y1, z1, x2, y2, z2, shades) => {
+      face([[x1,y1,z2],[x2,y1,z2],[x2,y2,z2],[x1,y2,z2]], shades[0]);
+      face([[x2,y1,z1],[x2,y1,z2],[x2,y2,z2],[x2,y2,z1]], shades[1]);
+      face([[x1,y1,z1],[x1,y2,z1],[x2,y2,z1],[x2,y1,z1]], shades[0]);
+      face([[x1,y1,z1],[x1,y1,z2],[x1,y2,z2],[x1,y2,z1]], shades[1]);
+      face([[x1,y2,z1],[x1,y2,z2],[x2,y2,z2],[x2,y2,z1]], shades[2]);
+    };
+    path([[-165,-5,-175],[165,-5,-175],[165,-5,190],[-165,-5,190]], '#151013', '#6e3f5355');
+    path([[-165,-5,190],[165,-5,190],[165,-15,190],[-165,-15,190]], '#21151c', '#5e3b4b66');
+    for (let z = -150; z <= 150; z += 50) path([[-155,-4,z],[155,-4,z]], null, '#7d526222', .6);
+    for (let x = -150; x <= 150; x += 50) path([[x,-4,-170],[x,-4,185]], null, '#7d526222', .6);
+    path([[-150,-3,0],[150,-3,0]], null, '#ff4f9aaa', 1);
+
+    const layers = [
+      { z: -29 - unfold * 77, shift: -unfold * 22, shade: ['#211b20','#3c2a35','#6b4e5e'] },
+      { z: 0, shift: unfold * 15, shade: ['#39222e','#6c344e','#b35780'] },
+      { z: 29 + unfold * 77, shift: unfold * 46, shade: ['#292328','#4e3c47','#887280'] }
+    ];
+    layers.forEach(layer => {
+      const z = layer.z, y = layer.shift;
+      box(-105,y,z-13,-72,205+y,z+13,layer.shade);
+      box(72,y,z-13,105,205+y,z+13,layer.shade);
+      box(-105,205+y,z-13,105,239+y,z+13,layer.shade);
+    });
+    // The policy plane is an illustration of the configured tool boundary,
+    // not a process sandbox or an independently witnessed execution record.
+    face([[-71,0,0],[-71,203,0],[71,203,0],[71,0,0]], '#ff4f9a0a', '#ff78b477');
+    faces.sort((a, b) => a.depth - b.depth).forEach(item => path(item.points, item.color, item.edge));
+
+    if (unfold > .2 && !narrow.matches) {
+      context.globalAlpha = clamp((unfold - .2) / .45);
+      context.font = '500 12px Manrope, sans-serif';
+      context.fillStyle = '#dbc4cf';
+      const labels = ['RECORD', 'POLICY', 'ACTION'];
+      layers.forEach((layer, index) => {
+        const a = project(112, 30 + layer.shift, layer.z);
+        const b = project(154, 30 + layer.shift, layer.z);
+        context.beginPath(); context.moveTo(...a); context.lineTo(...b);
+        context.lineWidth = .7; context.strokeStyle = '#c07599'; context.stroke();
+        context.textAlign = 'right';
+        context.fillText(labels[index], Math.min(width - 8, b[0] + 40), b[1] + 18);
+      });
+      context.globalAlpha = 1;
+    }
+  }
+
+  function render() {
+    frame = 0;
+    if (!visible || document.hidden) return;
+    const rect = scene.getBoundingClientRect();
+    const ratio = Math.min(devicePixelRatio || 1, 1.75);
+    if (width !== rect.width || height !== rect.height) {
+      width = rect.width; height = rect.height;
+      canvas.width = Math.round(width * ratio); canvas.height = Math.round(height * ratio);
+      context.setTransform(ratio, 0, 0, ratio, 0, 0);
+    }
+    if (!width || !height) return;
+    const bounds = journey.getBoundingClientRect();
+    progress = narrow.matches || reduced.matches ? .64 : clamp(-bounds.top / Math.max(1, bounds.height - innerHeight));
+    draw();
+  }
+  function schedule() {
+    if (!frame && visible && !document.hidden) frame = requestAnimationFrame(render);
+  }
+  new ResizeObserver(schedule).observe(scene);
+  new IntersectionObserver(entries => {
+    visible = entries[0].isIntersecting;
+    if (visible) schedule(); else { cancelAnimationFrame(frame); frame = 0; }
+  }).observe(scene);
+  addEventListener('scroll', schedule, { passive: true });
+  addEventListener('resize', schedule, { passive: true });
+  document.addEventListener('visibilitychange', schedule);
+  reduced.addEventListener('change', schedule);
+  narrow.addEventListener('change', schedule);
+  document.documentElement.classList.add('scene-ready');
+  schedule();
+})();

--- a/docs/assets/landing.js
+++ b/docs/assets/landing.js
@@ -33,17 +33,16 @@
       if (fill) { context.fillStyle = fill; context.fill(); }
       if (stroke) { context.strokeStyle = stroke; context.lineWidth = weight; context.stroke(); }
     };
-    const faces = [];
-    const face = (points, color, edge = '#ac819744') => {
-      const depth = points.reduce((sum, point) => sum + (point[2] * Math.cos(yaw) + point[0] * Math.sin(yaw)) * Math.cos(pitch) + point[1] * Math.sin(pitch), 0) / points.length;
-      faces.push({ points, color, edge, depth });
-    };
-    const box = (x1, y1, z1, x2, y2, z2, shades) => {
-      face([[x1,y1,z2],[x2,y1,z2],[x2,y2,z2],[x1,y2,z2]], shades[0]);
-      face([[x2,y1,z1],[x2,y1,z2],[x2,y2,z2],[x2,y2,z1]], shades[1]);
-      face([[x1,y1,z1],[x1,y2,z1],[x2,y2,z1],[x2,y1,z1]], shades[0]);
-      face([[x1,y1,z1],[x1,y1,z2],[x1,y2,z2],[x1,y2,z1]], shades[1]);
-      face([[x1,y2,z1],[x1,y2,z2],[x2,y2,z2],[x2,y2,z1]], shades[2]);
+    const arch = ({ z, shift: y, shade }) => {
+      const back = z - 13, front = z + 13;
+      const face = (points, color) => path(points, color, '#ac819744');
+      // The camera stays above/right of the front. These are the exposed
+      // walls and top of one joined arch; its pillar-to-beam caps are internal.
+      face([[105,y,back],[105,y,front],[105,239+y,front],[105,239+y,back]], shade[1]);
+      face([[-72,y,back],[-72,205+y,back],[-72,205+y,front],[-72,y,front]], shade[1]);
+      face([[-105,239+y,back],[-105,239+y,front],[105,239+y,front],[105,239+y,back]], shade[2]);
+      face([[-105,y,front],[-72,y,front],[-72,205+y,front],[72,205+y,front],
+        [72,y,front],[105,y,front],[105,239+y,front],[-105,239+y,front]], shade[0]);
     };
     path([[-165,-5,-175],[165,-5,-175],[165,-5,190],[-165,-5,190]], '#151013', '#6e3f5355');
     path([[-165,-5,190],[165,-5,190],[165,-15,190],[-165,-15,190]], '#21151c', '#5e3b4b66');
@@ -56,16 +55,14 @@
       { z: 0, shift: unfold * 15, shade: ['#39222e','#6c344e','#b35780'] },
       { z: 29 + unfold * 77, shift: unfold * 46, shade: ['#292328','#4e3c47','#887280'] }
     ];
-    layers.forEach(layer => {
-      const z = layer.z, y = layer.shift;
-      box(-105,y,z-13,-72,205+y,z+13,layer.shade);
-      box(72,y,z-13,105,205+y,z+13,layer.shade);
-      box(-105,205+y,z-13,105,239+y,z+13,layer.shade);
+    // The z slabs never overlap, so complete layers draw back-to-front.
+    // The policy plane sits in the gap just behind the middle slab (z=-13).
+    // It illustrates the configured boundary, not a process sandbox or an
+    // independently witnessed execution record.
+    layers.forEach((layer, index) => {
+      if (index === 1) path([[-71,0,-14],[-71,203,-14],[71,203,-14],[71,0,-14]], '#ff4f9a0a', '#ff78b477');
+      arch(layer);
     });
-    // The policy plane is an illustration of the configured tool boundary,
-    // not a process sandbox or an independently witnessed execution record.
-    face([[-71,0,0],[-71,203,0],[71,203,0],[71,0,0]], '#ff4f9a0a', '#ff78b477');
-    faces.sort((a, b) => a.depth - b.depth).forEach(item => path(item.points, item.color, item.edge));
 
     if (unfold > .2 && !narrow.matches) {
       context.globalAlpha = clamp((unfold - .2) / .45);

--- a/docs/assets/landing.js
+++ b/docs/assets/landing.js
@@ -3,7 +3,7 @@
   const canvas = document.querySelector('.boundary-canvas');
   const scene = document.querySelector('.threshold-figure');
   const journey = document.querySelector('.hero');
-  if (!canvas || !scene || !journey) return;
+  if (!canvas || !scene || !journey || !window.ResizeObserver || !window.IntersectionObserver) return;
   const context = canvas.getContext('2d');
   if (!context) return;
   const reduced = matchMedia('(prefers-reduced-motion: reduce)');
@@ -107,7 +107,9 @@
     visible = entries[0].isIntersecting;
     if (visible) schedule(); else { cancelAnimationFrame(frame); frame = 0; }
   }).observe(scene);
-  addEventListener('scroll', schedule, { passive: true });
+  addEventListener('scroll', () => {
+    if (!narrow.matches && !reduced.matches) schedule();
+  }, { passive: true });
   addEventListener('resize', schedule, { passive: true });
   document.addEventListener('visibilitychange', schedule);
   reduced.addEventListener('change', schedule);

--- a/docs/index.html
+++ b/docs/index.html
@@ -930,6 +930,8 @@
             *, *::before, *::after { transition: none !important; }
         }
     </style>
+    <link rel="stylesheet" href="assets/landing.css">
+    <script src="assets/landing.js" defer></script>
 </head>
 <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -974,6 +976,7 @@
     <section class="hero" aria-labelledby="hero-title">
         <div class="hero-grid">
             <div class="hero-copy">
+              <div class="story-intro">
                 <p class="eyebrow">v1.8.0 · Open-source control for AI agents</p>
                 <h1 id="hero-title">
                     <span class="first-line">Let agents move fast.</span>
@@ -989,10 +992,34 @@
                     <li>Open source</li>
                     <li>Built for real agent workflows</li>
                 </ul>
+              </div>
+              <article class="story-chapter" id="boundary-scope">
+                <p class="chapter-index">01 / The boundary</p>
+                <h2>Give access<br>a precise edge.</h2>
+                <p>A tool request has a name, a target, and consequences. Rampart evaluates the action your integration exposes against your policies.</p>
+                <div class="request-example">
+                  <span>Example request</span>
+                  <code>read → ~/.ssh/id_ed25519</code>
+                  <p>Standard policy: <code>block-credential-access</code></p>
+                  <p>Matches <code>**/.ssh/id_*</code>; public keys ending in <code>.pub</code> are excluded.</p>
+                </div>
+              </article>
+              <article class="story-chapter" id="boundary-record">
+                <p class="chapter-index">02 / The decision</p>
+                <h2>Your rules.<br>A visible record.</h2>
+                <p>The matching policy denies the request. The decision enters the audit trail, with the rule and action connected for review.</p>
+                <div class="decision-example" aria-label="Illustrative policy decision">
+                  <span>Private-key read</span><span class="decision-deny">Denied</span>
+                  <span>Matching policy</span><code>block-credential-access</code>
+                  <span>Decision recorded</span><span>Audit trail</span>
+                </div>
+                <p class="story-scope">This example illustrates a configured boundary. An audit decision does not prove that an action executed.</p>
+              </article>
             </div>
 
             <div class="threshold">
                 <div class="threshold-figure" aria-hidden="true">
+                    <canvas class="boundary-canvas" aria-hidden="true"></canvas>
                     <svg class="architecture" aria-hidden="true" focusable="false" viewBox="0 0 720 720" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
                         <path class="mass" d="M72 720V180H648V720Z"/>
                         <path class="mass plane-top" d="M72 180L132 132H696L648 180Z"/>
@@ -1006,6 +1033,7 @@
                     </svg>
                 </div>
                 <p class="boundary-note">The boundary evaluates what the integration exposes</p>
+                <p class="scene-legend" aria-hidden="true">Action <span>→</span> Policy <span>→</span> Record</p>
             </div>
         </div>
     </section>

--- a/docs/index.html
+++ b/docs/index.html
@@ -101,7 +101,7 @@
                 </ul>
               </div>
               <article class="story-chapter" id="boundary-scope">
-                <p class="chapter-index">01 / The boundary</p>
+                <p class="chapter-index">The boundary</p>
                 <h2>Give access<br>a precise edge.</h2>
                 <p>A tool request has a name, a target, and consequences. Rampart evaluates the action your integration exposes against your policies.</p>
                 <div class="request-example">
@@ -112,7 +112,7 @@
                 </div>
               </article>
               <article class="story-chapter" id="boundary-record">
-                <p class="chapter-index">02 / The decision</p>
+                <p class="chapter-index">The decision</p>
                 <h2>Your rules.<br>A visible record.</h2>
                 <p>The matching policy denies the request. The decision enters the audit trail, with the rule and action connected for review.</p>
                 <div class="decision-example" aria-label="Illustrative policy decision">
@@ -147,7 +147,7 @@
 
     <section class="premise" id="premise" aria-labelledby="premise-title">
         <div class="premise-inner">
-            <p class="premise-index">03 / The premise</p>
+            <p class="premise-index">The premise</p>
             <h2 class="premise-title" id="premise-title">Autonomy<br>needs an edge.</h2>
             <div class="premise-copy">
                 <p>Agents are useful because they can act. That same access can turn a bad instruction, poisoned context, or confident mistake into a real system change.</p>
@@ -179,7 +179,7 @@
     <section class="workflow" id="get-started" aria-labelledby="workflow-title">
       <div class="section-shell">
         <div class="section-heading">
-          <p class="chapter-index">04 / Put it to work</p>
+          <p class="chapter-index">Put it to work</p>
           <h2 id="workflow-title">From installed<br>to inspected.</h2>
           <p>A working boundary starts with the integration you actually use. Install Rampart, configure protection, then check what that setup can prove.</p>
         </div>
@@ -210,7 +210,7 @@
 
     <section class="integration-section section-shell" id="integrations" aria-labelledby="integration-title">
       <div class="section-heading">
-        <p class="chapter-index">05 / Meet your tools where they act</p>
+        <p class="chapter-index">Meet your tools where they act</p>
         <h2 id="integration-title">One policy layer.<br>Specific boundaries.</h2>
         <p>Use the integration's documented path. Protection, approval, and failure behavior depend on what the host exposes.</p>
       </div>
@@ -234,7 +234,7 @@
     </section>
 
     <section class="boundary-summary section-shell" aria-labelledby="boundary-summary-title">
-      <div><p class="chapter-index">06 / Know the boundary</p><h2 id="boundary-summary-title">Control you<br>can account for.</h2></div>
+      <div><p class="chapter-index">Know the boundary</p><h2 id="boundary-summary-title">Control you<br>can account for.</h2></div>
       <div class="boundary-details">
         <article><h3>Policy you own</h3><p>Readable rules decide which represented requests may proceed, need approval, or must be denied.</p><a class="text-action" href="https://docs.rampart.sh/reference/policy-schema/">Explore the policy schema</a></article>
         <article><h3>A decision trail</h3><p>Hash-chained records connect actions and policy decisions. Detecting a complete local rewrite requires evidence retained independently.</p><a class="text-action" href="https://docs.rampart.sh/features/audit-trail/">Understand audit guarantees</a></article>

--- a/docs/index.html
+++ b/docs/index.html
@@ -37,899 +37,6 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600&amp;family=Newsreader:opsz,wght@6..72,300;6..72,400&amp;display=swap" rel="stylesheet">
-    <style>
-        :root {
-            color-scheme: dark;
-            --obsidian: #0b0a0a;
-            --charcoal: #141212;
-            --graphite: #1d1a1b;
-            --bone: #f1ede7;
-            --muted: #a49d98;
-            --quiet: #77716e;
-            --line: rgba(241, 237, 231, 0.14);
-            --line-quiet: rgba(241, 237, 231, 0.075);
-            --pink: #ff4f9a;
-            --pink-soft: #ff8dbb;
-            --sans: "Manrope", "Helvetica Neue", Arial, sans-serif;
-            --display: "Newsreader", Georgia, serif;
-            --mono: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
-            --gutter: clamp(18px, 2.6vw, 40px);
-            --page: min(calc(100% - (var(--gutter) + var(--gutter))), 1480px);
-        }
-
-        * { box-sizing: border-box; }
-
-        html {
-            background: var(--obsidian);
-            scroll-behavior: smooth;
-        }
-
-        body {
-            margin: 0;
-            background: var(--obsidian);
-            color: var(--bone);
-            font-family: var(--sans);
-            font-size: 16px;
-            line-height: 1.55;
-            -webkit-font-smoothing: antialiased;
-            text-rendering: optimizeLegibility;
-        }
-
-        a { color: inherit; }
-
-        button { font: inherit; }
-
-        .sr-only {
-            position: absolute;
-            width: 1px;
-            height: 1px;
-            padding: 0;
-            margin: -1px;
-            overflow: hidden;
-            clip: rect(0, 0, 0, 0);
-            white-space: nowrap;
-            border: 0;
-        }
-
-        a:focus-visible,
-        button:focus-visible {
-            outline: 2px solid var(--pink);
-            outline-offset: 5px;
-        }
-
-        .skip-link {
-            position: fixed;
-            top: 14px;
-            left: 14px;
-            z-index: 100;
-            padding: 10px 14px;
-            background: var(--bone);
-            color: var(--obsidian);
-            font-size: 0.78rem;
-            font-weight: 600;
-            text-decoration: none;
-            transform: translateY(-180%);
-        }
-
-        .skip-link:focus { transform: translateY(0); }
-
-        .site-header {
-            position: absolute;
-            inset: 0 0 auto;
-            z-index: 20;
-            padding-top: 24px;
-            isolation: isolate;
-        }
-
-        .site-header::before {
-            content: "";
-            position: absolute;
-            inset: 0 0 auto;
-            z-index: 0;
-            height: 92px;
-            border-bottom: 1px solid var(--line-quiet);
-            background: var(--obsidian);
-            pointer-events: none;
-        }
-
-        .nav {
-            position: relative;
-            z-index: 1;
-            width: var(--page);
-            margin: 0 auto;
-            display: grid;
-            grid-template-columns: minmax(180px, 1fr) auto minmax(180px, 1fr);
-            align-items: center;
-            gap: 32px;
-        }
-
-        .brand {
-            display: inline-flex;
-            align-items: center;
-            justify-self: start;
-            min-height: 44px;
-            gap: 12px;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: -0.02em;
-            text-decoration: none;
-        }
-
-        .brand-mark {
-            width: 20px;
-            height: 23px;
-            color: var(--pink);
-        }
-
-        .nav-links,
-        .nav-actions {
-            display: flex;
-            align-items: center;
-            gap: 28px;
-        }
-
-        .nav-links a,
-        .github-link {
-            position: relative;
-            display: inline-flex;
-            align-items: center;
-            min-height: 44px;
-            color: #c3bdb8;
-            font-size: 0.74rem;
-            font-weight: 500;
-            letter-spacing: 0.02em;
-            text-decoration: none;
-            transition: color 160ms ease;
-        }
-
-        .nav-links a::after,
-        .github-link::after {
-            content: "";
-            position: absolute;
-            right: 0;
-            bottom: 5px;
-            left: 0;
-            height: 1px;
-            color: var(--pink);
-            background: currentColor;
-            opacity: 0.8;
-            transform: scaleX(0);
-            transform-origin: left;
-            transition: transform 160ms ease;
-        }
-
-        .nav-links a:hover,
-        .github-link:hover { color: var(--bone); }
-
-        .nav-links a:hover::after,
-        .nav-links a:focus-visible::after,
-        .github-link:hover::after,
-        .github-link:focus-visible::after {
-            color: var(--pink);
-            transform: scaleX(1);
-        }
-
-        .nav-actions { justify-self: end; }
-
-        .nav-toggle,
-        .mobile-nav { display: none; }
-
-        .nav-install {
-            display: inline-flex;
-            align-items: center;
-            min-height: 44px;
-            padding: 0 17px;
-            border: 1px solid var(--bone);
-            background: var(--bone);
-            color: var(--obsidian);
-            font-size: 0.73rem;
-            font-weight: 600;
-            text-decoration: none;
-            transition: background 160ms ease, border-color 160ms ease;
-        }
-
-        .nav-install:hover {
-            border-color: var(--pink);
-            background: var(--pink);
-        }
-
-        main { overflow: clip; }
-
-        .hero {
-            position: relative;
-            min-height: 680px;
-            min-height: clamp(680px, 88svh, 800px);
-            isolation: isolate;
-            border-bottom: 1px solid var(--line-quiet);
-        }
-
-        .hero::before {
-            content: "";
-            position: absolute;
-            inset: 0;
-            z-index: -3;
-            background:
-                linear-gradient(104deg, #100e0e 0 50%, #090909 50% 100%),
-                var(--obsidian);
-        }
-
-        .hero::after {
-            content: "";
-            position: absolute;
-            inset: 0;
-            z-index: -2;
-            background:
-                radial-gradient(ellipse at 70% 48%, rgba(255,255,255,0.026), transparent 38%),
-                linear-gradient(180deg, rgba(255,255,255,0.018), transparent 22%);
-            pointer-events: none;
-        }
-
-        .hero-grid {
-            width: var(--page);
-            min-height: 680px;
-            min-height: clamp(680px, 88svh, 800px);
-            margin: 0 auto;
-            display: grid;
-            grid-template-columns: repeat(2, minmax(0, 1fr));
-            align-items: stretch;
-        }
-
-        .hero-copy {
-            position: relative;
-            z-index: 3;
-            display: flex;
-            flex-direction: column;
-            justify-content: center;
-            padding: 140px clamp(36px, 4.8vw, 76px) 62px 0;
-        }
-
-        .eyebrow {
-            margin: 0 0 28px;
-            color: #c4bdb8;
-            font-family: var(--mono);
-            font-size: 0.64rem;
-            line-height: 1;
-            letter-spacing: 0.16em;
-            text-transform: uppercase;
-        }
-
-        h1,
-        h2,
-        p { margin-top: 0; }
-
-        h1 {
-            max-width: 760px;
-            margin-bottom: 30px;
-            font-family: var(--display);
-            font-size: clamp(3.7rem, 5.9vw, 6.65rem);
-            font-weight: 300;
-            letter-spacing: -0.055em;
-            line-height: 0.86;
-        }
-
-        h1 .first-line,
-        h1 .final-line { display: block; }
-
-        h1 .first-line {
-            color: #a39c97;
-            font-size: 0.72em;
-            font-style: italic;
-            letter-spacing: -0.045em;
-            line-height: 1.05;
-        }
-
-        h1 .final-line { white-space: nowrap; }
-
-        .hero-intro {
-            max-width: 570px;
-            margin-bottom: 34px;
-            color: #bbb4af;
-            font-size: clamp(1rem, 1.25vw, 1.16rem);
-            line-height: 1.7;
-        }
-
-        .hero-actions {
-            display: flex;
-            align-items: center;
-            gap: 24px;
-        }
-
-        .primary-action,
-        .secondary-action,
-        .text-action {
-            display: inline-flex;
-            align-items: center;
-            text-decoration: none;
-        }
-
-        .primary-action {
-            min-height: 50px;
-            padding: 0 22px;
-            background: var(--bone);
-            color: var(--obsidian);
-            font-size: 0.76rem;
-            font-weight: 600;
-            transition: background 160ms ease;
-        }
-
-        .primary-action:hover { background: var(--pink); }
-
-        .secondary-action,
-        .text-action {
-            gap: 11px;
-            color: #d3cdc7;
-            font-size: 0.76rem;
-            font-weight: 500;
-        }
-
-        .secondary-action { min-height: 44px; }
-
-        .secondary-action::after,
-        .text-action::after {
-            content: "";
-            width: 22px;
-            height: 1px;
-            background: var(--pink);
-            transition: width 160ms ease;
-        }
-
-        .secondary-action:hover::after,
-        .secondary-action:focus-visible::after,
-        .text-action:hover::after,
-        .text-action:focus-visible::after {
-            width: 32px;
-        }
-
-        .hero-facts {
-            display: grid;
-            grid-template-columns: repeat(3, minmax(0, 1fr));
-            max-width: 610px;
-            margin: 48px 0 0;
-            padding: 15px 0;
-            border-top: 1px solid var(--line);
-            border-bottom: 1px solid var(--line-quiet);
-            list-style: none;
-            color: #9b9490;
-            font-family: var(--mono);
-            font-size: 0.64rem;
-            line-height: 1.45;
-            letter-spacing: 0.08em;
-            text-transform: uppercase;
-        }
-
-        .hero-facts li {
-            padding: 0 14px;
-            border-left: 1px solid var(--line-quiet);
-        }
-
-        .hero-facts li:first-child {
-            padding-left: 0;
-            border-left: 0;
-        }
-
-        .threshold {
-            position: relative;
-            min-height: 100%;
-            z-index: 2;
-        }
-
-        .threshold::before {
-            content: "";
-            position: absolute;
-            top: 0;
-            bottom: 0;
-            left: 0;
-            width: 1px;
-            background: var(--pink);
-            box-shadow: 0 0 16px rgba(255,79,154,0.1);
-        }
-
-        .threshold::after {
-            content: "";
-            position: absolute;
-            inset: 0 -18vw 0 1px;
-            z-index: -1;
-            background:
-                linear-gradient(114deg, rgba(255,255,255,0.022) 0 38%, transparent 38.15%),
-                linear-gradient(90deg, rgba(255,79,154,0.024), transparent 15%);
-            -webkit-mask-image: linear-gradient(90deg, #000, rgba(0,0,0,0.7) 68%, transparent 100%);
-            mask-image: linear-gradient(90deg, #000, rgba(0,0,0,0.7) 68%, transparent 100%);
-        }
-
-        .threshold-figure {
-            position: absolute;
-            inset: 13% 0 0 3%;
-            margin: 0;
-        }
-
-        .architecture {
-            width: 100%;
-            height: 100%;
-            color: rgba(241,237,231,0.2);
-            overflow: hidden;
-            shape-rendering: geometricPrecision;
-        }
-
-        .architecture .mass {
-            fill: rgba(255,255,255,0.036);
-            stroke: rgba(241,237,231,0.18);
-            vector-effect: non-scaling-stroke;
-        }
-
-        .architecture .plane-top { fill: rgba(255,255,255,0.085); }
-        .architecture .plane-side { fill: rgba(255,255,255,0.018); }
-
-        .architecture .cut {
-            fill: #090909;
-            stroke: rgba(241,237,231,0.3);
-            vector-effect: non-scaling-stroke;
-        }
-
-        .architecture .reveal,
-        .architecture .datum,
-        .architecture .route-in,
-        .architecture .route-out {
-            fill: none;
-            stroke-linecap: square;
-            stroke-linejoin: miter;
-            vector-effect: non-scaling-stroke;
-        }
-
-        .architecture .reveal,
-        .architecture .datum { stroke: rgba(241,237,231,0.1); }
-
-        .architecture .route-in { stroke: rgba(241,237,231,0.23); }
-        .architecture .route-out { stroke: rgba(241,237,231,0.5); }
-
-        .architecture .decision-gate {
-            fill: none;
-            stroke: var(--pink);
-            stroke-width: 1.25;
-            vector-effect: non-scaling-stroke;
-        }
-
-        .boundary-note {
-            position: absolute;
-            left: 26px;
-            bottom: 40px;
-            max-width: 180px;
-            margin: 0;
-            color: #938c87;
-            font-family: var(--mono);
-            font-size: 0.63rem;
-            line-height: 1.55;
-            letter-spacing: 0.1em;
-            text-transform: uppercase;
-        }
-
-        .boundary-note::before {
-            content: "";
-            display: block;
-            width: 22px;
-            height: 1px;
-            margin-bottom: 12px;
-            background: var(--pink);
-        }
-
-        .premise {
-            position: relative;
-            background: var(--charcoal);
-        }
-
-        .premise::before {
-            content: "";
-            position: absolute;
-            top: -1px;
-            left: 50%;
-            width: 1px;
-            height: 112px;
-            background: var(--pink);
-        }
-
-        .premise-inner {
-            width: var(--page);
-            min-height: 600px;
-            margin: 0 auto;
-            padding: 112px 0 88px;
-            display: grid;
-            grid-template-columns: repeat(2, minmax(0, 1fr));
-            grid-template-rows: auto 1fr auto;
-            column-gap: 0;
-        }
-
-        .premise-index {
-            grid-column: 1;
-            grid-row: 1;
-            margin: 0 0 56px;
-            color: #938c87;
-            font-family: var(--mono);
-            font-size: 0.66rem;
-            line-height: 1.5;
-            letter-spacing: 0.12em;
-            text-transform: uppercase;
-        }
-
-        .premise-title {
-            grid-column: 1;
-            grid-row: 2;
-            min-width: 0;
-            margin: 0;
-            padding-right: clamp(42px, 5vw, 80px);
-            font-family: var(--display);
-            font-size: clamp(4rem, 6.6vw, 6.8rem);
-            font-weight: 300;
-            letter-spacing: -0.055em;
-            line-height: 0.9;
-        }
-
-        .premise-copy {
-            grid-column: 2;
-            grid-row: 2;
-            min-width: 0;
-            align-self: start;
-            padding: 4px 0 0 clamp(42px, 5vw, 80px);
-        }
-
-        .premise-copy p {
-            max-width: 440px;
-            margin-bottom: 22px;
-            color: #bbb4af;
-            font-size: 1.02rem;
-            line-height: 1.75;
-        }
-
-        .premise-copy .supporting {
-            margin: 35px 0 0;
-            padding-top: 22px;
-            border-top: 1px solid var(--line);
-            color: var(--bone);
-            font-family: var(--display);
-            font-size: 1.34rem;
-            font-style: italic;
-            line-height: 1.35;
-        }
-
-        .scope-note {
-            grid-column: 2;
-            grid-row: 3;
-            align-self: end;
-            max-width: 440px;
-            margin: 62px 0 0 clamp(42px, 5vw, 80px);
-            padding: 22px 0 0;
-            border-top: 1px solid var(--line);
-            color: #9d9691;
-            font-size: 0.84rem;
-            line-height: 1.7;
-        }
-
-        .scope-note strong {
-            color: #b9b1ac;
-            font-weight: 500;
-        }
-
-        .scope-note .text-action {
-            width: max-content;
-            min-height: 44px;
-            margin-top: 10px;
-        }
-
-        .outcome-rail {
-            grid-column: 1 / -1;
-            grid-row: 4;
-            display: grid;
-            grid-template-columns: repeat(4, minmax(0, 1fr));
-            margin-top: 76px;
-            border-top: 1px solid var(--line);
-            border-bottom: 1px solid var(--line-quiet);
-        }
-
-        .outcome {
-            position: relative;
-            min-width: 0;
-            padding: 19px 24px 22px;
-            border-left: 1px solid var(--line-quiet);
-        }
-
-        .outcome:first-child {
-            padding-left: 0;
-            border-left: 0;
-        }
-
-        .outcome:nth-child(2)::before {
-            content: "";
-            position: absolute;
-            top: -1px;
-            left: 24px;
-            width: 28px;
-            height: 1px;
-            background: var(--pink);
-        }
-
-        .outcome-name {
-            margin: 0 0 8px;
-            color: var(--bone);
-            font-family: var(--mono);
-            font-size: 0.67rem;
-            letter-spacing: 0.13em;
-        }
-
-        .outcome-copy {
-            margin: 0;
-            color: #938c87;
-            font-size: 0.78rem;
-            line-height: 1.55;
-        }
-
-        @media (max-width: 1120px) {
-            .nav { gap: 20px; }
-            .nav-links { gap: 18px; }
-            .nav-links a,
-            .github-link { font-size: 0.69rem; }
-            .hero-copy { padding-right: 36px; }
-        }
-
-        @media (max-width: 959px) {
-            .site-header { padding-top: 18px; }
-            .site-header::before { height: 74px; }
-            .nav { grid-template-columns: 1fr 44px auto; gap: 10px; }
-            .nav-links { display: none; }
-            .nav-actions { gap: 12px; }
-            .nav-actions .github-link { display: none; }
-            .nav-install { padding: 0 13px; }
-
-            .nav-toggle {
-                position: relative;
-                display: grid;
-                place-items: center;
-                width: 44px;
-                height: 44px;
-                padding: 0;
-                border: 1px solid var(--line);
-                background: transparent;
-                color: var(--bone);
-                cursor: pointer;
-            }
-
-            .nav-toggle-lines,
-            .nav-toggle-lines::before {
-                display: block;
-                width: 16px;
-                height: 1px;
-                background: currentColor;
-                transition: transform 160ms ease;
-            }
-
-            .nav-toggle-lines::before {
-                content: "";
-                transform: translateY(-5px);
-            }
-
-            .nav-toggle[aria-expanded="true"] .nav-toggle-lines { transform: rotate(45deg); }
-            .nav-toggle[aria-expanded="true"] .nav-toggle-lines::before { transform: rotate(-90deg); }
-
-            .mobile-nav:not([hidden]) {
-                position: absolute;
-                z-index: 1;
-                top: 74px;
-                left: 50%;
-                display: grid;
-                grid-template-columns: repeat(2, minmax(0, 1fr));
-                width: var(--page);
-                padding: 10px 0;
-                border-top: 1px solid var(--pink);
-                border-bottom: 1px solid var(--line);
-                background: var(--obsidian);
-                box-shadow: 0 24px 54px rgba(0,0,0,0.35);
-                transform: translateX(-50%);
-            }
-
-            .mobile-nav a {
-                display: flex;
-                align-items: center;
-                min-height: 48px;
-                padding: 0 16px;
-                border-left: 1px solid var(--line-quiet);
-                color: #d3cdc7;
-                font-size: 0.75rem;
-                text-decoration: none;
-                transition: background 160ms ease, color 160ms ease;
-            }
-
-            .mobile-nav a:hover,
-            .mobile-nav a:focus-visible {
-                background: rgba(255,79,154,0.06);
-                color: var(--bone);
-            }
-
-            .mobile-nav a:nth-child(odd) { border-left: 0; }
-            .mobile-nav a:last-child { grid-column: 1 / -1; border-top: 1px solid var(--line-quiet); }
-
-            .hero,
-            .hero-grid { min-height: auto; }
-
-            .hero::before { background: #090909; }
-
-            .hero-grid {
-                display: flex;
-                flex-direction: column;
-            }
-
-            .hero-copy {
-                min-height: 650px;
-                justify-content: flex-start;
-                padding: 128px 0 64px;
-            }
-
-            .hero-copy::before {
-                content: "";
-                position: absolute;
-                inset: 0 calc(50% - 50vw);
-                z-index: -1;
-                background: linear-gradient(168deg, #100e0e 0 84%, #0d0c0c 84% 100%);
-                pointer-events: none;
-            }
-
-            .eyebrow { margin-bottom: 26px; }
-
-            h1 {
-                max-width: 530px;
-                margin-bottom: 28px;
-                font-size: clamp(3.55rem, 10.5vw, 5rem);
-                line-height: 0.89;
-            }
-
-            h1 .first-line { font-size: 0.66em; }
-            h1 .final-line { white-space: normal; }
-
-            .hero-intro {
-                max-width: 500px;
-                font-size: 0.98rem;
-                line-height: 1.65;
-            }
-
-            .hero-actions { gap: 18px; }
-            .hero-facts { margin-top: 42px; }
-
-            .threshold {
-                min-height: clamp(310px, 55vw, 420px);
-                overflow: hidden;
-            }
-
-            .threshold::before { left: 0; }
-            .threshold::after { inset: 0 calc(0px - var(--gutter)) 0 1px; }
-            .threshold-figure { inset: 0; }
-            .architecture { transform: scale(1.1); transform-origin: center bottom; }
-            .boundary-note { bottom: 26px; left: 18px; }
-
-            .premise::before {
-                left: var(--gutter);
-                height: 74px;
-            }
-
-            .premise-inner {
-                min-height: auto;
-                padding: 94px 0 82px;
-                display: block;
-            }
-
-            .premise-index { margin: 0 0 46px; }
-            .premise-title {
-                max-width: 610px;
-                margin: 0 0 56px;
-                padding: 0;
-                font-size: clamp(3.7rem, 12vw, 5.4rem);
-            }
-            .premise-copy { max-width: 540px; padding: 0; }
-            .scope-note {
-                max-width: 540px;
-                margin: 60px 0 0;
-                padding: 22px 0 0;
-            }
-
-            .outcome-rail { margin-top: 60px; }
-        }
-
-        @media (max-width: 460px) {
-            .brand { gap: 9px; font-size: 0.84rem; }
-            .brand-mark { width: 18px; height: 21px; }
-            .hero-copy { min-height: 0; padding-bottom: 54px; }
-            h1 { font-size: clamp(3rem, 15vw, 3.75rem); }
-            .hero-actions { align-items: flex-start; flex-direction: column; }
-            .primary-action { width: 100%; justify-content: center; }
-            .hero-facts {
-                grid-template-columns: repeat(2, minmax(0, 1fr));
-                font-size: 0.62rem;
-            }
-            .hero-facts li { min-height: 34px; padding: 0 10px; }
-            .hero-facts li:nth-child(3) {
-                grid-column: 1 / -1;
-                min-height: 40px;
-                margin-top: 10px;
-                padding: 10px 0 0;
-                border-top: 1px solid var(--line-quiet);
-                border-left: 0;
-            }
-            .boundary-note { max-width: 150px; font-size: 0.61rem; }
-            .premise-title {
-                margin-bottom: 44px;
-                font-size: clamp(2.9rem, 14vw, 3.5rem);
-                line-height: 0.94;
-            }
-            .premise-copy p { font-size: 1rem; }
-            .scope-note { font-size: 0.86rem; }
-            .outcome-rail { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-            .outcome { padding: 18px 14px 20px; }
-            .outcome:nth-child(odd) { padding-left: 0; border-left: 0; }
-            .outcome:nth-child(n + 3) { border-top: 1px solid var(--line-quiet); }
-            .outcome:nth-child(2)::before { left: 14px; }
-        }
-
-        @media (max-width: 959px) and (max-height: 600px) and (orientation: landscape) {
-            .hero,
-            .hero-grid { min-height: 520px; }
-
-            .hero-grid {
-                display: grid;
-                grid-template-columns: repeat(2, minmax(0, 1fr));
-            }
-
-            .hero-copy {
-                min-height: 520px;
-                padding: 92px 28px 34px 0;
-            }
-
-            h1 {
-                margin-bottom: 18px;
-                font-size: clamp(2.8rem, 6vw, 3.4rem);
-            }
-
-            .hero-intro {
-                margin-bottom: 18px;
-                font-size: 0.88rem;
-                line-height: 1.5;
-            }
-
-            .eyebrow { line-height: 1.5; }
-            .hero-actions { flex-flow: row wrap; gap: 14px; }
-            .primary-action { width: auto; }
-            .hero-facts { display: none; }
-            .threshold { min-height: 520px; }
-            .boundary-note { top: 310px; bottom: auto; }
-
-            .premise::before { left: 50%; height: 90px; }
-            .premise-inner {
-                display: grid;
-                grid-template-columns: repeat(2, minmax(0, 1fr));
-                grid-template-rows: auto auto auto auto;
-                padding: 90px 0 60px;
-            }
-            .premise-index { grid-column: 1; grid-row: 1; margin: 0 0 34px; }
-            .premise-title {
-                grid-column: 1;
-                grid-row: 2;
-                margin: 0;
-                padding-right: 32px;
-                font-size: clamp(3.1rem, 6vw, 4rem);
-            }
-            .premise-copy {
-                grid-column: 2;
-                grid-row: 2;
-                max-width: none;
-                padding: 0 0 0 32px;
-            }
-            .scope-note {
-                grid-column: 2;
-                grid-row: 3;
-                margin: 40px 0 0 32px;
-            }
-            .outcome-rail { grid-column: 1 / -1; grid-row: 4; }
-        }
-
-        @media (prefers-reduced-motion: reduce) {
-            html { scroll-behavior: auto; }
-            *, *::before, *::after { transition: none !important; }
-        }
-    </style>
     <link rel="stylesheet" href="assets/landing.css">
     <script src="assets/landing.js" defer></script>
 </head>
@@ -982,7 +89,7 @@
                     <span class="first-line">Let agents move fast.</span>
                     <span class="final-line">Keep the final say.</span>
                 </h1>
-                <p class="hero-intro">Rampart places a policy boundary between AI agents and the tools they use. Routine work continues. Dangerous actions stop. When an integration supports approval, consequential decisions come back to you.</p>
+                <p class="hero-intro">Rampart places a policy boundary between AI agents and the tools they use. Routine work continues. Your rules block prohibited actions. When an integration supports approval, consequential decisions come back to you.</p>
                 <div class="hero-actions">
                     <a class="primary-action external-link" href="https://docs.rampart.sh/getting-started/installation/" target="_blank" rel="noopener noreferrer" aria-label="Install Rampart (opens in a new tab)">Install Rampart</a>
                     <a class="secondary-action" href="https://docs.rampart.sh/getting-started/how-it-works/" target="_blank" rel="noopener noreferrer" aria-label="See how it works (opens in a new tab)">See how it works</a>
@@ -1040,12 +147,12 @@
 
     <section class="premise" id="premise" aria-labelledby="premise-title">
         <div class="premise-inner">
-            <p class="premise-index">01 / The premise</p>
+            <p class="premise-index">03 / The premise</p>
             <h2 class="premise-title" id="premise-title">Autonomy<br>needs an edge.</h2>
             <div class="premise-copy">
                 <p>Agents are useful because they can act. That same access can turn a bad instruction, poisoned context, or confident mistake into a real system change.</p>
                 <p>Rampart gives that access a boundary.</p>
-                <p class="supporting">Not another permission prompt. A policy layer built for the decisions that matter.</p>
+                <p class="supporting">Define what can proceed, what needs approval, and what must stop.</p>
             </div>
             <p class="scope-note"><strong>Precisely scoped.</strong> Rampart evaluates actions delivered through configured hooks, plugins, proxies, APIs, and process boundaries. It is a control layer, not a sandbox or a claim of universal interception. <a class="text-action" href="https://docs.rampart.sh/reference/threat-model/" target="_blank" rel="noopener noreferrer" aria-label="Read the threat model (opens in a new tab)">Read the threat model</a></p>
             <div class="outcome-rail" role="list" aria-label="Rampart policy outcomes">
@@ -1059,7 +166,7 @@
                 </div>
                 <div class="outcome" role="listitem">
                     <p class="outcome-name">DENY</p>
-                    <p class="outcome-copy">Known dangerous actions stop before execution.</p>
+                    <p class="outcome-copy">Rules deny prohibited requests at the configured boundary.</p>
                 </div>
                 <div class="outcome" role="listitem">
                     <p class="outcome-name">WATCH</p>
@@ -1068,10 +175,100 @@
             </div>
         </div>
     </section>
+
+    <section class="workflow" id="get-started" aria-labelledby="workflow-title">
+      <div class="section-shell">
+        <div class="section-heading">
+          <p class="chapter-index">04 / Put it to work</p>
+          <h2 id="workflow-title">From installed<br>to inspected.</h2>
+          <p>A working boundary starts with the integration you actually use. Install Rampart, configure protection, then check what that setup can prove.</p>
+        </div>
+        <ol class="workflow-steps">
+          <li>
+            <span class="step-number">01</span><h3>Install</h3>
+            <p>One binary. Policies you can read and change.</p>
+            <div class="command-block"><code id="install-command">brew install peg/tap/rampart</code><button class="copy-command" data-copy="install-command" type="button" aria-label="Copy Homebrew install command" hidden>Copy</button></div>
+            <a class="text-action" href="https://docs.rampart.sh/getting-started/installation/">Linux, macOS &amp; Windows installation</a>
+          </li>
+          <li>
+            <span class="step-number">02</span><h3>Protect</h3>
+            <p>Discover supported installed tools and configure their Rampart boundary.</p>
+            <div class="command-block"><code id="protect-command">rampart protect</code><button class="copy-command" data-copy="protect-command" type="button" aria-label="Copy protect command" hidden>Copy</button></div>
+            <a class="text-action" href="https://docs.rampart.sh/getting-started/quickstart/">Follow the quickstart</a>
+          </li>
+          <li>
+            <span class="step-number">03</span><h3>Verify</h3>
+            <p>Run safe canaries and read the evidence level for each configured integration.</p>
+            <div class="command-block"><code id="verify-command">rampart verify --all</code><button class="copy-command" data-copy="verify-command" type="button" aria-label="Copy verify command" hidden>Copy</button></div>
+            <a class="text-action" href="https://docs.rampart.sh/getting-started/support-matrix/">Understand verification coverage</a>
+          </li>
+        </ol>
+        <p class="workflow-note">Verification does not invoke a model or execute the represented actions. Host verification and adapter checks provide different evidence; the result tells you which boundary was checked.</p>
+        <p class="sr-only" id="copy-status" role="status" aria-live="polite"></p>
+      </div>
+    </section>
+
+    <section class="integration-section section-shell" id="integrations" aria-labelledby="integration-title">
+      <div class="section-heading">
+        <p class="chapter-index">05 / Meet your tools where they act</p>
+        <h2 id="integration-title">One policy layer.<br>Specific boundaries.</h2>
+        <p>Use the integration's documented path. Protection, approval, and failure behavior depend on what the host exposes.</p>
+      </div>
+      <div class="integration-grid">
+        <article class="integration-card">
+          <p class="integration-kind">Managed native guard</p>
+          <h3>OpenClaw</h3>
+          <p>Connect the bundled plugin to Rampart's local policy service. A live plugin-boundary verifier checks the configured installation.</p>
+          <code>rampart protect openclaw</code>
+          <a class="text-action" href="https://docs.rampart.sh/integrations/openclaw/">OpenClaw setup and limits</a>
+        </article>
+        <article class="integration-card">
+          <p class="integration-kind">Native hooks</p>
+          <h3>Claude Code</h3>
+          <p>Apply local policy through the native hook interface. Verification checks installed configuration and adapter behavior; it does not prove host ingestion.</p>
+          <code>rampart setup claude-code</code>
+          <a class="text-action" href="https://docs.rampart.sh/integrations/claude-code/">Claude Code setup and limits</a>
+        </article>
+      </div>
+      <div class="integration-more"><p>Codex, Cline, Copilot, MCP, and more.<br><span>Support levels and approval paths vary. Experimental integrations stay clearly labeled.</span></p><a class="text-action" href="https://docs.rampart.sh/getting-started/support-matrix/">See the complete support matrix</a></div>
+    </section>
+
+    <section class="boundary-summary section-shell" aria-labelledby="boundary-summary-title">
+      <div><p class="chapter-index">06 / Know the boundary</p><h2 id="boundary-summary-title">Control you<br>can account for.</h2></div>
+      <div class="boundary-details">
+        <article><h3>Policy you own</h3><p>Readable rules decide which represented requests may proceed, need approval, or must be denied.</p><a class="text-action" href="https://docs.rampart.sh/reference/policy-schema/">Explore the policy schema</a></article>
+        <article><h3>A decision trail</h3><p>Hash-chained records connect actions and policy decisions. Detecting a complete local rewrite requires evidence retained independently.</p><a class="text-action" href="https://docs.rampart.sh/features/audit-trail/">Understand audit guarantees</a></article>
+        <article><h3>A precise scope</h3><p>Allowed programs can have effects beyond their represented request. Pair Rampart with appropriate credentials, resource permissions, sandboxing, and egress controls.</p><a class="text-action" href="https://docs.rampart.sh/reference/threat-model/">Read the architecture and threat model</a></article>
+      </div>
+    </section>
+
+    <section class="closing section-shell" aria-labelledby="closing-title">
+      <p class="chapter-index">Your tools. Your authority.</p>
+      <h2 id="closing-title">Build with room to move.</h2>
+      <div class="closing-actions"><a class="primary-action" href="https://docs.rampart.sh/getting-started/installation/">Install Rampart</a><a class="text-action" href="https://docs.rampart.sh/getting-started/upgrade/">Upgrade an existing installation</a></div>
+    </section>
 </main>
+<footer class="site-footer section-shell"><a class="footer-brand" href="/">Rampart<span>Open source · Apache 2.0</span></a><nav aria-label="Footer navigation"><a href="https://docs.rampart.sh/">Documentation</a><a href="https://github.com/peg/rampart/releases">Releases</a><a href="https://github.com/peg/rampart/blob/main/SECURITY.md">Report a vulnerability</a><a href="https://github.com/peg/rampart">GitHub</a></nav></footer>
 
 <script>
     (() => {
+        document.documentElement.classList.add('navigation-ready');
+        document.querySelectorAll('.copy-command').forEach(button => {
+            if (!navigator.clipboard) return;
+            button.hidden = false;
+            button.addEventListener('click', async () => {
+                const command = document.getElementById(button.dataset.copy).textContent;
+                const status = document.getElementById('copy-status');
+                try {
+                    await navigator.clipboard.writeText(command);
+                    status.textContent = 'Command copied.';
+                    button.textContent = 'Copied';
+                    setTimeout(() => { button.textContent = 'Copy'; }, 1800);
+                } catch {
+                    status.textContent = 'Copy unavailable. Select and copy the command text.';
+                }
+            });
+        });
         const menuToggle = document.querySelector('.nav-toggle');
         const mobileMenu = document.querySelector('#mobile-menu');
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -38,7 +38,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600&amp;family=Newsreader:opsz,wght@6..72,300;6..72,400&amp;display=swap" rel="stylesheet">
     <link rel="stylesheet" href="assets/landing.css">
-    <script src="assets/landing.js" defer></script>
+    <script src="assets/landing.js?v=55735dcec642" defer></script>
 </head>
 <body>
 <a class="skip-link" href="#main">Skip to content</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -248,7 +248,7 @@
       <div class="closing-actions"><a class="primary-action" href="https://docs.rampart.sh/getting-started/installation/">Install Rampart</a><a class="text-action" href="https://docs.rampart.sh/getting-started/upgrade/">Upgrade an existing installation</a></div>
     </section>
 </main>
-<footer class="site-footer section-shell"><a class="footer-brand" href="/">Rampart<span>Open source · Apache 2.0</span></a><nav aria-label="Footer navigation"><a href="https://docs.rampart.sh/">Documentation</a><a href="https://github.com/peg/rampart/releases">Releases</a><a href="https://github.com/peg/rampart/blob/main/SECURITY.md">Report a vulnerability</a><a href="https://github.com/peg/rampart">GitHub</a></nav></footer>
+<footer class="site-footer section-shell"><a class="footer-brand" href="/">Rampart<span>Open source · Apache 2.0</span></a><nav aria-label="Footer navigation"><a href="https://docs.rampart.sh/">Documentation</a><a href="https://docs.rampart.sh/getting-started/troubleshooting/">Help &amp; feedback</a><a href="https://github.com/peg/rampart/releases">Releases</a><a href="https://github.com/peg/rampart/blob/main/SECURITY.md">Report a vulnerability</a><a href="https://github.com/peg/rampart">GitHub</a></nav></footer>
 
 <script>
     (() => {


### PR DESCRIPTION
Refresh the landing page with a short architectural scroll sequence connecting a represented action, policy and audit record, followed by install, protect and verify guidance. Preserve the static site, installation endpoints, URLs and existing visual identity. The continuous arch geometry incorporates the reviewed occlusion correction; decorative section-number prefixes are removed.

The scene uses bounded local Canvas 2D rendering with a static SVG/HTML fallback, native scrolling, no animation at rest, and reduced-motion/mobile behavior. Copy states integration and audit limits, distinguishes verification evidence levels, and links to help and feedback. Stable metadata still identifies the published 1.8.1 release.

Validation: exact head `7d5e4e0` contains released staging `894672a` and passed all 9 GitHub checks. Full local source/security checks, installer mirror equality, JS/metadata/fragment checks and isolated desktop/phone, menu, no-JS and reduced-motion browser checks passed. This PR prepares the 1.9 website; it does not change deployment ownership.
