### PR TITLE
docs: distinguish host failure and verification boundaries

### DIFF
--- a/assurance/integrations.yaml
+++ b/assurance/integrations.yaml
@@ -38,7 +38,7 @@ integrations:
     evidence:
       - path: cmd/rampart/cli/verify_test.go
         kind: integration
-        proves: Verification rejects incomplete or stale plugin canary results.
+        proves: Verification checks managed configuration and rejects incomplete or stale canary results from the loaded plugin's gateway method.
       - path: internal/plugin/openclaw/provider-surface-replay.mjs
         kind: integration
         proves: Current OpenClaw built-ins and provider aliases reach typed policy surfaces, action consequences remain conservative, unknown tools fail closed locally, and every apply_patch target is evaluated with deny-wins behavior.
@@ -52,6 +52,7 @@ integrations:
         kind: upstream_latest
         proves: A disposable OpenClaw installation resolves the stable npm release and exercises the real plugin boundary.
     limitations:
+      - rampart verify openclaw reaches the installed gateway plugin and its policy mapping; it does not run an authenticated agent turn or prove tool execution and approval resume through the host dispatcher.
       - Rampart evaluates OpenClaw tool calls, not arbitrary network syscalls made inside an allowed process.
       - Host behavior after an uncaught plugin exception is not yet independently proven fail-closed.
       - Unknown plugin and MCP tool names deny until Rampart has an explicit typed mapping for them.
@@ -79,7 +80,8 @@ integrations:
     degraded:
       policy_unavailable: local
       adapter_error: host_defined
-      timeout: host_defined
+      # A command-hook timeout supplies no veto; Claude's own permissions still apply.
+      timeout: allow
     approval: native
     verification:
       level: active
@@ -99,12 +101,16 @@ integrations:
       - path: cmd/rampart/cli/setup_test.go
         kind: unit
         proves: Setup preserves existing settings while installing required hook events.
+      - path: cmd/rampart/cli/verify_test.go
+        kind: integration
+        proves: Verification checks installed hook configuration and directly invokes the adapter with a non-executing denial canary; it does not launch Claude.
     limitations:
       - No rolling latest-Claude compatibility job currently exercises the installed host.
       - rampart verify claude-code proves installed configuration and adapter behavior but does not prove Claude loaded or invoked the hook.
       - Documented hook-visible tools are mapped, and in enforce mode future unknown PreToolUse tools deny until Rampart is updated.
       - Host-owned or server-side actions that do not emit lifecycle hooks are outside this boundary; Claude's EndConversation tool is a documented benign example.
-      - Subagent, hook-crash, and host-timeout behavior need live conformance tests.
+      - Claude's documented command-hook timeout and launch-failure behavior does not block PreToolUse; adapter failures without a blocking exit or valid denial also permit normal host permission processing.
+      - Subagent and host-failure contracts have not been proven through authenticated live conformance tests.
 
   - id: cline
     display_name: Cline

--- a/docs-site/getting-started/support-matrix.md
+++ b/docs-site/getting-started/support-matrix.md
@@ -25,6 +25,14 @@ execute the represented actions. A target is not promoted merely because its
 configuration exists: OpenClaw's live plugin can earn `host_verified`, while
 ordinary native-hook checks earn `adapter_verified`.
 
+These labels describe different probes. Native-hook verification inspects
+installed settings and invokes Rampart's adapter directly. OpenClaw verification
+calls `rampart.verify` on the running gateway plugin, which exercises the same
+policy mapping used by its pre-tool hook. Neither probe runs an authenticated
+agent turn or demonstrates a tool's execution or approval resume through the
+host dispatcher. Package startup and rolling compatibility tests are separate
+evidence, not a promotion of adapter checks to host ingestion.
+
 Static-only integrations are excluded from the aggregate rather than reported
 as passing. In particular, use `rampart doctor` for Hermes installation status
 and the isolated latest-Hermes compatibility check for runtime evidence.
@@ -202,26 +210,34 @@ and the isolated latest-Hermes compatibility check for runtime evidence.
 
 ## Degraded behavior notes
 
-- **Claude Code / Cline / Codex / Antigravity / GitHub Copilot / Cursor native hooks or plugins**, plus the experimental Gemini CLI adapter: local allow/deny policy
-  evaluation works when `rampart serve` is down. Rampart-handled parse and
-  policy errors deny in enforce mode, but an unexpected hook crash or host
-  timeout follows the host's behavior. Dashboard features and external
-  approvals need the service; Codex and Cursor approval-required actions deny
-  when their queue is unavailable.
-- **GitHub Copilot**: native `ask` does not require the Rampart service. Copilot
-  CLI `PreToolUse` command errors deny, but CLI hook timeouts always fail open,
-  even for administrator policy hooks. VS Code blocks exit code 2 but treats
-  other hook errors as warnings; unexpected crashes are not claimed fail-closed.
-- **Cline**: Rampart enables POSIX files with executable permissions; Cline's
-  Hooks UI can disable them. Windows uses `.ps1` file presence and PowerShell.
-  Current Cline source keeps hooks outside `--data-dir`/`CLINE_DATA_DIR`, and
-  legacy CLI `--yolo` bypasses runtime hooks entirely. Current Cline CLI logs
-  and continues after pre-hook errors/timeouts/invalid control output, and runs
-  post-tool hooks asynchronously without consuming their control response.
-- **OpenClaw native plugin**: depends on `rampart serve`; sensitive tools block when the service is unavailable, while configured lower-risk fail-open tools may still proceed.
-- **Hermes Agent plugin**: depends on `rampart serve`; all tools fail closed when unavailable by default. Operators may explicitly opt selected tools into degraded fail-open behavior.
-- **Legacy OpenClaw patching**: compatibility-only path; requires re-patching after upgrades.
-- **Wrapper / preload / API paths**: behavior depends on integration settings and fail-open/fail-closed configuration.
+In enforce mode, Rampart returns a denial for malformed tool input, invalid
+policy, and other handled decision failures. A host that never starts the hook,
+cancels it, or ignores its response owns the resulting behavior. The table
+describes the managed integration; monitor mode and explicit fail-open settings
+weaken enforcement. A host continuing its permission flow does not mean it will
+necessarily execute the tool.
+
+| Integration | `rampart serve` unavailable | Host hook failure or timeout |
+| --- | --- | --- |
+| [Claude Code](../integrations/claude-code.md) | Local policy and native `ask` remain available. | Command-hook timeout or launch failure supplies no veto; normal Claude permissions apply. A valid denial or blocking exit still blocks. [Upstream contract](https://code.claude.com/docs/en/hooks#timeouts) |
+| [Cline](../integrations/cline.md) | Local policy remains available; `ask` cancels with context. | Current CLI continues after pre-hook launch, timeout, or control-parse errors. Post-tool file hooks are observational. |
+| [Codex](../integrations/codex-cli.md) | Local allow/deny remains available; external approvals deny when unavailable. | Host-controlled; unexpected crash and timeout behavior is not claimed fail-closed. |
+| [Gemini CLI](../integrations/gemini-cli.md) (experimental) | Local allow/deny remains available; external approvals deny when unavailable. | Host-controlled; unexpected crash and timeout behavior is not claimed fail-closed. |
+| [Antigravity](../integrations/antigravity.md) | Local policy and native `force_ask` remain available. | Host-controlled; unexpected crash and timeout behavior is not claimed fail-closed. |
+| [GitHub Copilot](../integrations/github-copilot.md) | Local policy and native `ask` remain available. | CLI command errors deny, but CLI timeouts continue, including policy hooks. VS Code blocks exit 2 and treats other errors as warnings. |
+| [Cursor local Agent](../integrations/cursor.md) | Local allow/deny remains available; external approvals deny when unavailable. | Managed `failClosed: true` requests blocking on crash, timeout, or invalid JSON. Installed configuration and adapter checks do not prove host ingestion. [Upstream contract](https://cursor.com/docs/hooks#per-script-configuration-options) |
+| [OpenClaw native plugin](../integrations/openclaw.md) | All tools deny by default, including routine tools. | Rampart catches adapter exceptions and denies on its service request deadline. Failure outside that handler remains host-controlled. |
+| [Hermes Agent](../integrations/hermes.md) (experimental) | All tools deny by default. | Rampart catches adapter exceptions and service timeouts; Hermes skips a callback that escapes with an exception. |
+
+OpenClaw and Hermes operators can explicitly opt tools into degraded fail-open
+behavior; `rampart protect openclaw` installs an empty opt-out list. OpenClaw's
+[native approval limits](../integrations/openclaw.md)
+and trusted-plugin composition boundary also apply.
+
+Disabled or undiscovered hooks provide no interception. See each integration's
+activation requirements, including Cline's legacy `--yolo` bypass. Legacy
+OpenClaw patching requires re-patching after upgrades. Wrapper, preload, and
+custom API paths depend on their own configuration and caller behavior.
 
 The machine-readable source for current integration guarantees and evidence is
 [`assurance/integrations.yaml`](https://github.com/peg/rampart/blob/main/assurance/integrations.yaml).

--- a/docs-site/integrations/claude-code.md
+++ b/docs-site/integrations/claude-code.md
@@ -92,8 +92,19 @@ When Claude Code wants to run a command, it sends the tool call to `rampart hook
 
 Calls denied by the working `PreToolUse` hook do not execute. If a response-side rule denies successful tool
 output, Rampart returns a shape-preserving `updatedToolOutput` with string
-content redacted and a block reason. The tool has already run, but the original
-content is not passed into Claude's next model turn.
+content redacted and a block reason. The tool has already run. Claude replaces
+what the model sees only if it accepts that output shape; this does not remove
+prior side effects or upstream telemetry. See Claude's
+[post-tool contract](https://code.claude.com/docs/en/hooks#posttooluse-decision-control).
+
+### Failure boundary
+
+Local policy evaluation and native `ask` do not require `rampart serve`.
+Rampart-handled malformed input and policy errors deny in enforce mode.
+Claude command-hook timeouts and launch failures supply no veto; normal host
+permissions apply. This differs from Claude Agent SDK callback hooks. See the
+[upstream failure contract](https://code.claude.com/docs/en/hooks#timeouts) and
+the [per-host failure table](../getting-started/support-matrix.md#degraded-behavior-notes).
 
 ## Usage
 
@@ -112,8 +123,9 @@ confirm which calls actually crossed the Rampart boundary.
 rampart verify claude-code
 ```
 
-This checks installed hook configuration and exercises the adapter with safe,
-non-executing canaries. It does not launch a model. See
+This checks installed hook configuration, readable hook-disabling settings,
+and the adapter with safe, non-executing canaries. It does not launch Claude or
+prove that a Claude process loaded and invoked the hook. See
 [Security Assurance](../getting-started/security-assurance.md) for the exact
 claim boundary.
 

--- a/docs-site/integrations/openclaw.md
+++ b/docs-site/integrations/openclaw.md
@@ -189,7 +189,13 @@ For example, approving `sudo apt-get install nmap` always writes:
 rampart verify openclaw
 ```
 
-The verification command checks routine work, destructive actions, credential access, policy tampering, direct external network commands, publishing, cross-conversation messages, opaque interpreters, and package publishing. Its fixed canaries traverse policy evaluation and the live plugin's decision mapping without executing the represented actions.
+The verification command checks managed configuration and policy canaries,
+then calls `rampart.verify` on the running gateway. That plugin method feeds
+fixed, non-executing canaries through the same normalization and decision
+mapping as `before_tool_call`. It proves the current plugin is loaded and can
+reach Rampart; it does not invoke the agent's tool dispatcher or exercise a
+native approval's resume path. An authenticated agent turn is separate
+evidence and is not run by this command.
 
 Use `rampart doctor` for the broader installation health report. Expected output when fully configured includes:
 
@@ -200,9 +206,8 @@ Use `rampart doctor` for the broader installation health report. Expected output
 ✓ Approval path: native OpenClaw UI active
 ```
 
-For safe end-to-end confidence, run `rampart verify openclaw`. It checks the
-installed plugin and exercises allow, ask, and deny behavior without executing
-the represented actions or invoking a model.
+See the [support matrix](../getting-started/support-matrix.md#degraded-behavior-notes)
+for service failure defaults and the limits of each verification level.
 
 Or check plugin status directly:
 


### PR DESCRIPTION
The support matrix now distinguishes a host's failure behavior from a Rampart decision, and explains what each verifier actually exercises. Claude command-hook timeouts are recorded as providing no veto under the current upstream contract; Cursor's managed `failClosed` setting and OpenClaw's default all-tool denial on service loss are described separately.

The Claude and OpenClaw guides now distinguish adapter invocation, loaded-plugin policy checks, and authenticated host execution or approval resume. Existing support tiers and runtime behavior remain unchanged. The existing degraded-behavior anchor is retained for incoming links.

Validation: current primary Claude and Cursor contracts reviewed, manifest checks and existing verifier/adapter tests passed, strict MkDocs and full source/security validation passed. These documentation corrections do not claim new authenticated host conformance evidence.
