### PR TITLE
test(bridge): wait for cleanup after denial delivery

### DIFF
--- a/internal/bridge/openclaw_test.go
+++ b/internal/bridge/openclaw_test.go
@@ -973,10 +973,20 @@ func TestBridgeAuditFailureRespectsMode(t *testing.T) {
 				assert.Equal(t, test.wantDecision, params["decision"])
 			}
 
-			bridge.pendingMu.Lock()
-			_, pending := bridge.pendingCommands[approvalID]
-			bridge.pendingMu.Unlock()
-			assert.Equal(t, test.wantPending, pending)
+			isPending := func() bool {
+				bridge.pendingMu.Lock()
+				defer bridge.pendingMu.Unlock()
+				_, pending := bridge.pendingCommands[approvalID]
+				return pending
+			}
+			if test.wantDecision != "" {
+				// The gateway can receive a denial before the bridge finishes cleanup.
+				require.Eventually(t, func() bool {
+					return isPending() == test.wantPending
+				}, time.Second, 5*time.Millisecond, "unexpected pending state after audit failure")
+			} else {
+				assert.Equal(t, test.wantPending, isPending())
+			}
 		})
 	}
 }


### PR DESCRIPTION
The bridge audit-failure test could receive a correct denial on Windows and inspect pending state before the bridge finished cleanup. A received WebSocket frame is not a cleanup barrier.

Keep the ID/decision assertions and wait up to one second for pending-state cleanup only in response-producing cases. The no-response cases retain their immediate state assertions. Missing cleanup still fails; production behavior is unchanged.

Validation: independent exact-head review, full Go/vet/security checks, 30 repeated focused race-test runs, and whitespace checks. Native Windows CI must pass before merge. This is a narrowly scoped validation correction found while preparing 1.8.1 in #416.
