### PR TITLE
fix(site): keep artwork sharp and documentation search responsive

### DIFF
--- a/docs-site/assets/search-input.js
+++ b/docs-site/assets/search-input.js
@@ -1,0 +1,19 @@
+(() => {
+  "use strict";
+
+  // Material 9.7 observes search changes on keyup and focus, but not input.
+  // Forward input-only edits (including mobile input and committed composition)
+  // until the theme observes input itself. Its value filters deduplicate keyup.
+  const refreshSearch = (event) => {
+    const input = event.target;
+    if (!(input instanceof HTMLInputElement) ||
+        !input.matches('[data-md-component="search-query"]') ||
+        event.isComposing) return;
+
+    // Keep this local to the query observer, away from global keyboard shortcuts.
+    input.dispatchEvent(new Event("keyup"));
+  };
+
+  document.addEventListener("input", refreshSearch);
+  document.addEventListener("compositionend", refreshSearch);
+})();

--- a/docs/assets/landing.js
+++ b/docs/assets/landing.js
@@ -8,7 +8,7 @@
   if (!context) return;
   const reduced = matchMedia('(prefers-reduced-motion: reduce)');
   const narrow = matchMedia('(max-width: 959px)');
-  let width = 0, height = 0, progress = 0, frame = 0, visible = true;
+  let width = 0, height = 0, pixelRatio = 0, progress = 0, frame = 0, visible = true;
   const clamp = value => Math.max(0, Math.min(1, value));
   const smooth = value => { const t = clamp(value); return t * t * (3 - 2 * t); };
 
@@ -86,8 +86,8 @@
     if (!visible || document.hidden) return;
     const rect = scene.getBoundingClientRect();
     const ratio = Math.min(devicePixelRatio || 1, 1.75);
-    if (width !== rect.width || height !== rect.height) {
-      width = rect.width; height = rect.height;
+    if (width !== rect.width || height !== rect.height || pixelRatio !== ratio) {
+      width = rect.width; height = rect.height; pixelRatio = ratio;
       canvas.width = Math.round(width * ratio); canvas.height = Math.round(height * ratio);
       context.setTransform(ratio, 0, 0, ratio, 0, 0);
     }

--- a/docs/index.html
+++ b/docs/index.html
@@ -38,7 +38,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600&amp;family=Newsreader:opsz,wght@6..72,300;6..72,400&amp;display=swap" rel="stylesheet">
     <link rel="stylesheet" href="assets/landing.css">
-    <script src="assets/landing.js?v=55735dcec642" defer></script>
+    <script src="assets/landing.js?v=dc44e2d3ea57" defer></script>
 </head>
 <body>
 <a class="skip-link" href="#main">Skip to content</a>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,9 @@ theme:
 extra_css:
   - assets/extra.css
 
+extra_javascript:
+  - assets/search-input.js
+
 markdown_extensions:
   - abbr
   - admonition


### PR DESCRIPTION
The landing artwork now refreshes its backing resolution after a pixel-density change, including resizes that leave its CSS dimensions unchanged. The existing resolution cap and 3D geometry are preserved.

The bundled documentation theme observes key-up and focus events, so input-only edits could leave a visible query with stale results. A small adapter now forwards input and completed composition to the existing search observer. It skips active composition and does not bubble synthetic keyboard events to global shortcuts; the theme deduplicates unchanged query values.

Validation: 29 landing checks per browser and 13 documentation checks per browser in Chromium, Chrome, WebKit, and Linux Firefox. Paired baseline/fixed search checks reproduce and correct input-only and composition-commit failures; ordinary typing, keyboard paste/cut, clearing, duplicate-value filtering, and shortcut isolation pass. Maintainer local quick/full checks, strict documentation build, JavaScript syntax, and diff checks pass. Viewports and composition events are emulated; physical devices and shipping Safari/Edge applications were not tested.
