### PR TITLE
docs: prepare the 1.9.0 release metadata

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -15,7 +15,7 @@ body:
     attributes:
       label: Rampart version
       description: The version number from `rampart version`, or say if installation failed before you could check.
-      placeholder: "1.8.1"
+      placeholder: "1.9.0"
     validations:
       required: true
   - type: input

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.0] - 2026-09-07
+
 ### Added
 
 - **Opt-in production guard** — Require approval for the documented infrastructure
@@ -32,6 +34,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Clearer troubleshooting and feedback** — Current setup and verification
   commands replace stale service and repair instructions. A structured bug form
   gathers minimal redacted reports and keeps security disclosures private.
+- **More meaningful regression checks** — Isolate setup fixtures, require actual
+  MCP and audit output, restore engine fuzz inputs previously skipped by a stale
+  fixture, and exercise the real HTTP handler. Consolidate duplicate preset
+  checks, verify effective Windows handle permissions, and build docs strictly.
 
 ## [1.8.1] - 2026-09-04
 

--- a/assurance/integrations.yaml
+++ b/assurance/integrations.yaml
@@ -1,5 +1,5 @@
 schema_version: rampart.assurance.v2
-baseline_release: v1.8.1
+baseline_release: v1.9.0
 reviewed_at: "2026-08-17"
 
 # Version 2 uses the canonical Rampart command target as each integration id

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -214,9 +214,10 @@ policy decisions, not proof of execution or independent audit witnessing.
 
 ## Current release
 
-Rampart v1.8.1 repairs current OpenClaw installation and execution-policy
-compatibility, connects complete redacted approval review with immutable retry
-identity, and strengthens supported same-command download/execution checks.
+Rampart v1.9.0 adds an opt-in [production guard](guides/production-guard.md),
+bounded service diagnostic logs, and an experimental
+[external audit witness](features/external-witness.md). The website and docs
+share a refreshed design, clearer troubleshooting, and improved browser support.
 Read the [upgrade guidance](getting-started/upgrade.md) for approval-state backups
 and native OpenClaw review limits. See the [release
 notes](https://github.com/peg/rampart/releases/latest) for the concise upgrade

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -1,6 +1,6 @@
 # Threat Model
 
-> Last reviewed: 2026-09-04 | Applies to: v1.8.1+
+> Last reviewed: 2026-09-04 | Applies to: v1.9.0+
 
 Rampart is a policy engine for AI agents — not a sandbox, not a hypervisor, not a full isolation boundary. This document describes what Rampart protects against, what it doesn't, and why.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -28,7 +28,7 @@
       "url": "https://rampart.sh",
       "applicationCategory": "SecurityApplication",
       "operatingSystem": "Linux, macOS, Windows",
-      "softwareVersion": "1.8.1",
+      "softwareVersion": "1.9.0",
       "license": "https://opensource.org/licenses/Apache-2.0",
       "codeRepository": "https://github.com/peg/rampart"
     }
@@ -84,7 +84,7 @@
         <div class="hero-grid">
             <div class="hero-copy">
               <div class="story-intro">
-                <p class="eyebrow">v1.8.1 · Open-source control for AI agents</p>
+                <p class="eyebrow">v1.9.0 · Open-source control for AI agents</p>
                 <h1 id="hero-title">
                     <span class="first-line">Let agents move fast.</span>
                     <span class="final-line">Keep the final say.</span>


### PR DESCRIPTION
Prepare the 1.9.0 release metadata for the integrated feature and test-quality work. Move the factual Unreleased entries into a dated 1.9.0 section, describe the current release in the documentation, and synchronize the landing page, assurance baseline, threat-model applicability and bug-report version example.

Support tiers, integration guarantees and last-reviewed dates are unchanged. Production guard remains opt-in and external witnessing remains experimental. The 1.8.1 fixes stay in their original release section. Bundled plugin and SDK versions remain independently versioned.

Validation: full local Go/vet/security-assurance checks, strict MkDocs build, release-metadata synchronization checks, and independent review. This PR targets staging; it does not publish the release or deploy the public websites.
