### PR TITLE
fix(hermes): restore native approvals on 0.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   commands replace stale service and repair instructions. A structured bug form
   gathers minimal redacted reports and keeps security disclosures private.
 
+### Fixed
+
+- **Hermes v0.21.1 native approvals** — Recognize the host's additional approval
+  dispatcher while preserving approval identity checks and older supported
+  resolver paths. Unrecognized approval flows continue to block safely.
+
 ## [1.8.1] - 2026-09-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Hermes v0.21.1 native approvals** — Recognize the host's additional approval
   dispatcher while preserving approval identity checks and older supported
-  resolver paths. Unrecognized approval flows continue to block safely.
+  resolver paths. Keep working-directory identity correct across supported
+  Hermes paths. Unrecognized approval flows continue to block safely.
 
 ## [1.8.1] - 2026-09-04
 

--- a/assurance/integrations.yaml
+++ b/assurance/integrations.yaml
@@ -243,6 +243,7 @@ integrations:
       - A release that cannot load Hermes' packaged plugin manager fails the rolling compatibility gate and is not inferred compatible from its source tree.
       - Operators may explicitly weaken degraded behavior by configuring selected tools to fail open; the default denies every tool.
       - Hermes tools outside the plugin's typed map, including MCP and delegated-agent tools, fail closed but are not claimed as covered policy surfaces.
+      - Other plugins that rewrite tool arguments share the trusted host boundary; re-evaluation of their rewrites and arbitrary plugin composition are not verified.
       - Delegated-agent and authenticated live-host E2E are not present.
 
   - id: gemini

--- a/docs-site/getting-started/support-matrix.md
+++ b/docs-site/getting-started/support-matrix.md
@@ -233,6 +233,9 @@ OpenClaw and Hermes operators can explicitly opt tools into degraded fail-open
 behavior; `rampart protect openclaw` installs an empty opt-out list. OpenClaw's
 [native approval limits](../integrations/openclaw.md)
 and trusted-plugin composition boundary also apply.
+Hermes likewise treats other argument-rewriting plugins as part of the
+[trusted host boundary](../integrations/hermes.md#decision-behavior);
+their rewrites are not verified as re-evaluated by Rampart.
 
 Disabled or undiscovered hooks provide no interception. See each integration's
 activation requirements, including Cline's legacy `--yolo` bypass. Legacy

--- a/docs-site/integrations/hermes.md
+++ b/docs-site/integrations/hermes.md
@@ -103,6 +103,11 @@ directory from applying to another. A Rampart token is therefore required for
 native `ask` approval; without one, `ask` fails closed while ordinary allow and
 deny decisions continue to work.
 
+Other Hermes plugins that rewrite tool arguments share the trusted host
+boundary. Rampart evaluates the arguments supplied to its hook; it cannot
+guarantee that another plugin's rewrites are re-evaluated before execution.
+The isolated compatibility harness does not verify arbitrary plugin composition.
+
 For an availability-first deployment, `fail_open_tools` can explicitly list
 individual Hermes names such as `web_search`. This weakens the enforcement
 boundary and is never enabled by default; credential-bearing reads should stay

--- a/internal/plugin/hermes/__init__.py
+++ b/internal/plugin/hermes/__init__.py
@@ -810,6 +810,7 @@ def _hermes_supports_native_approval() -> bool:
     )
     resolver = getattr(hermes_plugins, "resolve_pre_tool_block", None)
     resolution_helper = getattr(hermes_plugins, "_resolve_block_from_details", None)
+    dispatch_helper = getattr(hermes_plugins, "_dispatch_pre_tool_call_hooks", None)
     if not (
         callable(public_getter)
         and callable(details_getter)
@@ -824,9 +825,10 @@ def _hermes_supports_native_approval() -> bool:
     # and the resolver supplies ``details.rule_key`` to the approval gate.
     # Hermes v0.20.2 moved the gate into ``_resolve_block_from_details``; for
     # that shape, also prove that the resolver passes the same directive into
-    # the helper. If source is unavailable or a future host delegates this
-    # differently, fail closed until that contract is reviewed instead of
-    # guessing from names.
+    # the helper. v0.21.1 delegates through ``_dispatch_pre_tool_call_hooks``;
+    # additionally prove that its resolved block is returned to the caller.
+    # If source is unavailable or a future host delegates differently, fail
+    # closed until that contract is reviewed instead of guessing from names.
     try:
         details_tree = ast.parse(textwrap.dedent(inspect.getsource(details_getter)))
         resolver_tree = ast.parse(textwrap.dedent(inspect.getsource(resolver)))
@@ -839,6 +841,94 @@ def _hermes_supports_native_approval() -> bool:
         if isinstance(node.func, ast.Attribute):
             return node.func.attr
         return ""
+
+    def named_call(node: ast.AST, name: str, arguments: tuple[str, ...]) -> bool:
+        return (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == name
+            and len(node.args) == len(arguments)
+            and all(
+                isinstance(argument, ast.Name) and argument.id == expected
+                for argument, expected in zip(node.args, arguments)
+            )
+        )
+
+    def function_body(tree: ast.Module) -> list[ast.stmt]:
+        if len(tree.body) != 1 or not isinstance(tree.body[0], ast.FunctionDef):
+            return []
+        body = tree.body[0].body
+        if (
+            body
+            and isinstance(body[0], ast.Expr)
+            and isinstance(body[0].value, ast.Constant)
+            and isinstance(body[0].value.value, str)
+        ):
+            body = body[1:]
+        return body
+
+    def forwards_hook_kwargs(node: ast.Call) -> bool:
+        return (
+            len(node.keywords) == 1
+            and node.keywords[0].arg is None
+            and isinstance(node.keywords[0].value, ast.Name)
+            and node.keywords[0].value.id == "hook_kwargs"
+        )
+
+    def assigns_call(
+        node: ast.stmt, target: str, name: str, arguments: tuple[str, ...]
+    ) -> bool:
+        return (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+            and node.targets[0].id == target
+            and named_call(node.value, name, arguments)
+        )
+
+    # Only accept the reviewed straight-line dispatcher form. Merely finding
+    # calls somewhere in its source would not prove the approval result wins.
+    resolver_body = function_body(resolver_tree)
+    if (
+        len(resolver_body) == 1
+        and isinstance(resolver_body[0], ast.Return)
+        and isinstance(resolver_body[0].value, ast.Subscript)
+        and named_call(
+            resolver_body[0].value.value,
+            "_dispatch_pre_tool_call_hooks",
+            ("tool_name", "args"),
+        )
+        and forwards_hook_kwargs(resolver_body[0].value.value)
+        and isinstance(resolver_body[0].value.slice, ast.Constant)
+        and type(resolver_body[0].value.slice.value) is int
+        and resolver_body[0].value.slice.value == 0
+    ):
+        if not callable(dispatch_helper) or not callable(resolution_helper):
+            return False
+        try:
+            dispatch_tree = ast.parse(textwrap.dedent(inspect.getsource(dispatch_helper)))
+        except (OSError, TypeError, SyntaxError, IndentationError):
+            return False
+        body = function_body(dispatch_tree)
+        if not (
+            len(body) == 3
+            and assigns_call(
+                body[0], "details", "_get_pre_tool_call_directive_details",
+                ("tool_name", "args"),
+            )
+            and forwards_hook_kwargs(body[0].value)
+            and assigns_call(
+                body[1], "block_msg", "_resolve_block_from_details",
+                ("details", "tool_name"),
+            )
+            and isinstance(body[2], ast.Return)
+            and isinstance(body[2].value, ast.Tuple)
+            and len(body[2].value.elts) == 2
+            and isinstance(body[2].value.elts[0], ast.Name)
+            and body[2].value.elts[0].id == "block_msg"
+        ):
+            return False
+        resolver_tree = dispatch_tree
 
     result_rule_key_is_captured = any(
         isinstance(node, ast.Assign)

--- a/internal/plugin/hermes/__init__.py
+++ b/internal/plugin/hermes/__init__.py
@@ -39,7 +39,7 @@ from pathlib import Path
 from typing import Any, Callable, Mapping
 from urllib.parse import quote, urlsplit
 
-VERSION = "1.7.1"
+VERSION = "1.7.2"
 
 DEFAULT_SERVE_URL = "http://127.0.0.1:9090"
 DEFAULT_TIMEOUT_MS = 3000
@@ -1019,7 +1019,6 @@ def _effective_terminal_cwd(task_id: str) -> str | None:
         resolve_overrides = getattr(hermes_terminal, "resolve_task_overrides")
         get_session_cwd = getattr(hermes_terminal, "get_session_cwd")
         resolve_cwd = getattr(hermes_terminal, "_resolve_command_cwd")
-        container_backends = getattr(hermes_terminal, "_CONTAINER_BACKENDS")
         unusable_container_cwd = getattr(
             hermes_terminal, "_is_unusable_container_cwd"
         )
@@ -1036,25 +1035,70 @@ def _effective_terminal_cwd(task_id: str) -> str | None:
         ):
             return None
 
+        parameters = inspect.signature(resolve_cwd).parameters
+        legacy_parameters = {"workdir", "default_cwd", "session_key"}
+        modern_cwd = set(parameters) == legacy_parameters | {"env_type"}
+        if not modern_cwd and set(parameters) != legacy_parameters:
+            return None
+        if any(
+            parameter.kind not in (
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                inspect.Parameter.KEYWORD_ONLY,
+            )
+            for parameter in parameters.values()
+        ):
+            return None
+        if modern_cwd:
+            # Current hosts classify plugin backends too, and may mount this
+            # task's host workspace at /workspace. Reuse their shared helpers.
+            is_container_backend = getattr(hermes_terminal, "_is_container_backend")
+            resolve_host_cwd = getattr(hermes_terminal, "_resolve_task_host_cwd")
+            if not callable(is_container_backend) or not callable(resolve_host_cwd):
+                return None
+        else:
+            container_backends = getattr(hermes_terminal, "_CONTAINER_BACKENDS")
+            if not isinstance(container_backends, (set, frozenset)) or not all(
+                isinstance(backend, str) for backend in container_backends
+            ):
+                return None
+
         config = get_config()
         overrides = resolve_overrides(task_id)
         if not isinstance(config, Mapping) or not isinstance(overrides, Mapping):
             return None
         env_type = config.get("env_type")
         cwd = overrides.get("cwd") or get_session_cwd(task_id) or config.get("cwd")
-        if not isinstance(env_type, str) or not isinstance(cwd, str) or not cwd:
+        if not isinstance(env_type, str) or not env_type or not isinstance(cwd, str) or not cwd:
             return None
-        if env_type in container_backends and unusable_container_cwd(cwd):
-            cwd = config.get("cwd")
-            if not isinstance(cwd, str) or not cwd:
+        container = is_container_backend(env_type) if modern_cwd else env_type in container_backends
+        if not isinstance(container, bool):
+            return None
+        if container:
+            unusable_cwd = unusable_container_cwd(cwd)
+            if not isinstance(unusable_cwd, bool):
                 return None
-        session_key = get_current_session_key(default="") or (task_id or "")
-        effective_cwd = resolve_cwd(
-            workdir=None,
-            default_cwd=cwd,
-            session_key=session_key,
-        )
-    except (ImportError, AttributeError, KeyError, OSError, TypeError, ValueError):
+            if unusable_cwd:
+                host_cwd = resolve_host_cwd(config, task_id) if modern_cwd else None
+                if host_cwd is not None and not isinstance(host_cwd, str):
+                    return None
+                cwd = "/workspace" if host_cwd else config.get("cwd")
+                if not isinstance(cwd, str) or not cwd:
+                    return None
+        current_session_key = get_current_session_key(default="")
+        if current_session_key is not None and not isinstance(current_session_key, str):
+            return None
+        session_key = current_session_key or (task_id or "")
+        if not isinstance(session_key, str):
+            return None
+        if modern_cwd:
+            effective_cwd = resolve_cwd(
+                workdir=None, default_cwd=cwd, session_key=session_key, env_type=env_type,
+            )
+        else:
+            effective_cwd = resolve_cwd(
+                workdir=None, default_cwd=cwd, session_key=session_key,
+            )
+    except Exception:
         return None
     return effective_cwd if isinstance(effective_cwd, str) and effective_cwd else None
 

--- a/internal/plugin/hermes/embed_test.go
+++ b/internal/plugin/hermes/embed_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestVersionReadsManifest(t *testing.T) {
-	if got, want := Version(), "1.7.1"; got != want {
+	if got, want := Version(), "1.7.2"; got != want {
 		t.Fatalf("Version() = %q, want %q", got, want)
 	}
 }
@@ -97,7 +97,7 @@ func TestExtractRollsBackManagedPluginOnActivationFailure(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	oldManifest = bytes.Replace(oldManifest, []byte("version: 1.7.1"), []byte("version: 1.6.0"), 1)
+	oldManifest = bytes.Replace(oldManifest, []byte("version: "+Version()), []byte("version: 1.6.0"), 1)
 	if err := os.WriteFile(manifestPath, oldManifest, 0o600); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/plugin/hermes/plugin.yaml
+++ b/internal/plugin/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: rampart
-version: 1.7.1
+version: 1.7.2
 description: Experimental Rampart policy gate for Hermes Agent pre_tool_call hooks
 author: peg
 provides_hooks:

--- a/internal/plugin/hermes/test_hermes_plugin.py
+++ b/internal/plugin/hermes/test_hermes_plugin.py
@@ -639,6 +639,163 @@ class HermesPluginTests(unittest.TestCase):
         self.assertNotEqual(safe_key, other_key)
         self.assertIsNone(ambiguous_key)
 
+    def test_effective_terminal_cwd_uses_the_host_backend_and_session(self) -> None:
+        cases = (
+            ("configured directory", {}, "/configured"),
+            ("task override", {"override_cwd": "/override"}, "/override"),
+            ("task record", {"records": {"task": "/task"}}, "/task"),
+            (
+                "current session wins",
+                {"override_cwd": "/override", "session_key": "session",
+                 "records": {"task": "/task", "session": "/session"}},
+                "/session",
+            ),
+            (
+                "configured backend stays authoritative",
+                {"override_env": "plugin-container", "override_cwd": "/host/work",
+                 "host_cwd": "/host/work"},
+                "/host/work",
+            ),
+            (
+                "container override without mount",
+                {"env_type": "plugin-container", "override_cwd": "/host/work"},
+                "/configured",
+            ),
+            (
+                "container override with mount",
+                {"env_type": "plugin-container", "override_cwd": "/host/work",
+                 "host_cwd": "/host/work"},
+                "/workspace",
+            ),
+            (
+                "container task record with mount",
+                {"env_type": "plugin-container", "records": {"task": "/host/work"},
+                 "host_cwd": "/host/work"},
+                "/workspace",
+            ),
+            (
+                "unusable current-session record",
+                {"env_type": "plugin-container", "session_key": "session",
+                 "records": {"session": "/host/work"}},
+                "/configured",
+            ),
+            (
+                "valid container current-session record",
+                {"env_type": "plugin-container", "session_key": "session",
+                 "records": {"session": "/sandbox/work"}},
+                "/sandbox/work",
+            ),
+            ("legacy resolver", {"legacy": True}, "/configured"),
+            (
+                "legacy container override",
+                {"legacy": True, "env_type": "legacy-container",
+                 "override_cwd": "/host/work"},
+                "/configured",
+            ),
+        )
+        for label, options, expected in cases:
+            with self.subTest(label=label):
+                modules, _, calls = self._terminal_cwd_runtime(**options)
+                with mock.patch.dict(sys.modules, modules):
+                    self.assertEqual(plugin._effective_terminal_cwd("task"), expected)
+                self.assertEqual(len(calls), 1)
+                self.assertIsNone(calls[0]["workdir"])
+                self.assertEqual(calls[0]["session_key"], options.get("session_key") or "task")
+                if not options.get("legacy"):
+                    self.assertEqual(calls[0]["env_type"], options.get("env_type", "local"))
+
+    def test_effective_terminal_cwd_refuses_unknown_host_contracts(self) -> None:
+        def raises(*args, **kwargs):
+            raise RuntimeError("host helper failed")
+
+        def unknown_resolver(*, workdir, default_cwd, session_key, env_type, new_context=None):
+            return default_cwd
+
+        def bad_result(*, workdir, default_cwd, session_key, env_type):
+            return {"cwd": default_cwd}
+
+        cases = (
+            ("missing predicate", "_is_container_backend", None),
+            ("missing mount helper", "_resolve_task_host_cwd", None),
+            ("unknown resolver signature", "_resolve_command_cwd", unknown_resolver),
+            ("opaque resolver signature", "_resolve_command_cwd", lambda **kwargs: "/unsafe"),
+            ("invalid predicate result", "_is_container_backend", lambda _: "yes"),
+            ("invalid mount result", "_resolve_task_host_cwd", lambda *_: {"cwd": "/host/work"}),
+            ("invalid path predicate", "_is_unusable_container_cwd", lambda _: 1),
+            ("invalid config", "_get_env_config", lambda: []),
+            ("invalid overrides", "resolve_task_overrides", lambda _: []),
+            ("invalid resolved directory", "_resolve_command_cwd", bad_result),
+            ("helper exception", "_resolve_task_host_cwd", raises),
+        )
+        for label, attribute, replacement in cases:
+            with self.subTest(label=label):
+                modules, terminal, _ = self._terminal_cwd_runtime(
+                    env_type="plugin-container", override_cwd="/host/work"
+                )
+                setattr(terminal, attribute, replacement)
+                with mock.patch.dict(sys.modules, modules):
+                    self.assertIsNone(plugin._effective_terminal_cwd("task"))
+
+        for session_key in (True, False):
+            with self.subTest(session_key=session_key):
+                modules, _, _ = self._terminal_cwd_runtime(session_key=session_key)
+                with mock.patch.dict(sys.modules, modules):
+                    self.assertIsNone(plugin._effective_terminal_cwd("task"))
+
+    @staticmethod
+    def _terminal_cwd_runtime(
+        *, env_type="local", override_cwd=None, override_env=None,
+        records=None, session_key="", host_cwd=None, legacy=False,
+    ):
+        """Synthetic host helpers; no terminal environment or process is created."""
+        tools_package = types.ModuleType("tools")
+        tools_package.__path__ = []
+        terminal = types.ModuleType("tools.terminal_tool")
+        approval = types.ModuleType("tools.approval")
+        tools_package.terminal_tool = terminal
+        tools_package.approval = approval
+        records = records or {}
+        calls = []
+        host_config = {"env_type": env_type, "cwd": "/configured"}
+        terminal._get_env_config = lambda: host_config
+
+        def task_overrides(task):
+            if task != "task":
+                raise AssertionError("override lookup changed task identity")
+            return {"cwd": override_cwd, "env_type": override_env}
+
+        def task_host_cwd(config, task):
+            if config is not host_config or task != "task":
+                raise AssertionError("mount lookup changed config or task identity")
+            return host_cwd
+
+        terminal.resolve_task_overrides = task_overrides
+        terminal.get_session_cwd = records.get
+        terminal._is_unusable_container_cwd = lambda cwd: cwd.startswith("/host/")
+        approval.get_current_session_key = lambda default: session_key
+
+        def modern_resolver(*, workdir, default_cwd, session_key=None, env_type=None):
+            calls.append(dict(workdir=workdir, default_cwd=default_cwd,
+                              session_key=session_key, env_type=env_type))
+            recorded = records.get(session_key)
+            if recorded and terminal._is_container_backend(env_type) and terminal._is_unusable_container_cwd(recorded):
+                return default_cwd
+            return recorded or default_cwd
+
+        def legacy_resolver(*, workdir, default_cwd, session_key=None):
+            calls.append(dict(workdir=workdir, default_cwd=default_cwd, session_key=session_key))
+            return records.get(session_key) or default_cwd
+
+        if legacy:
+            terminal._CONTAINER_BACKENDS = frozenset({"legacy-container"})
+            terminal._resolve_command_cwd = legacy_resolver
+        else:
+            terminal._is_container_backend = lambda backend: backend == "plugin-container"
+            terminal._resolve_task_host_cwd = task_host_cwd
+            terminal._resolve_command_cwd = modern_resolver
+        return ({"tools": tools_package, "tools.terminal_tool": terminal,
+                 "tools.approval": approval}, terminal, calls)
+
     def test_terminal_approval_key_requires_absolute_explicit_workdir(self) -> None:
         config = plugin.load_config()
 

--- a/internal/plugin/hermes/test_hermes_plugin.py
+++ b/internal/plugin/hermes/test_hermes_plugin.py
@@ -53,9 +53,13 @@ class HermesPluginTests(unittest.TestCase):
         def resolve_block_from_details(*_):
             return None
 
+        def dispatch_pre_tool_call_hooks(*_):
+            return None
+
         hermes_plugins._get_pre_tool_call_directive_details = details_getter
         hermes_plugins.resolve_pre_tool_block = resolve_pre_tool_block
         hermes_plugins._resolve_block_from_details = resolve_block_from_details
+        hermes_plugins._dispatch_pre_tool_call_hooks = dispatch_pre_tool_call_hooks
         directive_type = type(
             "_PreToolCallDirective",
             (),
@@ -88,7 +92,18 @@ class HermesPluginTests(unittest.TestCase):
                         rule_key=details.rule_key or tool_name,
                     )
             """,
+            dispatch_pre_tool_call_hooks: """
+                def _dispatch_pre_tool_call_hooks(tool_name, args, **hook_kwargs):
+                    details = _get_pre_tool_call_directive_details(tool_name, args, **hook_kwargs)
+                    block_msg = _resolve_block_from_details(
+                        details, tool_name,
+                        **{k: hook_kwargs.get(k, "") for k in ("turn_id", "tool_call_id", "session_id")},
+                    )
+                    return (block_msg, details.modified_args)
+            """,
         }
+        original_gate_source = sources[resolve_block_from_details]
+        dispatcher_source = sources[dispatch_pre_tool_call_hooks]
 
         with (
             mock.patch.dict(sys.modules, modules),
@@ -105,6 +120,131 @@ class HermesPluginTests(unittest.TestCase):
                     return request_tool_approval(tool_name, details.message, rule_key=tool_name)
             """
             self.assertFalse(plugin._hermes_supports_native_approval())
+
+            delegated_resolver_source = """
+                def resolve_pre_tool_block(tool_name, args, **hook_kwargs):
+                    return _dispatch_pre_tool_call_hooks(tool_name, args, **hook_kwargs)[0]
+            """
+            sources[resolve_pre_tool_block] = delegated_resolver_source
+            self.assertTrue(plugin._hermes_supports_native_approval())
+
+            for label, function, source in (
+                (
+                    "wrong result index", resolve_pre_tool_block,
+                    delegated_resolver_source.replace("[0]", "[1]"),
+                ),
+                (
+                    "substituted original arguments", resolve_pre_tool_block,
+                    delegated_resolver_source.replace(
+                        "(tool_name, args, **hook_kwargs)[0]",
+                        "(tool_name, {}, **hook_kwargs)[0]",
+                    ),
+                ),
+                (
+                    "substituted original tool", resolve_pre_tool_block,
+                    delegated_resolver_source.replace(
+                        "_dispatch_pre_tool_call_hooks(tool_name, args, **hook_kwargs)",
+                        "_dispatch_pre_tool_call_hooks(other_tool, args, **hook_kwargs)",
+                    ),
+                ),
+                (
+                    "lost original context", resolve_pre_tool_block,
+                    delegated_resolver_source.replace(
+                        "_dispatch_pre_tool_call_hooks(tool_name, args, **hook_kwargs)",
+                        "_dispatch_pre_tool_call_hooks(tool_name, args)",
+                    ),
+                ),
+                (
+                    "substituted details input", dispatch_pre_tool_call_hooks,
+                    dispatcher_source.replace(
+                        "_get_pre_tool_call_directive_details(tool_name, args, **hook_kwargs)",
+                        "_get_pre_tool_call_directive_details(tool_name, {}, **hook_kwargs)",
+                    ),
+                ),
+                (
+                    "substituted details tool", dispatch_pre_tool_call_hooks,
+                    dispatcher_source.replace(
+                        "_get_pre_tool_call_directive_details(tool_name, args, **hook_kwargs)",
+                        "_get_pre_tool_call_directive_details(other_tool, args, **hook_kwargs)",
+                    ),
+                ),
+                (
+                    "substituted details context", dispatch_pre_tool_call_hooks,
+                    dispatcher_source.replace(
+                        "_get_pre_tool_call_directive_details(tool_name, args, **hook_kwargs)",
+                        "_get_pre_tool_call_directive_details(tool_name, args, **other_kwargs)",
+                    ),
+                ),
+                (
+                    "substituted task identity", dispatch_pre_tool_call_hooks,
+                    dispatcher_source.replace(
+                        "_get_pre_tool_call_directive_details(tool_name, args, **hook_kwargs)",
+                        "_get_pre_tool_call_directive_details(tool_name, args, task_id='other')",
+                    ),
+                ),
+                (
+                    "substituted details", dispatch_pre_tool_call_hooks,
+                    dispatcher_source.replace(
+                        "details, tool_name,", "other_details, tool_name,"
+                    ),
+                ),
+                (
+                    "missing details lookup", dispatch_pre_tool_call_hooks,
+                    dispatcher_source.replace(
+                        "details = _get_pre_tool_call_directive_details(tool_name, args, **hook_kwargs)",
+                        "details = other_details",
+                    ),
+                ),
+                (
+                    "discarded approval output", dispatch_pre_tool_call_hooks,
+                    dispatcher_source.replace(
+                        "return (block_msg, details.modified_args)",
+                        "return (None, details.modified_args)",
+                    ),
+                ),
+                (
+                    "swapped result slots", dispatch_pre_tool_call_hooks,
+                    dispatcher_source.replace(
+                        "return (block_msg, details.modified_args)",
+                        "return (details.modified_args, block_msg)",
+                    ),
+                ),
+                (
+                    "overwritten details", dispatch_pre_tool_call_hooks,
+                    dispatcher_source.replace(
+                        "block_msg =",
+                        "details = other_details\n                    block_msg =",
+                    ),
+                ),
+                (
+                    "lost rule key", resolve_block_from_details,
+                    original_gate_source.replace(
+                        "rule_key=details.rule_key or tool_name", "rule_key=tool_name"
+                    ),
+                ),
+            ):
+                with self.subTest(label=label):
+                    original = sources[function]
+                    sources[function] = source
+                    try:
+                        self.assertFalse(plugin._hermes_supports_native_approval())
+                    finally:
+                        sources[function] = original
+
+            with mock.patch.object(hermes_plugins, "_dispatch_pre_tool_call_hooks", None):
+                self.assertFalse(plugin._hermes_supports_native_approval())
+            with mock.patch.object(hermes_plugins, "_resolve_block_from_details", None):
+                self.assertFalse(plugin._hermes_supports_native_approval())
+
+            def source_without_dispatcher(function):
+                if function is dispatch_pre_tool_call_hooks:
+                    raise OSError("dispatcher source unavailable")
+                return sources[function]
+
+            with mock.patch.object(
+                plugin.inspect, "getsource", side_effect=source_without_dispatcher
+            ):
+                self.assertFalse(plugin._hermes_supports_native_approval())
 
             sources[resolve_pre_tool_block] = """
                 def resolve_pre_tool_block(tool_name, args):


### PR DESCRIPTION
Hermes 0.21.1 changed native approval dispatch and terminal working-directory helpers. Rampart conservatively blocks approval requests when it cannot recognize those contracts or derive the exact call identity.

Recognize the reviewed dispatcher form only when it forwards the original tool, arguments and hook metadata, passes the resulting directive into the existing approval helper, and returns that helper's block result. Terminal identity now follows the host's task/session directory precedence and container workspace mapping through its shared helpers. Older resolver paths remain supported; unknown or incomplete flows still block. Regression cases reject substituted identity, omitted metadata, discarded approval results and missing source. The bundled Hermes adapter is versioned 1.7.2. The integration docs, support matrix and assurance manifest clarify the trusted boundary around other plugins that rewrite arguments; Hermes remains experimental.

Validation: focused Python regression and harness-isolation checks, inspection against the exact official Hermes 0.21.1 source, full source/vet/security-assurance checks, strict docs, and independent review. Exact-head platform CI, the isolated latest-Hermes dispatcher check and OpenClaw source/container checks pass. Cline package startup remains blocked by the disposable x86 host's CPU; it is tracked separately from this Hermes change and will receive native ARM64 validation on the final release candidate. No model calls or authenticated host-ingestion claim are added.
