### PR TITLE
test: remove duplicate checks and assert CLI outcomes

### DIFF
--- a/cmd/rampart/cli/cli_unit2_test.go
+++ b/cmd/rampart/cli/cli_unit2_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/peg/rampart/internal/audit"
@@ -114,37 +115,6 @@ func TestExtractPrimaryRequestValue(t *testing.T) {
 	}
 }
 
-// --- resolveTestPolicyPath (test_cmd.go) ---
-
-func TestResolveTestPolicyPath(t *testing.T) {
-	t.Run("existing file", func(t *testing.T) {
-		dir := t.TempDir()
-		p := filepath.Join(dir, "rampart.yaml")
-		os.WriteFile(p, []byte("version: 1"), 0o644)
-
-		got, cleanup, err := resolveTestPolicyPath(p)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		defer cleanup()
-		if got != p {
-			t.Errorf("expected %s, got %s", p, got)
-		}
-	})
-
-	t.Run("fallback to embedded", func(t *testing.T) {
-		// Use a non-existent path so it falls through
-		got, cleanup, err := resolveTestPolicyPath("/nonexistent/rampart.yaml")
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		defer cleanup()
-		if got == "" {
-			t.Error("expected non-empty path")
-		}
-	})
-}
-
 // --- createShellShim (wrap.go) ---
 
 func TestCreateShellShim_Coverage(t *testing.T) {
@@ -234,36 +204,55 @@ func TestNewPolicyLintCmd_FileNotFound(t *testing.T) {
 
 func TestNewPolicyLintCmd_ValidFile(t *testing.T) {
 	dir := t.TempDir()
+	testSetHome(t, dir)
 	p := filepath.Join(dir, "policy.yaml")
-	os.WriteFile(p, []byte("version: \"1\"\ndefault_action: deny\nrules:\n  - action: allow\n    when:\n      tool: exec\n"), 0o644)
+	if err := os.WriteFile(p, []byte(`version: "1"
+default_action: deny
+policies:
+  - name: allow-echo
+    match:
+      tool: exec
+    rules:
+      - action: allow
+        when:
+          command_matches: ["echo *"]
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
 
 	var out bytes.Buffer
 	cmd := newPolicyLintCmd()
 	cmd.SetOut(&out)
 	cmd.SetErr(&bytes.Buffer{})
 	cmd.SetArgs([]string{p})
-	// This may call os.Exit(1), but we're just testing the path
-	_ = cmd.Execute()
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := strings.TrimSpace(out.String()), p+": no issues found"; got != want {
+		t.Fatalf("lint output = %q, want %q", got, want)
+	}
 }
 
 // --- newLogCmd paths (log.go) ---
 
 func TestNewLogCmd(t *testing.T) {
+	dir := t.TempDir()
+	testSetHome(t, dir)
 	cmd := &cobra.Command{Use: "root"}
 	logCmd := newLogCmd(&rootOptions{})
 	cmd.AddCommand(logCmd)
 
 	// Test with empty audit dir
-	dir := t.TempDir()
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&bytes.Buffer{})
 	cmd.SetContext(context.Background())
 	cmd.SetArgs([]string{"log", "--audit-dir", dir})
-	err := cmd.Execute()
-	// Empty dir should be OK (no events)
-	if err != nil {
-		t.Logf("log cmd error (may be expected): %v", err)
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(out.String()); got != "No events found." {
+		t.Fatalf("empty log output = %q", got)
 	}
 }
 

--- a/cmd/rampart/cli/cli_unit3_test.go
+++ b/cmd/rampart/cli/cli_unit3_test.go
@@ -37,38 +37,6 @@ func TestNewInitCmd_AlreadyExists(t *testing.T) {
 	}
 }
 
-func TestNewInitCmd_Force(t *testing.T) {
-	dir := t.TempDir()
-	testSetHome(t, dir)
-	p := filepath.Join(dir, "rampart.yaml")
-	os.WriteFile(p, []byte("existing"), 0o644)
-
-	var out bytes.Buffer
-	root := NewRootCmd(context.Background(), &out, &bytes.Buffer{})
-	root.SetArgs([]string{"init", "--config", p, "--force"})
-	err := root.Execute()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func TestNewInitCmd_NewFile(t *testing.T) {
-	dir := t.TempDir()
-	testSetHome(t, dir)
-	p := filepath.Join(dir, "rampart.yaml")
-
-	var out bytes.Buffer
-	root := NewRootCmd(context.Background(), &out, &bytes.Buffer{})
-	root.SetArgs([]string{"init", "--config", p})
-	err := root.Execute()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if _, err := os.Stat(p); err != nil {
-		t.Error("expected config file to be created")
-	}
-}
-
 func TestNewInitCmd_WithProfile(t *testing.T) {
 	dir := t.TempDir()
 	testSetHome(t, dir)
@@ -249,44 +217,45 @@ func TestNewPreloadCmd_NoArgs(t *testing.T) {
 
 func TestNewHookCmd_NoStdin(t *testing.T) {
 	dir := t.TempDir()
+	testSetHome(t, dir)
+	t.Chdir(dir)
+	t.Setenv("RAMPART_TOKEN", "")
 	p := filepath.Join(dir, "rampart.yaml")
-	os.WriteFile(p, []byte(`version: "1"
+	if err := os.WriteFile(p, []byte(`version: "1"
 default_action: allow
-`), 0o644)
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	auditDir := filepath.Join(dir, "audit")
 
 	var out, errBuf bytes.Buffer
 	root := NewRootCmd(context.Background(), &out, &errBuf)
-	root.SetArgs([]string{"hook", "--config", p})
-
-	// Redirect stdin to empty
-	oldStdin := os.Stdin
-	r, w, _ := os.Pipe()
-	w.Close()
-	os.Stdin = r
-	defer func() { os.Stdin = oldStdin }()
-
-	err := root.Execute()
-	_ = err // may error on stdin read
-}
-
-// --- version command ---
-
-func TestVersionCmd(t *testing.T) {
-	var out bytes.Buffer
-	root := NewRootCmd(context.Background(), &out, &bytes.Buffer{})
-	root.SetArgs([]string{"version"})
-	err := root.Execute()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	root.SetIn(strings.NewReader(""))
+	root.SetArgs([]string{"hook", "--config", p, "--mode", "enforce", "--audit-dir", auditDir, "--serve-url", "http://127.0.0.1:1"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("clean EOF returned an error: %v", err)
 	}
-}
-
-// --- status command ---
-
-func TestStatusCmd_NoServer(t *testing.T) {
-	var out bytes.Buffer
-	root := NewRootCmd(context.Background(), &out, &bytes.Buffer{})
-	root.SetArgs([]string{"status", "--addr", "http://127.0.0.1:1"})
-	// Should fail connecting
-	_ = root.Execute()
+	var got hookOutput
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("decode clean EOF response: %v; output: %s", err, &out)
+	}
+	if got.Decision != "" || got.HookSpecificOutput == nil || got.HookSpecificOutput.HookEventName != "PreToolUse" || got.HookSpecificOutput.PermissionDecision != "allow" {
+		t.Fatalf("unexpected clean EOF response: %+v", got)
+	}
+	if errBuf.Len() != 0 {
+		t.Fatalf("clean EOF wrote stderr: %s", &errBuf)
+	}
+	files, err := listAuditFiles(auditDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, file := range files {
+		events, err := readAuditEvents(file)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(events) != 0 {
+			t.Fatalf("clean EOF must not record a policy decision, got %d events", len(events))
+		}
+	}
 }

--- a/cmd/rampart/cli/cli_unit_test.go
+++ b/cmd/rampart/cli/cli_unit_test.go
@@ -292,17 +292,6 @@ func TestListPending(t *testing.T) {
 // --- loadLogEvents (log.go) ---
 
 func TestLoadLogEvents(t *testing.T) {
-	t.Run("empty dir", func(t *testing.T) {
-		dir := t.TempDir()
-		events, err := loadLogEvents(dir, false, false)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if len(events) != 0 {
-			t.Errorf("expected 0 events, got %d", len(events))
-		}
-	})
-
 	t.Run("today only no files", func(t *testing.T) {
 		dir := t.TempDir()
 		events, err := loadLogEvents(dir, true, false)

--- a/cmd/rampart/cli/status_test.go
+++ b/cmd/rampart/cli/status_test.go
@@ -16,6 +16,8 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"net"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -53,6 +55,48 @@ func TestStatusCmdDefaultHumanOutput(t *testing.T) {
 	var payload map[string]any
 	if jsonErr := json.Unmarshal([]byte(stdout), &payload); jsonErr == nil {
 		t.Fatal("default status output should not be JSON")
+	}
+}
+
+func TestStatusCmd_NoServer(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+	t.Chdir(home)
+	t.Setenv("PATH", home)
+	for _, key := range []string{"CLAUDE_CONFIG_DIR", "HERMES_HOME", "COPILOT_HOME", "APPDATA", "LOCALAPPDATA", "ProgramData"} {
+		t.Setenv(key, filepath.Join(home, key))
+	}
+	t.Setenv("OPENCLAW_STATE_DIR", filepath.Join(home, ".openclaw"))
+	t.Setenv("OPENCLAW_CONFIG_PATH", filepath.Join(home, ".openclaw", "openclaw.json"))
+	t.Setenv("RAMPART_OPENCLAW_BIN", filepath.Join(home, "missing-openclaw"))
+	t.Setenv("RAMPART_URL", "http://127.0.0.1:1")
+
+	// Simulate unavailable service endpoints, including fallback ports, without
+	// probing any service on the machine running the test.
+	probes := 0
+	oldClient := rampartHTTPClient
+	rampartHTTPClient = &http.Client{Transport: redirectTestTransport(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet || req.URL.Path != "/healthz" {
+			t.Errorf("unexpected status request: %s %s", req.Method, req.URL.Path)
+		}
+		probes++
+		return nil, net.ErrClosed
+	})}
+	t.Cleanup(func() { rampartHTTPClient = oldClient })
+
+	stdout, stderr, err := runCLI(t, "status", "--json")
+	if err != nil {
+		t.Fatalf("offline status returned an error: %v", err)
+	}
+	var got statusJSONOutput
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("decode offline status: %v; output: %s", err, stdout)
+	}
+	if probes == 0 || got.SchemaVersion != statusSchemaVersion || got.ServerRunning {
+		t.Fatalf("offline status: probes=%d schema=%q server_running=%t", probes, got.SchemaVersion, got.ServerRunning)
+	}
+	if stderr != "" {
+		t.Fatalf("offline status wrote stderr: %s", stderr)
 	}
 }
 

--- a/internal/engine/ask_test.go
+++ b/internal/engine/ask_test.go
@@ -20,22 +20,6 @@ import (
 
 // ── ParseAction ──────────────────────────────────────────────────────────────
 
-func TestParseAction_Ask(t *testing.T) {
-	a, err := ParseAction("ask")
-	if err != nil {
-		t.Fatalf("ParseAction(\"ask\") unexpected error: %v", err)
-	}
-	if a != ActionAsk {
-		t.Errorf("ParseAction(\"ask\") = %v, want ActionAsk", a)
-	}
-}
-
-func TestParseAction_AskString(t *testing.T) {
-	if got := ActionAsk.String(); got != "ask" {
-		t.Errorf("ActionAsk.String() = %q, want \"ask\"", got)
-	}
-}
-
 func TestParseAction_AllActions(t *testing.T) {
 	// Ensure each action round-trips through ParseAction → String cleanly.
 	cases := []struct {
@@ -89,8 +73,6 @@ func TestRuleParseAction_Ask(t *testing.T) {
 	}
 }
 
-// TestRuleAskAuditEnabled_RequireApprovalAlias removed — require_approval was removed in v0.9.9.
-
 func TestRuleAskAuditEnabled_AskExplicitAudit(t *testing.T) {
 	r := Rule{Action: "ask", Ask: AskActionConfig{Audit: true}}
 	if !r.AskAuditEnabled() {
@@ -111,8 +93,6 @@ func TestRuleHeadlessOnlyEnabled_AskExplicit(t *testing.T) {
 		t.Fatal("expected ask.headless_only=true to enable headless-only mode")
 	}
 }
-
-// TestRuleHeadlessOnlyEnabled_RequireApprovalFalse removed — require_approval was removed in v0.9.9.
 
 // ── Policy evaluation with action: ask ───────────────────────────────────────
 

--- a/internal/mcp/proxy_test.go
+++ b/internal/mcp/proxy_test.go
@@ -1860,7 +1860,7 @@ func TestRun_EndToEnd(t *testing.T) {
 // Test: Security bypass scenarios
 // ---------------------------------------------------------------------------
 
-func TestSecurityBypass_MethodCaseSensitivity(t *testing.T) {
+func TestHandleClientLine_MethodCaseSensitivity(t *testing.T) {
 	eng := buildDenyAllEngine(t)
 	childIn := &bytes.Buffer{}
 	parentOut := &bytes.Buffer{}
@@ -1870,19 +1870,12 @@ func TestSecurityBypass_MethodCaseSensitivity(t *testing.T) {
 		WithMode("enforce"), WithLogger(silentLogger()))
 	p.parentOut = parentOut
 
-	// Try uppercase method — should NOT be caught as tools/call
+	// JSON-RPC method names are case-sensitive; the child owns unknown methods.
 	line := `{"jsonrpc":"2.0","id":1,"method":"Tools/Call","params":{"name":"exec_command","arguments":{"command":"whoami"}}}` + "\n"
-	err := p.handleClientLine([]byte(line))
-	if err != nil {
-		t.Fatalf("handleClientLine: %v", err)
-	}
-
-	// This bypasses the check (method is case-sensitive in JSON-RPC).
-	// Document that this is expected behavior — MCP method names are case-sensitive.
-	// The line should be forwarded to child since it doesn't match "tools/call".
-	if childIn.Len() == 0 {
-		t.Log("Non-matching method forwarded (expected — method names are case-sensitive)")
-	}
+	require.NoError(t, p.handleClientLine([]byte(line)))
+	require.Equal(t, line, childIn.String(), "forward the unrecognized method unchanged")
+	require.Empty(t, parentOut.String(), "the child supplies the method response")
+	require.Empty(t, sink.getEvents(), "an unrecognized method is not a tool evaluation")
 }
 
 func TestSecurityBypass_ExtraFieldsInParams(t *testing.T) {

--- a/policies/policies_test.go
+++ b/policies/policies_test.go
@@ -43,19 +43,3 @@ func TestEmbeddedPoliciesParse(t *testing.T) {
 		})
 	}
 }
-
-func TestProfileNamesMatchFiles(t *testing.T) {
-	entries, err := FS.ReadDir(".")
-	require.NoError(t, err)
-
-	yamlFiles := make(map[string]bool)
-	for _, e := range entries {
-		if !e.IsDir() && e.Name() != "embed.go" && e.Name() != "policies_test.go" {
-			yamlFiles[e.Name()] = true
-		}
-	}
-
-	for _, name := range ProfileNames {
-		assert.True(t, yamlFiles[name+".yaml"], "profile %s should have a matching YAML file", name)
-	}
-}


### PR DESCRIPTION
Several smoke tests discarded command errors or never asserted their stated behavior. Require actual lint and empty-log output, an isolated clean-EOF hook response without audit decisions, offline status through the current command and a stubbed HTTP transport, and unchanged MCP forwarding for case-sensitive method names. Replace the obsolete status flag and leaking stdin pipe fixture.

Remove seven duplicate test functions and one duplicate subtest whose behavior remains covered by equivalent or stronger tests. The change affects only seven Go test files; runtime source, policy bytes, integrations, website assets, dependencies and CI workflows are unchanged.

Validation: full Go tests, vet and security assurance; focused repaired tests with race detection repeated ten times; an isolated compiled mutation confirms the MCP assertion detects dropped forwarding; independent review and diff checks. Exact-head platform and packaging CI must pass before integration into staging.
