### PR TITLE
fix(audit): recover from incomplete appends without losing prior records

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,10 @@ jobs:
       - name: Install Linux preload dependencies
         if: runner.os == 'Linux'
         run: |
-          sudo apt-get update
+          test -f /etc/apt/sources.list.d/ubuntu.sources
+          sudo apt-get update \
+            -o Dir::Etc::sourcelist=/etc/apt/sources.list.d/ubuntu.sources \
+            -o Dir::Etc::sourceparts=-
           sudo apt-get install --no-install-recommends libcurl4-openssl-dev
 
       - name: Download dependencies

--- a/internal/audit/jsonl.go
+++ b/internal/audit/jsonl.go
@@ -219,12 +219,20 @@ func managedAuditFiles(dir string) ([]string, error) {
 	return files, nil
 }
 
+type auditAppendFile interface {
+	io.Writer
+	Stat() (os.FileInfo, error)
+	Sync() error
+	Truncate(int64) error
+	Close() error
+}
+
 // JSONLSink is an append-only JSONL audit sink with hash chaining.
 type JSONLSink struct {
 	mu sync.Mutex
 
 	dir            string
-	file           *os.File
+	file           auditAppendFile
 	currentFile    string
 	currentSize    int64
 	lastHash       string
@@ -398,16 +406,8 @@ func (s *JSONLSink) Write(event Event) error {
 			}
 		}
 		eventStart := s.currentSize
-		if _, err := s.file.Write(line); err != nil {
+		if err := s.appendRecordLocked(line); err != nil {
 			return fmt.Errorf("audit: write event: %w", err)
-		}
-
-		s.currentSize += int64(len(line))
-
-		if s.fsync {
-			if err := s.file.Sync(); err != nil {
-				return fmt.Errorf("audit: fsync event: %w", err)
-			}
 		}
 
 		s.lastHash = encodedEvent.Hash
@@ -432,6 +432,49 @@ func (s *JSONLSink) Write(event Event) error {
 
 		return nil
 	})
+}
+
+// appendRecordLocked requires the directory lock. Only a partial append from
+// this write may be rolled back; existing corrupt records remain fail-closed.
+func (s *JSONLSink) appendRecordLocked(line []byte) error {
+	n, err := s.file.Write(line)
+	if n != len(line) {
+		if err == nil {
+			err = io.ErrShortWrite
+		}
+		if n > 0 && n < len(line) {
+			err = errors.Join(err, s.rollbackPartialAppendLocked(n))
+		}
+	}
+	if err != nil {
+		return err
+	}
+	s.currentSize += int64(n)
+	if s.fsync {
+		if err := s.file.Sync(); err != nil {
+			return fmt.Errorf("fsync record: %w", err)
+		}
+	}
+	return nil
+}
+
+func (s *JSONLSink) rollbackPartialAppendLocked(written int) error {
+	info, err := s.file.Stat()
+	if err != nil {
+		return fmt.Errorf("inspect partial append: %w", err)
+	}
+	if info.Size() != s.currentSize+int64(written) {
+		return fmt.Errorf("cannot roll back partial append: file size changed")
+	}
+	if err := s.file.Truncate(s.currentSize); err != nil {
+		return fmt.Errorf("roll back partial append: %w", err)
+	}
+	if s.fsync {
+		if err := s.file.Sync(); err != nil {
+			return fmt.Errorf("persist partial append rollback: %w", err)
+		}
+	}
+	return nil
 }
 
 // Flush flushes pending data to disk.

--- a/internal/audit/jsonl.go
+++ b/internal/audit/jsonl.go
@@ -507,16 +507,17 @@ func (s *JSONLSink) Close() error {
 	if s.file == nil {
 		return nil
 	}
+	var closeErr error
 	if s.fsync {
 		if err := s.file.Sync(); err != nil {
-			return fmt.Errorf("audit: close sync: %w", err)
+			closeErr = fmt.Errorf("audit: close sync: %w", err)
 		}
 	}
 	if err := s.file.Close(); err != nil {
-		return fmt.Errorf("audit: close sink file: %w", err)
+		closeErr = errors.Join(closeErr, fmt.Errorf("audit: close sink file: %w", err))
 	}
 	s.file = nil
-	return nil
+	return closeErr
 }
 
 func (s *JSONLSink) filePath() string {

--- a/internal/audit/jsonl_test.go
+++ b/internal/audit/jsonl_test.go
@@ -1262,6 +1262,7 @@ func TestJSONLSink_PartialAppendRollbackFailure(t *testing.T) {
 			require.NoError(t, sink.Write(sampleEvent("exec")))
 			prefix, err := os.ReadFile(sink.filePath())
 			require.NoError(t, err)
+			file := sink.file
 			sink.file = &partialAuditFile{auditAppendFile: sink.file, armed: true, writeError: syscall.ENOSPC,
 				truncateError: tc.truncateError, syncError: tc.syncError, extraWrite: tc.extraWrite}
 			err = sink.Write(sampleEvent("write"))
@@ -1276,6 +1277,9 @@ func TestJSONLSink_PartialAppendRollbackFailure(t *testing.T) {
 			require.NoError(t, err)
 			if tc.syncError != nil {
 				assert.Equal(t, prefix, after)
+				require.ErrorIs(t, sink.Close(), rollbackError)
+				_, err := file.Stat()
+				require.ErrorIs(t, err, os.ErrClosed, "a sync failure must not leak the audit file handle")
 				return
 			}
 			require.Greater(t, len(after), len(prefix))

--- a/internal/audit/jsonl_test.go
+++ b/internal/audit/jsonl_test.go
@@ -1278,8 +1278,7 @@ func TestJSONLSink_PartialAppendRollbackFailure(t *testing.T) {
 			if tc.syncError != nil {
 				assert.Equal(t, prefix, after)
 				require.ErrorIs(t, sink.Close(), rollbackError)
-				_, err := file.Stat()
-				require.ErrorIs(t, err, os.ErrClosed, "a sync failure must not leak the audit file handle")
+				require.ErrorIs(t, file.Close(), os.ErrClosed, "a sync failure must not leak the audit file handle")
 				return
 			}
 			require.Greater(t, len(after), len(prefix))

--- a/internal/audit/jsonl_test.go
+++ b/internal/audit/jsonl_test.go
@@ -17,6 +17,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"os"
@@ -27,6 +28,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -1182,23 +1184,149 @@ func TestJSONLSink_WriteCompactsOversizedDecisionFields(t *testing.T) {
 	assert.True(t, valid)
 }
 
-func TestJSONLSink_WriteErrorDoesNotUpdateHash(t *testing.T) {
-	dir := t.TempDir()
-	sink, err := NewJSONLSink(dir, WithFsync(false))
-	require.NoError(t, err)
+func TestJSONLSink_PartialAppendPreservesChain(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		header     bool
+		writeError error
+		wantError  error
+	}{
+		{name: "event ENOSPC", writeError: syscall.ENOSPC, wantError: syscall.ENOSPC},
+		{name: "event short write", wantError: io.ErrShortWrite},
+		{name: "rotation header ENOSPC", header: true, writeError: syscall.ENOSPC, wantError: syscall.ENOSPC},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			sink, err := NewJSONLSink(dir)
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = sink.Close() })
+			require.NoError(t, sink.Write(sampleEvent("exec")))
+			before := sink.currentSharedStateLocked()
+			previousFile := sink.currentFile
+			if tc.header {
+				require.NoError(t, sink.file.Close())
+				name, err := sink.nextRotatedFilenameLocked()
+				require.NoError(t, err)
+				require.NoError(t, sink.openNamedFileLocked(name))
+			}
+			prefix, err := os.ReadFile(sink.filePath())
+			require.NoError(t, err)
+			sink.file = &partialAuditFile{auditAppendFile: sink.file, armed: true, writeError: tc.writeError}
+			if tc.header {
+				err = sink.withDirectoryLock(func() error { return sink.writeChainContinuationLocked(previousFile) })
+			} else {
+				err = sink.Write(sampleEvent("write"))
+			}
+			require.ErrorIs(t, err, tc.wantError)
+			after, err := os.ReadFile(sink.filePath())
+			require.NoError(t, err)
+			assert.Equal(t, prefix, after, "only the uncommitted partial append may be removed")
+			assert.Equal(t, int64(len(prefix)), sink.currentSize)
+			assert.Equal(t, before.LastHash, sink.lastHash)
+			assert.Equal(t, before.EventCount, sink.eventCount)
+			count, err := VerifyManagedChain(dir)
+			require.NoError(t, err)
+			assert.Equal(t, int64(1), count)
 
-	// Write one good event.
-	require.NoError(t, sink.Write(sampleEvent("exec")))
-	hashAfterFirst := sink.lastHash
+			// A restarted writer and the original writer must both continue the
+			// retained chain without retrying or publishing the failed event.
+			reopened, err := NewJSONLSink(dir)
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = reopened.Close() })
+			require.NoError(t, reopened.Write(sampleEvent("read")))
+			require.NoError(t, sink.Write(sampleEvent("edit")))
+			count, err = VerifyManagedChain(dir)
+			require.NoError(t, err)
+			assert.Equal(t, int64(3), count)
+		})
+	}
+}
 
-	// Close the underlying file to cause a write error.
-	require.NoError(t, sink.Close())
+func TestJSONLSink_PartialAppendRollbackFailure(t *testing.T) {
+	rollbackError := errors.New("injected rollback failure")
+	for _, tc := range []struct {
+		name          string
+		truncateError error
+		syncError     error
+		extraWrite    bool
+	}{
+		{name: "truncate fails", truncateError: rollbackError},
+		{name: "rollback sync fails", syncError: rollbackError},
+		{name: "unexpected append", extraWrite: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			sink, err := NewJSONLSink(dir)
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = sink.Close() })
+			require.NoError(t, sink.Write(sampleEvent("exec")))
+			prefix, err := os.ReadFile(sink.filePath())
+			require.NoError(t, err)
+			sink.file = &partialAuditFile{auditAppendFile: sink.file, armed: true, writeError: syscall.ENOSPC,
+				truncateError: tc.truncateError, syncError: tc.syncError, extraWrite: tc.extraWrite}
+			err = sink.Write(sampleEvent("write"))
+			require.ErrorIs(t, err, syscall.ENOSPC)
+			if !tc.extraWrite {
+				require.ErrorIs(t, err, rollbackError)
+			} else {
+				require.ErrorContains(t, err, "size changed")
+			}
+			assert.Equal(t, int64(1), sink.eventCount)
+			after, err := os.ReadFile(sink.filePath())
+			require.NoError(t, err)
+			if tc.syncError != nil {
+				assert.Equal(t, prefix, after)
+				return
+			}
+			require.Greater(t, len(after), len(prefix))
+			assert.Equal(t, prefix, after[:len(prefix)])
+			_, err = NewJSONLSink(dir)
+			require.ErrorContains(t, err, "unterminated audit record")
+			unchanged, err := os.ReadFile(sink.filePath())
+			require.NoError(t, err)
+			assert.Equal(t, after, unchanged, "startup must not silently repair unexplained corruption")
+		})
+	}
+}
 
-	err = sink.Write(sampleEvent("exec"))
-	assert.Error(t, err)
+type partialAuditFile struct {
+	auditAppendFile
+	armed         bool
+	writeError    error
+	truncateError error
+	syncError     error
+	extraWrite    bool
+}
 
-	// lastHash should not have changed on error.
-	assert.Equal(t, hashAfterFirst, sink.lastHash)
+func (f *partialAuditFile) Write(p []byte) (int, error) {
+	if !f.armed {
+		return f.auditAppendFile.Write(p)
+	}
+	f.armed = false
+	n, err := f.auditAppendFile.Write(p[:min(7, len(p))])
+	if err != nil {
+		return n, err
+	}
+	if f.extraWrite {
+		if _, err := f.auditAppendFile.Write([]byte("unexpected")); err != nil {
+			return n, err
+		}
+	}
+	return n, f.writeError
+}
+
+func (f *partialAuditFile) Truncate(size int64) error {
+	if f.truncateError != nil {
+		return f.truncateError
+	}
+	return f.auditAppendFile.Truncate(size)
+}
+
+func (f *partialAuditFile) Sync() error {
+	if f.syncError != nil {
+		return f.syncError
+	}
+	return f.auditAppendFile.Sync()
 }
 
 func sampleEvent(tool string) Event {

--- a/internal/audit/path_security.go
+++ b/internal/audit/path_security.go
@@ -9,12 +9,38 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"github.com/peg/rampart/internal/filetxn"
 	"github.com/peg/rampart/internal/securefile"
 )
 
 const maxAuditMetadataBytes = 1024 * 1024
+
+type auditAppendHandle struct {
+	*os.File
+}
+
+func (f *auditAppendHandle) Truncate(size int64) error {
+	if runtime.GOOS != "windows" {
+		return f.File.Truncate(size)
+	}
+	// Go's Windows append handles lack FILE_WRITE_DATA, which truncation
+	// requires. Reopen without O_APPEND and verify the original file identity.
+	before, err := f.Stat()
+	if err != nil {
+		return err
+	}
+	file, err := openAuditRegular(f.Name(), os.O_WRONLY)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	if err := validateOpenAuditFile(f.Name(), file, before); err != nil {
+		return err
+	}
+	return file.Truncate(size)
+}
 
 // validateAuditDirectory rejects a symlink or non-directory at the audit root.
 // We intentionally validate the configured leaf rather than every ancestor:

--- a/internal/audit/rotate.go
+++ b/internal/audit/rotate.go
@@ -102,7 +102,7 @@ func (s *JSONLSink) openNamedFileLocked(name string) error {
 			return fmt.Errorf("audit: persist jsonl directory entry: %w", err)
 		}
 	}
-	s.file = file
+	s.file = &auditAppendHandle{File: file}
 	s.currentFile = name
 	s.currentSize = info.Size()
 	return nil
@@ -120,16 +120,8 @@ func (s *JSONLSink) writeChainContinuationLocked(prevFile string) error {
 	}
 
 	line = append(line, '\n')
-	if _, err := s.file.Write(line); err != nil {
+	if err := s.appendRecordLocked(line); err != nil {
 		return fmt.Errorf("audit: write chain continuation: %w", err)
-	}
-
-	s.currentSize += int64(len(line))
-	if !s.fsync {
-		return nil
-	}
-	if err := s.file.Sync(); err != nil {
-		return fmt.Errorf("audit: fsync chain continuation: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
A partial audit append, such as an out-of-space write, can leave an unterminated record that keeps subsequent tool actions blocked even after storage is available again. Roll back only the incomplete bytes from the current append while holding the audit directory lock, and continue returning the write failure so the affected action stays denied.

Apply the same handling to rotation headers. On Windows, reopen the append file with truncation access and verify its identity before shortening it. Also close the file handle when the final sync fails, while preserving the error. Existing unexplained corruption remains fail-closed; this does not repair previously damaged logs.

Scope Linux preload package-index refresh to Ubuntu sources. This removes an unrelated third-party repository dependency from setup while retaining package integrity checks and every existing CI job.

Validation:

- The regression failed before the fix and passes afterward, covering short writes, continuation headers, restarted and multiple writers, rollback failures, preservation of earlier records, and handle cleanup after a sync failure.
- `go test ./...`, `go vet ./...`, `make security-assurance`, focused audit race tests, and `git diff --check` pass locally.
- An isolated installed OpenClaw flow passed upgrade/configuration preservation, native approvals, service unavailability, actual audit ENOSPC with the action blocked, successful continuation after space was freed, and continuation after restart. A scripted protocol peer drove the real host; no model inference was involved.
- Full Linux (race suite), macOS, Windows, container, cross-platform packaging, Python SDK, and CI gate checks passed on `450e367076bcf8f3c344a9e208b0ea557e7b5b33`: https://github.com/peg/rampart/actions/runs/34384255107. Workflow syntax also passed actionlint.
