### PR TITLE
fix: keep assurance and posture claims within observed evidence

### DIFF
--- a/cmd/rampart/cli/assurance_status.go
+++ b/cmd/rampart/cli/assurance_status.go
@@ -306,6 +306,15 @@ func integrationEnvironmentFingerprintAt(driver integrationDriver, home, policyE
 		}
 		fmt.Fprintf(hash, "%s:%s:%d:%d\n", executable, resolved, info.Size(), info.ModTime().UnixNano())
 	}
+	if driver.OpenClaw {
+		config, err := openClawAssuranceConfiguration()
+		if err != nil {
+			return "", fmt.Errorf("inspect OpenClaw enforcement configuration: %w", err)
+		}
+		if err := json.NewEncoder(hash).Encode(config); err != nil {
+			return "", fmt.Errorf("fingerprint OpenClaw enforcement configuration: %w", err)
+		}
+	}
 	policyDir := filepath.Join(home, ".rampart", "policies")
 	entries, err := os.ReadDir(policyDir)
 	if err != nil {
@@ -347,6 +356,66 @@ func integrationEnvironmentFingerprintAt(driver integrationDriver, home, policyE
 		}
 	}
 	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+// Only the owned enforcement settings enter the receipt fingerprint. Provider
+// configuration and other plugins are not evidence for this verifier, and
+// included provider files must not be traversed just to refresh local status.
+type openClawAssuranceConfig struct {
+	PluginCurrent bool   `json:"plugin_current"`
+	ExecMode      string `json:"exec_mode"`
+	Plugin        struct {
+		Enabled           *bool    `json:"enabled"`
+		ServeURL          string   `json:"serveUrl"`
+		TimeoutMS         *float64 `json:"timeoutMs"`
+		FailOpen          *bool    `json:"failOpen"`
+		FailOpenTools     []string `json:"failOpenTools"`
+		ApprovalTimeoutMS *float64 `json:"approvalTimeoutMs"`
+	} `json:"plugin"`
+}
+
+func openClawAssuranceConfiguration() (openClawAssuranceConfig, error) {
+	var config openClawAssuranceConfig
+	bin, _ := findOpenClawBinary()
+	stateDir, configPath, err := resolveOpenClawStateDir(bin)
+	if err != nil {
+		return config, err
+	}
+	execConfig, err := readVerifiedOpenClawExecConfigAt(configPath)
+	if err != nil {
+		return config, fmt.Errorf("managed exec settings are unavailable or invalid")
+	}
+	config.ExecMode = openClawExecPolicyIdentity(execConfig)
+	config.PluginCurrent = openClawPluginCurrent(getOpenClawPluginStateAt(stateDir, configPath))
+	plugins, err := loadOpenClawPluginsConfig(configPath)
+	if err != nil {
+		return config, fmt.Errorf("managed plugin settings are unavailable or invalid")
+	}
+	entries, ok := plugins["entries"].(map[string]any)
+	if !ok {
+		return config, fmt.Errorf("managed plugin entry is unavailable or invalid")
+	}
+	entry, ok := entries["rampart"].(map[string]any)
+	if !ok {
+		return config, fmt.Errorf("managed plugin entry is unavailable or invalid")
+	}
+	settings, ok := entry["config"].(map[string]any)
+	if !ok {
+		return config, fmt.Errorf("managed plugin configuration is unavailable or invalid")
+	}
+	data, err := json.Marshal(settings)
+	if err != nil {
+		return config, fmt.Errorf("managed plugin configuration is invalid")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&config.Plugin); err != nil {
+		return config, fmt.Errorf("managed plugin configuration is invalid")
+	}
+	if validateCredentialEndpoint(config.Plugin.ServeURL, "file") != nil {
+		return config, fmt.Errorf("managed plugin endpoint is invalid")
+	}
+	return config, nil
 }
 
 func collectIntegrationAssuranceStatuses(now time.Time, serverRunning bool) []integrationAssuranceStatus {

--- a/cmd/rampart/cli/assurance_status_test.go
+++ b/cmd/rampart/cli/assurance_status_test.go
@@ -4,11 +4,14 @@
 package cli
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	ocplugin "github.com/peg/rampart/internal/plugin/openclaw"
 
 	hermesplugin "github.com/peg/rampart/internal/plugin/hermes"
 )
@@ -83,6 +86,143 @@ func TestVerificationReceiptInvalidatesAfterConfigurationChange(t *testing.T) {
 	if status.AssuranceLevel == assuranceAdapterVerified || status.StaleReason != "integration environment changed since verification" {
 		t.Fatalf("stale Codex assurance status = %#v", status)
 	}
+}
+
+func TestOpenClawReceiptInvalidatesOwnedConfigurationDrift(t *testing.T) {
+	for _, tc := range []struct {
+		name, file, before, after string
+	}{
+		{"fail open", "plugins.json", `"failOpen":false`, `"failOpen":true `},
+		{"plugin disabled", "plugins.json", `"enabled":true`, `"enabled":null`},
+		{"policy timeout", "plugins.json", `"timeoutMs":3000`, `"timeoutMs":4000`},
+		{"approval timeout", "plugins.json", `"approvalTimeoutMs":120000`, `"approvalTimeoutMs":240000`},
+		{"plugin endpoint", "plugins.json", `localhost:9090`, `localhost:9999`},
+		{"malformed plugin setting", "plugins.json", `"failOpen":false`, `"failOpen":"bad"`},
+		{"exec mode", "tools.json", `"full"`, `"auto"`},
+		{"invalid exec mode", "tools.json", `"full"`, `"oops"`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			stateDir := installOpenClawAssuranceFixture(t, home)
+			now := time.Now().UTC().Truncate(time.Second)
+			if err := writeVerificationReceipt(passingAssuranceReport("openclaw", now)); err != nil {
+				t.Fatal(err)
+			}
+			status, ok := findAssuranceStatus(collectIntegrationAssuranceStatuses(now, true), "openclaw")
+			if !ok || status.AssuranceLevel != assuranceHostVerified {
+				t.Fatalf("initial assurance = %#v, found=%t", status, ok)
+			}
+			path := filepath.Join(stateDir, tc.file)
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			changed := bytes.Replace(data, []byte(tc.before), []byte(tc.after), 1)
+			if bytes.Equal(data, changed) || len(data) != len(changed) {
+				t.Fatal("fixture must change content without changing file size")
+			}
+			info, err := os.Stat(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(path, changed, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Chtimes(path, info.ModTime(), info.ModTime()); err != nil {
+				t.Fatal(err)
+			}
+			status, ok = findAssuranceStatus(collectIntegrationAssuranceStatuses(now.Add(time.Minute), true), "openclaw")
+			if !ok || status.AssuranceLevel == assuranceHostVerified || status.StaleReason != "integration environment changed since verification" {
+				t.Fatalf("drifted assurance = %#v, found=%t", status, ok)
+			}
+		})
+	}
+}
+
+func TestOpenClawReceiptInvalidatesPluginContentDrift(t *testing.T) {
+	home := t.TempDir()
+	stateDir := installOpenClawAssuranceFixture(t, home)
+	now := time.Now().UTC().Truncate(time.Second)
+	if err := writeVerificationReceipt(passingAssuranceReport("openclaw", now)); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(stateDir, openclawPluginDir, "index.js")
+	file, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, writeErr := file.WriteString("\n// modified installation\n")
+	closeErr := file.Close()
+	if writeErr != nil || closeErr != nil {
+		t.Fatalf("modify plugin: write=%v close=%v", writeErr, closeErr)
+	}
+	status, ok := findAssuranceStatus(collectIntegrationAssuranceStatuses(now.Add(time.Minute), true), "openclaw")
+	if !ok || status.AssuranceLevel == assuranceHostVerified || status.StaleReason != "integration environment changed since verification" {
+		t.Fatalf("modified plugin assurance = %#v, found=%t", status, ok)
+	}
+}
+
+func TestOpenClawReceiptIgnoresUnrelatedConfiguration(t *testing.T) {
+	home := t.TempDir()
+	stateDir := installOpenClawAssuranceFixture(t, home)
+	now := time.Now().UTC().Truncate(time.Second)
+	if err := writeVerificationReceipt(passingAssuranceReport("openclaw", now)); err != nil {
+		t.Fatal(err)
+	}
+	// A provider include is deliberately unreadable as JSON. Status must not
+	// traverse it, nor fingerprint provider values or another plugin's settings.
+	if err := os.WriteFile(filepath.Join(stateDir, "providers.json"), []byte("synthetic-private-provider-state"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(stateDir, "plugins.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data = bytes.Replace(data, []byte(`"other-plugin":{"enabled":false}`), []byte(`"other-plugin":{"enabled":true}`), 1)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	status, ok := findAssuranceStatus(collectIntegrationAssuranceStatuses(now.Add(time.Minute), true), "openclaw")
+	if !ok || status.AssuranceLevel != assuranceHostVerified || status.StaleReason != "" {
+		t.Fatalf("unrelated configuration invalidated assurance: %#v, found=%t", status, ok)
+	}
+	receiptPath, err := verificationReceiptPath("openclaw")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err = os.ReadFile(receiptPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, private := range []string{home, "private-provider", "provider-token", "other-plugin", "localhost:9090"} {
+		if bytes.Contains(data, []byte(private)) {
+			t.Fatalf("receipt retained configuration detail %q", private)
+		}
+	}
+}
+
+func installOpenClawAssuranceFixture(t *testing.T, home string) string {
+	t.Helper()
+	testSetHome(t, home)
+	testSetOpenClawBinary(t, home)
+	stateDir := filepath.Join(home, ".openclaw")
+	t.Setenv("OPENCLAW_STATE_DIR", stateDir)
+	t.Setenv("OPENCLAW_CONFIG_PATH", filepath.Join(stateDir, "openclaw.json"))
+	if err := ocplugin.Extract(filepath.Join(stateDir, openclawPluginDir)); err != nil {
+		t.Fatal(err)
+	}
+	for name, content := range map[string]string{
+		"openclaw.json":  `{"tools":{"$include":"tools.json"},"plugins":{"$include":"plugins.json"},"models":{"$include":"providers.json"}}`,
+		"tools.json":     `{"exec":{"mode":"full"}}`,
+		"plugins.json":   `{"allow":["rampart"],"entries":{"rampart":{"config":{"enabled":true,"failOpen":false,"failOpenTools":[],"timeoutMs":3000,"approvalTimeoutMs":120000,"serveUrl":"http://localhost:9090"}},"other-plugin":{"enabled":false}}}`,
+		"providers.json": `{"credential":"synthetic-provider-token"}`,
+	} {
+		if err := os.WriteFile(filepath.Join(stateDir, name), []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return stateDir
 }
 
 func TestVerificationReceiptInvalidatesAfterPolicyChange(t *testing.T) {

--- a/cmd/rampart/cli/report.go
+++ b/cmd/rampart/cli/report.go
@@ -128,15 +128,15 @@ func newReportComplianceCmd(rootOpts *rootOptions, defaultAuditDir string) *cobr
 		Short: "Generate security posture report",
 		Long: `Generate a security posture report from audit logs.
 
-This report evaluates how well your Rampart deployment enforces key
-agent security controls. It can be shared with security teams as
-supporting evidence for compliance efforts.
+This report summarizes local audit and policy evidence. It does not certify
+enforcement, human oversight, or compliance. WARN identifies evidence that
+requires further review, not a reason to weaken policy.
 
 Controls evaluated:
-  RC-1 Tool Call Authorization  — All tool calls evaluated against policy
-  RC-2 Audit Logging            — Tamper-evident audit chain maintained
-  RC-3 Human-in-the-Loop        — Sensitive ops require human approval
-  RC-4 Data Exfiltration Prev.  — Credential/sensitive path access blocked
+  RC-1 Tool Call Authorization  — Audit events observed; host coverage unproven
+  RC-2 Audit Logging            — Local hash chain and present anchors checked
+  RC-3 Human-in-the-Loop        — Approval requests observed; oversight unproven
+  RC-4 Data Exfiltration Prev.  — Policy keywords observed; enforcement unproven
 
 Note: a fresh installation with no audit history will show FAIL.
 Run Rampart with an agent to generate audit logs, then re-run this report.

--- a/docs-site/guides/compliance.md
+++ b/docs-site/guides/compliance.md
@@ -4,157 +4,69 @@ title: Security Posture Report
 
 # Security Posture Report
 
-`rampart report compliance` generates a security posture report that evaluates how well your Rampart deployment enforces key agent security controls.
+`rampart report compliance` summarizes local audit and policy evidence. It does
+not certify enforcement, human oversight, or compliance with an external
+standard. The `compliance` command name remains for compatibility.
 
-## What it checks
-
-The report evaluates four areas of Rampart's enforcement:
-
-| Control | Name | What it checks |
-|---------|------|----------------|
-| RC-1 | Tool Call Authorization | Observed Rampart decisions show policy evaluation at the configured boundary |
-| RC-2 | Audit Logging | A tamper-evident audit chain is maintained |
-| RC-3 | Human-in-the-Loop | Sensitive operations require human approval |
-| RC-4 | Data Exfiltration Prevention | Credential and sensitive path access is blocked |
-
-These are Rampart's own controls — they are not part of an external compliance standard. If your organization needs to comply with frameworks like [AIUC-1](https://aiuc-1.com), [SOC 2](https://www.aicpa.org/soc2), or [NIST AI RMF](https://www.nist.gov/artificial-intelligence/risk-management-framework), this report can serve as supporting evidence but does not constitute certification.
-
-## Generating a report
+## Generate a report
 
 ```bash
 rampart report compliance
+rampart report compliance --since 2026-02-01 --until 2026-02-28
+rampart report compliance --format json --output posture-report.json
 ```
 
-Example output (with audit logs):
+Dates use `YYYY-MM-DD`. The default reporting period is the last 30 days.
+The JSON report includes the period, Rampart version, decision counts and
+per-control evidence. Review it before sharing: evidence can include local
+audit and policy paths.
 
-```
-Rampart Security Posture Report
-================================
-This report evaluates how well your Rampart deployment enforces key
-agent security controls.
-Learn more: https://docs.rampart.sh/guides/compliance/
+## What the controls establish
 
-Report ID: 3a1e1cc1-09b5-4641-b502-3ef8b1f9fc29
-Generated: 2026-02-28T22:08:48Z
-Period: 2026-01-29 to 2026-02-28
-Rampart Version: v0.8.1
-Standard: Rampart Security Posture
-Overall Status: PASS
+| Control | Evidence collected | Limit |
+|---------|--------------------|-------|
+| RC-1 — Tool Call Authorization | Audit events within the reporting period | Events do not prove that every host action was evaluated or that the host enforced each decision. |
+| RC-2 — Audit Logging | Hash-chain validation across available audit files, plus consistency checks for any local anchors | Local consistency does not establish that all original events or anchors are present. |
+| RC-3 — Human-in-the-Loop | Number of `ask` and legacy `require_approval` decisions | A request does not prove that a human reviewed or resolved it, or that the host enforced the result. |
+| RC-4 — Data Exfiltration Prevention | Sensitive-path keywords near deny text in the supplied policy file | This heuristic does not validate policy syntax, loaded configuration, rule matching, or actual prevention. |
 
-Decision Counts
----------------
-Total: 1,247
-Allow: 1,089 (87%)
-Deny: 143 (11%)
-Ask: 15 (1%)
+RC-1, RC-3 and RC-4 report **WARN** when evidence is available because those
+observations cannot prove enforcement. Finding more requests or policy keywords
+does not turn them into a passing assurance claim. RC-2 can report **PASS** when
+the available local chain and anchors validate.
 
-Controls
---------
-RC-1 PASS Tool Call Authorization
- - 1,247 tool calls evaluated against policy
- - 0 tool calls bypassed policy evaluation
-
-RC-2 PASS Audit Logging
- - Audit chain verified: 1,247 events, 0 hash mismatches
-
-RC-3 PASS Human-in-the-Loop
- - 15 ask decisions recorded in reporting period
-
-RC-4 PASS Data Exfiltration Prevention
- - Policy covers: /etc/shadow, ~/.ssh/*, *.env, ~/.aws/credentials
-```
+An otherwise healthy installation will therefore normally produce an overall
+**PARTIAL** result. This means additional evidence is needed; it is not a reason
+to weaken policy. A deployment that denies every forbidden action may correctly
+have no approval requests.
 
 ## Status levels
 
 | Status | Meaning |
 |--------|---------|
-| PASS | All four controls pass |
-| PARTIAL | Some controls pass, some warn |
-| FAIL | One or more controls fail |
+| PASS | The stated check passed within its documented boundary. |
+| WARN | The evidence is missing or insufficient to establish the control. |
+| PARTIAL | Overall result when at least one control warns and none fail. |
+| FAIL | A required local check failed or audit logs were unavailable. |
 
-!!! note
-    A fresh installation with no audit history will show FAIL. This is expected — run Rampart with an agent to generate audit logs, then re-run the report.
+A fresh installation without audit logs reports FAIL because there is no audit
+chain to inspect. An empty, valid audit file can pass chain validation while the
+other controls remain unproven.
 
-## Date ranges
+## Follow up on the evidence
 
-Scope the report to a specific period:
+- **RC-1:** Check installation with `rampart doctor`, then validate harmless
+  allowed and denied actions through the actual host. Consult the
+  [support matrix](../getting-started/support-matrix.md) for each verifier's limits.
+- **RC-2:** Run `rampart audit verify` to inspect local chain integrity. For
+  evidence held outside the local machine, see
+  [external witnessing](../features/external-witness.md).
+- **RC-3:** Validate complete redacted review, denial, expiry and allow-once
+  behavior through the host's approval flow. Keep deny rules for actions that
+  must remain forbidden; do not replace them with asks to improve report counts.
+- **RC-4:** Review the active policy and safely verify representative
+  sensitive-path denials. A matching keyword is not proof that a rule applies.
 
-```bash
-rampart report compliance --since 2026-02-01
-rampart report compliance --since 2026-02-01 --until 2026-02-28
-```
-
-Dates use `YYYY-MM-DD` format. The default period is the last 30 days.
-
-## JSON output
-
-For CI pipelines or tooling integrations:
-
-```bash
-rampart report compliance --format json
-rampart report compliance --format json --output posture-report.json
-```
-
-JSON output includes the full evidence array per control, suitable for internal audits or sharing with security teams.
-
-## What each control evaluates
-
-### RC-1 — Tool Call Authorization
-
-Checks that Rampart is actively evaluating tool calls. Passes if:
-- Audit logs exist with allow or deny decisions
-- No evidence of policy bypass
-
-This is evidence about calls present in Rampart's audit period, not proof that
-the host exposed every possible action to Rampart.
-
-### RC-2 — Audit Logging
-
-Verifies the tamper-evident hash chain in audit logs. Each event's hash covers the previous event's hash — if any event is modified or deleted, chain verification fails.
-
-### RC-3 — Human-in-the-Loop
-
-Checks that `ask` decisions exist in the audit log during the period. Passes if at least one human approval was requested.
-
-If all sensitive operations are auto-denied rather than asking for approval, this control will warn. Consider using `action: ask` for borderline operations.
-
-### RC-4 — Data Exfiltration Prevention
-
-Checks that the active policy contains rules blocking access to credential paths (`/etc/shadow`, `~/.ssh/*`, `*.env`, `~/.aws/credentials`, etc.).
-
-This check uses keyword proximity heuristics on the policy file — manual review of your policy is recommended for full assurance.
-
-## Sharing with security teams
-
-The JSON report includes:
-
-- Report ID (UUID for tracking)
-- Generation timestamp and Rampart version
-- Audit period and decision counts
-- Per-control status and evidence array
-- Chain verification result
-
-Export and share:
-
-```bash
-rampart report compliance --format json --output posture-$(date +%Y-%m-%d).json
-```
-
-## Improving your posture
-
-1. **RC-1**: Ensure Rampart hooks are installed and active (`rampart doctor`)
-2. **RC-2**: Ensure audit logging is enabled (on by default)
-3. **RC-3**: Use `action: ask` for sensitive operations instead of always-deny
-4. **RC-4**: Use `rampart init --profile standard` or ensure your policy covers credential paths
-
-Run `rampart doctor` to verify your setup before generating a report.
-
-## Relationship to compliance frameworks
-
-Rampart's security posture report is designed to provide evidence that can support compliance with external frameworks:
-
-- **[AIUC-1](https://aiuc-1.com)**: Tool call authorization, audit logging, and human oversight align with AIUC-1's security and accountability principles
-- **SOC 2**: Tamper-evident audit chain and access controls support Trust Services Criteria
-- **NIST AI RMF**: Policy enforcement and monitoring support the Govern and Measure functions
-
-However, Rampart does not certify compliance with any external standard. Compliance determinations require assessment by qualified auditors against the full requirements of each framework.
+The report can support an organization's assessment alongside deployment
+configuration and behavioral evidence. It cannot make a compliance determination
+on its own.

--- a/internal/report/compliance.go
+++ b/internal/report/compliance.go
@@ -217,9 +217,12 @@ func (r *PostureReport) applyAuditControlResults(auditDir string, auditFiles []s
 
 	if len(periodEvents) > 0 {
 		r.Controls["RC-1"] = ComplianceControl{
-			Name:     "Tool Call Authorization",
-			Status:   ControlStatusPass,
-			Evidence: []string{fmt.Sprintf("Found %d audited tool-call events in reporting period.", len(periodEvents))},
+			Name:   "Tool Call Authorization",
+			Status: ControlStatusWarn,
+			Evidence: []string{
+				fmt.Sprintf("Found %d audit events in reporting period.", len(periodEvents)),
+				"Recorded events do not prove that every host action was evaluated or that the host enforced each decision.",
+			},
 		}
 	} else {
 		r.Controls["RC-1"] = ComplianceControl{
@@ -233,15 +236,18 @@ func (r *PostureReport) applyAuditControlResults(auditDir string, auditFiles []s
 
 	if counts.Ask > 0 {
 		r.Controls["RC-3"] = ComplianceControl{
-			Name:     "Human-in-the-Loop",
-			Status:   ControlStatusPass,
-			Evidence: []string{fmt.Sprintf("Found %d ask decisions in reporting period.", counts.Ask)},
+			Name:   "Human-in-the-Loop",
+			Status: ControlStatusWarn,
+			Evidence: []string{
+				fmt.Sprintf("Found %d approval requests (ask decisions) in reporting period.", counts.Ask),
+				"An approval request does not prove that a human reviewed or resolved it, or that the host enforced the result.",
+			},
 		}
 	} else {
 		r.Controls["RC-3"] = ComplianceControl{
 			Name:     "Human-in-the-Loop",
 			Status:   ControlStatusWarn,
-			Evidence: []string{"No ask decisions found in reporting period."},
+			Evidence: []string{"No approval requests (ask decisions) found in reporting period. This does not indicate a policy weakness; denied actions may need no approval."},
 		}
 	}
 }
@@ -297,17 +303,16 @@ func (r *PostureReport) applyPolicyControlResult(policyPath string) {
 		return
 	}
 
-	// Note: evaluateSensitiveDenyCoverage uses keyword proximity heuristics,
-	// not semantic YAML parsing. Manual review of the policy file is recommended
-	// for full assurance that deny rules actually match the sensitive paths.
+	// This scan observes policy text, not a parsed or loaded enforcement policy.
+	// Keyword proximity cannot establish that any represented access is blocked.
 	covered, found, missing := evaluateSensitiveDenyCoverage(string(data))
-	heuristicNote := "Note: coverage check is keyword proximity heuristic — manual policy review recommended for full assurance."
+	heuristicNote := "Keyword proximity does not validate policy syntax, loaded configuration, rule matching, or prevention of data exfiltration."
 	if covered {
 		r.Controls["RC-4"] = ComplianceControl{
 			Name:   "Data Exfiltration Prevention",
-			Status: ControlStatusPass,
+			Status: ControlStatusWarn,
 			Evidence: []string{
-				fmt.Sprintf("Keyword proximity check passed for: %s", strings.Join(found, ", ")),
+				fmt.Sprintf("Found sensitive-path keywords near deny text for: %s", strings.Join(found, ", ")),
 				heuristicNote,
 			},
 		}
@@ -600,8 +605,8 @@ func FormatPostureTextReport(report *PostureReport) string {
 
 	_, _ = fmt.Fprintf(&b, "Rampart Security Posture Report\n")
 	_, _ = fmt.Fprintf(&b, "================================\n")
-	_, _ = fmt.Fprintf(&b, "This report evaluates how well your Rampart deployment enforces key\n")
-	_, _ = fmt.Fprintf(&b, "agent security controls.\n")
+	_, _ = fmt.Fprintf(&b, "This report summarizes local audit and policy evidence. It does not\n")
+	_, _ = fmt.Fprintf(&b, "certify enforcement, human oversight, or compliance.\n")
 	_, _ = fmt.Fprintf(&b, "Learn more: https://docs.rampart.sh/guides/compliance/\n\n")
 	_, _ = fmt.Fprintf(&b, "Report ID: %s\n", report.ReportID)
 	_, _ = fmt.Fprintf(&b, "Generated: %s\n", report.GeneratedAt.Format(time.RFC3339))
@@ -631,23 +636,23 @@ func FormatPostureTextReport(report *PostureReport) string {
 		}
 	}
 
-	// Remediation hints for non-compliant controls.
+	// Evidence gaps do not justify weakening policy or replacing user settings.
 	var remediations []string
 	if c, ok := report.Controls["RC-1"]; ok && c.Status != ControlStatusPass {
-		remediations = append(remediations, "RC-1: Run 'rampart doctor' to verify hooks are installed, then use an AI agent to generate audit events.")
+		remediations = append(remediations, "RC-1: Check installation with 'rampart doctor'; validate allow and deny behavior through the actual host boundary.")
 	}
 	if c, ok := report.Controls["RC-2"]; ok && c.Status == ControlStatusFail {
 		remediations = append(remediations, "RC-2: Run 'rampart audit verify' to inspect chain integrity. Old or manually-edited audit files can cause hash mismatches.")
 	}
 	if c, ok := report.Controls["RC-3"]; ok && c.Status != ControlStatusPass {
-		remediations = append(remediations, "RC-3: Use 'action: ask' (not 'action: deny') for sensitive operations so human approval events appear in the audit log.")
+		remediations = append(remediations, "RC-3: Validate complete action review and approval resolution through the host. Keep deny rules where actions must remain forbidden.")
 	}
 	if c, ok := report.Controls["RC-4"]; ok && c.Status != ControlStatusPass {
-		remediations = append(remediations, "RC-4: Run 'rampart init --profile standard --force' to ensure credential-blocking rules are active.")
+		remediations = append(remediations, "RC-4: Validate the active policy and safely check representative sensitive-path denials through the host; keyword matches alone are insufficient.")
 	}
 	if len(remediations) > 0 {
-		_, _ = fmt.Fprintf(&b, "\nRemediation\n")
-		_, _ = fmt.Fprintf(&b, "-----------\n")
+		_, _ = fmt.Fprintf(&b, "\nFollow-up checks\n")
+		_, _ = fmt.Fprintf(&b, "----------------\n")
 		for _, r := range remediations {
 			_, _ = fmt.Fprintf(&b, "  %s\n", r)
 		}

--- a/internal/report/compliance_test.go
+++ b/internal/report/compliance_test.go
@@ -39,13 +39,14 @@ func TestExpandHomePathAcceptsWindowsSeparator(t *testing.T) {
 	}
 }
 
-func TestGeneratePostureReport_Compliant(t *testing.T) {
+func TestGeneratePostureReportObservationsDoNotProveEnforcement(t *testing.T) {
 	dir := t.TempDir()
 	now := time.Date(2026, 2, 28, 12, 0, 0, 0, time.UTC)
 
 	events := makeEvents(t, now,
 		"allow",
 		"ask",
+		"approved",
 		"deny",
 	)
 	writeAuditFile(t, dir, "audit-20260228.jsonl", events)
@@ -78,23 +79,39 @@ policies:
 	if rep.Standard != "Rampart Security Posture" {
 		t.Fatalf("standard = %q, want Rampart Security Posture", rep.Standard)
 	}
-	if rep.Summary.ComplianceStatus != ComplianceStatusCompliant {
-		t.Fatalf("status = %s, want %s", rep.Summary.ComplianceStatus, ComplianceStatusCompliant)
+	if rep.Summary.ComplianceStatus != ComplianceStatusPartial {
+		t.Fatalf("status = %s, want %s", rep.Summary.ComplianceStatus, ComplianceStatusPartial)
 	}
-	if rep.Summary.DecisionCounts.Total != 3 || rep.Summary.DecisionCounts.Ask != 1 {
+	if rep.Summary.DecisionCounts.Total != 4 || rep.Summary.DecisionCounts.Ask != 1 {
 		t.Fatalf("unexpected decision counts: %+v", rep.Summary.DecisionCounts)
-	}
-	if rep.Controls["RC-1"].Status != ControlStatusPass {
-		t.Fatalf("RC-1 status = %s, want PASS", rep.Controls["RC-1"].Status)
 	}
 	if rep.Controls["RC-2"].Status != ControlStatusPass {
 		t.Fatalf("RC-2 status = %s, want PASS", rep.Controls["RC-2"].Status)
 	}
-	if rep.Controls["RC-3"].Status != ControlStatusPass {
-		t.Fatalf("RC-3 status = %s, want PASS", rep.Controls["RC-3"].Status)
+	for _, control := range []string{"RC-1", "RC-3", "RC-4"} {
+		if rep.Controls[control].Status != ControlStatusWarn {
+			t.Fatalf("%s status = %s, want WARN for observational evidence", control, rep.Controls[control].Status)
+		}
 	}
-	if rep.Controls["RC-4"].Status != ControlStatusPass {
-		t.Fatalf("RC-4 status = %s, want PASS", rep.Controls["RC-4"].Status)
+	if !strings.Contains(strings.Join(rep.Controls["RC-3"].Evidence, " "), "does not prove that a human reviewed or resolved it") {
+		t.Fatalf("approval requests and recorded resolutions must not imply oversight proof: %v", rep.Controls["RC-3"].Evidence)
+	}
+	text := FormatPostureTextReport(rep)
+	if !strings.Contains(text, "Keep deny rules") || strings.Contains(text, "--force") {
+		t.Fatalf("evidence follow-up must not weaken or replace policy: %s", text)
+	}
+}
+
+func TestPosturePolicyKeywordsCannotPassInvalidPolicy(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "policy.yaml")
+	if err := os.WriteFile(path, []byte("action: deny\n: [ invalid YAML /etc/shadow ~/.ssh/ .env credentials\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	report := &PostureReport{Controls: make(map[string]ComplianceControl)}
+	report.applyPolicyControlResult(path)
+	control := report.Controls["RC-4"]
+	if control.Status != ControlStatusWarn || !strings.Contains(strings.Join(control.Evidence, " "), "does not validate policy syntax") {
+		t.Fatalf("keyword presence must remain inconclusive: %#v", control)
 	}
 }
 


### PR DESCRIPTION
OpenClaw verification receipts previously missed changes to owned enforcement settings. Receipts now account for plugin configuration, managed exec policy and installed plugin integrity, while excluding unrelated provider state. Malformed owned settings invalidate the evidence.

Posture reports now distinguish observed audit activity and policy keywords from demonstrated enforcement or human oversight. RC-1, RC-3 and RC-4 remain WARN for those observations; RC-2 retains actual chain validation. Removed suggestions to weaken deny rules or force-replace policy, and updated CLI help and the posture guide.

Validation: full Go tests, vet, security assurance, focused configuration-drift/report regressions, strict docs build, canonical-document check and diff check passed. Regressions cover equal-size/equal-mtime changes and unrelated provider settings. Status remains a bounded local evidence cache, not a live host-dispatch attestation.
