### PR TITLE
fix: preserve complete actions through external approvals

### DIFF
--- a/cmd/rampart/cli/hook.go
+++ b/cmd/rampart/cli/hook.go
@@ -937,9 +937,7 @@ Cline setup: Use "rampart setup cline" to install hooks automatically.`,
 						autoDiscovered: serveAutoDiscovered,
 						errWriter:      cmd.ErrOrStderr(),
 					}
-					command, _ := call.Params["command"].(string)
-					path := call.Path() // handles both "file_path" (Claude Code) and "path"
-					result := approvalClient.requestApprovalCtx(cmd.Context(), call.Tool, command, call.Agent, path, call.RunID, call.ToolCallID, reasonMsg, 5*time.Minute)
+					result := approvalClient.requestApprovalCtx(cmd.Context(), call, reasonMsg, 5*time.Minute)
 					if result == hookAsk {
 						return fmt.Errorf("hook: ask.headless_only could not reach rampart serve approval flow; native ask fallback is disabled")
 					}
@@ -957,10 +955,8 @@ Cline setup: Use "rampart setup cline" to install hooks automatically.`,
 						autoDiscovered: serveAutoDiscovered,
 						errWriter:      cmd.ErrOrStderr(),
 					}
-					command, _ := call.Params["command"].(string)
-					path := call.Path()
 					registerCtx, cancelRegister := context.WithTimeout(cmd.Context(), 400*time.Millisecond)
-					if approvalID, regErr := approvalClient.registerAskAuditCtx(registerCtx, call.Tool, command, call.Agent, path, call.RunID, call.ToolCallID, reasonMsg); regErr == nil {
+					if approvalID, regErr := approvalClient.registerAskAuditCtx(registerCtx, call, reasonMsg); regErr == nil {
 						auditApprovalID = approvalID
 					} else {
 						logger.Debug("hook: ask audit registration failed (best-effort)", "error", regErr)
@@ -1001,10 +997,8 @@ Cline setup: Use "rampart setup cline" to install hooks automatically.`,
 						autoDiscovered: serveAutoDiscovered,
 						errWriter:      cmd.ErrOrStderr(),
 					}
-					command, _ := call.Params["command"].(string)
-					path := call.Path()
 					registerCtx, cancelRegister := context.WithTimeout(cmd.Context(), 400*time.Millisecond)
-					if approvalID, regErr := approvalClient.registerAskAuditCtx(registerCtx, call.Tool, command, call.Agent, path, call.RunID, call.ToolCallID, reasonMsg); regErr == nil {
+					if approvalID, regErr := approvalClient.registerAskAuditCtx(registerCtx, call, reasonMsg); regErr == nil {
 						auditApprovalID = approvalID
 					} else {
 						logger.Debug("hook: ask audit registration failed (best-effort)", "error", regErr)

--- a/cmd/rampart/cli/hook_approval.go
+++ b/cmd/rampart/cli/hook_approval.go
@@ -16,6 +16,9 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/peg/rampart/internal/approval"
+	"github.com/peg/rampart/internal/engine"
 )
 
 // hookApprovalClient delegates require_approval decisions to a running
@@ -29,22 +32,12 @@ type hookApprovalClient struct {
 	errWriter      io.Writer
 }
 
-// createApprovalRequest is the JSON body POSTed to POST /v1/approvals.
-type createApprovalRequest struct {
-	Tool       string `json:"tool"`
-	Command    string `json:"command,omitempty"`
-	Agent      string `json:"agent"`
-	Path       string `json:"path,omitempty"`
-	Message    string `json:"message"`
-	RunID      string `json:"run_id,omitempty"`
-	ToolCallID string `json:"tool_call_id,omitempty"`
-}
-
 // createApprovalResponse is the JSON returned from POST /v1/approvals.
 type createApprovalResponse struct {
-	ID        string `json:"id"`
-	Status    string `json:"status"`
-	ExpiresAt string `json:"expires_at"`
+	ActionVersion int    `json:"action_version"`
+	ID            string `json:"id"`
+	Status        string `json:"status"`
+	ExpiresAt     string `json:"expires_at"`
 }
 
 // pollApprovalResponse is the JSON returned from GET /v1/approvals/{id}.
@@ -53,21 +46,25 @@ type pollApprovalResponse struct {
 	Status string `json:"status"`
 }
 
+func decodeApprovalResponse(body io.Reader, target any) error {
+	const maxBytes = 1 << 20
+	data, err := io.ReadAll(io.LimitReader(body, maxBytes+1))
+	if err != nil {
+		return err
+	}
+	if len(data) > maxBytes {
+		return fmt.Errorf("approval response exceeds size limit")
+	}
+	return json.Unmarshal(data, target)
+}
+
 // requestApprovalCtx creates an approval and polls until resolved. The context
 // allows cancellation (for example, when the user presses Ctrl-C).
-func (c *hookApprovalClient) requestApprovalCtx(ctx context.Context, tool, command, agent, path, runID, toolCallID, message string, timeout time.Duration) hookDecisionType {
-	message = enrichApprovalMessage(message, command)
-
-	// Create the approval
-	body := createApprovalRequest{
-		Tool:       tool,
-		Command:    command,
-		Agent:      agent,
-		Path:       path,
-		Message:    message,
-		RunID:      runID,
-		ToolCallID: toolCallID,
-	}
+func (c *hookApprovalClient) requestApprovalCtx(ctx context.Context, call engine.ToolCall, message string, timeout time.Duration) hookDecisionType {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	message = enrichApprovalMessage(message, call.Command())
+	body := approval.NewExternalRequest(call, message)
 
 	data, err := json.Marshal(body)
 	if err != nil {
@@ -106,10 +103,8 @@ func (c *hookApprovalClient) requestApprovalCtx(ctx context.Context, tool, comma
 	// 200 means the approval was already resolved (auto-approve or bulk-resolve).
 	// Status field determines the outcome — don't assume approved.
 	if resp.StatusCode == http.StatusOK {
-		var autoResp struct {
-			Status string `json:"status"`
-		}
-		if err := json.NewDecoder(resp.Body).Decode(&autoResp); err == nil {
+		var autoResp createApprovalResponse
+		if err := decodeApprovalResponse(resp.Body, &autoResp); err == nil && autoResp.ActionVersion == approval.ExternalActionVersion && ctx.Err() == nil {
 			switch autoResp.Status {
 			case "approved":
 				c.logger.Debug("hook: run auto-approved by bulk-resolve, skipping queue")
@@ -121,20 +116,24 @@ func (c *hookApprovalClient) requestApprovalCtx(ctx context.Context, tool, comma
 			}
 		}
 		c.logger.Error("hook: unexpected 200 from approval create", "url", c.serveURL)
-		return hookAsk
+		return hookDeny
 	}
 
 	if resp.StatusCode != http.StatusCreated {
-		respBody, _ := io.ReadAll(resp.Body)
-		c.logger.Error("hook: create approval failed", "status", resp.StatusCode, "body", string(respBody))
+		c.logger.Error("hook: create approval failed", "status", resp.StatusCode)
 		fmt.Fprintf(c.stderrWriter(), "⚠ Rampart serve returned %d, falling back to native prompt\n", resp.StatusCode)
 		return hookAsk
 	}
 
 	var created createApprovalResponse
-	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+	if err := decodeApprovalResponse(resp.Body, &created); err != nil {
 		c.logger.Error("hook: decode approval response", "error", err)
 		return hookAsk
+	}
+
+	if created.ActionVersion != approval.ExternalActionVersion {
+		fmt.Fprintln(c.stderrWriter(), "Approval service cannot preserve the complete action; upgrade and restart rampart serve")
+		return hookDeny
 	}
 
 	// Guard against a serve bug returning 201 with an empty ID — polling
@@ -155,21 +154,19 @@ func (c *hookApprovalClient) requestApprovalCtx(ctx context.Context, tool, comma
 
 // pollApprovalCtx polls GET /v1/approvals/{id} every 500ms until resolved.
 func (c *hookApprovalClient) pollApprovalCtx(ctx context.Context, id string, timeout time.Duration) hookDecisionType {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
 	client := newRampartHTTPClient(5 * time.Second)
-	deadline := time.After(timeout)
 	ticker := time.NewTicker(500 * time.Millisecond)
 	defer ticker.Stop()
 
 	for {
 		select {
 		case <-ctx.Done():
-			fmt.Fprintf(c.stderrWriter(), "⚠ Approval cancelled\n")
-			return hookDeny
-		case <-deadline:
-			fmt.Fprintf(c.stderrWriter(), "⏰ Approval timed out — no response received within %s\n", timeout)
+			fmt.Fprintf(c.stderrWriter(), "⚠ Approval cancelled or timed out\n")
 			return hookDeny
 		case <-ticker.C:
-			req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%s/v1/approvals/%s", c.serveURL, id), nil)
+			req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%s/v1/approvals/%s", c.serveURL, url.PathEscape(id)), nil)
 			if err != nil {
 				continue
 			}
@@ -196,10 +193,16 @@ func (c *hookApprovalClient) pollApprovalCtx(ctx context.Context, id string, tim
 			}
 
 			var status pollApprovalResponse
-			err = json.NewDecoder(resp.Body).Decode(&status)
+			err = decodeApprovalResponse(resp.Body, &status)
 			resp.Body.Close()
-			if err != nil {
-				continue
+			if ctx.Err() != nil {
+				return hookDeny
+			}
+			if resp.StatusCode != http.StatusOK {
+				return hookDeny
+			}
+			if err != nil || status.ID != id {
+				return hookDeny
 			}
 
 			switch status.Status {
@@ -227,16 +230,8 @@ func (c *hookApprovalClient) stderrWriter() io.Writer {
 
 // registerAskAuditCtx creates a pending approval in serve for ask+audit
 // visibility, but does not wait for human resolution.
-func (c *hookApprovalClient) registerAskAuditCtx(ctx context.Context, tool, command, agent, path, runID, toolCallID, message string) (string, error) {
-	body := createApprovalRequest{
-		Tool:       tool,
-		Command:    command,
-		Agent:      agent,
-		Path:       path,
-		Message:    enrichApprovalMessage(message, command),
-		RunID:      runID,
-		ToolCallID: toolCallID,
-	}
+func (c *hookApprovalClient) registerAskAuditCtx(ctx context.Context, call engine.ToolCall, message string) (string, error) {
+	body := approval.NewExternalRequest(call, enrichApprovalMessage(message, call.Command()))
 	data, err := json.Marshal(body)
 	if err != nil {
 		return "", err
@@ -256,22 +251,16 @@ func (c *hookApprovalClient) registerAskAuditCtx(ctx context.Context, tool, comm
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusOK {
-		var autoResp struct {
-			ID string `json:"id"`
-		}
-		if err := json.NewDecoder(resp.Body).Decode(&autoResp); err != nil {
-			return "", err
-		}
-		return autoResp.ID, nil
-	}
-	if resp.StatusCode != http.StatusCreated {
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("create approval returned status %d", resp.StatusCode)
 	}
 
 	var created createApprovalResponse
-	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+	if err := decodeApprovalResponse(resp.Body, &created); err != nil {
 		return "", err
+	}
+	if created.ActionVersion != approval.ExternalActionVersion || created.ID == "" {
+		return "", fmt.Errorf("approval service did not acknowledge the complete action")
 	}
 	return created.ID, nil
 }

--- a/cmd/rampart/cli/hook_approval_integration_test.go
+++ b/cmd/rampart/cli/hook_approval_integration_test.go
@@ -1,0 +1,126 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/peg/rampart/internal/approval"
+	"github.com/peg/rampart/internal/audit"
+	"github.com/peg/rampart/internal/engine"
+	"github.com/peg/rampart/internal/proxy"
+	"github.com/stretchr/testify/require"
+)
+
+// Exercise both production endpoints: a client-only mock cannot detect a
+// server that accepts the request while silently discarding action fields.
+func TestHookApprovalClientServerContract(t *testing.T) {
+	dir := t.TempDir()
+	policy := filepath.Join(dir, "policy.yaml")
+	require.NoError(t, os.WriteFile(policy, []byte("version: '1'\ndefault_action: deny\npolicies: []\n"), 0600))
+	eng, err := engine.New(engine.NewFileStore(policy), testLogger())
+	require.NoError(t, err)
+	sink, err := audit.NewJSONLSink(filepath.Join(dir, "audit"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, sink.Close()) })
+	srv := proxy.New(eng, sink, proxy.WithToken("contract-test-token"), proxy.WithLogger(testLogger()))
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	served := make(chan error, 1)
+	go func() { served <- srv.Serve(listener) }()
+	base := "http://" + listener.Addr().String()
+	httpClient := &http.Client{Timeout: 5 * time.Second}
+	request := func(method, path string, value any) []byte {
+		t.Helper()
+		data, err := json.Marshal(value)
+		require.NoError(t, err)
+		req, err := http.NewRequest(method, base+path, bytes.NewReader(data))
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer contract-test-token")
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode, string(body))
+		return body
+	}
+	request("GET", "/healthz", nil) // server is installed before cleanup can run
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		require.NoError(t, srv.Shutdown(ctx))
+		require.NoError(t, <-served)
+	})
+	call := engine.ToolCall{
+		ID: "original-audit-event", Tool: "write", Agent: "codex", AgentDepth: 1,
+		Session: "session", RunID: "run", ToolCallID: "host-call", WorkDir: dir,
+		Params: map[string]any{"file_path": "first.txt", "content": "harmless marker", "targets": []any{"first.txt", "last.txt"}, "revision": json.Number("9007199254740993"), "password": "synthetic-private-value"},
+		Input:  map[string]any{"original_tool": "apply_patch"},
+	}
+	client := &hookApprovalClient{serveURL: base, token: "contract-test-token", logger: testLogger(), errWriter: io.Discard}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	result := make(chan hookDecisionType, 1)
+	go func() { result <- client.requestApprovalCtx(ctx, call, "review the complete write", 10*time.Second) }()
+	var pending *approval.Request
+	require.Eventually(t, func() bool {
+		items := srv.Approvals().List()
+		if len(items) == 1 {
+			pending = items[0]
+			return true
+		}
+		return false
+	}, 5*time.Second, 10*time.Millisecond)
+	view := request("GET", "/v1/approvals/"+pending.ID, nil)
+	var detail struct{ Action approval.ActionReview }
+	decoder := json.NewDecoder(bytes.NewReader(view))
+	decoder.UseNumber()
+	require.NoError(t, decoder.Decode(&detail))
+	require.Equal(t, call.ToolCallID, detail.Action.ToolCallID)
+	require.Equal(t, call.Session, detail.Action.Session)
+	require.Equal(t, call.RunID, detail.Action.RunID)
+	require.Equal(t, call.WorkDir, detail.Action.WorkDir)
+	require.Equal(t, call.AgentDepth, detail.Action.AgentDepth)
+	require.Equal(t, "harmless marker", detail.Action.Params["content"])
+	require.Equal(t, call.Params["targets"], detail.Action.Params["targets"])
+	require.Equal(t, call.Params["revision"], detail.Action.Params["revision"])
+	require.Equal(t, call.Input, detail.Action.Input)
+	require.NotContains(t, string(view), "synthetic-private-value")
+	request("POST", "/v1/approvals/"+pending.ID+"/resolve", map[string]any{"approved": true, "resolved_by": "contract-test"})
+	select {
+	case decision := <-result:
+		require.Equal(t, hookAllow, decision)
+	case <-time.After(5 * time.Second):
+		t.Fatal("approved hook did not resume")
+	}
+	require.NoError(t, sink.Flush())
+	files, err := filepath.Glob(filepath.Join(dir, "audit", "*.jsonl"))
+	require.NoError(t, err)
+	require.NotEmpty(t, files)
+	var resolutions []audit.Event
+	for _, path := range files {
+		events, _, err := audit.ReadEventsFromOffset(path, 0)
+		require.NoError(t, err)
+		for _, event := range events {
+			if event.Request["action"] == "approval_resolved" {
+				resolutions = append(resolutions, event)
+			}
+		}
+	}
+	require.Len(t, resolutions, 1)
+	require.Equal(t, call.ID, resolutions[0].Request["event_id"])
+	require.Equal(t, call.ToolCallID, resolutions[0].ToolCallID)
+	require.Equal(t, call.Session, resolutions[0].Session)
+}

--- a/cmd/rampart/cli/hook_approval_integration_test.go
+++ b/cmd/rampart/cli/hook_approval_integration_test.go
@@ -25,6 +25,12 @@ import (
 // Exercise both production endpoints: a client-only mock cannot detect a
 // server that accepts the request while silently discarding action fields.
 func TestHookApprovalClientServerContract(t *testing.T) {
+	for _, session := range []string{"project-session", ""} {
+		t.Run("session="+session, func(t *testing.T) { testHookApprovalClientServerContract(t, session) })
+	}
+}
+
+func testHookApprovalClientServerContract(t *testing.T, session string) {
 	dir := t.TempDir()
 	policy := filepath.Join(dir, "policy.yaml")
 	require.NoError(t, os.WriteFile(policy, []byte("version: '1'\ndefault_action: deny\npolicies: []\n"), 0600))
@@ -65,7 +71,7 @@ func TestHookApprovalClientServerContract(t *testing.T) {
 	})
 	call := engine.ToolCall{
 		ID: "original-audit-event", Tool: "write", Agent: "codex", AgentDepth: 1,
-		Session: "session", RunID: "run", ToolCallID: "host-call", WorkDir: dir,
+		Session: session, RunID: "run", ToolCallID: "host-call", WorkDir: dir,
 		Params: map[string]any{"file_path": "first.txt", "content": "harmless marker", "targets": []any{"first.txt", "last.txt"}, "revision": json.Number("9007199254740993"), "password": "synthetic-private-value"},
 		Input:  map[string]any{"original_tool": "apply_patch"},
 	}

--- a/cmd/rampart/cli/hook_approval_test.go
+++ b/cmd/rampart/cli/hook_approval_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -11,10 +12,61 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/peg/rampart/internal/engine"
+	"github.com/stretchr/testify/require"
 )
 
 func requestApprovalForTest(client *hookApprovalClient, tool, command, agent, path, runID, message string, timeout time.Duration) hookDecisionType {
-	return client.requestApprovalCtx(context.Background(), tool, command, agent, path, runID, "", message, timeout)
+	return client.requestApprovalCtx(context.Background(), engine.ToolCall{Tool: tool, Agent: agent, Session: "hook", RunID: runID, Params: map[string]any{"command": command, "path": path}}, message, timeout)
+}
+
+func TestHookApprovalRejectsUnacknowledgedOrInvalidResponses(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		createStatus int
+		createBody   string
+		pollBody     string
+	}{
+		{"old queued service", 201, `{"id":"approval","status":"pending"}`, ""},
+		{"old auto approving service", 200, `{"id":"approval","status":"approved"}`, ""},
+		{"malformed auto approval", 200, `{"action_version":1,"status":"approved"} {}`, ""},
+		{"oversized auto approval", 200, `{"action_version":1,"status":"approved"}` + strings.Repeat(" ", 1<<20), ""},
+		{"different approval", 201, `{"action_version":1,"id":"approval","status":"pending"}`, `{"id":"another-approval","status":"approved"}`},
+		{"malformed resolution", 201, `{"action_version":1,"id":"approval","status":"pending"}`, `{"id":"approval","status":"approved"} {}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == "POST" {
+					w.WriteHeader(tc.createStatus)
+					_, _ = io.WriteString(w, tc.createBody)
+					return
+				}
+				_, _ = io.WriteString(w, tc.pollBody)
+			}))
+			defer srv.Close()
+			client := &hookApprovalClient{serveURL: srv.URL, token: "synthetic", logger: testLogger(), errWriter: io.Discard}
+			require.Equal(t, hookDeny, requestApprovalForTest(client, "exec", "echo marker", "codex", "", "", "review", 3*time.Second))
+		})
+	}
+}
+
+func TestHookApprovalLateResolutionCannotAllow(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" {
+			w.WriteHeader(201)
+			_, _ = io.WriteString(w, `{"action_version":1,"id":"approval","status":"pending"}`)
+			return
+		}
+		cancel()
+		_, _ = io.WriteString(w, `{"id":"approval","status":"approved"}`)
+	}))
+	defer srv.Close()
+	client := &hookApprovalClient{serveURL: srv.URL, token: "synthetic", logger: testLogger(), errWriter: io.Discard}
+	call := engine.ToolCall{Tool: "exec", Agent: "codex", Session: "s", Params: map[string]any{"command": "echo marker"}}
+	require.Equal(t, hookDeny, client.requestApprovalCtx(ctx, call, "review", 3*time.Second))
 }
 
 func TestHookApprovalClient_Approved(t *testing.T) {
@@ -25,9 +77,10 @@ func TestHookApprovalClient_Approved(t *testing.T) {
 		case r.Method == "POST" && r.URL.Path == "/v1/approvals":
 			w.WriteHeader(http.StatusCreated)
 			json.NewEncoder(w).Encode(map[string]any{
-				"id":         "test-123",
-				"status":     "pending",
-				"expires_at": time.Now().Add(5 * time.Minute).Format(time.RFC3339),
+				"id":             "test-123",
+				"status":         "pending",
+				"action_version": 1,
+				"expires_at":     time.Now().Add(5 * time.Minute).Format(time.RFC3339),
 			})
 		case r.Method == "GET" && r.URL.Path == "/v1/approvals/test-123":
 			n := pollCount.Add(1)
@@ -63,9 +116,10 @@ func TestHookApprovalClient_Denied(t *testing.T) {
 		case r.Method == "POST" && r.URL.Path == "/v1/approvals":
 			w.WriteHeader(http.StatusCreated)
 			json.NewEncoder(w).Encode(map[string]any{
-				"id":         "test-456",
-				"status":     "pending",
-				"expires_at": time.Now().Add(5 * time.Minute).Format(time.RFC3339),
+				"id":             "test-456",
+				"status":         "pending",
+				"action_version": 1,
+				"expires_at":     time.Now().Add(5 * time.Minute).Format(time.RFC3339),
 			})
 		case r.Method == "GET" && r.URL.Path == "/v1/approvals/test-456":
 			json.NewEncoder(w).Encode(map[string]any{
@@ -136,9 +190,10 @@ func TestHookApprovalClient_AutoDiscoverApproved(t *testing.T) {
 		case r.Method == "POST" && r.URL.Path == "/v1/approvals":
 			w.WriteHeader(http.StatusCreated)
 			json.NewEncoder(w).Encode(map[string]any{
-				"id":         "auto-1",
-				"status":     "pending",
-				"expires_at": time.Now().Add(5 * time.Minute).Format(time.RFC3339),
+				"id":             "auto-1",
+				"status":         "pending",
+				"action_version": 1,
+				"expires_at":     time.Now().Add(5 * time.Minute).Format(time.RFC3339),
 			})
 		case r.Method == "GET" && r.URL.Path == "/v1/approvals/auto-1":
 			json.NewEncoder(w).Encode(map[string]any{
@@ -224,9 +279,10 @@ func TestHookApprovalClient_Timeout(t *testing.T) {
 		case r.Method == "POST" && r.URL.Path == "/v1/approvals":
 			w.WriteHeader(http.StatusCreated)
 			json.NewEncoder(w).Encode(map[string]any{
-				"id":         "test-789",
-				"status":     "pending",
-				"expires_at": time.Now().Add(5 * time.Minute).Format(time.RFC3339),
+				"id":             "test-789",
+				"status":         "pending",
+				"action_version": 1,
+				"expires_at":     time.Now().Add(5 * time.Minute).Format(time.RFC3339),
 			})
 		case r.Method == "GET" && r.URL.Path == "/v1/approvals/test-789":
 			// Always return pending

--- a/cmd/rampart/cli/hook_ask_audit_test.go
+++ b/cmd/rampart/cli/hook_ask_audit_test.go
@@ -38,7 +38,7 @@ policies:
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/approvals":
 			createCount.Add(1)
 			w.WriteHeader(http.StatusCreated)
-			_ = json.NewEncoder(w).Encode(map[string]any{"id": "a1", "status": "pending"})
+			_ = json.NewEncoder(w).Encode(map[string]any{"action_version": 1, "id": "a1", "status": "pending"})
 		default:
 			http.NotFound(w, r)
 		}
@@ -103,7 +103,7 @@ policies:
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/approvals":
 			createCount.Add(1)
 			w.WriteHeader(http.StatusCreated)
-			_ = json.NewEncoder(w).Encode(map[string]any{"id": "ap-alias-1", "status": "pending"})
+			_ = json.NewEncoder(w).Encode(map[string]any{"action_version": 1, "id": "ap-alias-1", "status": "pending"})
 		default:
 			http.NotFound(w, r)
 		}
@@ -173,12 +173,12 @@ policies:
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/approvals":
 			createCount.Add(1)
 			w.WriteHeader(http.StatusCreated)
-			_ = json.NewEncoder(w).Encode(map[string]any{"id": "ap-audit-1", "status": "pending"})
+			_ = json.NewEncoder(w).Encode(map[string]any{"action_version": 1, "id": "ap-audit-1", "status": "pending"})
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/approvals/ap-audit-1/resolve":
 			resolveCount.Add(1)
 			_ = json.NewDecoder(r.Body).Decode(&lastResolveBody)
 			w.WriteHeader(http.StatusOK)
-			_ = json.NewEncoder(w).Encode(map[string]any{"id": "ap-audit-1", "status": "approved"})
+			_ = json.NewEncoder(w).Encode(map[string]any{"action_version": 1, "id": "ap-audit-1", "status": "approved"})
 		default:
 			http.NotFound(w, r)
 		}
@@ -252,12 +252,12 @@ policies:
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/approvals":
 			createCount.Add(1)
 			w.WriteHeader(http.StatusCreated)
-			_ = json.NewEncoder(w).Encode(map[string]any{"id": "ap-audit-denied-1", "status": "pending"})
+			_ = json.NewEncoder(w).Encode(map[string]any{"action_version": 1, "id": "ap-audit-denied-1", "status": "pending"})
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/approvals/ap-audit-denied-1/resolve":
 			resolveCount.Add(1)
 			_ = json.NewDecoder(r.Body).Decode(&lastResolveBody)
 			w.WriteHeader(http.StatusOK)
-			_ = json.NewEncoder(w).Encode(map[string]any{"id": "ap-audit-denied-1", "status": "denied"})
+			_ = json.NewEncoder(w).Encode(map[string]any{"action_version": 1, "id": "ap-audit-denied-1", "status": "denied"})
 		default:
 			http.NotFound(w, r)
 		}

--- a/cmd/rampart/cli/hook_ask_test.go
+++ b/cmd/rampart/cli/hook_ask_test.go
@@ -284,11 +284,11 @@ func TestHookActionAsk_HeadlessOnly_DoesNotEmitPermissionDecisionAsk(t *testing.
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/approvals":
 			createCount.Add(1)
 			w.WriteHeader(http.StatusCreated)
-			_ = json.NewEncoder(w).Encode(map[string]any{"id": "ap-headless-1", "status": "pending"})
+			_ = json.NewEncoder(w).Encode(map[string]any{"action_version": 1, "id": "ap-headless-1", "status": "pending"})
 		case r.Method == http.MethodGet && r.URL.Path == "/v1/approvals/ap-headless-1":
 			pollCount.Add(1)
 			w.WriteHeader(http.StatusOK)
-			_ = json.NewEncoder(w).Encode(map[string]any{"id": "ap-headless-1", "status": "approved"})
+			_ = json.NewEncoder(w).Encode(map[string]any{"action_version": 1, "id": "ap-headless-1", "status": "approved"})
 		default:
 			http.NotFound(w, r)
 		}

--- a/cmd/rampart/cli/hook_codex.go
+++ b/cmd/rampart/cli/hook_codex.go
@@ -321,12 +321,6 @@ func resolveExternalHookApproval(
 		)
 	}
 
-	command := call.Command()
-	if command == "" && call.Path() == "" {
-		if data, err := json.Marshal(call.Params); err == nil {
-			command = string(data)
-		}
-	}
 	client := &hookApprovalClient{
 		serveURL:       strings.TrimRight(serveURL, "/"),
 		token:          serveToken,
@@ -339,12 +333,7 @@ func resolveExternalHookApproval(
 	}
 	result := client.requestApprovalCtx(
 		cmd.Context(),
-		call.Tool,
-		command,
-		call.Agent,
-		call.Path(),
-		call.RunID,
-		call.ToolCallID,
+		call,
 		reason,
 		5*time.Minute,
 	)

--- a/cmd/rampart/cli/hook_codex_test.go
+++ b/cmd/rampart/cli/hook_codex_test.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/peg/rampart/internal/approval"
 	"github.com/peg/rampart/internal/engine"
 	"github.com/spf13/cobra"
 )
@@ -427,7 +428,7 @@ func TestOutputHookResultCodexPreservesNativePermissions(t *testing.T) {
 }
 
 func TestResolveCodexApprovalPreservesExactToolIdentity(t *testing.T) {
-	var request createApprovalRequest
+	var request approval.ExternalRequest
 	var requests []string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requests = append(requests, r.Method+" "+r.URL.Path)
@@ -439,9 +440,9 @@ func TestResolveCodexApprovalPreservesExactToolIdentity(t *testing.T) {
 				t.Fatal(err)
 			}
 			w.WriteHeader(http.StatusCreated)
-			_ = json.NewEncoder(w).Encode(map[string]any{"id": "codex-approval-1", "status": "pending"})
+			_ = json.NewEncoder(w).Encode(map[string]any{"action_version": 1, "id": "codex-approval-1", "status": "pending"})
 		case r.Method == http.MethodGet && r.URL.Path == "/v1/approvals/codex-approval-1":
-			_ = json.NewEncoder(w).Encode(map[string]any{"status": "approved"})
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "codex-approval-1", "status": "approved"})
 		default:
 			http.NotFound(w, r)
 		}
@@ -454,6 +455,7 @@ func TestResolveCodexApprovalPreservesExactToolIdentity(t *testing.T) {
 	cmd.SetOut(&stdout)
 	call := engine.ToolCall{
 		Tool:       "exec",
+		Session:    "hook",
 		Agent:      "codex",
 		RunID:      "session-1",
 		ToolCallID: "call-1",

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -333,7 +333,17 @@ curl -X POST "http://127.0.0.1:9090/v1/preflight/exec" \
 ```
 
 ## POST /v1/approvals
-Creates an external/manual approval request.
+Creates an external/manual approval request. Rampart hooks send the complete
+represented action using `action_version: 1`. The response must acknowledge
+that version before the hook can accept a resolution; upgrade and restart
+`rampart serve` alongside the hook binary. Older services cannot acknowledge
+the fields they previously discarded.
+
+Each creation represents one waiting external invocation. Approving it lets
+that invocation resume through polling; it does not create a second grant for
+`/v1/tool/*`, even when host run and tool-call IDs are present. Separate
+creations remain separate pending approvals. Explicit future run grants are
+still scoped to the exact agent, session, run, and credential owner.
 
 ### Request Headers
 - `Authorization: Bearer <admin-scoped-token>` (eval-only credentials are rejected)
@@ -344,17 +354,36 @@ Creates an external/manual approval request.
 ```json
 {
   "type": "object",
-  "required": ["tool", "agent", "message"],
+  "required": ["action_version", "tool", "agent", "session", "params"],
+  "additionalProperties": false,
   "properties": {
+    "action_version": { "const": 1 },
+    "event_id": { "type": "string" },
     "tool": { "type": "string" },
-    "command": { "type": "string" },
-    "path": { "type": "string" },
     "agent": { "type": "string" },
+    "agent_depth": { "type": "integer", "minimum": 0 },
+    "session": { "type": "string" },
+    "workdir": { "type": "string" },
+    "params": { "type": "object" },
+    "input": { "type": "object" },
     "message": { "type": "string" },
-    "run_id": { "type": "string" }
+    "run_id": { "type": "string" },
+    "tool_call_id": { "type": "string" }
   }
 }
 ```
+
+`params` retains every represented parameter, including file content, patch
+text and all targets. `input` retains additional represented host input;
+`workdir` retains host-supplied working-directory context. Secret values are
+redacted before review and persistence. The optional `event_id` correlates the
+original hook audit event with the later approval-resolution event.
+
+Legacy manual clients may omit `action_version` and send `tool`, `agent`,
+`command`, `path`, `message`, `run_id` and `tool_call_id`. These requests use
+session `hook` and receive `action_version: 0`; they cannot express a complete
+file/edit action. Mixing legacy command/path fields with versioned parameters,
+unknown fields, and unsupported versions returns `400`.
 
 ### Response Body Schema
 Created (`201`):
@@ -362,8 +391,9 @@ Created (`201`):
 ```json
 {
   "type": "object",
-  "required": ["id", "status", "expires_at"],
+  "required": ["action_version", "id", "status", "expires_at"],
   "properties": {
+    "action_version": { "type": "integer", "enum": [0, 1] },
     "id": { "type": "string" },
     "status": { "type": "string" },
     "expires_at": { "type": "string", "format": "date-time" }
@@ -375,6 +405,7 @@ Auto-approved (`200`, when an explicit owner-bound run grant is active):
 
 ```json
 {
+  "action_version": 1,
   "id": "01J...",
   "status": "approved",
   "message": "auto-approved by bulk-resolve",
@@ -386,7 +417,7 @@ Auto-approved (`200`, when an explicit owner-bound run grant is active):
 - `201 Created` approval created
 - `200 OK` auto-approved by an active grant for the exact
   agent/session/run/credential-owner scope
-- `400 Bad Request` invalid JSON
+- `400 Bad Request` malformed or unsupported action request
 - `401 Unauthorized`
 - `403 Forbidden` valid credential without admin scope
 - `503 Service Unavailable` approval queue full
@@ -396,7 +427,7 @@ Auto-approved (`200`, when an explicit owner-bound run grant is active):
 curl -X POST "http://127.0.0.1:9090/v1/approvals" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"tool":"exec","command":"kubectl delete pod foo","agent":"claude-code","message":"requires approval"}'
+  -d '{"action_version":1,"tool":"write","agent":"example-agent","session":"example-session","params":{"file_path":"marker.txt","content":"reviewed marker"},"message":"Review this write"}'
 ```
 
 ## GET /v1/approvals

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -354,7 +354,7 @@ still scoped to the exact agent, session, run, and credential owner.
 ```json
 {
   "type": "object",
-  "required": ["action_version", "tool", "agent", "session", "params"],
+  "required": ["action_version", "tool", "agent", "params"],
   "additionalProperties": false,
   "properties": {
     "action_version": { "const": 1 },
@@ -378,6 +378,8 @@ text and all targets. `input` retains additional represented host input;
 `workdir` retains host-supplied working-directory context. Secret values are
 redacted before review and persistence. The optional `event_id` correlates the
 original hook audit event with the later approval-resolution event.
+`session` may be absent when no project-session label is available; missing
+scope context cannot authorize future calls through a run grant.
 
 Legacy manual clients may omit `action_version` and send `tool`, `agent`,
 `command`, `path`, `message`, `run_id` and `tool_call_id`. These requests use

--- a/internal/approval/external.go
+++ b/internal/approval/external.go
@@ -70,9 +70,8 @@ func (r ExternalRequest) ToolCall() (engine.ToolCall, error) {
 	}
 	switch r.ActionVersion {
 	case ExternalActionVersion:
-		if strings.TrimSpace(r.Tool) == "" || strings.TrimSpace(r.Agent) == "" ||
-			strings.TrimSpace(r.Session) == "" || r.Params == nil || r.AgentDepth < 0 {
-			return engine.ToolCall{}, fmt.Errorf("versioned approval requires tool, agent, session, params and non-negative agent_depth")
+		if strings.TrimSpace(r.Tool) == "" || strings.TrimSpace(r.Agent) == "" || r.Params == nil || r.AgentDepth < 0 {
+			return engine.ToolCall{}, fmt.Errorf("versioned approval requires tool, agent, params and non-negative agent_depth")
 		}
 		if r.Command != "" || r.Path != "" {
 			return engine.ToolCall{}, fmt.Errorf("versioned approval must represent command and path in params")

--- a/internal/approval/external.go
+++ b/internal/approval/external.go
@@ -1,0 +1,96 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0
+
+package approval
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/peg/rampart/internal/engine"
+)
+
+const ExternalActionVersion = 1
+
+// ExternalRequest carries the original action to an external approval owner.
+// Unlike ActionReview, it is unredacted transport input. Store creation takes
+// an immutable snapshot and redacts it before persistence or operator output.
+type ExternalRequest struct {
+	ActionVersion int            `json:"action_version,omitempty"`
+	EventID       string         `json:"event_id,omitempty"`
+	Tool          string         `json:"tool"`
+	Agent         string         `json:"agent"`
+	AgentDepth    int            `json:"agent_depth,omitempty"`
+	Session       string         `json:"session,omitempty"`
+	RunID         string         `json:"run_id,omitempty"`
+	ToolCallID    string         `json:"tool_call_id,omitempty"`
+	WorkDir       string         `json:"workdir,omitempty"`
+	Params        map[string]any `json:"params"`
+	Input         map[string]any `json:"input,omitempty"`
+	Message       string         `json:"message"`
+	// Command and Path are accepted only for pre-versioned manual clients.
+	Command string `json:"command,omitempty"`
+	Path    string `json:"path,omitempty"`
+}
+
+func NewExternalRequest(call engine.ToolCall, message string) ExternalRequest {
+	return ExternalRequest{
+		ActionVersion: ExternalActionVersion, EventID: call.ID,
+		Tool: call.Tool, Agent: call.Agent, AgentDepth: call.AgentDepth,
+		Session: call.Session, RunID: call.RunID, ToolCallID: call.ToolCallID,
+		WorkDir: call.WorkDir, Params: call.Params, Input: call.Input, Message: message,
+	}
+}
+
+// DecodeExternalRequest preserves exact JSON numbers in action identity and
+// refuses unknown fields rather than acknowledging a partially understood call.
+func DecodeExternalRequest(r io.Reader) (ExternalRequest, error) {
+	var req ExternalRequest
+	dec := json.NewDecoder(r)
+	dec.UseNumber()
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&req); err != nil {
+		return req, err
+	}
+	var extra any
+	if err := dec.Decode(&extra); !errors.Is(err, io.EOF) {
+		return req, fmt.Errorf("approval request must contain exactly one JSON object")
+	}
+	return req, nil
+}
+
+func (r ExternalRequest) ToolCall() (engine.ToolCall, error) {
+	call := engine.ToolCall{
+		ID: r.EventID, Tool: r.Tool, Agent: r.Agent, AgentDepth: r.AgentDepth,
+		Session: r.Session, RunID: r.RunID, ToolCallID: r.ToolCallID,
+		WorkDir: r.WorkDir, Params: r.Params, Input: r.Input,
+	}
+	switch r.ActionVersion {
+	case ExternalActionVersion:
+		if strings.TrimSpace(r.Tool) == "" || strings.TrimSpace(r.Agent) == "" ||
+			strings.TrimSpace(r.Session) == "" || r.Params == nil || r.AgentDepth < 0 {
+			return engine.ToolCall{}, fmt.Errorf("versioned approval requires tool, agent, session, params and non-negative agent_depth")
+		}
+		if r.Command != "" || r.Path != "" {
+			return engine.ToolCall{}, fmt.Errorf("versioned approval must represent command and path in params")
+		}
+	case 0:
+		if r.Params != nil || r.Input != nil || r.Session != "" || r.WorkDir != "" || r.EventID != "" || r.AgentDepth != 0 {
+			return engine.ToolCall{}, fmt.Errorf("complete action fields require action_version=1")
+		}
+		call.Session = "hook"
+		call.Params = map[string]any{}
+		if r.Command != "" {
+			call.Params["command"] = r.Command
+		}
+		if r.Path != "" {
+			call.Params["path"] = r.Path
+		}
+	default:
+		return engine.ToolCall{}, fmt.Errorf("unsupported approval action_version")
+	}
+	return call, nil
+}

--- a/internal/approval/review.go
+++ b/internal/approval/review.go
@@ -74,6 +74,7 @@ func redactedCall(call engine.ToolCall) (engine.ToolCall, bool, error) {
 // consults the caller's maps or invokes their JSON marshalers a second time.
 func redactCallSnapshot(snapshot engine.ToolCall, encoded []byte) (engine.ToolCall, bool, error) {
 	review := ReviewCall(snapshot)
+	snapshot.ID = notify.SanitizeCommand(snapshot.ID)
 	snapshot.Tool, snapshot.Agent = review.Tool, review.Agent
 	snapshot.Session, snapshot.RunID, snapshot.ToolCallID = review.Session, review.RunID, review.ToolCallID
 	snapshot.WorkDir = notify.SanitizeCommand(snapshot.WorkDir)

--- a/internal/approval/store.go
+++ b/internal/approval/store.go
@@ -225,6 +225,7 @@ type persistRecord struct {
 	Redacted        bool           `json:"redacted,omitempty"`
 	ScopeRedacted   bool           `json:"run_scope_redacted,omitempty"`
 	ID              string         `json:"id"`
+	EventID         string         `json:"event_id,omitempty"`
 	Tool            string         `json:"tool"`
 	Agent           string         `json:"agent"`
 	AgentDepth      int            `json:"agent_depth,omitempty"`
@@ -461,7 +462,7 @@ func replayGrantVersion(key string) int {
 func (s *Store) Create(call engine.ToolCall, decision engine.Decision) (*Request, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.createLocked(call, decision, "")
+	return s.createLocked(call, decision, "", true)
 }
 
 // CreateOrAutoApproved atomically checks the run-scoped auto-approval cache
@@ -483,6 +484,17 @@ func (s *Store) CreateOrAutoApprovedWithExpiry(
 	decision engine.Decision,
 	ownerScope string,
 ) (*Request, time.Time, bool, error) {
+	return s.createOrAutoApprovedWithExpiry(call, decision, ownerScope, true)
+}
+
+// CreateExternalOrAutoApprovedWithExpiry keeps each held external hook request
+// separate. Its approval wakes that invocation through polling, so it must not
+// also grant an HTTP evaluation replay or release a second waiting invocation.
+func (s *Store) CreateExternalOrAutoApprovedWithExpiry(call engine.ToolCall, decision engine.Decision, ownerScope string) (*Request, time.Time, bool, error) {
+	return s.createOrAutoApprovedWithExpiry(call, decision, ownerScope, false)
+}
+
+func (s *Store) createOrAutoApprovedWithExpiry(call engine.ToolCall, decision engine.Decision, ownerScope string, replay bool) (*Request, time.Time, bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -493,12 +505,12 @@ func (s *Store) CreateOrAutoApprovedWithExpiry(
 	if expiresAt, ok := s.autoApprovalExpiryLocked(call, ownerScope); ok {
 		return nil, expiresAt, true, nil
 	}
-	req, err := s.createLocked(call, decision, ownerScope)
+	req, err := s.createLocked(call, decision, ownerScope, replay)
 	return req, time.Time{}, false, err
 }
 
 // createLocked enqueues one request. The caller must hold s.mu.
-func (s *Store) createLocked(call engine.ToolCall, decision engine.Decision, ownerScope string) (*Request, error) {
+func (s *Store) createLocked(call engine.ToolCall, decision engine.Decision, ownerScope string, replay bool) (*Request, error) {
 	if s.closed {
 		return nil, ErrStoreClosed
 	}
@@ -511,7 +523,10 @@ func (s *Store) createLocked(call engine.ToolCall, decision engine.Decision, own
 	if err != nil {
 		return nil, fmt.Errorf("approval: cannot snapshot action: %w", err)
 	}
-	key := s.keyedIdentity(ownerBoundKey(dedupKey(call), ownerScope))
+	key := ""
+	if replay {
+		key = s.keyedIdentity(ownerBoundKey(dedupKey(call), ownerScope))
+	}
 	review, redacted, err := redactCallSnapshot(call, encoded)
 	if err != nil {
 		return nil, fmt.Errorf("approval: cannot snapshot action: %w", err)
@@ -1633,6 +1648,7 @@ func toRecord(req *Request) persistRecord {
 		Redacted:        req.redacted,
 		ScopeRedacted:   req.scopeRedacted,
 		ID:              req.ID,
+		EventID:         call.ID,
 		Tool:            call.Tool,
 		Agent:           call.Agent,
 		AgentDepth:      call.AgentDepth,
@@ -1663,6 +1679,7 @@ func fromRecord(rec persistRecord) (*Request, bool) {
 	}
 
 	call := engine.ToolCall{
+		ID:         rec.EventID,
 		Tool:       rec.Tool,
 		Agent:      rec.Agent,
 		AgentDepth: rec.AgentDepth,

--- a/internal/approval/store_test.go
+++ b/internal/approval/store_test.go
@@ -128,6 +128,41 @@ func TestCreateAndResolveApproval(t *testing.T) {
 	}
 }
 
+func TestExternalApprovalRestartKeepsInvocationsSeparate(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "approvals.jsonl")
+	store := NewStore(WithPersistenceFile(path))
+	t.Cleanup(store.Close)
+	call := testCall()
+	call.WorkDir = "/synthetic-workspace"
+	call.Params = map[string]any{"file_path": "marker.txt", "content": "review me", "password": "synthetic-private"}
+	first, _, auto, err := store.CreateExternalOrAutoApprovedWithExpiry(call, testDecision(), "owner")
+	require.NoError(t, err)
+	require.False(t, auto)
+	second, _, _, err := store.CreateExternalOrAutoApprovedWithExpiry(call, testDecision(), "owner")
+	require.NoError(t, err)
+	require.NotEqual(t, first.ID, second.ID, "separate held invocations must not share one authorization")
+	store.Close()
+	journal, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.NotContains(t, string(journal), "synthetic-private")
+	store = NewStore(WithPersistenceFile(path))
+	t.Cleanup(store.Close)
+	restored, found := store.Get(first.ID)
+	require.True(t, found)
+	require.Equal(t, call.ID, restored.Call.ID)
+	require.Equal(t, call.ToolCallID, restored.Call.ToolCallID)
+	require.Equal(t, call.WorkDir, restored.Call.WorkDir)
+	require.Equal(t, "review me", restored.Call.Params["content"])
+	require.NoError(t, store.Resolve(first.ID, true, "reviewer"))
+	other, found := store.Get(second.ID)
+	require.True(t, found)
+	require.Equal(t, StatusPending, other.Status)
+	_, consumed, err := store.ConsumeApprovedFor(call, "owner")
+	require.NoError(t, err)
+	require.False(t, consumed, "polling approval must not also grant an HTTP execution replay")
+	require.NoError(t, store.Resolve(second.ID, false, "reviewer"))
+}
+
 func TestResolveBeforePublishOrdersJournalAndAuditBeforeAuthorization(t *testing.T) {
 	persistFile := filepath.Join(t.TempDir(), "approvals.jsonl")
 	store := NewStore(WithPersistenceFile(persistFile))

--- a/internal/proxy/approval_handlers.go
+++ b/internal/proxy/approval_handlers.go
@@ -15,36 +15,38 @@ import (
 	"github.com/peg/rampart/internal/approval"
 	"github.com/peg/rampart/internal/audit"
 	"github.com/peg/rampart/internal/engine"
+	"github.com/peg/rampart/internal/token"
 )
 
 func (s *Server) handleCreateApproval(w http.ResponseWriter, r *http.Request) {
-	if !s.checkAdminAuth(w, r) {
+	identity, authErr := s.identify(r)
+	if identity == nil {
+		writeError(w, http.StatusUnauthorized, authErr)
 		return
 	}
-
-	var req createApprovalRequest
-	if err := decodeJSONBody(r.Body, &req); err != nil {
-		writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid request body: %v", err))
+	if !identity.HasScope(token.ScopeAdmin) {
+		writeError(w, http.StatusForbidden, "this endpoint requires admin scope")
 		return
 	}
-
-	params := map[string]any{}
-	if req.Command != "" {
-		params["command"] = req.Command
-	}
-	if req.Path != "" {
-		params["path"] = req.Path
+	ownerScope := ""
+	if identity.Token != nil {
+		ownerScope = identity.Token.Hash
 	}
 
-	call := engine.ToolCall{
-		ID:        audit.NewEventID(),
-		Agent:     req.Agent,
-		Session:   "hook",
-		RunID:     req.RunID,
-		Tool:      req.Tool,
-		Params:    params,
-		Timestamp: time.Now().UTC(),
+	req, err := approval.DecodeExternalRequest(r.Body)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid approval request")
+		return
 	}
+	call, err := req.ToolCall()
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if call.ID == "" {
+		call.ID = audit.NewEventID()
+	}
+	call.Timestamp = time.Now().UTC()
 
 	decision := engine.Decision{
 		Action:  engine.ActionRequireApproval,
@@ -54,7 +56,7 @@ func (s *Server) handleCreateApproval(w http.ResponseWriter, r *http.Request) {
 	// Check run-scoped authorization and enqueue atomically. A bulk cache
 	// publication can never slip between a stale check and Create, leaving an
 	// orphan pending request for a call that should have been auto-approved.
-	pending, grantExpiresAt, autoApproved, err := s.approvals.CreateOrAutoApprovedWithExpiry(call, decision, "")
+	pending, grantExpiresAt, autoApproved, err := s.approvals.CreateExternalOrAutoApprovedWithExpiry(call, decision, ownerScope)
 	if err != nil {
 		s.logger.Error("proxy: approval store full", "error", err)
 		writeError(w, http.StatusServiceUnavailable, err.Error())
@@ -63,10 +65,11 @@ func (s *Server) handleCreateApproval(w http.ResponseWriter, r *http.Request) {
 	if autoApproved {
 		s.logger.Debug("proxy: run auto-approved (hook), bypassing approval queue", "tool", req.Tool, "run_id", call.RunID)
 		writeJSON(w, http.StatusOK, map[string]any{
-			"id":         audit.NewEventID(),
-			"status":     "approved",
-			"message":    "auto-approved by bulk-resolve",
-			"expires_at": grantExpiresAt.UTC().Format(time.RFC3339Nano),
+			"id":             audit.NewEventID(),
+			"status":         "approved",
+			"message":        "auto-approved by bulk-resolve",
+			"expires_at":     grantExpiresAt.UTC().Format(time.RFC3339Nano),
+			"action_version": req.ActionVersion,
 		})
 		return
 	}
@@ -75,9 +78,7 @@ func (s *Server) handleCreateApproval(w http.ResponseWriter, r *http.Request) {
 	s.logger.Info("proxy: external approval created",
 		"id", pending.ID,
 		"tool", req.Tool,
-		"command", req.Command,
 		"agent", req.Agent,
-		"message", req.Message,
 	)
 
 	if s.shouldNotify(decision.Action.String()) {
@@ -85,9 +86,10 @@ func (s *Server) handleCreateApproval(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusCreated, map[string]any{
-		"id":         pending.ID,
-		"status":     pending.Status.String(),
-		"expires_at": pending.ExpiresAt.Format(time.RFC3339),
+		"id":             pending.ID,
+		"status":         pending.Status.String(),
+		"expires_at":     pending.ExpiresAt.Format(time.RFC3339),
+		"action_version": req.ActionVersion,
 	})
 }
 
@@ -268,6 +270,7 @@ func approvalResolutionEvent(resolved *approval.Request, approved, persistReques
 			"resolution":        resolution,
 			"resolved_by":       resolvedBy,
 			"approval_id":       resolved.ID,
+			"event_id":          resolved.Call.ID,
 			"persist_requested": approved && persistRequested,
 			"persist":           false,
 		},

--- a/internal/proxy/approval_review_test.go
+++ b/internal/proxy/approval_review_test.go
@@ -95,7 +95,7 @@ func TestExternalApprovalRejectsPartialActionFormats(t *testing.T) {
 	srv, token, _ := setupTestServer(t, "version: '1'\ndefault_action: deny\npolicies: []\n", "enforce")
 	for _, body := range []string{
 		`{"action_version":2,"tool":"write","agent":"test","session":"s","params":{}}`,
-		`{"action_version":1,"tool":"write","agent":"test","params":{}}`,
+		`{"action_version":1,"tool":"write","agent":"","params":{}}`,
 		`{"action_version":1,"tool":"write","agent":"test","session":"s"}`,
 		`{"action_version":1,"tool":"write","agent":"test","session":"s","params":{},"command":"different action"}`,
 		`{"action_version":1,"tool":"write","agent":"test","session":"s","params":{},"future_identity":"unknown"}`,

--- a/internal/proxy/approval_review_test.go
+++ b/internal/proxy/approval_review_test.go
@@ -90,3 +90,23 @@ policies:
 	require.Contains(t, preview.Body.String(), `"action"`)
 	require.NotContains(t, preview.Body.String(), "synthetic-private")
 }
+
+func TestExternalApprovalRejectsPartialActionFormats(t *testing.T) {
+	srv, token, _ := setupTestServer(t, "version: '1'\ndefault_action: deny\npolicies: []\n", "enforce")
+	for _, body := range []string{
+		`{"action_version":2,"tool":"write","agent":"test","session":"s","params":{}}`,
+		`{"action_version":1,"tool":"write","agent":"test","params":{}}`,
+		`{"action_version":1,"tool":"write","agent":"test","session":"s"}`,
+		`{"action_version":1,"tool":"write","agent":"test","session":"s","params":{},"command":"different action"}`,
+		`{"action_version":1,"tool":"write","agent":"test","session":"s","params":{},"future_identity":"unknown"}`,
+		`{"tool":"write","agent":"test","params":{"file_path":"lost.txt"}}`,
+		`{"tool":"exec","agent":"test","command":"echo marker"} {}`,
+	} {
+		req := httptest.NewRequest("POST", "/v1/approvals", strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer "+token)
+		rr := httptest.NewRecorder()
+		srv.handler().ServeHTTP(rr, req)
+		require.Equal(t, http.StatusBadRequest, rr.Code, body)
+	}
+	require.Empty(t, srv.approvals.List())
+}

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -556,16 +556,6 @@ func (req toolRequest) validateTrustedHostedApproval() error {
 	return fmt.Errorf("hosted approval requests require approval_owner.mode=hosted or both openclaw_hosted and skip_pending_approval")
 }
 
-// createApprovalRequest is the JSON body for POST /v1/approvals.
-type createApprovalRequest struct {
-	Tool    string `json:"tool"`
-	Command string `json:"command,omitempty"`
-	Agent   string `json:"agent"`
-	Path    string `json:"path,omitempty"`
-	Message string `json:"message"`
-	RunID   string `json:"run_id,omitempty"`
-}
-
 type resolveRequest struct {
 	Approved   bool   `json:"approved"`
 	ResolvedBy string `json:"resolved_by"`


### PR DESCRIPTION
External approval requests previously reduced a represented action to command/path fields and lost host call identity at the server. Hooks now send a shared versioned contract containing every represented parameter, input, working directory and correlation identifier. The server acknowledges the format, redacts review/persistence data, and binds run authorization to the credential owner.

Each held hook invocation receives its own approval; resolving it cannot also grant an HTTP execution replay. Hook clients reject incompatible services, mismatched approval IDs, malformed or oversized replies, and responses arriving after cancellation or timeout. Existing manual command/path clients remain accepted; new hook binaries require an updated, restarted approval service.

Validation: full Go tests, vet, security assurance, focused race checks, strict docs build and canonical-document check passed. Added real client/server round-trip coverage, persistence/restart isolation, and transport failure regressions. Installed Codex 0.153.2 validation also passed using isolated synthetic state and a scripted loopback Responses peer: approve-once, deny, expiry, exact retry, changed-command retry, changed-directory retry, and cancellation before late approval. Marker effects and correlated audit records were checked through the real host dispatcher; no model provider was called. This validates the external hook/approval path, not Codex’s native workspace sandbox or inputs omitted by Codex hooks. The non-Git workspace journey exposed and now covers an absent project-session label. GitHub CI must pass on the current head before merge readiness.
