### PR TITLE
fix: default Python SDK policy requests to fail closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Python SDK clients now fail closed by default on transport and server failures,
+  including custom clients supplied to guards and non-consuming preview calls.
+  Existing callers that deliberately need availability fallback must explicitly
+  set `fail_open=True`; policy denials and invalid responses remain errors or
+  denied decisions. Health checks still return `False` when unavailable.
+
 ## [1.9.1] - 2026-09-10
 
 ### Security

--- a/docs-site/integrations/python-agents.md
+++ b/docs-site/integrations/python-agents.md
@@ -52,6 +52,22 @@ consumes one-shot grants and call-count state exactly once, and does not execute
 the function unless Rampart returns a consistent allow decision. Its default
 client fails closed when the policy service is unavailable or malformed.
 
+`RampartClient()` also fails closed by default, so supplying a custom client
+to change its URL or timeout preserves this protection. Transport failures and
+timeouts raise `RampartConnectionError`; HTTP server errors raise
+`RampartServerError`. Guards do not execute when these errors occur, including
+when `raise_on_deny=False`.
+
+**Upgrading earlier SDK source checkouts:** calls that omitted `fail_open`
+previously returned a synthetic allow during transport/server failures. They
+now raise, including `preflight`, `check_*`, and their async equivalents.
+Handle availability exceptions without executing the guarded operation.
+If the application deliberately needs the previous availability fallback, use
+`RampartClient(fail_open=True)` explicitly. This does not override policy
+deny/ask or invalid decision responses. Explicit true/false settings and healthy
+decisions retain their behavior; `health()` and `ahealth()` still return `False`
+when unavailable.
+
 ## Preflight API
 
 Check if a command would be allowed without executing it:

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -141,18 +141,43 @@ asyncio.run(main())
 client = rampart.RampartClient(
     url="https://rampart.example.com:8080",
     token="your-auth-token",
-    fail_open=True,  # Allow calls if server is unreachable (default)
+    fail_open=False, # Raise on transport/server failures (default)
     timeout=30.0,    # Request timeout in seconds
 )
 
-# Fail-closed mode (recommended for security boundaries)
-strict_client = rampart.RampartClient(fail_open=False)
+# Explicit availability choice: allow calls during transport/server failures.
+availability_client = rampart.RampartClient(fail_open=True)
 ```
 
 Non-loopback endpoints must use HTTPS because policy requests contain tool-call
 metadata even when no bearer token is configured. The SDK also ignores ambient
 proxy variables and refuses HTTP redirects so control-plane credentials and
 tool data remain bound to the configured Rampart endpoint.
+
+### Failure behavior and migration
+
+`RampartClient()` now defaults to `fail_open=False`, including clients supplied
+to decorators or `set_default_client()`. Transport failures and timeouts raise
+`RampartConnectionError`; HTTP server errors raise `RampartServerError`. Guards
+do not execute the wrapped function when these exceptions occur, even with
+`raise_on_deny=False`. That option only controls how policy denials are reported.
+
+Earlier SDK source checkouts defaulted to `fail_open=True`. Upgrading callers
+that omit the option changes outage behavior from a synthetic allow decision
+to an exception. This also affects `preflight`, `check_*`, and their async
+equivalents. Handle availability exceptions where the application can report or
+retry the unavailable operation, without treating them as authorization.
+
+Applications that deliberately prefer availability can retain the previous
+fallback with `RampartClient(fail_open=True)`. This permits calls during eligible
+transport failures and HTTP 5xx responses; returned decisions identify the
+fallback with a `fail-open` message. It does not override a policy deny/ask,
+authentication errors, or invalid decision responses. Explicit `True` and
+`False` configurations retain their existing behavior.
+
+Healthy decisions and the distinction between non-consuming previews and
+state-consuming enforcement are unchanged. `health()` and `ahealth()` remain
+observational and return `False` when the service is unavailable.
 
 ## API Reference
 
@@ -208,9 +233,11 @@ class Decision:
 - `session`: Session identifier for policy context
 - `raise_on_deny`: Whether to raise exception on denial (default: True)
 
-When no custom client is supplied, decorators create a fail-closed client.
-Pass an explicitly configured client only if your application has made a
-deliberate availability-versus-enforcement choice.
+Decorators and newly constructed custom clients fail closed by default.
+Supplying a client to customize its URL or timeout preserves that behavior.
+Only an explicitly configured `fail_open=True` client opts into availability
+fallbacks. Connection and server exceptions still propagate when
+`raise_on_deny=False`; a denied decision returns `None` without executing.
 
 ## Examples
 

--- a/sdks/python/rampart/client.py
+++ b/sdks/python/rampart/client.py
@@ -162,15 +162,15 @@ class RampartClient:
     Provides methods to check tool calls against policies and query server health.
     Supports both synchronous and asynchronous operation via the async client.
 
-    The client fails open by default - if the server is unreachable, tool calls
-    are allowed to proceed. This ensures agent operation continues even if the
-    policy server is down.
+    Policy requests fail closed by default: connection and server failures
+    raise an exception. Set fail_open=True explicitly only when the application
+    should allow calls without a policy decision during those failures.
 
     Args:
         url: Base URL of the Rampart server (default: http://localhost:9090)
         token: Bearer token for authentication (default: reads from the
             RAMPART_TOKEN environment variable)
-        fail_open: Whether to allow calls when server is unreachable (default: True)
+        fail_open: Allow transport/server failures explicitly (default: False)
         timeout: Request timeout in seconds (default: 30)
 
     Example:
@@ -184,7 +184,7 @@ class RampartClient:
         self,
         url: Optional[str] = None,
         token: Optional[str] = None,
-        fail_open: bool = True,
+        fail_open: bool = False,
         timeout: float = 30.0,
     ):
         raw_url = (

--- a/sdks/python/rampart/decorators.py
+++ b/sdks/python/rampart/decorators.py
@@ -44,9 +44,7 @@ def get_default_client() -> RampartClient:
     """Get the default client, creating a fail-closed guard client if needed."""
     global _default_client
     if _default_client is None:
-        # Decorators sit directly on an execution boundary. Preserve the
-        # generic client's historical availability-first default, but never
-        # turn a policy-service outage into implicit authorization here.
+        # Keep the execution boundary's fail-closed choice explicit.
         _default_client = RampartClient(fail_open=False)
     return _default_client
 
@@ -62,8 +60,10 @@ def guard(
 ) -> Callable[[F], F]:
     """Decorator to wrap a function with Rampart policy checks.
 
-    The decorator performs a preflight check before calling the wrapped function.
+    The decorator enforces policy before calling the wrapped function, consuming
+    stateful once and call-count rules.
     By default, it raises RampartDeniedError if the call is denied by policy.
+    Connection and server errors propagate even when raise_on_deny=False.
 
     Args:
         tool_name: Name of the tool for policy evaluation

--- a/sdks/python/tests/test_client.py
+++ b/sdks/python/tests/test_client.py
@@ -14,6 +14,7 @@
 """Unit tests for the Rampart client."""
 
 import base64
+import json
 import os
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -41,7 +42,7 @@ class TestRampartClient:
             client = RampartClient()
             assert client.url == "http://localhost:9090"
             assert client.token is None
-        assert client.fail_open is True
+        assert client.fail_open is False
 
     def test_default_decorator_client_fails_closed(self):
         """Execution-boundary decorators must not authorize on server outage."""
@@ -906,3 +907,83 @@ class TestDecorators:
 
             result = run_command("dangerous command")
             assert result is None  # Function not called, returns None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("asynchronous", [False, True], ids=["sync", "async"])
+@pytest.mark.parametrize(
+    "response_kind,availability_opt_in,raise_on_deny,expected_error,executes",
+    [
+        ("connection", False, False, RampartConnectionError, False),
+        ("timeout", False, False, RampartConnectionError, False),
+        ("server-error", False, False, RampartServerError, False),
+        ("connection", True, False, None, True),
+        ("server-error", True, False, None, True),
+        ("deny", True, True, RampartDeniedError, False),
+        ("ask", True, False, None, False),
+        ("malformed", True, False, RampartServerError, False),
+        ("allow", False, True, None, True),
+    ],
+)
+async def test_custom_client_guard_failure_behavior(
+    asynchronous,
+    response_kind,
+    availability_opt_in,
+    raise_on_deny,
+    expected_error,
+    executes,
+):
+    """Join the real client/parser to the guard's observable execution boundary."""
+    calls = []
+    effects = []
+
+    def respond(request):
+        calls.append(request)
+        assert request.url.path == "/v1/preflight/exec"
+        assert json.loads(request.content)["enforce"] is True
+        if response_kind == "connection":
+            raise httpx.ConnectError("unavailable", request=request)
+        if response_kind == "timeout":
+            raise httpx.ReadTimeout("timed out", request=request)
+        if response_kind == "server-error":
+            return httpx.Response(503, text="service unavailable")
+        allowed = response_kind in {"allow", "malformed"}
+        action = "deny" if response_kind == "malformed" else response_kind
+        return httpx.Response(200, json={"allowed": allowed, "decision": action})
+
+    # Supplying a client just to customize its timeout must preserve the
+    # default guard's outage protection. Availability requires explicit True.
+    options = {"fail_open": True} if availability_opt_in else {}
+    client = RampartClient(url="http://127.0.0.1:9090", timeout=2, **options)
+    transport = httpx.MockTransport(respond)
+    if asynchronous:
+        client._async_client = httpx.AsyncClient(transport=transport)
+    else:
+        client._client = httpx.Client(transport=transport)
+
+    def operation(command):
+        effects.append(command)
+        return "executed"
+
+    async def async_operation(command):
+        return operation(command)
+
+    protected = exec_guard(client=client, raise_on_deny=raise_on_deny)(
+        async_operation if asynchronous else operation
+    )
+
+    async def invoke():
+        if asynchronous:
+            return await protected("marker")
+        return protected("marker")
+
+    try:
+        if expected_error is not None:
+            with pytest.raises(expected_error):
+                await invoke()
+        else:
+            assert await invoke() == ("executed" if executes else None)
+        assert effects == (["marker"] if executes else [])
+        assert len(calls) == 1
+    finally:
+        await client.aclose()


### PR DESCRIPTION
Supplying `RampartClient(timeout=2)` to a guard previously changed its outage behavior from fail-closed to fail-open, because the general client's default differed from the default guard client. Make omitted `fail_open` default to `False` for every client. Guards now preserve outage protection when callers customize connection settings.

This deliberately changes compatibility for earlier SDK source checkouts: transport and HTTP server failures raise the existing exceptions, including for non-consuming preview callers. Explicit `fail_open=True` preserves the previous availability fallback; policy deny/ask, invalid responses, healthy decisions and `health()` observation keep their behavior. The SDK README, integration guide and changelog explain migration. No SDK package or Rampart release version is bumped.

Validation:

- 64 SDK tests and formatting, lint, type and wheel-build checks passed. Joined tests exercise the real client/parser and sync/async guards with observable execution effects; the six default-outage cases failed before the fix.
- The built wheel passed an isolated real-service journey covering preview versus once-rule consumption, deny, outage exceptions, health observation, explicit fallback and audit correlation. No model/provider calls were used.
- Strict documentation build, `go test ./...`, `go vet ./...`, `make security-assurance` and `git diff --check` passed.
- The maintainer review gate passed at `1d7c11b413ddd33cb1c1c8234f3d90b11a93a722`, based on current staging. Required Linux/macOS/Windows, container, cross-platform packaging, documentation and Python 3.9/3.12 CI passed. Independent focused review found no actionable issue.

This is one focused change toward 2.0; it does not claim new host integration coverage.
