### PR TITLE
fix: bind service assurance to the observed runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bind service verification receipts to the observed endpoint, server start,
+  build and enforce mode. Status separates CLI and service builds; stale or
+  legacy runtime evidence requires reverification. Service-optional native
+  hooks retain independent local adapter verification without HTTP.
+
 ## [1.9.1] - 2026-09-10
 
 ### Security

--- a/cmd/rampart/cli/assurance_status.go
+++ b/cmd/rampart/cli/assurance_status.go
@@ -5,6 +5,7 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -59,22 +60,24 @@ type verificationReceipt struct {
 	SafeCanaries           bool                       `json:"safe_canaries"`
 	Summary                verificationSummary        `json:"summary"`
 	Checks                 []verificationReceiptCheck `json:"checks"`
+	Runtime                *serviceRuntimeObservation `json:"runtime,omitempty"`
 }
 
 type integrationAssuranceStatus struct {
-	ID                  string         `json:"id"`
-	DisplayName         string         `json:"display_name"`
-	Boundary            string         `json:"boundary"`
-	ServiceRequired     bool           `json:"service_required"`
-	Installed           bool           `json:"installed"`
-	Configured          bool           `json:"configured"`
-	AssuranceLevel      assuranceLevel `json:"assurance_level"`
-	EvidenceSource      string         `json:"evidence_source,omitempty"`
-	CheckedAt           *time.Time     `json:"checked_at,omitempty"`
-	EvidenceExpiresAt   *time.Time     `json:"evidence_expires_at,omitempty"`
-	VerificationCommand string         `json:"verification_command"`
-	RecommendedCommand  string         `json:"recommended_command,omitempty"`
-	StaleReason         string         `json:"stale_reason,omitempty"`
+	ID                  string                     `json:"id"`
+	DisplayName         string                     `json:"display_name"`
+	Boundary            string                     `json:"boundary"`
+	ServiceRequired     bool                       `json:"service_required"`
+	Installed           bool                       `json:"installed"`
+	Configured          bool                       `json:"configured"`
+	AssuranceLevel      assuranceLevel             `json:"assurance_level"`
+	EvidenceSource      string                     `json:"evidence_source,omitempty"`
+	CheckedAt           *time.Time                 `json:"checked_at,omitempty"`
+	EvidenceExpiresAt   *time.Time                 `json:"evidence_expires_at,omitempty"`
+	VerificationCommand string                     `json:"verification_command"`
+	RecommendedCommand  string                     `json:"recommended_command,omitempty"`
+	StaleReason         string                     `json:"stale_reason,omitempty"`
+	Runtime             *serviceRuntimeObservation `json:"runtime,omitempty"`
 }
 
 func assuranceLevelForReport(report verificationReport) assuranceLevel {
@@ -116,8 +119,10 @@ func writeVerificationReceipt(report verificationReport) error {
 		return fmt.Errorf("resolve home: %w", err)
 	}
 	policyEndpoint := report.policyEndpoint
-	if policyEndpoint == "" {
-		policyEndpoint = resolveServeURL("")
+	if !driver.ServiceRequired {
+		policyEndpoint = ""
+	} else if report.Runtime != nil {
+		policyEndpoint = report.Runtime.Endpoint
 	}
 	fingerprint, err := integrationEnvironmentFingerprintAt(driver, home, policyEndpoint)
 	if err != nil {
@@ -139,6 +144,7 @@ func writeVerificationReceipt(report verificationReport) error {
 		SafeCanaries:           report.SafeCanaries,
 		Summary:                report.Summary,
 		Checks:                 make([]verificationReceiptCheck, 0, len(report.Checks)),
+		Runtime:                report.Runtime,
 	}
 	for _, check := range report.Checks {
 		receipt.Checks = append(receipt.Checks, verificationReceiptCheck{ID: check.ID, Status: check.Status})
@@ -220,6 +226,12 @@ func readVerificationReceipt(integrationID string) (verificationReceipt, error) 
 }
 
 func validateVerificationReceipt(receipt verificationReceipt, integrationID string) error {
+	if receipt.Runtime != nil {
+		endpoint, err := serviceEndpoint(receipt.Runtime.Endpoint)
+		if err != nil || endpoint != receipt.Runtime.Endpoint || !runtimeIdentified(receipt.Runtime.RuntimeIdentity) || receipt.Runtime.Mode != "enforce" {
+			return fmt.Errorf("receipt has invalid runtime evidence")
+		}
+	}
 	if receipt.SchemaVersion != verificationReceiptSchemaVersion {
 		return fmt.Errorf("unsupported receipt schema")
 	}
@@ -272,7 +284,11 @@ func validateVerificationReceipt(receipt verificationReceipt, integrationID stri
 }
 
 func integrationEnvironmentFingerprint(driver integrationDriver, home string) (string, error) {
-	return integrationEnvironmentFingerprintAt(driver, home, resolveServeURL(""))
+	endpoint, err := integrationServiceEndpoint(driver)
+	if err != nil {
+		return "", err
+	}
+	return integrationEnvironmentFingerprintAt(driver, home, endpoint)
 }
 
 func integrationEnvironmentFingerprintAt(driver integrationDriver, home, policyEndpoint string) (string, error) {
@@ -418,12 +434,17 @@ func openClawAssuranceConfiguration() (openClawAssuranceConfig, error) {
 	return config, nil
 }
 
-func collectIntegrationAssuranceStatuses(now time.Time, serverRunning bool) []integrationAssuranceStatus {
+func collectIntegrationAssuranceStatuses(now time.Time) []integrationAssuranceStatus {
 	home, err := os.UserHomeDir()
 	if err != nil || strings.TrimSpace(home) == "" {
 		return []integrationAssuranceStatus{}
 	}
 	statuses := make([]integrationAssuranceStatus, 0)
+	type runtimeResult struct {
+		observation serviceRuntimeObservation
+		err         error
+	}
+	runtimes := make(map[string]runtimeResult)
 	for _, driver := range supportedIntegrationDrivers() {
 		installed := driver.Installed != nil && driver.Installed(home)
 		configured := integrationConfiguredForAssurance(driver, home)
@@ -456,11 +477,6 @@ func collectIntegrationAssuranceStatuses(now time.Time, serverRunning bool) []in
 		status.CheckedAt = &receipt.CheckedAt
 		status.EvidenceExpiresAt = &receipt.ExpiresAt
 		status.EvidenceSource = "local_verification_receipt"
-		if driver.ServiceRequired && !serverRunning {
-			status.StaleReason = "Rampart policy service is unavailable"
-			statuses = append(statuses, status)
-			continue
-		}
 		if receipt.CheckedAt.After(now.Add(5 * time.Minute)) {
 			status.StaleReason = "verification time is in the future"
 			statuses = append(statuses, status)
@@ -481,6 +497,36 @@ func collectIntegrationAssuranceStatuses(now time.Time, serverRunning bool) []in
 			status.StaleReason = "integration environment changed since verification"
 			statuses = append(statuses, status)
 			continue
+		}
+		if driver.ServiceRequired {
+			if receipt.Runtime == nil {
+				status.StaleReason = "verification receipt lacks runtime identity"
+				statuses = append(statuses, status)
+				continue
+			}
+			endpoint, endpointErr := integrationServiceEndpoint(driver)
+			if endpointErr != nil || endpoint != receipt.Runtime.Endpoint {
+				status.StaleReason = "integration service endpoint changed since verification"
+				statuses = append(statuses, status)
+				continue
+			}
+			current, found := runtimes[endpoint]
+			if !found {
+				ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+				current.observation, current.err = observeServiceRuntime(ctx, endpoint, 150*time.Millisecond)
+				cancel()
+				runtimes[endpoint] = current
+			}
+			if current.err != nil {
+				status.StaleReason = "Rampart policy service is unavailable"
+			} else if current.observation != *receipt.Runtime {
+				status.StaleReason = "service instance, build, or mode changed since verification"
+			}
+			if status.StaleReason != "" {
+				statuses = append(statuses, status)
+				continue
+			}
+			status.Runtime = receipt.Runtime
 		}
 		status.AssuranceLevel = receipt.AssuranceLevel
 		statuses = append(statuses, status)

--- a/cmd/rampart/cli/assurance_status_test.go
+++ b/cmd/rampart/cli/assurance_status_test.go
@@ -5,6 +5,8 @@ package cli
 
 import (
 	"bytes"
+	"github.com/peg/rampart/internal/proxy"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -28,7 +30,7 @@ func TestHermesUsesCommonStaticAssuranceStatus(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	status, ok := findAssuranceStatus(collectIntegrationAssuranceStatuses(time.Now().UTC(), false), "hermes")
+	status, ok := findAssuranceStatus(collectIntegrationAssuranceStatuses(time.Now().UTC()), "hermes")
 	if !ok {
 		t.Fatal("Hermes assurance status missing")
 	}
@@ -51,7 +53,7 @@ func TestVerificationReceiptPromotesConfiguredIntegration(t *testing.T) {
 		t.Fatalf("writeVerificationReceipt: %v", err)
 	}
 
-	status, ok := findAssuranceStatus(collectIntegrationAssuranceStatuses(checkedAt.Add(time.Minute), false), "codex")
+	status, ok := findAssuranceStatus(collectIntegrationAssuranceStatuses(checkedAt.Add(time.Minute)), "codex")
 	if !ok {
 		t.Fatal("Codex assurance status missing")
 	}
@@ -79,7 +81,7 @@ func TestVerificationReceiptInvalidatesAfterConfigurationChange(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	status, ok := findAssuranceStatus(collectIntegrationAssuranceStatuses(checkedAt.Add(time.Minute), false), "codex")
+	status, ok := findAssuranceStatus(collectIntegrationAssuranceStatuses(checkedAt.Add(time.Minute)), "codex")
 	if !ok {
 		t.Fatal("Codex assurance status missing")
 	}
@@ -108,7 +110,7 @@ func TestOpenClawReceiptInvalidatesOwnedConfigurationDrift(t *testing.T) {
 			if err := writeVerificationReceipt(passingAssuranceReport("openclaw", now)); err != nil {
 				t.Fatal(err)
 			}
-			status, ok := findAssuranceStatus(collectIntegrationAssuranceStatuses(now, true), "openclaw")
+			status, ok := findAssuranceStatus(collectIntegrationAssuranceStatuses(now), "openclaw")
 			if !ok || status.AssuranceLevel != assuranceHostVerified {
 				t.Fatalf("initial assurance = %#v, found=%t", status, ok)
 			}
@@ -131,7 +133,7 @@ func TestOpenClawReceiptInvalidatesOwnedConfigurationDrift(t *testing.T) {
 			if err := os.Chtimes(path, info.ModTime(), info.ModTime()); err != nil {
 				t.Fatal(err)
 			}
-			status, ok = findAssuranceStatus(collectIntegrationAssuranceStatuses(now.Add(time.Minute), true), "openclaw")
+			status, ok = findAssuranceStatus(collectIntegrationAssuranceStatuses(now.Add(time.Minute)), "openclaw")
 			if !ok || status.AssuranceLevel == assuranceHostVerified || status.StaleReason != "integration environment changed since verification" {
 				t.Fatalf("drifted assurance = %#v, found=%t", status, ok)
 			}
@@ -156,7 +158,7 @@ func TestOpenClawReceiptInvalidatesPluginContentDrift(t *testing.T) {
 	if writeErr != nil || closeErr != nil {
 		t.Fatalf("modify plugin: write=%v close=%v", writeErr, closeErr)
 	}
-	status, ok := findAssuranceStatus(collectIntegrationAssuranceStatuses(now.Add(time.Minute), true), "openclaw")
+	status, ok := findAssuranceStatus(collectIntegrationAssuranceStatuses(now.Add(time.Minute)), "openclaw")
 	if !ok || status.AssuranceLevel == assuranceHostVerified || status.StaleReason != "integration environment changed since verification" {
 		t.Fatalf("modified plugin assurance = %#v, found=%t", status, ok)
 	}
@@ -183,7 +185,7 @@ func TestOpenClawReceiptIgnoresUnrelatedConfiguration(t *testing.T) {
 	if err := os.WriteFile(path, data, 0o600); err != nil {
 		t.Fatal(err)
 	}
-	status, ok := findAssuranceStatus(collectIntegrationAssuranceStatuses(now.Add(time.Minute), true), "openclaw")
+	status, ok := findAssuranceStatus(collectIntegrationAssuranceStatuses(now.Add(time.Minute)), "openclaw")
 	if !ok || status.AssuranceLevel != assuranceHostVerified || status.StaleReason != "" {
 		t.Fatalf("unrelated configuration invalidated assurance: %#v, found=%t", status, ok)
 	}
@@ -195,7 +197,7 @@ func TestOpenClawReceiptIgnoresUnrelatedConfiguration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, private := range []string{home, "private-provider", "provider-token", "other-plugin", "localhost:9090"} {
+	for _, private := range []string{home, "private-provider", "provider-token", "other-plugin"} {
 		if bytes.Contains(data, []byte(private)) {
 			t.Fatalf("receipt retained configuration detail %q", private)
 		}
@@ -206,6 +208,9 @@ func installOpenClawAssuranceFixture(t *testing.T, home string) string {
 	t.Helper()
 	testSetHome(t, home)
 	testSetOpenClawBinary(t, home)
+	oldClient := rampartHTTPClient
+	rampartHTTPClient = &http.Client{Transport: redirectTestTransport(func(req *http.Request) (*http.Response, error) { return statusTestHealthResponse(req, "enforce"), nil })}
+	t.Cleanup(func() { rampartHTTPClient = oldClient })
 	stateDir := filepath.Join(home, ".openclaw")
 	t.Setenv("OPENCLAW_STATE_DIR", stateDir)
 	t.Setenv("OPENCLAW_CONFIG_PATH", filepath.Join(stateDir, "openclaw.json"))
@@ -246,13 +251,13 @@ func TestVerificationReceiptInvalidatesAfterPolicyChange(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	status, ok := findAssuranceStatus(collectIntegrationAssuranceStatuses(checkedAt.Add(time.Minute), false), "codex")
+	status, ok := findAssuranceStatus(collectIntegrationAssuranceStatuses(checkedAt.Add(time.Minute)), "codex")
 	if !ok || status.StaleReason != "integration environment changed since verification" {
 		t.Fatalf("policy-mutated assurance status = %#v, found=%t", status, ok)
 	}
 }
 
-func TestVerificationReceiptInvalidatesWhenPolicyEndpointChanges(t *testing.T) {
+func TestLocalAdapterReceiptDoesNotDependOnPolicyEndpoint(t *testing.T) {
 	home := t.TempDir()
 	testSetHome(t, home)
 	installCodexAssuranceFixture(t, home)
@@ -264,9 +269,9 @@ func TestVerificationReceiptInvalidatesWhenPolicyEndpointChanges(t *testing.T) {
 		t.Fatalf("writeVerificationReceipt: %v", err)
 	}
 
-	status, ok := findAssuranceStatus(collectIntegrationAssuranceStatuses(checkedAt.Add(time.Minute), false), "codex")
-	if !ok || status.StaleReason != "integration environment changed since verification" {
-		t.Fatalf("endpoint-mutated assurance status = %#v, found=%t", status, ok)
+	status, ok := findAssuranceStatus(collectIntegrationAssuranceStatuses(checkedAt.Add(time.Minute)), "codex")
+	if !ok || status.StaleReason != "" || status.AssuranceLevel != assuranceAdapterVerified || status.Runtime != nil {
+		t.Fatalf("local adapter assurance depends on HTTP: %#v, found=%t", status, ok)
 	}
 }
 
@@ -280,7 +285,7 @@ func TestVerificationReceiptExpires(t *testing.T) {
 		t.Fatalf("writeVerificationReceipt: %v", err)
 	}
 
-	status, ok := findAssuranceStatus(collectIntegrationAssuranceStatuses(now, false), "codex")
+	status, ok := findAssuranceStatus(collectIntegrationAssuranceStatuses(now), "codex")
 	if !ok || status.StaleReason != "verification evidence expired" || status.AssuranceLevel != assuranceConfigured {
 		t.Fatalf("expired assurance status = %#v, found=%t", status, ok)
 	}
@@ -372,7 +377,7 @@ func installCodexAssuranceFixture(t *testing.T, home string) {
 }
 
 func passingAssuranceReport(target string, checkedAt time.Time) verificationReport {
-	return summarizeVerification(verificationReport{
+	report := verificationReport{
 		SchemaVersion: verifyJSONSchemaVersion,
 		GeneratedAt:   checkedAt.UTC().Format(time.RFC3339),
 		Target:        target,
@@ -381,7 +386,12 @@ func passingAssuranceReport(target string, checkedAt time.Time) verificationRepo
 			{ID: "configuration", Name: "Configuration", Status: verificationPass, Message: "configured"},
 			{ID: "behavior", Name: "Behavior", Status: verificationPass, Message: "blocked"},
 		},
-	})
+	}
+	if driver, ok := findIntegrationDriver(target); ok && driver.ServiceRequired {
+		endpoint, _ := integrationServiceEndpoint(driver)
+		report.Runtime = &serviceRuntimeObservation{Endpoint: endpoint, RuntimeIdentity: proxy.RuntimeIdentity{InstanceID: "test-service-instance-0001", Version: "1.9.0", Commit: "test-commit", Mode: "enforce"}}
+	}
+	return summarizeVerification(report)
 }
 
 func findAssuranceStatus(statuses []integrationAssuranceStatus, id string) (integrationAssuranceStatus, bool) {

--- a/cmd/rampart/cli/httpclient.go
+++ b/cmd/rampart/cli/httpclient.go
@@ -13,6 +13,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/peg/rampart/internal/proxy"
 )
 
 // rampartHTTPClient is used for all outgoing HTTP requests from CLI commands
@@ -89,13 +91,7 @@ func validateCredentialEndpoint(rawURL, tokenSource string) error {
 
 const maxRampartHealthResponseBytes = 4 << 10
 
-type rampartHealthResponse struct {
-	Service       string `json:"service"`
-	Status        string `json:"status"`
-	Mode          string `json:"mode"`
-	UptimeSeconds *int   `json:"uptime_seconds"`
-	Version       string `json:"version"`
-}
+type rampartHealthResponse = proxy.HealthResponse
 
 // fetchRampartHealth verifies that healthURL belongs to a Rampart server, not
 // merely that an unrelated process happens to return HTTP 200 on the same port.

--- a/cmd/rampart/cli/serve.go
+++ b/cmd/rampart/cli/serve.go
@@ -581,7 +581,7 @@ func newServeCmd(opts *rootOptions, deps *serveDeps) *cobra.Command {
 
 				// Write serve state file for discovery by doctor/watch/log.
 				if rampartDir != "" {
-					if err := writeServeState(rampartDir, listenPort, os.Getpid(), tlsCfg != nil); err != nil {
+					if err := writeServeState(rampartDir, listenPort, os.Getpid(), tlsCfg != nil, proxyServer.RuntimeIdentity()); err != nil {
 						logger.Warn("serve: failed to write state file", "error", err)
 					}
 				}

--- a/cmd/rampart/cli/serve_state.go
+++ b/cmd/rampart/cli/serve_state.go
@@ -11,11 +11,14 @@ import (
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/peg/rampart/internal/proxy"
 )
 
 // serveState is written by `rampart serve` so other commands (doctor, watch, log)
 // can discover the serve URL and port without requiring flags or env vars.
 type serveState struct {
+	proxy.RuntimeIdentity
 	URL        string `json:"url"`
 	Port       int    `json:"port"`
 	PID        int    `json:"pid"`
@@ -29,7 +32,7 @@ const (
 )
 
 // writeServeState writes the serve state to ~/.rampart/serve.state.
-func writeServeState(dir string, port, pid int, tls bool) error {
+func writeServeState(dir string, port, pid int, tls bool, identity proxy.RuntimeIdentity) error {
 	scheme := "http"
 	if tls {
 		scheme = "https"
@@ -39,11 +42,12 @@ func writeServeState(dir string, port, pid int, tls bool) error {
 		executable, _ = filepath.Abs(executable)
 	}
 	state := serveState{
-		URL:        fmt.Sprintf("%s://localhost:%d", scheme, port),
-		Port:       port,
-		PID:        pid,
-		Started:    time.Now().UTC().Format(time.RFC3339),
-		Executable: executable,
+		RuntimeIdentity: identity,
+		URL:             fmt.Sprintf("%s://localhost:%d", scheme, port),
+		Port:            port,
+		PID:             pid,
+		Started:         time.Now().UTC().Format(time.RFC3339Nano),
+		Executable:      executable,
 	}
 	data, err := json.Marshal(state)
 	if err != nil {

--- a/cmd/rampart/cli/serve_test.go
+++ b/cmd/rampart/cli/serve_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/peg/rampart/internal/engine"
+	"github.com/peg/rampart/internal/proxy"
 	"github.com/peg/rampart/policies"
 	"github.com/stretchr/testify/require"
 )
@@ -379,7 +380,7 @@ func TestServeStatePublishesPrivateExecutableIdentity(t *testing.T) {
 		t.Fatal(err)
 	}
 	const pid = 4242
-	if err := writeServeState(dir, 19090, pid, false); err != nil {
+	if err := writeServeState(dir, 19090, pid, false, proxy.RuntimeIdentity{}); err != nil {
 		t.Fatal(err)
 	}
 	want, err := os.Executable()

--- a/cmd/rampart/cli/service_runtime.go
+++ b/cmd/rampart/cli/service_runtime.go
@@ -1,0 +1,150 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/peg/rampart/internal/proxy"
+)
+
+// serviceRuntimeObservation records what the selected endpoint actually served.
+// It contains no credentials, PID, executable path, or process arguments.
+type serviceRuntimeObservation struct {
+	proxy.RuntimeIdentity
+	Endpoint string `json:"endpoint"`
+}
+
+func runtimeIdentified(identity proxy.RuntimeIdentity) bool {
+	if len(identity.InstanceID) < 16 || len(identity.InstanceID) > 128 || strings.TrimSpace(identity.Commit) == "" {
+		return false
+	}
+	for _, c := range identity.InstanceID {
+		if !((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-' || c == '_') {
+			return false
+		}
+	}
+	return strings.TrimSpace(identity.Version) != "" && (identity.Mode == "enforce" || identity.Mode == "monitor" || identity.Mode == "disabled")
+}
+
+func serviceEndpoint(raw string) (string, error) {
+	endpoint := strings.TrimRight(strings.TrimSpace(raw), "/")
+	u, err := url.Parse(endpoint)
+	if err != nil || u.Host == "" || u.Opaque != "" || (u.Scheme != "http" && u.Scheme != "https") ||
+		u.User != nil || u.RawQuery != "" || u.Fragment != "" || u.Path != "" {
+		return "", fmt.Errorf("service endpoint must be an absolute HTTP(S) origin without credentials, paths, queries, or fragments")
+	}
+	return endpoint, nil
+}
+
+func observeServiceRuntime(ctx context.Context, endpoint string, timeout time.Duration) (serviceRuntimeObservation, error) {
+	var observed serviceRuntimeObservation
+	endpoint, err := serviceEndpoint(endpoint)
+	if err != nil {
+		return observed, err
+	}
+	observed.Endpoint = endpoint
+	client, closeClient, err := serviceRuntimeClient(endpoint, timeout)
+	if err != nil {
+		return observed, err
+	}
+	defer closeClient()
+	health, err := fetchRampartHealth(ctx, client, endpoint+"/healthz")
+	if err != nil {
+		return observed, err
+	}
+	observed.RuntimeIdentity = health.RuntimeIdentity
+	return observed, nil
+}
+
+// serviceRuntimeClient is shared by health and preflight so both requests use
+// the same endpoint trust. No redirected request receives control credentials.
+func serviceRuntimeClient(endpoint string, timeout time.Duration) (*http.Client, func(), error) {
+	client := *rampartHTTPClient
+	client.Timeout = timeout
+	client.CheckRedirect = newRampartHTTPClient(timeout).CheckRedirect
+	if strings.HasPrefix(endpoint, "https://") && isLoopbackURL(endpoint) {
+		if home, err := os.UserHomeDir(); err == nil {
+			if _, certErr := os.Stat(filepath.Join(home, ".rampart", "tls", "cert.pem")); !os.IsNotExist(certErr) {
+				u, _ := url.Parse(endpoint)
+				return localServeHealthClient(u, home, os.ReadFile, timeout)
+			}
+		}
+	}
+	return &client, func() {}, nil
+}
+
+// integrationServiceEndpoint follows the endpoint consumed by that integration,
+// not an unrelated healthy default service. Local hooks do not require HTTP.
+func integrationServiceEndpoint(driver integrationDriver) (string, error) {
+	if !driver.ServiceRequired {
+		return "", nil
+	}
+	if driver.OpenClaw {
+		config, err := openClawAssuranceConfiguration()
+		if err != nil {
+			return "", err
+		}
+		return serviceEndpoint(config.Plugin.ServeURL)
+	}
+	endpoint, err := resolveServeURLStrict("", fmt.Sprintf("http://localhost:%d", defaultServePort))
+	if err != nil {
+		return "", err
+	}
+	return serviceEndpoint(endpoint)
+}
+
+func readPrivateServeState(dir string) (serveState, error) {
+	var state serveState
+	path := filepath.Join(dir, serveStateFile)
+	info, err := os.Lstat(path)
+	if err != nil {
+		return state, err
+	}
+	if !info.Mode().IsRegular() || info.Size() > maxServeStateFileBytes || (runtime.GOOS != "windows" && info.Mode().Perm()&0o077 != 0) {
+		return state, fmt.Errorf("serve.state is not a bounded private regular file")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return state, err
+	}
+	if len(data) > maxServeStateFileBytes {
+		return state, fmt.Errorf("serve.state exceeds size limit")
+	}
+	err = json.Unmarshal(data, &state)
+	return state, err
+}
+
+func ownedServiceRuntime(observed serviceRuntimeObservation) bool {
+	if !runtimeIdentified(observed.RuntimeIdentity) || !isLoopbackURL(observed.Endpoint) {
+		return false
+	}
+	dir, err := rampartDir()
+	if err != nil {
+		return false
+	}
+	state, err := readPrivateServeState(dir)
+	if err != nil || state.PID <= 0 || state.RuntimeIdentity != observed.RuntimeIdentity {
+		return false
+	}
+	stateURL, err := validateLocalServeStateURL(state)
+	if err != nil {
+		return false
+	}
+	endpoint, _ := url.Parse(observed.Endpoint)
+	if stateURL.Scheme != endpoint.Scheme || stateURL.Port() != endpoint.Port() {
+		return false
+	}
+	owned, _, err := isRampartServeProcess(state.PID)
+	return err == nil && owned
+}

--- a/cmd/rampart/cli/service_runtime_test.go
+++ b/cmd/rampart/cli/service_runtime_test.go
@@ -1,0 +1,157 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/peg/rampart/internal/proxy"
+)
+
+func TestServiceReceiptRejectsReplacementAndModeChange(t *testing.T) {
+	for _, field := range []string{"instance", "build", "mode", "unavailable"} {
+		t.Run(field, func(t *testing.T) {
+			home := t.TempDir()
+			installOpenClawAssuranceFixture(t, home)
+			now := time.Now().UTC().Truncate(time.Second)
+			report := passingAssuranceReport("openclaw", now)
+			if err := writeVerificationReceipt(report); err != nil {
+				t.Fatal(err)
+			}
+			before, _ := findAssuranceStatus(collectIntegrationAssuranceStatuses(now), "openclaw")
+			if before.AssuranceLevel != assuranceHostVerified {
+				t.Fatalf("initial evidence: %#v", before)
+			}
+			// A healthy global/default endpoint cannot rescue the host's endpoint.
+			t.Setenv("RAMPART_URL", "http://127.0.0.1:19999")
+			rampartHTTPClient = &http.Client{Transport: redirectTestTransport(func(req *http.Request) (*http.Response, error) {
+				if req.URL.Host != "localhost:9090" {
+					t.Errorf("probed unrelated endpoint %s", req.URL.Host)
+				}
+				if field == "unavailable" {
+					return nil, io.EOF
+				}
+				response := statusTestHealthResponse(req, "enforce")
+				body, _ := io.ReadAll(response.Body)
+				switch field {
+				case "instance":
+					body = bytes.ReplaceAll(body, []byte("test-service-instance-0001"), []byte("test-service-instance-0002"))
+				case "build":
+					body = bytes.ReplaceAll(body, []byte("test-commit"), []byte("other-commit"))
+				case "mode":
+					body = bytes.ReplaceAll(body, []byte("enforce"), []byte("monitor"))
+				}
+				response.Body = io.NopCloser(bytes.NewReader(body))
+				return response, nil
+			})}
+			after, _ := findAssuranceStatus(collectIntegrationAssuranceStatuses(now), "openclaw")
+			if after.AssuranceLevel == assuranceHostVerified || after.StaleReason == "" {
+				t.Fatalf("stale runtime promoted: %#v", after)
+			}
+		})
+	}
+}
+
+func TestLegacyReceiptDoesNotAcquireRuntimeEvidence(t *testing.T) {
+	home := t.TempDir()
+	installOpenClawAssuranceFixture(t, home)
+	now := time.Now().UTC().Truncate(time.Second)
+	report := passingAssuranceReport("openclaw", now)
+	report.policyEndpoint = report.Runtime.Endpoint
+	report.Runtime = nil
+	if err := writeVerificationReceipt(report); err != nil {
+		t.Fatal(err)
+	}
+	status, _ := findAssuranceStatus(collectIntegrationAssuranceStatuses(now), "openclaw")
+	if status.AssuranceLevel != assuranceConfigured || status.StaleReason != "verification receipt lacks runtime identity" || status.Runtime != nil {
+		t.Fatalf("legacy receipt: %#v", status)
+	}
+}
+
+func TestVerificationRejectsRuntimeChangeDuringCanaries(t *testing.T) {
+	for _, change := range []string{"instance", "mode"} {
+		t.Run(change, func(t *testing.T) {
+			installVerificationToken(t, "verification-token")
+			probes := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/healthz" {
+					probes++
+					identity := proxy.RuntimeIdentity{InstanceID: "test-service-instance-0001", Version: "test", Commit: "test-commit", Mode: "enforce"}
+					if probes > 1 {
+						if change == "instance" {
+							identity.InstanceID = "test-service-instance-0002"
+						} else {
+							identity.Mode = "monitor"
+						}
+					}
+					uptime := 1
+					_ = json.NewEncoder(w).Encode(proxy.HealthResponse{RuntimeIdentity: identity, Service: "rampart", Status: "ok", UptimeSeconds: &uptime})
+					return
+				}
+				var request struct {
+					Params map[string]any `json:"params"`
+				}
+				if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+					t.Error(err)
+				}
+				decision := "deny"
+				if request.Params["command"] == "pwd" {
+					decision = "allow"
+				}
+				_ = json.NewEncoder(w).Encode(preflightResponse{Allowed: decision == "allow", Decision: decision})
+			}))
+			defer server.Close()
+			report := runBehavioralVerification(context.Background(), "policy", server.URL, time.Second)
+			if report.Runtime != nil || report.Summary.Failed != 1 || report.Summary.Passed != 5 || probes != 2 {
+				t.Fatalf("changed runtime report: %#v probes=%d", report, probes)
+			}
+		})
+	}
+}
+
+func TestVerificationOverrideCannotReplaceHostEndpoint(t *testing.T) {
+	installOpenClawAssuranceFixture(t, t.TempDir())
+	report := runBehavioralVerification(context.Background(), "openclaw", "http://127.0.0.1:19999", time.Second)
+	if report.Runtime != nil || report.Summary.Unverified != 1 || len(report.Checks) != 1 || !strings.Contains(report.Checks[0].Hint, "differs") {
+		t.Fatalf("mismatched override: %#v", report)
+	}
+}
+
+func TestReuseReportsLegacyAndRefusesNonEnforcingServiceWithoutMutation(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+	path := filepath.Join(home, ".rampart", "token")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	const canary = "synthetic-private-token"
+	if err := os.WriteFile(path, []byte(canary), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, mode := range []string{"enforce", "monitor", "disabled"} {
+		var output bytes.Buffer
+		observed := serviceRuntimeObservation{Endpoint: "https://example.invalid", RuntimeIdentity: proxy.RuntimeIdentity{Version: "1.9.1", Mode: mode}}
+		err := reportReusableServe(&output, observed)
+		if (err == nil) != (mode == "enforce") {
+			t.Fatalf("mode=%s error=%v", mode, err)
+		}
+		if !strings.Contains(output.String(), "1.9.1") || !strings.Contains(output.String(), mode) || !strings.Contains(output.String(), "ownership unproven") || strings.Contains(output.String(), canary) {
+			t.Fatalf("reuse output: %s", output.String())
+		}
+	}
+	data, err := os.ReadFile(path)
+	if err != nil || string(data) != canary {
+		t.Fatal("reuse modified the existing token")
+	}
+}

--- a/cmd/rampart/cli/setup_openclaw_plugin.go
+++ b/cmd/rampart/cli/setup_openclaw_plugin.go
@@ -1921,9 +1921,11 @@ func ensureServeRunningForURL(w io.Writer, errW io.Writer, serveURL string) erro
 	if serveURL == "" {
 		return fmt.Errorf("rampart policy service URL is empty")
 	}
-	if isSetupServeReachableAt(serveURL) {
-		fmt.Fprintf(w, "✓ Rampart serve is running at %s\n", serveURL)
-		return nil
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	observed, healthErr := observeServiceRuntime(ctx, serveURL, 500*time.Millisecond)
+	cancel()
+	if healthErr == nil {
+		return reportReusableServe(w, observed)
 	}
 	defaultURL := fmt.Sprintf("http://localhost:%d", defaultServePort)
 	if serveURL != defaultURL {
@@ -1944,9 +1946,8 @@ func ensureServeRunningForURL(w io.Writer, errW io.Writer, serveURL string) erro
 		// Wait up to 3 seconds for serve to come up.
 		for i := 0; i < 6; i++ {
 			time.Sleep(500 * time.Millisecond)
-			if isSetupServeReachableAt(serveURL) {
-				fmt.Fprintln(w, "✓ Rampart serve started (system service)")
-				return nil
+			if observed, err := observeServiceRuntime(context.Background(), serveURL, 500*time.Millisecond); err == nil {
+				return reportReusableServe(w, observed)
 			}
 		}
 		fmt.Fprintln(errW, "⚠ rampart serve service install did not become reachable; trying background fallback")
@@ -1963,6 +1964,21 @@ func ensureServeRunningForURL(w io.Writer, errW io.Writer, serveURL string) erro
 	return nil
 }
 
+func reportReusableServe(w io.Writer, observed serviceRuntimeObservation) error {
+	ownership := "ownership unproven; service left unchanged"
+	if ownedServiceRuntime(observed) {
+		ownership = "owned local service"
+	}
+	fmt.Fprintf(w, "Rampart service at %s: version %s, mode %s (%s)\n", observed.Endpoint, observed.Version, observed.Mode, ownership)
+	if observed.Mode != "enforce" {
+		return fmt.Errorf("the configured service is in %s mode; restart it in enforce mode using its existing service definition or launch settings before protecting this integration", observed.Mode)
+	}
+	if !runtimeIdentified(observed.RuntimeIdentity) {
+		fmt.Fprintln(w, "Legacy service is available; per-start runtime assurance requires updating the service and reverifying.")
+	}
+	return nil
+}
+
 func startServeBackgroundFallback(rampartBin, serveURL string, w io.Writer, errW io.Writer) error {
 	cmd := osexec.Command(rampartBin, "serve", "--background")
 	cmd.Stdout = w
@@ -1972,9 +1988,8 @@ func startServeBackgroundFallback(rampartBin, serveURL string, w io.Writer, errW
 	}
 	for i := 0; i < 10; i++ {
 		time.Sleep(500 * time.Millisecond)
-		if isSetupServeReachableAt(serveURL) {
-			fmt.Fprintln(w, "✓ Rampart serve started (background fallback)")
-			return nil
+		if observed, err := observeServiceRuntime(context.Background(), serveURL, 500*time.Millisecond); err == nil {
+			return reportReusableServe(w, observed)
 		}
 	}
 	return fmt.Errorf("rampart serve --background did not become reachable after 5s")

--- a/cmd/rampart/cli/status.go
+++ b/cmd/rampart/cli/status.go
@@ -51,6 +51,8 @@ const statusSchemaVersion = "rampart.status.v1"
 type statusSnapshot struct {
 	generatedAt   time.Time
 	buildVersion  string
+	service       *serviceRuntimeObservation
+	serviceOwned  bool
 	protected     []string
 	integrations  []integrationAssuranceStatus
 	mode          string
@@ -67,6 +69,9 @@ type statusJSONOutput struct {
 	SchemaVersion string                       `json:"schema_version"`
 	GeneratedAt   time.Time                    `json:"generated_at"`
 	BuildVersion  string                       `json:"build_version"`
+	BuildCommit   string                       `json:"build_commit"`
+	Service       *serviceRuntimeObservation   `json:"service,omitempty"`
+	ServiceOwned  bool                         `json:"service_owned"`
 	Protected     []string                     `json:"protected_agents"`
 	Integrations  []integrationAssuranceStatus `json:"integrations"`
 	Mode          string                       `json:"mode"`
@@ -110,6 +115,17 @@ func runStatus(w io.Writer, jsonOut bool) error {
 		useColor,
 	)
 	fmt.Fprintln(w, box)
+	fmt.Fprintf(w, "CLI: %s (%s)\n", snapshot.buildVersion, build.Commit)
+	if snapshot.service != nil {
+		ownership := "ownership unproven"
+		if snapshot.serviceOwned {
+			ownership = "owned local service"
+		}
+		fmt.Fprintf(w, "Service: %s (%s), %s, %s · %s\n", snapshot.service.Version, snapshot.service.Commit, snapshot.service.Mode, ownership, snapshot.service.Endpoint)
+		if !runtimeIdentified(snapshot.service.RuntimeIdentity) {
+			fmt.Fprintln(w, "Service freshness is unavailable for this legacy health response; runtime-bound verification requires an updated service.")
+		}
+	}
 	printIntegrationAssurance(w, snapshot.integrations, snapshot.generatedAt)
 
 	printStatusHints(w, snapshot.serverRunning, snapshot.protected, snapshot.allow, snapshot.deny, snapshot.pending)
@@ -121,19 +137,31 @@ func collectStatusSnapshot(generatedAt time.Time) statusSnapshot {
 		generatedAt = time.Now().UTC()
 	}
 	protected := detectProtectedAgents()
-	health, healthErr := configuredServiceHealth()
+	endpoint, endpointErr := resolveServeURLStrict("", fmt.Sprintf("http://localhost:%d", defaultServePort))
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+	health, healthErr := observeServiceRuntime(ctx, endpoint, 150*time.Millisecond)
+	if endpointErr != nil {
+		healthErr = endpointErr
+	}
 	serverRunning := healthErr == nil
 	mode := "unknown"
+	var service *serviceRuntimeObservation
+	serviceOwned := false
 	if serverRunning {
 		mode = health.Mode
+		service = &health
+		serviceOwned = ownedServiceRuntime(health)
 	}
 	defaultAction := detectPolicyDefault()
 	allow, deny, pending, lastDeny := todayEventsAt(generatedAt)
 	return statusSnapshot{
 		generatedAt:   generatedAt,
 		buildVersion:  build.Version,
+		service:       service,
+		serviceOwned:  serviceOwned,
 		protected:     protected,
-		integrations:  collectIntegrationAssuranceStatuses(generatedAt, serverRunning),
+		integrations:  collectIntegrationAssuranceStatuses(generatedAt),
 		mode:          mode,
 		defaultAction: defaultAction,
 		serverRunning: serverRunning,
@@ -159,6 +187,9 @@ func writeStatusJSON(w io.Writer, snapshot statusSnapshot) error {
 		SchemaVersion: statusSchemaVersion,
 		GeneratedAt:   snapshot.generatedAt,
 		BuildVersion:  snapshot.buildVersion,
+		BuildCommit:   build.Commit,
+		Service:       snapshot.service,
+		ServiceOwned:  snapshot.serviceOwned,
 		Protected:     protected,
 		Integrations:  integrations,
 		Mode:          snapshot.mode,

--- a/cmd/rampart/cli/status_test.go
+++ b/cmd/rampart/cli/status_test.go
@@ -254,10 +254,6 @@ func TestStatusUnavailableConfiguredEndpointInvalidatesServiceReceipt(t *testing
 	if err := writeVerificationReceipt(passingAssuranceReport("cursor", now)); err != nil {
 		t.Fatal(err)
 	}
-	initial, ok := findAssuranceStatus(collectIntegrationAssuranceStatuses(now, true), "cursor")
-	if !ok || initial.AssuranceLevel != assuranceAdapterVerified {
-		t.Fatalf("initial Cursor assurance = %#v, found=%t", initial, ok)
-	}
 
 	var probes []string
 	oldClient := rampartHTTPClient
@@ -275,7 +271,7 @@ func TestStatusUnavailableConfiguredEndpointInvalidatesServiceReceipt(t *testing
 	if snapshot.serverRunning || snapshot.mode != "unknown" {
 		t.Fatalf("unavailable endpoint: running=%t mode=%q", snapshot.serverRunning, snapshot.mode)
 	}
-	if len(probes) != 1 || probes[0] != "127.0.0.1:19099" {
+	if len(probes) != 2 || probes[0] != "127.0.0.1:19099" || probes[1] != "127.0.0.1:19099" {
 		t.Fatalf("status probed endpoints other than its configured service: %v", probes)
 	}
 	status, ok := findAssuranceStatus(snapshot.integrations, "cursor")
@@ -289,7 +285,7 @@ func statusTestHealthResponse(req *http.Request, mode string) *http.Response {
 		StatusCode: http.StatusOK,
 		Request:    req,
 		Header:     make(http.Header),
-		Body:       io.NopCloser(strings.NewReader(fmt.Sprintf(`{"service":"rampart","status":"ok","mode":%q,"uptime_seconds":1,"version":"1.9.0"}`, mode))),
+		Body:       io.NopCloser(strings.NewReader(fmt.Sprintf(`{"service":"rampart","status":"ok","mode":%q,"uptime_seconds":1,"version":"1.9.0","commit":"test-commit","instance_id":"test-service-instance-0001"}`, mode))),
 	}
 }
 

--- a/cmd/rampart/cli/upgrade.go
+++ b/cmd/rampart/cli/upgrade.go
@@ -1254,6 +1254,17 @@ func verifyRestartedServeState(
 			return nil, fmt.Errorf("restarted runtime version mismatch: expected %s, got %q", expected, health.Version)
 		}
 	}
+	if state.InstanceID != "" || health.InstanceID != "" {
+		if !runtimeIdentified(state.RuntimeIdentity) || state.RuntimeIdentity != health.RuntimeIdentity {
+			return nil, fmt.Errorf("restarted runtime identity does not match fresh owned serve.state")
+		}
+		var previous serveState
+		if previousExists && json.Unmarshal(previousState, &previous) == nil && previous.InstanceID == state.InstanceID {
+			return nil, fmt.Errorf("restarted runtime reused the previous instance identity")
+		}
+	} else if cmp, ok := compareReleaseVersions(expectedVersion, "v1.9.1"); !ok || cmp > 0 {
+		return nil, fmt.Errorf("restarted runtime lacks instance identity; legacy recovery is limited to v1.9.1 and older")
+	}
 	return append([]byte(nil), stateData...), nil
 }
 

--- a/cmd/rampart/cli/upgrade_health_test.go
+++ b/cmd/rampart/cli/upgrade_health_test.go
@@ -16,7 +16,46 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/peg/rampart/internal/proxy"
 )
+
+func TestServeRestartVerifierBindsSameVersionHealthToOwnedInstance(t *testing.T) {
+	for _, tc := range []struct {
+		name, expected, stateID, healthID, previousID string
+		wantError                                     bool
+	}{
+		{"matching", "v2.0.0", "fresh-instance-0001", "fresh-instance-0001", "previous-instance-0001", false},
+		{"unrelated same version", "v2.0.0", "fresh-instance-0001", "other-instance-0001", "previous-instance-0001", true},
+		{"reused instance", "v2.0.0", "fresh-instance-0001", "fresh-instance-0001", "fresh-instance-0001", true},
+		{"modern identity missing", "v2.0.0", "", "", "previous-instance-0001", true},
+		{"legacy rollback", "v1.9.1", "", "", "previous-instance-0001", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			uptime := 1
+			identity := proxy.RuntimeIdentity{InstanceID: tc.healthID, Version: tc.expected, Commit: "same-build", Mode: "enforce"}
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_ = json.NewEncoder(w).Encode(proxy.HealthResponse{RuntimeIdentity: identity, Service: "rampart", Status: "ok", UptimeSeconds: &uptime})
+			}))
+			defer server.Close()
+			parsed, _ := url.Parse(server.URL)
+			port, _ := strconv.Atoi(parsed.Port())
+			state := serveState{URL: server.URL, Port: port, PID: 4242, Started: time.Now().UTC().Format(time.RFC3339Nano), RuntimeIdentity: identity}
+			state.InstanceID = tc.stateID
+			previous := state
+			previous.InstanceID = tc.previousID
+			previous.Started = time.Now().Add(-time.Minute).UTC().Format(time.RFC3339Nano)
+			data, _ := json.Marshal(state)
+			previousData, _ := json.Marshal(previous)
+			deps := testServeRestartVerifierDeps(func(int) (bool, string, error) { return true, "rampart serve", nil })
+			_, err := verifyRestartedServeState(context.Background(), home, os.ReadFile, data, tc.expected, previousData, true, time.Now().Add(-time.Second), deps)
+			if (err != nil) != tc.wantError {
+				t.Fatalf("activation error=%v, wantError=%t", err, tc.wantError)
+			}
+		})
+	}
+}
 
 func TestServeRestartVerifierRejectsStaleState(t *testing.T) {
 	home := t.TempDir()

--- a/cmd/rampart/cli/verify.go
+++ b/cmd/rampart/cli/verify.go
@@ -1473,7 +1473,7 @@ func summarizeVerification(report verificationReport) verificationReport {
 
 func printVerificationReport(w io.Writer, report verificationReport) {
 	fmt.Fprintf(w, "Rampart behavioral verification — %s\n\n", report.Target)
-	fmt.Fprintln(w, "Safe canaries only: no commands, file reads, messages, or external network requests are executed.")
+	fmt.Fprintln(w, "Safe canaries do not execute tools or contact their represented targets.")
 	fmt.Fprintln(w, "HTTP checks use preflight; local adapter checks use temporary audit storage. Neither adds canary events to your audit log.")
 	fmt.Fprintln(w)
 	printVerificationResult(w, report)
@@ -1481,7 +1481,7 @@ func printVerificationReport(w io.Writer, report verificationReport) {
 
 func printVerificationBatchReport(w io.Writer, report verificationBatchReport) {
 	fmt.Fprintf(w, "Rampart behavioral verification — configured integrations with safe verifiers (%d targets)\n\n", report.Summary.Targets)
-	fmt.Fprintln(w, "Safe canaries only: no models, commands, file reads, messages, or external network requests are invoked.")
+	fmt.Fprintln(w, "Safe canaries do not invoke models, execute tools, or contact their represented targets.")
 	fmt.Fprintln(w, "HTTP checks use preflight; local adapter checks use temporary audit storage. Neither adds canary events to your audit log.")
 	fmt.Fprintln(w, "Static-only integrations are not included; use `rampart doctor` for their installation status.")
 	for index, result := range report.Results {

--- a/cmd/rampart/cli/verify.go
+++ b/cmd/rampart/cli/verify.go
@@ -44,6 +44,7 @@ type verificationCheck struct {
 	Actual   string             `json:"actual,omitempty"`
 	Message  string             `json:"message"`
 	Hint     string             `json:"hint,omitempty"`
+	runtime  *serviceRuntimeObservation
 }
 
 type verificationSummary struct {
@@ -72,13 +73,14 @@ func latestAuditEvent(auditDir string) (audit.Event, error) {
 }
 
 type verificationReport struct {
-	SchemaVersion  string              `json:"schema_version"`
-	GeneratedAt    string              `json:"generated_at"`
-	Target         string              `json:"target"`
-	SafeCanaries   bool                `json:"safe_canaries"`
-	Assurance      assuranceLevel      `json:"assurance_level"`
-	Summary        verificationSummary `json:"summary"`
-	Checks         []verificationCheck `json:"checks"`
+	SchemaVersion  string                     `json:"schema_version"`
+	GeneratedAt    string                     `json:"generated_at"`
+	Target         string                     `json:"target"`
+	SafeCanaries   bool                       `json:"safe_canaries"`
+	Assurance      assuranceLevel             `json:"assurance_level"`
+	Summary        verificationSummary        `json:"summary"`
+	Checks         []verificationCheck        `json:"checks"`
+	Runtime        *serviceRuntimeObservation `json:"runtime,omitempty"`
 	policyEndpoint string
 }
 
@@ -125,24 +127,21 @@ func newVerifyCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "verify [openclaw|claude-code|cline|codex|gemini|antigravity|copilot|cursor|policy]",
 		Short: "Actively verify that agent safety boundaries really block",
-		Long: `Run non-destructive behavioral canaries against the live Rampart policy path.
+		Long: `Run non-destructive behavioral canaries against Rampart's integration boundaries.
 
 The canaries never execute commands, read files, send messages, or contact an
-external network. They use Rampart's policy endpoint and a decoy path/domain
-to prove the decisions the installed integration would receive. OpenClaw
-verification also runs fixed canaries through the live before_tool_call
-implementation.`,
+external network. Service-optional hooks verify their local installation,
+adapter and isolated audit behavior without HTTP. The policy target and
+service-backed integrations test the effective policy endpoint. OpenClaw also
+runs fixed canaries through the loaded before_tool_call implementation and
+compares its runtime observation with the CLI's observation.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if all {
 				if len(args) > 0 {
 					return fmt.Errorf("verify: --all cannot be combined with target %q", args[0])
 				}
-				resolvedURL, err := resolveServeURLStrict(serveURL, fmt.Sprintf("http://localhost:%d", defaultServePort))
-				if err != nil {
-					return fmt.Errorf("verify: resolve serve URL: %w", err)
-				}
-				report, receiptErr := runAllBehavioralVerifications(cmd.Context(), resolvedURL, timeout)
+				report, receiptErr := runAllBehavioralVerifications(cmd.Context(), serveURL, timeout)
 				if jsonOut {
 					if err := json.NewEncoder(cmd.OutOrStdout()).Encode(report); err != nil {
 						return fmt.Errorf("verify: encode aggregate report: %w", err)
@@ -187,11 +186,7 @@ implementation.`,
 				target = driver.VerifyTarget
 			}
 
-			resolvedURL, err := resolveServeURLStrict(serveURL, fmt.Sprintf("http://localhost:%d", defaultServePort))
-			if err != nil {
-				return fmt.Errorf("verify: resolve serve URL: %w", err)
-			}
-			report := runBehavioralVerification(cmd.Context(), target, resolvedURL, timeout)
+			report := runBehavioralVerification(cmd.Context(), target, serveURL, timeout)
 			receiptErr := writeVerificationReceipt(report)
 			if jsonOut {
 				if err := json.NewEncoder(cmd.OutOrStdout()).Encode(report); err != nil {
@@ -356,22 +351,85 @@ func behavioralCanaries(target string) []behavioralCanary {
 	return canaries
 }
 
-func runBehavioralVerification(ctx context.Context, target, serveURL string, timeout time.Duration) verificationReport {
+func runBehavioralVerification(ctx context.Context, target, serveURL string, timeout time.Duration) (report verificationReport) {
 	if timeout <= 0 {
 		timeout = 5 * time.Second
 	}
-	report := verificationReport{
-		SchemaVersion:  verifyJSONSchemaVersion,
-		GeneratedAt:    time.Now().UTC().Format(time.RFC3339),
-		Target:         target,
-		SafeCanaries:   true,
-		Checks:         make([]verificationCheck, 0),
-		policyEndpoint: strings.TrimRight(serveURL, "/"),
+	report = verificationReport{
+		SchemaVersion: verifyJSONSchemaVersion,
+		GeneratedAt:   time.Now().UTC().Format(time.RFC3339),
+		Target:        target,
+		SafeCanaries:  true,
+		Checks:        make([]verificationCheck, 0),
 	}
+	driver, isIntegration := findIntegrationDriver(target)
+	if isIntegration && !driver.ServiceRequired {
+		if driver.VerifyChecks != nil {
+			report.Checks = append(report.Checks, driver.VerifyChecks(ctx, timeout)...)
+		}
+		return summarizeVerification(report)
+	}
+	var endpointErr error
+	if isIntegration {
+		var effective string
+		effective, endpointErr = integrationServiceEndpoint(driver)
+		if endpointErr == nil && serveURL != "" {
+			override, err := serviceEndpoint(serveURL)
+			if err != nil || override != effective {
+				endpointErr = fmt.Errorf("verification override differs from the integration's configured service; configure the host endpoint first or omit --serve-url")
+			}
+		}
+		serveURL = effective
+	} else {
+		serveURL, endpointErr = resolveServeURLStrict(serveURL, fmt.Sprintf("http://localhost:%d", defaultServePort))
+	}
+	if endpointErr != nil {
+		report.Checks = append(report.Checks, verificationCheck{ID: "service-runtime", Name: "Integration service identity", Status: verificationUnverified, Message: "The effective service endpoint could not be established", Hint: endpointErr.Error()})
+		return summarizeVerification(report)
+	}
+	report.policyEndpoint = serveURL
+	before, runtimeErr := observeServiceRuntime(ctx, serveURL, timeout)
+	if runtimeErr != nil {
+		report.Checks = append(report.Checks, verificationCheck{ID: "service-runtime", Name: "Integration service identity", Status: verificationUnverified, Message: "The selected Rampart service is unavailable or returned invalid health", Hint: "Start the configured service and rerun verification"})
+		return summarizeVerification(report)
+	}
+	if before.Mode != "enforce" {
+		report.Checks = append(report.Checks, verificationCheck{ID: "service-runtime", Name: "Integration service identity", Status: verificationFail, Actual: before.Mode, Message: "The selected service is not enforcing policy", Hint: "Start the service in enforce mode and rerun verification"})
+		return summarizeVerification(report)
+	}
+	hostRuntimeMatched := !driver.OpenClaw
+	defer func() {
+		after, err := observeServiceRuntime(ctx, serveURL, timeout)
+		switch {
+		case err != nil || before != after:
+			report.Runtime = nil
+			report.Checks = append(report.Checks, verificationCheck{ID: "service-runtime", Name: "Stable service runtime", Status: verificationFail, Message: "The service changed or became unavailable during verification; no runtime evidence was retained", Hint: "Rerun verification against a stable enforcing service"})
+		case !runtimeIdentified(before.RuntimeIdentity):
+			report.Checks = append(report.Checks, verificationCheck{ID: "service-runtime", Name: "Stable service runtime", Status: verificationUnverified, Message: "This legacy service does not expose a runtime instance and build identity", Hint: "Update the service, then rerun verification"})
+		default:
+			if hostRuntimeMatched {
+				report.Runtime = &before
+			}
+		}
+		report = summarizeVerification(report)
+	}()
 
 	if target != "policy" {
 		if driver, ok := findIntegrationDriver(target); ok && driver.VerifyChecks != nil {
-			report.Checks = append(report.Checks, driver.VerifyChecks(ctx, timeout)...)
+			checks := driver.VerifyChecks(ctx, timeout)
+			for i := range checks {
+				if driver.OpenClaw && checks[i].runtime != nil {
+					if *checks[i].runtime == before {
+						hostRuntimeMatched = true
+					} else {
+						checks[i].Status = verificationFail
+						checks[i].Actual = "loaded plugin uses a different runtime"
+						checks[i].Message = "The loaded OpenClaw plugin verified a different service endpoint or instance from the CLI"
+						checks[i].Hint = "Restart the OpenClaw gateway to load its current configuration, then verify again"
+					}
+				}
+			}
+			report.Checks = append(report.Checks, checks...)
 		}
 	}
 
@@ -399,7 +457,12 @@ func runBehavioralVerification(ctx context.Context, target, serveURL string, tim
 		return summarizeVerification(report)
 	}
 
-	client := newRampartHTTPClient(timeout)
+	client, closeClient, clientErr := serviceRuntimeClient(serveURL, timeout)
+	if clientErr != nil {
+		report.Checks = append(report.Checks, verificationCheck{ID: "policy-transport", Name: "Policy endpoint trust", Status: verificationUnverified, Message: "The selected service trust could not be established"})
+		return summarizeVerification(report)
+	}
+	defer closeClient()
 	for _, canary := range behavioralCanaries(target) {
 		report.Checks = append(report.Checks, runPreflightCanary(ctx, client, strings.TrimRight(serveURL, "/"), token, target, canary))
 	}
@@ -1159,11 +1222,48 @@ func verifyOpenClawPluginLive(ctx context.Context, timeout time.Duration) verifi
 		check.Hint = "Run `rampart protect openclaw --reinstall`, restart the gateway, and verify again"
 		return check
 	}
+	observed, err := pluginVerificationRuntime(pluginResult["runtime"])
+	if err != nil {
+		check.Status = verificationFail
+		check.Actual = "invalid loaded runtime observation"
+		check.Message = "The loaded plugin returned invalid runtime evidence"
+		check.Hint = "Reinstall the current plugin, restart the gateway, and verify again"
+		return check
+	}
+	if observed == nil {
+		check.Status = verificationUnverified
+		check.Actual = "canaries passed; loaded runtime unverified"
+		check.Message = "Plugin canaries passed, but the loaded plugin did not identify a stable enforcing service"
+		check.Hint = "Update Rampart and its plugin, restart the gateway, and verify again"
+		return check
+	}
+	check.runtime = observed
 
 	check.Status = verificationPass
 	check.Actual = "complete and current"
 	check.Message = "The current bundled plugin reached Rampart through its policy mapping path and returned every expected canary decision"
 	return check
+}
+
+func pluginVerificationRuntime(value any) (*serviceRuntimeObservation, error) {
+	if value == nil {
+		return nil, nil
+	}
+	data, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	var observed serviceRuntimeObservation
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&observed); err != nil {
+		return nil, err
+	}
+	endpoint, err := serviceEndpoint(observed.Endpoint)
+	if err != nil || endpoint != observed.Endpoint || !isLoopbackURL(endpoint) || !runtimeIdentified(observed.RuntimeIdentity) || observed.Mode != "enforce" {
+		return nil, fmt.Errorf("incomplete or non-enforcing runtime observation")
+	}
+	return &observed, nil
 }
 
 func verifyOpenClawManagedConfig(ctx context.Context, openclawBin string) error {
@@ -1374,7 +1474,7 @@ func summarizeVerification(report verificationReport) verificationReport {
 func printVerificationReport(w io.Writer, report verificationReport) {
 	fmt.Fprintf(w, "Rampart behavioral verification — %s\n\n", report.Target)
 	fmt.Fprintln(w, "Safe canaries only: no commands, file reads, messages, or external network requests are executed.")
-	fmt.Fprintln(w, "Verification uses the local admin path and does not add events to Rampart's audit log.")
+	fmt.Fprintln(w, "HTTP checks use preflight; local adapter checks use temporary audit storage. Neither adds canary events to your audit log.")
 	fmt.Fprintln(w)
 	printVerificationResult(w, report)
 }
@@ -1382,7 +1482,7 @@ func printVerificationReport(w io.Writer, report verificationReport) {
 func printVerificationBatchReport(w io.Writer, report verificationBatchReport) {
 	fmt.Fprintf(w, "Rampart behavioral verification — configured integrations with safe verifiers (%d targets)\n\n", report.Summary.Targets)
 	fmt.Fprintln(w, "Safe canaries only: no models, commands, file reads, messages, or external network requests are invoked.")
-	fmt.Fprintln(w, "Verification uses the local admin path and does not add events to Rampart's audit log.")
+	fmt.Fprintln(w, "HTTP checks use preflight; local adapter checks use temporary audit storage. Neither adds canary events to your audit log.")
 	fmt.Fprintln(w, "Static-only integrations are not included; use `rampart doctor` for their installation status.")
 	for index, result := range report.Results {
 		if index > 0 {

--- a/cmd/rampart/cli/verify_test.go
+++ b/cmd/rampart/cli/verify_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -16,7 +17,6 @@ import (
 	"time"
 
 	hermesplugin "github.com/peg/rampart/internal/plugin/hermes"
-	ocplugin "github.com/peg/rampart/internal/plugin/openclaw"
 )
 
 func TestConfiguredVerificationTargetsIncludesPolicyAndConfiguredHooks(t *testing.T) {
@@ -263,18 +263,41 @@ func TestVerifyClaudeAndClineAdaptersBlockCanary(t *testing.T) {
 	}
 }
 
-func TestVerifyOpenClawPluginLiveParsesGatewayPayload(t *testing.T) {
+func TestOpenClawVerificationBindsLoadedRuntime(t *testing.T) {
 	skipOnWindows(t, "test uses a POSIX OpenClaw shim")
-	stateDir := t.TempDir()
-	pluginDir := filepath.Join(stateDir, openclawPluginDir)
-	if err := ocplugin.Extract(pluginDir); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(stateDir, "openclaw.json"), []byte(`{"plugins":{"allow":["rampart"],"entries":{"rampart":{"enabled":true}}},"tools":{"exec":{"mode":"full"}}}`), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	bin := filepath.Join(t.TempDir(), "openclaw")
-	shim := `#!/bin/sh
+	for _, scenario := range []struct {
+		name string
+		want assuranceLevel
+	}{
+		{"matching", assuranceHostVerified},
+		{"legacy", assuranceUnverified},
+		{"different endpoint", assuranceDegraded},
+		{"different instance", assuranceDegraded},
+	} {
+		t.Run(scenario.name, func(t *testing.T) {
+			home := t.TempDir()
+			installOpenClawAssuranceFixture(t, home)
+			t.Setenv("RAMPART_TOKEN", "verification-token")
+			t.Setenv("RAMPART_URL", "")
+			identity := map[string]string{
+				"endpoint": "http://localhost:9090", "instance_id": "test-service-instance-0001",
+				"version": "1.9.0", "commit": "test-commit", "mode": "enforce",
+			}
+			switch scenario.name {
+			case "different endpoint":
+				identity["endpoint"] = "http://localhost:19090"
+			case "different instance":
+				identity["instance_id"] = "test-service-instance-0002"
+			}
+			runtimeJSON := ""
+			if scenario.name != "legacy" {
+				data, err := json.Marshal(identity)
+				if err != nil {
+					t.Fatal(err)
+				}
+				runtimeJSON = `"runtime":` + string(data) + ","
+			}
+			shim := `#!/bin/sh
 if [ "$1" = "config" ] && [ "$2" = "get" ]; then
   case "$3" in
     tools.exec) printf '%s\n' '{"mode":"full"}' ;;
@@ -285,17 +308,64 @@ if [ "$1" = "config" ] && [ "$2" = "get" ]; then
 fi
 printf '%s\n' '[state-migrations] Legacy state migration notes:'
 printf '%s\n' '- Left plugin install index in place because shared SQLite state has conflicting plugin install metadata for: rampart'
-printf '%s\n' '{"result":{"schema":"rampart.plugin.verify.v1","runtime":{"endpoint":"http://localhost:9090","instance_id":"test-service-instance-0001","version":"1.9.1","commit":"test-commit","mode":"enforce"},"safeCanaries":true,"ok":true,"checks":[{"id":"routine-command","expected":"allow","actual":"allow","pass":true},{"id":"destructive-command","expected":"deny","actual":"deny","pass":true},{"id":"external-deployment","expected":"ask","actual":"ask","pass":true},{"id":"cross-conversation-message","expected":"ask","actual":"ask","pass":true},{"id":"credential-shell-read","expected":"deny","actual":"deny","pass":true},{"id":"opaque-interpreter","expected":"ask","actual":"ask","pass":true}]}}'
+printf '%s\n' '{"result":{"schema":"rampart.plugin.verify.v1",{{runtime}}"safeCanaries":true,"ok":true,"checks":[{"id":"routine-command","expected":"allow","actual":"allow","pass":true},{"id":"destructive-command","expected":"deny","actual":"deny","pass":true},{"id":"external-deployment","expected":"ask","actual":"ask","pass":true},{"id":"cross-conversation-message","expected":"ask","actual":"ask","pass":true},{"id":"credential-shell-read","expected":"deny","actual":"deny","pass":true},{"id":"opaque-interpreter","expected":"ask","actual":"ask","pass":true}]}}'
 `
-	if err := os.WriteFile(bin, []byte(shim), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("OPENCLAW_STATE_DIR", stateDir)
-	t.Setenv("RAMPART_OPENCLAW_BIN", bin)
+			bin := os.Getenv("RAMPART_OPENCLAW_BIN")
+			if err := os.WriteFile(bin, []byte(strings.Replace(shim, "{{runtime}}", runtimeJSON, 1)), 0o700); err != nil {
+				t.Fatal(err)
+			}
 
-	check := verifyOpenClawPluginLive(context.Background(), time.Second)
-	if check.Status != verificationPass {
-		t.Fatalf("unexpected check: %#v", check)
+			healthProbes := 0
+			rampartHTTPClient = &http.Client{Transport: redirectTestTransport(func(req *http.Request) (*http.Response, error) {
+				if req.URL.Host != "localhost:9090" {
+					t.Fatalf("unexpected configured endpoint: %s", req.URL.Host)
+				}
+				if req.URL.Path == "/healthz" {
+					healthProbes++
+					return statusTestHealthResponse(req, "enforce"), nil
+				}
+				if !strings.HasPrefix(req.URL.Path, "/v1/preflight/") {
+					t.Fatalf("unexpected control path: %s", req.URL.Path)
+				}
+				var request struct {
+					Params map[string]any `json:"params"`
+				}
+				if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+					t.Fatal(err)
+				}
+				command, _ := request.Params["command"].(string)
+				decision := "deny"
+				switch {
+				case command == "pwd", request.Params["action"] == "read":
+					decision = "allow"
+				case strings.HasPrefix(command, "git push "), strings.HasPrefix(command, "python3 -c "), command == "npm publish", request.Params["action"] == "send":
+					decision = "ask"
+				}
+				data, err := json.Marshal(preflightResponse{Allowed: decision == "allow", Decision: decision})
+				if err != nil {
+					t.Fatal(err)
+				}
+				return &http.Response{StatusCode: http.StatusOK, Request: req, Header: make(http.Header), Body: io.NopCloser(bytes.NewReader(data))}, nil
+			})}
+			report := runBehavioralVerification(context.Background(), "openclaw", "", time.Second)
+			if report.Assurance != scenario.want || healthProbes != 2 {
+				t.Fatalf("verification assurance=%s want=%s probes=%d report=%#v", report.Assurance, scenario.want, healthProbes, report)
+			}
+			matched := scenario.name == "matching"
+			if (report.Runtime != nil) != matched {
+				t.Fatalf("loaded runtime association: %#v", report.Runtime)
+			}
+			if err := writeVerificationReceipt(report); err != nil {
+				t.Fatal(err)
+			}
+			receipt, err := readVerificationReceipt("openclaw")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if receipt.AssuranceLevel != scenario.want || (receipt.Runtime != nil) != matched {
+				t.Fatalf("receipt promoted different or missing loaded runtime: %#v", receipt)
+			}
+		})
 	}
 }
 

--- a/cmd/rampart/cli/verify_test.go
+++ b/cmd/rampart/cli/verify_test.go
@@ -51,7 +51,7 @@ func TestRunAllBehavioralVerificationsWritesAggregateEvidence(t *testing.T) {
 	if err := installCodexHooks(filepath.Join(home, ".codex", "hooks.json"), command, commandWindows, false); err != nil {
 		t.Fatal(err)
 	}
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(verificationTestHandler(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") != "Bearer verification-token" {
 			t.Fatalf("authorization = %q", r.Header.Get("Authorization"))
 		}
@@ -78,7 +78,7 @@ func TestRunAllBehavioralVerificationsWritesAggregateEvidence(t *testing.T) {
 	if report.SchemaVersion != verifyAllJSONSchemaVersion || !report.SafeCanaries {
 		t.Fatalf("unexpected aggregate metadata: %#v", report)
 	}
-	if report.Summary.Targets != 2 || report.Summary.PassedTargets != 2 || report.Summary.Checks != 12 {
+	if report.Summary.Targets != 2 || report.Summary.PassedTargets != 2 || report.Summary.Checks != 7 {
 		t.Fatalf("unexpected aggregate summary: %#v", report.Summary)
 	}
 	if len(report.Results) != 2 || report.Results[0].Target != "policy" || report.Results[1].Target != "codex" {
@@ -101,7 +101,7 @@ func TestVerifyAllRejectsExplicitTarget(t *testing.T) {
 
 func TestBehavioralVerificationSafeCanariesPass(t *testing.T) {
 	installVerificationToken(t, "verification-token")
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(verificationTestHandler(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") != "Bearer verification-token" {
 			t.Fatalf("authorization = %q", r.Header.Get("Authorization"))
 		}
@@ -132,7 +132,7 @@ func TestBehavioralVerificationSafeCanariesPass(t *testing.T) {
 
 func TestBehavioralVerificationDetectsWrongDecision(t *testing.T) {
 	installVerificationToken(t, "verification-token")
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	server := httptest.NewServer(verificationTestHandler(func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{"allowed": true, "decision": "allow"})
 	}))
 	defer server.Close()
@@ -146,7 +146,11 @@ func TestBehavioralVerificationDetectsWrongDecision(t *testing.T) {
 func TestBehavioralVerificationReportsMissingTokenAsUnverified(t *testing.T) {
 	testSetHome(t, t.TempDir())
 	t.Setenv("RAMPART_TOKEN", "")
-	report := runBehavioralVerification(context.Background(), "policy", "http://127.0.0.1:1", 50*time.Millisecond)
+	server := httptest.NewServer(verificationTestHandler(func(http.ResponseWriter, *http.Request) {
+		t.Error("preflight must not run without a token")
+	}))
+	defer server.Close()
+	report := runBehavioralVerification(context.Background(), "policy", server.URL, time.Second)
 	if report.Summary.Unverified != 5 || report.Summary.Failed != 0 {
 		t.Fatalf("unexpected summary: %#v", report.Summary)
 	}
@@ -160,7 +164,7 @@ func TestBehavioralVerificationReportsMissingTokenAsUnverified(t *testing.T) {
 func TestBehavioralVerificationUsesEnvironmentToken(t *testing.T) {
 	testSetHome(t, t.TempDir())
 	t.Setenv("RAMPART_TOKEN", "environment-verification-token")
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(verificationTestHandler(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") != "Bearer environment-verification-token" {
 			t.Fatalf("authorization = %q", r.Header.Get("Authorization"))
 		}
@@ -281,7 +285,7 @@ if [ "$1" = "config" ] && [ "$2" = "get" ]; then
 fi
 printf '%s\n' '[state-migrations] Legacy state migration notes:'
 printf '%s\n' '- Left plugin install index in place because shared SQLite state has conflicting plugin install metadata for: rampart'
-printf '%s\n' '{"result":{"schema":"rampart.plugin.verify.v1","safeCanaries":true,"ok":true,"checks":[{"id":"routine-command","expected":"allow","actual":"allow","pass":true},{"id":"destructive-command","expected":"deny","actual":"deny","pass":true},{"id":"external-deployment","expected":"ask","actual":"ask","pass":true},{"id":"cross-conversation-message","expected":"ask","actual":"ask","pass":true},{"id":"credential-shell-read","expected":"deny","actual":"deny","pass":true},{"id":"opaque-interpreter","expected":"ask","actual":"ask","pass":true}]}}'
+printf '%s\n' '{"result":{"schema":"rampart.plugin.verify.v1","runtime":{"endpoint":"http://localhost:9090","instance_id":"test-service-instance-0001","version":"1.9.1","commit":"test-commit","mode":"enforce"},"safeCanaries":true,"ok":true,"checks":[{"id":"routine-command","expected":"allow","actual":"allow","pass":true},{"id":"destructive-command","expected":"deny","actual":"deny","pass":true},{"id":"external-deployment","expected":"ask","actual":"ask","pass":true},{"id":"cross-conversation-message","expected":"ask","actual":"ask","pass":true},{"id":"credential-shell-read","expected":"deny","actual":"deny","pass":true},{"id":"opaque-interpreter","expected":"ask","actual":"ask","pass":true}]}}'
 `
 	if err := os.WriteFile(bin, []byte(shim), 0o755); err != nil {
 		t.Fatal(err)
@@ -435,5 +439,17 @@ func installVerificationToken(t *testing.T, token string) {
 	}
 	if err := os.WriteFile(filepath.Join(dir, "token"), []byte(token), 0o600); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// verificationTestHandler models the health contract around real HTTP preflight
+// fixtures without requiring bearer credentials on the public health endpoint.
+func verificationTestHandler(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/healthz" {
+			_ = json.NewEncoder(w).Encode(map[string]any{"service": "rampart", "status": "ok", "mode": "enforce", "uptime_seconds": 1, "version": "test", "commit": "test-commit", "instance_id": "test-service-instance-0001"})
+			return
+		}
+		next(w, r)
 	}
 }

--- a/docs-site/reference/cli-commands.md
+++ b/docs-site/reference/cli-commands.md
@@ -88,10 +88,26 @@ it does not contain prompts, commands, host output, credentials, or filesystem
 paths. OpenClaw's live plugin verifier earns `host_verified`; the ordinary
 native-hook commands earn `adapter_verified` because they invoke Rampart's
 adapter without asking a model to act. Receipts expire after seven days and are
-treated as stale when Rampart, the configured boundary, the selected policy
-endpoint, local policy-file metadata, or a detected host executable changes.
+treated as stale when Rampart, the configured boundary, local policy-file contents, or a detected host executable changes. Service-backed
+evidence additionally binds the effective policy endpoint.
 They are local status caches, not tamper-resistant
 attestations.
+
+Service-backed evidence includes the exact service origin, per-start instance
+identifier, service build and enforce mode. Health observations before and
+after verification must match. OpenClaw also returns this observation from the
+loaded gateway plugin; changing a config file without reloading that plugin
+cannot verify the new endpoint. An explicit `--serve-url` must match the
+integration's effective endpoint. Legacy services or loaded plugins without
+runtime observations remain visible but require updating and reverification
+before earning this evidence.
+
+Service-optional native hooks verify their installation, local adapter and
+isolated audit behavior without HTTP. Their adapter receipts remain meaningful
+when the service is stopped or replaced. Use `rampart verify policy` separately
+to test HTTP policy decisions. Runtime observations establish only the service
+observed during these probes; they do not attest remote policy contents,
+continuous enforcement, or host tool execution.
 
 ### `rampart setup claude-code`
 
@@ -466,6 +482,15 @@ receipts fall back to current configuration state and explain why proof must be
 rerun. Evidence for a service-required integration is also stale whenever the
 configured Rampart policy service is unavailable; another daemon on a different
 port does not satisfy that check.
+
+Status reports the CLI build separately from the observed `service` version,
+commit, mode and endpoint. `service_owned` requires matching private process
+state and OS process identity; an instance identifier alone does not establish
+ownership. Service-backed receipts become stale after a service instance,
+build or mode change. Healthy older services are displayed even when they
+cannot supply the newer freshness evidence. Protection reports the actual
+reused service and refuses monitor or disabled mode without changing an
+external service or replacing an existing service definition.
 
 `mode` comes from the configured service's health response and is `unknown`
 when that service cannot be reached or identified. Local hook enforcement can

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -1307,15 +1307,26 @@ Unauthenticated health check.
 ```json
 {
   "type": "object",
-  "required": ["status", "mode", "uptime_seconds", "version"],
+  "required": ["service", "status", "mode", "uptime_seconds", "version", "commit", "instance_id"],
   "properties": {
+    "service": { "type": "string", "const": "rampart" },
     "status": { "type": "string" },
     "mode": { "type": "string" },
     "uptime_seconds": { "type": "integer" },
-    "version": { "type": "string" }
+    "version": { "type": "string" },
+    "commit": { "type": "string" },
+    "instance_id": { "type": "string" }
   }
 }
 ```
+
+`instance_id` is an opaque identifier generated for each server start. It is
+shared with the owner's private `serve.state`; health never returns a PID,
+executable path, launch arguments, or token. The identifier provides freshness
+evidence, not authentication or process ownership. `commit` is build metadata
+(including development-build values), not a cryptographic attestation. Older services may omit
+`commit` and `instance_id`; clients can display their version and mode while
+withholding runtime-bound verification evidence.
 
 ### Status Codes
 - `200 OK`

--- a/internal/plugin/openclaw/index.js
+++ b/internal/plugin/openclaw/index.js
@@ -485,16 +485,17 @@ function toolDisplayName(toolName, originalToolName) {
 // ─── Rampart API client ───────────────────────────────────────────────────────
 
 const MAX_CONTROL_RESPONSE_BYTES = 1024 * 1024;
+const MAX_HEALTH_RESPONSE_BYTES = 4 * 1024;
 const POLICY_DECISIONS = new Set(["allow", "watch", "ask", "deny"]);
 const APPROVAL_SEVERITIES = new Set(["info", "warning", "critical"]);
 
 class InvalidControlResponseError extends Error {}
 
-async function readControlResponseText(response) {
+async function readControlResponseText(response, maxBytes = MAX_CONTROL_RESPONSE_BYTES) {
   const declaredLength = response?.headers?.get?.("content-length");
   if (declaredLength !== null && declaredLength !== undefined && declaredLength !== "") {
     const parsedLength = Number(declaredLength);
-    if (Number.isFinite(parsedLength) && parsedLength > MAX_CONTROL_RESPONSE_BYTES) {
+    if (Number.isFinite(parsedLength) && parsedLength > maxBytes) {
       await response?.body?.cancel?.().catch(() => {});
       throw new InvalidControlResponseError("Rampart response exceeded the size limit");
     }
@@ -512,7 +513,7 @@ async function readControlResponseText(response) {
         const { done, value } = await reader.read();
         if (done) break;
         total += value?.byteLength ?? 0;
-        if (total > MAX_CONTROL_RESPONSE_BYTES) {
+        if (total > maxBytes) {
           await reader.cancel().catch(() => {});
           throw new InvalidControlResponseError("Rampart response exceeded the size limit");
         }
@@ -528,14 +529,14 @@ async function readControlResponseText(response) {
   // production Fetch path above performs the limit before buffering the body.
   if (typeof response?.text === "function") {
     const text = await response.text();
-    if (new TextEncoder().encode(text).byteLength > MAX_CONTROL_RESPONSE_BYTES) {
+    if (new TextEncoder().encode(text).byteLength > maxBytes) {
       throw new InvalidControlResponseError("Rampart response exceeded the size limit");
     }
     return text;
   }
   if (typeof response?.json === "function") {
     const text = JSON.stringify(await response.json());
-    if (new TextEncoder().encode(text).byteLength > MAX_CONTROL_RESPONSE_BYTES) {
+    if (new TextEncoder().encode(text).byteLength > maxBytes) {
       throw new InvalidControlResponseError("Rampart response exceeded the size limit");
     }
     return text;
@@ -543,8 +544,8 @@ async function readControlResponseText(response) {
   throw new InvalidControlResponseError("Rampart response body is unreadable");
 }
 
-async function readControlResponseJSON(response) {
-  const text = await readControlResponseText(response);
+async function readControlResponseJSON(response, maxBytes = MAX_CONTROL_RESPONSE_BYTES) {
+  const text = await readControlResponseText(response, maxBytes);
   try {
     return JSON.parse(text);
   } catch (err) {
@@ -557,6 +558,42 @@ function isConsistentPolicyDecision(result) {
   if (!POLICY_DECISIONS.has(result.decision)) return false;
   if (typeof result.allowed !== "boolean") return false;
   return result.allowed === (result.decision === "allow" || result.decision === "watch");
+}
+
+// Observe the endpoint captured by this loaded plugin, so CLI verification
+// cannot attribute its canary decisions to a different configured service.
+// Health is public: never send the control token or return arbitrary fields.
+async function observeVerificationRuntime(serveUrl) {
+  if (typeof serveUrl !== "string" || !isTrustedServeUrl(serveUrl)) return null;
+  const endpoint = serveUrl.trim().replace(/\/+$/, "");
+  try {
+    const response = await fetch(`${endpoint}/healthz`, {
+      method: "GET",
+      redirect: "error",
+      signal: AbortSignal.timeout(3000),
+    });
+    if (response.status !== 200) {
+      await response?.body?.cancel?.().catch(() => {});
+      return null;
+    }
+    const health = await readControlResponseJSON(response, MAX_HEALTH_RESPONSE_BYTES);
+    if (!health || health.service !== "rampart" || health.status !== "ok" ||
+        health.mode !== "enforce" || !Number.isInteger(health.uptime_seconds) || health.uptime_seconds < 0 ||
+        typeof health.instance_id !== "string" || !/^[A-Za-z0-9_-]{16,128}$/.test(health.instance_id) ||
+        typeof health.version !== "string" || !health.version.trim() ||
+        typeof health.commit !== "string" || !health.commit.trim()) return null;
+    return {
+      endpoint,
+      instance_id: health.instance_id,
+      version: health.version,
+      commit: health.commit,
+      mode: health.mode,
+    };
+  } catch {
+    // Legacy, unavailable, malformed and redirected health provide no runtime
+    // proof. The fixed canary results are still useful to older CLI versions.
+    return null;
+  }
 }
 
 /**
@@ -939,6 +976,7 @@ export function register(api) {
   // tool. The canaries are fixed here rather than caller-supplied so this RPC
   // can never become an execution or arbitrary policy-probing surface.
   api.registerGatewayMethod("rampart.verify", async ({ respond }) => {
+    const before = await observeVerificationRuntime(serveUrl);
     const canaryCtx = {
       agentId: "rampart-verification",
       sessionKey: "rampart-verification",
@@ -1007,11 +1045,15 @@ export function register(api) {
         });
       }
     }
+    const after = await observeVerificationRuntime(serveUrl);
+    const stableRuntime = before && after &&
+      ["endpoint", "instance_id", "version", "commit", "mode"].every((key) => before[key] === after[key]);
     respond(true, {
       schema: "rampart.plugin.verify.v1",
       safeCanaries: true,
       ok: checks.every((check) => check.pass),
       checks,
+      ...(stableRuntime ? { runtime: before } : {}),
     });
   });
 

--- a/internal/plugin/openclaw/provider-surface-replay.mjs
+++ b/internal/plugin/openclaw/provider-surface-replay.mjs
@@ -437,35 +437,86 @@ assert(authError?.block === true, '401 auth error should block sensitive tool ca
 assert(authError.blockReason.includes('HTTP 401'), `auth block reason should mention HTTP 401: ${authError.blockReason}`);
 scenarios.push('auth-error-fail-closed');
 
-const liveVerification = await withPlugin({
-  name: 'live-behavioral-verification',
-  fetchImpl: async (url, opts = {}) => {
-    assert(String(url).includes('/v1/preflight/'), `unexpected verification URL: ${url}`);
-    const body = parseBody({ opts });
-    const tool = decodeURIComponent(String(url).split('/v1/preflight/')[1]);
-    let decision = 'allow';
-    if (tool === 'exec' && body.params.command === 'rm -rf /') decision = 'deny';
-    if (tool === 'exec' && body.params.command?.startsWith('git push ')) decision = 'ask';
-    if (tool === 'message' && body.params.rampart_consequence === 'openclaw:external-message') decision = 'ask';
-    if (tool === 'exec' && body.params.command?.startsWith('cat ~/.ssh/id_')) decision = 'deny';
-    if (tool === 'exec' && body.params.command?.startsWith('python3 -c ')) decision = 'ask';
-    assert(body.verification === true, 'verification calls must request side-effect-free preflight mode');
-    return fetchJson({ decision, allowed: decision === 'allow', action: { version: 1, tool, params: body.params, input: body.input } });
-  },
-  invoke: async ({ gatewayMethods }) => {
-    const verify = gatewayMethods['rampart.verify'];
-    assert(typeof verify === 'function', 'rampart.verify gateway method missing');
-    let response;
-    await verify({ respond: (ok, payload) => { response = { ok, payload }; } });
-    return response;
-  },
-});
+const verificationEndpoint = 'http://127.0.0.1:19091';
+const verificationHealth = {
+  service: 'rampart', status: 'ok', uptime_seconds: 1,
+  instance_id: 'verification-instance-0001', version: '2.0.0', commit: 'fixture-commit', mode: 'enforce',
+};
+
+async function runVerificationScenario(name, healthResponse) {
+  const requests = [];
+  let healthCalls = 0;
+  const response = await withPlugin({
+    name,
+    pluginConfig: { serveUrl: verificationEndpoint },
+    fetchImpl: async (url, opts = {}) => {
+      requests.push(String(url));
+      assert(opts.redirect === 'error', 'verification must reject redirects');
+      if (String(url) === `${verificationEndpoint}/healthz`) {
+        assert(opts.method === 'GET' && opts.signal, 'health must use a bounded GET');
+        assert(!opts.headers?.Authorization, 'health must not carry the control token');
+        return healthResponse(++healthCalls);
+      }
+      assert(String(url).startsWith(`${verificationEndpoint}/v1/preflight/`), `unexpected verification URL: ${url}`);
+      const body = parseBody({ opts });
+      const tool = decodeURIComponent(String(url).split('/v1/preflight/')[1]);
+      let decision = 'allow';
+      if (tool === 'exec' && body.params.command === 'rm -rf /') decision = 'deny';
+      if (tool === 'exec' && body.params.command?.startsWith('git push ')) decision = 'ask';
+      if (tool === 'message' && body.params.rampart_consequence === 'openclaw:external-message') decision = 'ask';
+      if (tool === 'exec' && body.params.command?.startsWith('cat ~/.ssh/id_')) decision = 'deny';
+      if (tool === 'exec' && body.params.command?.startsWith('python3 -c ')) decision = 'ask';
+      assert(body.verification === true, 'verification calls must request side-effect-free preflight mode');
+      return fetchJson({ decision, allowed: decision === 'allow', action: { version: 1, tool, params: body.params, input: body.input } });
+    },
+    invoke: async ({ gatewayMethods }) => {
+      const verify = gatewayMethods['rampart.verify'];
+      assert(typeof verify === 'function', 'rampart.verify gateway method missing');
+      let result;
+      await verify({ respond: (ok, payload) => { result = { ok, payload }; } });
+      return result;
+    },
+  });
+  assert(healthCalls === 2 && requests.length === 8, `${name}: expected health around six fixed canaries`);
+  assert(requests[0].endsWith('/healthz') && requests.at(-1).endsWith('/healthz'), `${name}: health must bracket canaries`);
+  return response;
+}
+
+const liveVerification = await runVerificationScenario('live-behavioral-verification', () => fetchJson({
+  ...verificationHealth, token: 'synthetic-private-value', pid: 42, executable: '/synthetic/private/path',
+}));
 assert(liveVerification?.ok === true, 'gateway verification RPC should respond successfully');
 assert(liveVerification.payload?.schema === 'rampart.plugin.verify.v1', 'verification schema missing');
 assert(liveVerification.payload?.safeCanaries === true, 'verification must identify safe canaries');
 assert(liveVerification.payload?.ok === true, `verification failed: ${JSON.stringify(liveVerification.payload)}`);
 assert(liveVerification.payload?.checks?.length === 6, 'expected six plugin policy canaries');
+assert(JSON.stringify(liveVerification.payload.runtime) === JSON.stringify({
+  endpoint: verificationEndpoint,
+  instance_id: verificationHealth.instance_id,
+  version: verificationHealth.version,
+  commit: verificationHealth.commit,
+  mode: verificationHealth.mode,
+}), 'runtime proof must contain only the loaded endpoint and stable public identity');
 scenarios.push('live-behavioral-verification');
+
+for (const [name, healthResponse] of [
+  ['legacy-runtime', () => fetchJson({ service: 'rampart', status: 'ok', uptime_seconds: 1, version: '1.9.1', mode: 'enforce' })],
+  ['restarted-runtime', (call) => fetchJson({ ...verificationHealth, instance_id: `verification-instance-000${call}` })],
+  ['changed-runtime-build', (call) => fetchJson({ ...verificationHealth, commit: `fixture-commit-${call}` })],
+  ['monitor-runtime', () => fetchJson({ ...verificationHealth, mode: 'monitor' })],
+  ['disabled-runtime', () => fetchJson({ ...verificationHealth, mode: 'disabled' })],
+  ['unavailable-runtime', () => { throw new Error('synthetic private error'); }],
+  ['redirected-runtime', () => new Response(null, { status: 302 })],
+  ['malformed-runtime', () => new Response('{')],
+  ['oversized-runtime', () => new Response(JSON.stringify({ ...verificationHealth, extra: 'x'.repeat(4096) }))],
+]) {
+  const result = await runVerificationScenario(name, healthResponse);
+  assert(result?.ok === true && result.payload?.ok === true, `${name}: legacy canary result contract changed`);
+  assert(result.payload?.checks?.length === 6, `${name}: fixed canaries missing`);
+  assert(!Object.hasOwn(result.payload, 'runtime'), `${name}: runtime evidence must be withheld`);
+  assert(!JSON.stringify(result).includes('synthetic private error'), `${name}: private health error reflected`);
+  scenarios.push(`verification-${name}`);
+}
 
 const degraded = await withPlugin({
   name: 'degraded-sensitive-exec-blocks',

--- a/internal/proxy/eval_handlers.go
+++ b/internal/proxy/eval_handlers.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/peg/rampart/internal/approval"
 	"github.com/peg/rampart/internal/audit"
-	"github.com/peg/rampart/internal/build"
 	"github.com/peg/rampart/internal/engine"
 )
 
@@ -814,11 +813,10 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleHealth(w http.ResponseWriter, _ *http.Request) {
 	uptime := int(time.Since(s.startedAt).Seconds())
-	writeJSON(w, http.StatusOK, map[string]any{
-		"service":        "rampart",
-		"status":         "ok",
-		"mode":           s.mode,
-		"uptime_seconds": uptime,
-		"version":        build.Version,
+	writeJSON(w, http.StatusOK, HealthResponse{
+		RuntimeIdentity: s.RuntimeIdentity(),
+		Service:         "rampart",
+		Status:          "ok",
+		UptimeSeconds:   &uptime,
 	})
 }

--- a/internal/proxy/runtime.go
+++ b/internal/proxy/runtime.go
@@ -1,0 +1,29 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0
+
+package proxy
+
+import "github.com/peg/rampart/internal/build"
+
+// RuntimeIdentity identifies one server start. InstanceID is freshness evidence,
+// not authentication or proof that the process belongs to the current user.
+// Process IDs, executable paths, and launch arguments remain in private state.
+type RuntimeIdentity struct {
+	InstanceID string `json:"instance_id,omitempty"`
+	Version    string `json:"version"`
+	Commit     string `json:"commit,omitempty"`
+	Mode       string `json:"mode"`
+}
+
+// HealthResponse is the unauthenticated, credential-free health contract.
+type HealthResponse struct {
+	RuntimeIdentity
+	Service       string `json:"service"`
+	Status        string `json:"status"`
+	UptimeSeconds *int   `json:"uptime_seconds"`
+}
+
+// RuntimeIdentity returns the identity shared by health and private serve.state.
+func (s *Server) RuntimeIdentity() RuntimeIdentity {
+	return RuntimeIdentity{InstanceID: s.instanceID, Version: build.Version, Commit: build.Commit, Mode: s.mode}
+}

--- a/internal/proxy/runtime_test.go
+++ b/internal/proxy/runtime_test.go
@@ -28,7 +28,7 @@ func TestHealthIdentifiesOnlyTheServerStart(t *testing.T) {
 	if health.RuntimeIdentity != first.RuntimeIdentity() || health.Mode != "monitor" {
 		t.Fatalf("health identity = %#v", health)
 	}
-	for _, private := range []string{"synthetic-private-token", "pid", "executable", "arguments"} {
+	for _, private := range []string{"synthetic-private-token", `"pid":`, `"executable":`, `"arguments":`} {
 		if strings.Contains(response.Body.String(), private) {
 			t.Fatalf("health exposed private field %s", private)
 		}

--- a/internal/proxy/runtime_test.go
+++ b/internal/proxy/runtime_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0
+
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestHealthIdentifiesOnlyTheServerStart(t *testing.T) {
+	first := New(nil, nil, WithToken("synthetic-private-token"), WithMode("monitor"))
+	second := New(nil, nil, WithToken("synthetic-private-token"))
+	t.Cleanup(func() { _ = first.Shutdown(context.Background()) })
+	t.Cleanup(func() { _ = second.Shutdown(context.Background()) })
+	if first.RuntimeIdentity().InstanceID == "" || first.RuntimeIdentity().InstanceID == second.RuntimeIdentity().InstanceID {
+		t.Fatal("server starts must have distinct opaque identities")
+	}
+	response := httptest.NewRecorder()
+	first.handler().ServeHTTP(response, httptest.NewRequest("GET", "/healthz", nil))
+	var health HealthResponse
+	if err := json.Unmarshal(response.Body.Bytes(), &health); err != nil {
+		t.Fatal(err)
+	}
+	if health.RuntimeIdentity != first.RuntimeIdentity() || health.Mode != "monitor" {
+		t.Fatalf("health identity = %#v", health)
+	}
+	for _, private := range []string{"synthetic-private-token", "pid", "executable", "arguments"} {
+		if strings.Contains(response.Body.String(), private) {
+			t.Fatalf("health exposed private field %s", private)
+		}
+	}
+}

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -15,6 +15,7 @@ package proxy
 
 import (
 	"context"
+	"crypto/rand"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -57,6 +58,7 @@ type Server struct {
 	policyWriteMu       sync.Mutex
 	server              *http.Server
 	startedAt           time.Time
+	instanceID          string
 	notifyConfig        *engine.NotifyConfig
 	notificationSlots   chan struct{}
 	metricsEnabled      bool
@@ -178,7 +180,7 @@ func WithApprovalPersistenceFile(path string) Option {
 	}
 }
 
-// WithConfigPath sets the config path string shown in the /v1/policy endpoint.
+// WithConfigPath sets the config path string shown in the /v1/status endpoint.
 // Use "embedded:standard" when the embedded default policy is active.
 func WithConfigPath(path string) Option {
 	return func(s *Server) {
@@ -195,6 +197,7 @@ func New(eng *engine.Engine, sink audit.AuditSink, opts ...Option) *Server {
 		mode:              defaultMode,
 		logger:            slog.Default(),
 		startedAt:         time.Now().UTC(),
+		instanceID:        rand.Text(),
 		sse:               newSSEHub(),
 		stopCleanup:       make(chan struct{}),
 		notificationSlots: make(chan struct{}, maxConcurrentNotifications),


### PR DESCRIPTION
Cached service verification could outlive the process it tested, and a changed OpenClaw configuration file did not prove that the loaded gateway plugin had switched endpoints. Bind service evidence to the observed endpoint, per-start instance, build and enforce mode. OpenClaw's loaded plugin now supplies its own bounded before/after observation, which must agree with the CLI before a host receipt is retained.

Status displays CLI and service builds separately and only labels a local service owned when private process state and OS identity agree. Protection reports the actual reused service and refuses monitor/disabled mode without rewriting an external service. Compatible legacy enforcing services remain usable, but need an updated service/plugin and fresh verification for runtime-bound evidence. Upgrade activation also checks that fresh owned state and health identify the same new instance.

Local native-hook adapter verification remains independent of HTTP; `verify policy` separately checks the service. Runtime identifiers are freshness evidence, not authentication, continuous monitoring or proof of arbitrary tool effects. Canonical CLI/API documentation and the changelog describe these limits. Custom-launch preservation is a separate lifecycle change.

Validation at `6ccaac2bdf17697d7d8fa22fd0ec21307ab38c1f`:

- Full maintainer source gate (`go test ./...`, `go vet ./...`, `make security-assurance`, diff checks) passed.
- Focused race checks passed for runtime, receipt, verification, reuse and restart behavior. Joined CLI/plugin tests cover matching, missing, wrong-endpoint and wrong-instance evidence through persisted receipts.
- Plugin regression suites and embedded-plugin tests passed; strict docs build and canonical-document checks passed.
- Exact-head platform, package, container, policy and documentation CI passed, with independent review of the final joined change.
- Isolated OpenClaw 2026.9.4 acceptance passed eight runtime-evidence journeys through the actual loaded gateway plugin: restart freshness, monitor/disabled modes, configured versus loaded endpoints, and legacy-plugin recovery. No provider or model traffic was used.
- Codex 0.154.0 completed four actual hook-dispatch journeys with a scripted local model peer: approved source edit plus passing unit test, routine allow, denial without effects, and separate approval of a later invocation. Offline adapter evidence remained correctly distinct from HTTP service evidence. Native sandbox composition and macOS public service-stop behavior were not established by this fixture.

These results cover the stated boundaries; they do not attest custom upgrade preservation, continuous enforcement, or expanded host support. No release is created by this PR.
