### PR TITLE
fix: preserve service configuration and recover failed upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   build and enforce mode. Status separates CLI and service builds; stale or
   legacy runtime evidence requires reverification. Service-optional native
   hooks retain independent local adapter verification without HTTP.
+- Preserve private typed background launch settings during upgrades, including
+  the original working directory, custom policy/audit options and TLS
+  references. Refuse ambiguous legacy migration before stopping a service,
+  and distinguish a current CLI from an older running service.
 
 ## [1.9.1] - 2026-09-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the original working directory, custom policy/audit options and TLS
   references. Refuse ambiguous legacy migration before stopping a service,
   and distinguish a current CLI from an older running service.
+- Verify that upgraded services retain their endpoint and mode. Stop an owned
+  failed candidate before restoring the previous executable and runtime;
+  retain the backup and report incomplete recovery if ownership has changed.
 
 ## [1.9.1] - 2026-09-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bind service verification receipts to the observed endpoint, server start,
+  build and enforce mode. Status separates CLI and service builds; stale or
+  legacy runtime evidence requires reverification. Service-optional native
+  hooks retain independent local adapter verification without HTTP.
+
 ## [1.9.1] - 2026-09-10
 
 ### Security

--- a/cmd/rampart/cli/assurance_status.go
+++ b/cmd/rampart/cli/assurance_status.go
@@ -5,6 +5,7 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -59,22 +60,24 @@ type verificationReceipt struct {
 	SafeCanaries           bool                       `json:"safe_canaries"`
 	Summary                verificationSummary        `json:"summary"`
 	Checks                 []verificationReceiptCheck `json:"checks"`
+	Runtime                *serviceRuntimeObservation `json:"runtime,omitempty"`
 }
 
 type integrationAssuranceStatus struct {
-	ID                  string         `json:"id"`
-	DisplayName         string         `json:"display_name"`
-	Boundary            string         `json:"boundary"`
-	ServiceRequired     bool           `json:"service_required"`
-	Installed           bool           `json:"installed"`
-	Configured          bool           `json:"configured"`
-	AssuranceLevel      assuranceLevel `json:"assurance_level"`
-	EvidenceSource      string         `json:"evidence_source,omitempty"`
-	CheckedAt           *time.Time     `json:"checked_at,omitempty"`
-	EvidenceExpiresAt   *time.Time     `json:"evidence_expires_at,omitempty"`
-	VerificationCommand string         `json:"verification_command"`
-	RecommendedCommand  string         `json:"recommended_command,omitempty"`
-	StaleReason         string         `json:"stale_reason,omitempty"`
+	ID                  string                     `json:"id"`
+	DisplayName         string                     `json:"display_name"`
+	Boundary            string                     `json:"boundary"`
+	ServiceRequired     bool                       `json:"service_required"`
+	Installed           bool                       `json:"installed"`
+	Configured          bool                       `json:"configured"`
+	AssuranceLevel      assuranceLevel             `json:"assurance_level"`
+	EvidenceSource      string                     `json:"evidence_source,omitempty"`
+	CheckedAt           *time.Time                 `json:"checked_at,omitempty"`
+	EvidenceExpiresAt   *time.Time                 `json:"evidence_expires_at,omitempty"`
+	VerificationCommand string                     `json:"verification_command"`
+	RecommendedCommand  string                     `json:"recommended_command,omitempty"`
+	StaleReason         string                     `json:"stale_reason,omitempty"`
+	Runtime             *serviceRuntimeObservation `json:"runtime,omitempty"`
 }
 
 func assuranceLevelForReport(report verificationReport) assuranceLevel {
@@ -116,8 +119,10 @@ func writeVerificationReceipt(report verificationReport) error {
 		return fmt.Errorf("resolve home: %w", err)
 	}
 	policyEndpoint := report.policyEndpoint
-	if policyEndpoint == "" {
-		policyEndpoint = resolveServeURL("")
+	if !driver.ServiceRequired {
+		policyEndpoint = ""
+	} else if report.Runtime != nil {
+		policyEndpoint = report.Runtime.Endpoint
 	}
 	fingerprint, err := integrationEnvironmentFingerprintAt(driver, home, policyEndpoint)
 	if err != nil {
@@ -139,6 +144,7 @@ func writeVerificationReceipt(report verificationReport) error {
 		SafeCanaries:           report.SafeCanaries,
 		Summary:                report.Summary,
 		Checks:                 make([]verificationReceiptCheck, 0, len(report.Checks)),
+		Runtime:                report.Runtime,
 	}
 	for _, check := range report.Checks {
 		receipt.Checks = append(receipt.Checks, verificationReceiptCheck{ID: check.ID, Status: check.Status})
@@ -220,6 +226,12 @@ func readVerificationReceipt(integrationID string) (verificationReceipt, error) 
 }
 
 func validateVerificationReceipt(receipt verificationReceipt, integrationID string) error {
+	if receipt.Runtime != nil {
+		endpoint, err := serviceEndpoint(receipt.Runtime.Endpoint)
+		if err != nil || endpoint != receipt.Runtime.Endpoint || !runtimeIdentified(receipt.Runtime.RuntimeIdentity) || receipt.Runtime.Mode != "enforce" {
+			return fmt.Errorf("receipt has invalid runtime evidence")
+		}
+	}
 	if receipt.SchemaVersion != verificationReceiptSchemaVersion {
 		return fmt.Errorf("unsupported receipt schema")
 	}
@@ -272,7 +284,11 @@ func validateVerificationReceipt(receipt verificationReceipt, integrationID stri
 }
 
 func integrationEnvironmentFingerprint(driver integrationDriver, home string) (string, error) {
-	return integrationEnvironmentFingerprintAt(driver, home, resolveServeURL(""))
+	endpoint, err := integrationServiceEndpoint(driver)
+	if err != nil {
+		return "", err
+	}
+	return integrationEnvironmentFingerprintAt(driver, home, endpoint)
 }
 
 func integrationEnvironmentFingerprintAt(driver integrationDriver, home, policyEndpoint string) (string, error) {
@@ -418,12 +434,17 @@ func openClawAssuranceConfiguration() (openClawAssuranceConfig, error) {
 	return config, nil
 }
 
-func collectIntegrationAssuranceStatuses(now time.Time, serverRunning bool) []integrationAssuranceStatus {
+func collectIntegrationAssuranceStatuses(now time.Time) []integrationAssuranceStatus {
 	home, err := os.UserHomeDir()
 	if err != nil || strings.TrimSpace(home) == "" {
 		return []integrationAssuranceStatus{}
 	}
 	statuses := make([]integrationAssuranceStatus, 0)
+	type runtimeResult struct {
+		observation serviceRuntimeObservation
+		err         error
+	}
+	runtimes := make(map[string]runtimeResult)
 	for _, driver := range supportedIntegrationDrivers() {
 		installed := driver.Installed != nil && driver.Installed(home)
 		configured := integrationConfiguredForAssurance(driver, home)
@@ -456,11 +477,6 @@ func collectIntegrationAssuranceStatuses(now time.Time, serverRunning bool) []in
 		status.CheckedAt = &receipt.CheckedAt
 		status.EvidenceExpiresAt = &receipt.ExpiresAt
 		status.EvidenceSource = "local_verification_receipt"
-		if driver.ServiceRequired && !serverRunning {
-			status.StaleReason = "Rampart policy service is unavailable"
-			statuses = append(statuses, status)
-			continue
-		}
 		if receipt.CheckedAt.After(now.Add(5 * time.Minute)) {
 			status.StaleReason = "verification time is in the future"
 			statuses = append(statuses, status)
@@ -481,6 +497,36 @@ func collectIntegrationAssuranceStatuses(now time.Time, serverRunning bool) []in
 			status.StaleReason = "integration environment changed since verification"
 			statuses = append(statuses, status)
 			continue
+		}
+		if driver.ServiceRequired {
+			if receipt.Runtime == nil {
+				status.StaleReason = "verification receipt lacks runtime identity"
+				statuses = append(statuses, status)
+				continue
+			}
+			endpoint, endpointErr := integrationServiceEndpoint(driver)
+			if endpointErr != nil || endpoint != receipt.Runtime.Endpoint {
+				status.StaleReason = "integration service endpoint changed since verification"
+				statuses = append(statuses, status)
+				continue
+			}
+			current, found := runtimes[endpoint]
+			if !found {
+				ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+				current.observation, current.err = observeServiceRuntime(ctx, endpoint, 150*time.Millisecond)
+				cancel()
+				runtimes[endpoint] = current
+			}
+			if current.err != nil {
+				status.StaleReason = "Rampart policy service is unavailable"
+			} else if current.observation != *receipt.Runtime {
+				status.StaleReason = "service instance, build, or mode changed since verification"
+			}
+			if status.StaleReason != "" {
+				statuses = append(statuses, status)
+				continue
+			}
+			status.Runtime = receipt.Runtime
 		}
 		status.AssuranceLevel = receipt.AssuranceLevel
 		statuses = append(statuses, status)

--- a/cmd/rampart/cli/assurance_status_test.go
+++ b/cmd/rampart/cli/assurance_status_test.go
@@ -5,6 +5,8 @@ package cli
 
 import (
 	"bytes"
+	"github.com/peg/rampart/internal/proxy"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -28,7 +30,7 @@ func TestHermesUsesCommonStaticAssuranceStatus(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	status, ok := findAssuranceStatus(collectIntegrationAssuranceStatuses(time.Now().UTC(), false), "hermes")
+	status, ok := findAssuranceStatus(collectIntegrationAssuranceStatuses(time.Now().UTC()), "hermes")
 	if !ok {
 		t.Fatal("Hermes assurance status missing")
 	}
@@ -51,7 +53,7 @@ func TestVerificationReceiptPromotesConfiguredIntegration(t *testing.T) {
 		t.Fatalf("writeVerificationReceipt: %v", err)
 	}
 
-	status, ok := findAssuranceStatus(collectIntegrationAssuranceStatuses(checkedAt.Add(time.Minute), false), "codex")
+	status, ok := findAssuranceStatus(collectIntegrationAssuranceStatuses(checkedAt.Add(time.Minute)), "codex")
 	if !ok {
 		t.Fatal("Codex assurance status missing")
 	}
@@ -79,7 +81,7 @@ func TestVerificationReceiptInvalidatesAfterConfigurationChange(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	status, ok := findAssuranceStatus(collectIntegrationAssuranceStatuses(checkedAt.Add(time.Minute), false), "codex")
+	status, ok := findAssuranceStatus(collectIntegrationAssuranceStatuses(checkedAt.Add(time.Minute)), "codex")
 	if !ok {
 		t.Fatal("Codex assurance status missing")
 	}
@@ -108,7 +110,7 @@ func TestOpenClawReceiptInvalidatesOwnedConfigurationDrift(t *testing.T) {
 			if err := writeVerificationReceipt(passingAssuranceReport("openclaw", now)); err != nil {
 				t.Fatal(err)
 			}
-			status, ok := findAssuranceStatus(collectIntegrationAssuranceStatuses(now, true), "openclaw")
+			status, ok := findAssuranceStatus(collectIntegrationAssuranceStatuses(now), "openclaw")
 			if !ok || status.AssuranceLevel != assuranceHostVerified {
 				t.Fatalf("initial assurance = %#v, found=%t", status, ok)
 			}
@@ -131,7 +133,7 @@ func TestOpenClawReceiptInvalidatesOwnedConfigurationDrift(t *testing.T) {
 			if err := os.Chtimes(path, info.ModTime(), info.ModTime()); err != nil {
 				t.Fatal(err)
 			}
-			status, ok = findAssuranceStatus(collectIntegrationAssuranceStatuses(now.Add(time.Minute), true), "openclaw")
+			status, ok = findAssuranceStatus(collectIntegrationAssuranceStatuses(now.Add(time.Minute)), "openclaw")
 			if !ok || status.AssuranceLevel == assuranceHostVerified || status.StaleReason != "integration environment changed since verification" {
 				t.Fatalf("drifted assurance = %#v, found=%t", status, ok)
 			}
@@ -156,7 +158,7 @@ func TestOpenClawReceiptInvalidatesPluginContentDrift(t *testing.T) {
 	if writeErr != nil || closeErr != nil {
 		t.Fatalf("modify plugin: write=%v close=%v", writeErr, closeErr)
 	}
-	status, ok := findAssuranceStatus(collectIntegrationAssuranceStatuses(now.Add(time.Minute), true), "openclaw")
+	status, ok := findAssuranceStatus(collectIntegrationAssuranceStatuses(now.Add(time.Minute)), "openclaw")
 	if !ok || status.AssuranceLevel == assuranceHostVerified || status.StaleReason != "integration environment changed since verification" {
 		t.Fatalf("modified plugin assurance = %#v, found=%t", status, ok)
 	}
@@ -183,7 +185,7 @@ func TestOpenClawReceiptIgnoresUnrelatedConfiguration(t *testing.T) {
 	if err := os.WriteFile(path, data, 0o600); err != nil {
 		t.Fatal(err)
 	}
-	status, ok := findAssuranceStatus(collectIntegrationAssuranceStatuses(now.Add(time.Minute), true), "openclaw")
+	status, ok := findAssuranceStatus(collectIntegrationAssuranceStatuses(now.Add(time.Minute)), "openclaw")
 	if !ok || status.AssuranceLevel != assuranceHostVerified || status.StaleReason != "" {
 		t.Fatalf("unrelated configuration invalidated assurance: %#v, found=%t", status, ok)
 	}
@@ -195,7 +197,7 @@ func TestOpenClawReceiptIgnoresUnrelatedConfiguration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, private := range []string{home, "private-provider", "provider-token", "other-plugin", "localhost:9090"} {
+	for _, private := range []string{home, "private-provider", "provider-token", "other-plugin"} {
 		if bytes.Contains(data, []byte(private)) {
 			t.Fatalf("receipt retained configuration detail %q", private)
 		}
@@ -206,6 +208,9 @@ func installOpenClawAssuranceFixture(t *testing.T, home string) string {
 	t.Helper()
 	testSetHome(t, home)
 	testSetOpenClawBinary(t, home)
+	oldClient := rampartHTTPClient
+	rampartHTTPClient = &http.Client{Transport: redirectTestTransport(func(req *http.Request) (*http.Response, error) { return statusTestHealthResponse(req, "enforce"), nil })}
+	t.Cleanup(func() { rampartHTTPClient = oldClient })
 	stateDir := filepath.Join(home, ".openclaw")
 	t.Setenv("OPENCLAW_STATE_DIR", stateDir)
 	t.Setenv("OPENCLAW_CONFIG_PATH", filepath.Join(stateDir, "openclaw.json"))
@@ -246,13 +251,13 @@ func TestVerificationReceiptInvalidatesAfterPolicyChange(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	status, ok := findAssuranceStatus(collectIntegrationAssuranceStatuses(checkedAt.Add(time.Minute), false), "codex")
+	status, ok := findAssuranceStatus(collectIntegrationAssuranceStatuses(checkedAt.Add(time.Minute)), "codex")
 	if !ok || status.StaleReason != "integration environment changed since verification" {
 		t.Fatalf("policy-mutated assurance status = %#v, found=%t", status, ok)
 	}
 }
 
-func TestVerificationReceiptInvalidatesWhenPolicyEndpointChanges(t *testing.T) {
+func TestLocalAdapterReceiptDoesNotDependOnPolicyEndpoint(t *testing.T) {
 	home := t.TempDir()
 	testSetHome(t, home)
 	installCodexAssuranceFixture(t, home)
@@ -264,9 +269,9 @@ func TestVerificationReceiptInvalidatesWhenPolicyEndpointChanges(t *testing.T) {
 		t.Fatalf("writeVerificationReceipt: %v", err)
 	}
 
-	status, ok := findAssuranceStatus(collectIntegrationAssuranceStatuses(checkedAt.Add(time.Minute), false), "codex")
-	if !ok || status.StaleReason != "integration environment changed since verification" {
-		t.Fatalf("endpoint-mutated assurance status = %#v, found=%t", status, ok)
+	status, ok := findAssuranceStatus(collectIntegrationAssuranceStatuses(checkedAt.Add(time.Minute)), "codex")
+	if !ok || status.StaleReason != "" || status.AssuranceLevel != assuranceAdapterVerified || status.Runtime != nil {
+		t.Fatalf("local adapter assurance depends on HTTP: %#v, found=%t", status, ok)
 	}
 }
 
@@ -280,7 +285,7 @@ func TestVerificationReceiptExpires(t *testing.T) {
 		t.Fatalf("writeVerificationReceipt: %v", err)
 	}
 
-	status, ok := findAssuranceStatus(collectIntegrationAssuranceStatuses(now, false), "codex")
+	status, ok := findAssuranceStatus(collectIntegrationAssuranceStatuses(now), "codex")
 	if !ok || status.StaleReason != "verification evidence expired" || status.AssuranceLevel != assuranceConfigured {
 		t.Fatalf("expired assurance status = %#v, found=%t", status, ok)
 	}
@@ -372,7 +377,7 @@ func installCodexAssuranceFixture(t *testing.T, home string) {
 }
 
 func passingAssuranceReport(target string, checkedAt time.Time) verificationReport {
-	return summarizeVerification(verificationReport{
+	report := verificationReport{
 		SchemaVersion: verifyJSONSchemaVersion,
 		GeneratedAt:   checkedAt.UTC().Format(time.RFC3339),
 		Target:        target,
@@ -381,7 +386,12 @@ func passingAssuranceReport(target string, checkedAt time.Time) verificationRepo
 			{ID: "configuration", Name: "Configuration", Status: verificationPass, Message: "configured"},
 			{ID: "behavior", Name: "Behavior", Status: verificationPass, Message: "blocked"},
 		},
-	})
+	}
+	if driver, ok := findIntegrationDriver(target); ok && driver.ServiceRequired {
+		endpoint, _ := integrationServiceEndpoint(driver)
+		report.Runtime = &serviceRuntimeObservation{Endpoint: endpoint, RuntimeIdentity: proxy.RuntimeIdentity{InstanceID: "test-service-instance-0001", Version: "1.9.0", Commit: "test-commit", Mode: "enforce"}}
+	}
+	return summarizeVerification(report)
 }
 
 func findAssuranceStatus(statuses []integrationAssuranceStatus, id string) (integrationAssuranceStatus, bool) {

--- a/cmd/rampart/cli/httpclient.go
+++ b/cmd/rampart/cli/httpclient.go
@@ -13,6 +13,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/peg/rampart/internal/proxy"
 )
 
 // rampartHTTPClient is used for all outgoing HTTP requests from CLI commands
@@ -89,13 +91,7 @@ func validateCredentialEndpoint(rawURL, tokenSource string) error {
 
 const maxRampartHealthResponseBytes = 4 << 10
 
-type rampartHealthResponse struct {
-	Service       string `json:"service"`
-	Status        string `json:"status"`
-	Mode          string `json:"mode"`
-	UptimeSeconds *int   `json:"uptime_seconds"`
-	Version       string `json:"version"`
-}
+type rampartHealthResponse = proxy.HealthResponse
 
 // fetchRampartHealth verifies that healthURL belongs to a Rampart server, not
 // merely that an unrelated process happens to return HTTP 200 on the same port.

--- a/cmd/rampart/cli/serve.go
+++ b/cmd/rampart/cli/serve.go
@@ -581,7 +581,7 @@ func newServeCmd(opts *rootOptions, deps *serveDeps) *cobra.Command {
 
 				// Write serve state file for discovery by doctor/watch/log.
 				if rampartDir != "" {
-					if err := writeServeState(rampartDir, listenPort, os.Getpid(), tlsCfg != nil); err != nil {
+					if err := writeServeState(rampartDir, listenPort, os.Getpid(), tlsCfg != nil, proxyServer.RuntimeIdentity()); err != nil {
 						logger.Warn("serve: failed to write state file", "error", err)
 					}
 				}

--- a/cmd/rampart/cli/serve.go
+++ b/cmd/rampart/cli/serve.go
@@ -581,7 +581,19 @@ func newServeCmd(opts *rootOptions, deps *serveDeps) *cobra.Command {
 
 				// Write serve state file for discovery by doctor/watch/log.
 				if rampartDir != "" {
-					if err := writeServeState(rampartDir, listenPort, os.Getpid(), tlsCfg != nil, proxyServer.RuntimeIdentity()); err != nil {
+					workingDir, _ := os.Getwd()
+					launch := &serveLaunchSettings{
+						WorkingDir: workingDir, ConfigPath: opts.configPath, ConfigDir: configDir, AuditDir: auditDir,
+						Mode: mode, Port: listenPort, Addr: listenAddr, Syslog: syslogAddr, CEF: cef,
+						ResolveBaseURL: resolveBaseURL, SigningKey: signingKeyPath, Metrics: metrics, LogFile: logFilePath,
+						ReloadInterval: reloadInterval, ApprovalTimeout: approvalTimeout, TLSCert: tlsCert, TLSKey: tlsKey,
+						TLSAuto: tlsAuto, NoOpenClawBridge: noOpenClawBridge, Verbose: opts.verbose,
+					}
+					if err := launch.validate(); err != nil {
+						logger.Warn("serve: automatic restart settings unavailable; preserve original launch settings for manual upgrades", "reason", err)
+						launch = nil
+					}
+					if err := writeServeState(rampartDir, listenPort, os.Getpid(), tlsCfg != nil, proxyServer.RuntimeIdentity(), launch); err != nil {
 						logger.Warn("serve: failed to write state file", "error", err)
 					}
 				}

--- a/cmd/rampart/cli/serve_launch.go
+++ b/cmd/rampart/cli/serve_launch.go
@@ -171,7 +171,12 @@ func (settings serveLaunchSettings) restart(runner commandRunner, executable str
 // separately by upgrade and remain authoritative for their own launches.
 func legacyDefaultServeLaunch(pid int, home, executable string) (serveLaunchSettings, error) {
 	var settings serveLaunchSettings
-	logPath := filepath.Join(home, ".rampart", "serve.log")
+	// The released background launcher passed the log's resolved parent path
+	// to its child. Use that same spelling when HOME contains a directory alias.
+	logPath, err := resolveServeLogPath(filepath.Join(home, ".rampart", "serve.log"))
+	if err != nil {
+		return settings, legacyLaunchError()
+	}
 	var cwd string
 	var args []string
 	switch runtime.GOOS {

--- a/cmd/rampart/cli/serve_launch.go
+++ b/cmd/rampart/cli/serve_launch.go
@@ -1,0 +1,291 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"crypto/x509"
+	"fmt"
+	"io"
+	"net"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// serveLaunchSettings is private, typed restart state for the options serve
+// actually consumed. It deliberately has no argv, environment, or token field.
+// Relative paths retain their meaning through the original working directory.
+type serveLaunchSettings struct {
+	WorkingDir       string        `json:"working_dir"`
+	ConfigPath       string        `json:"config_path"`
+	ConfigDir        string        `json:"config_dir,omitempty"`
+	AuditDir         string        `json:"audit_dir"`
+	Mode             string        `json:"mode"`
+	Port             int           `json:"port"`
+	Addr             string        `json:"addr"`
+	Syslog           string        `json:"syslog,omitempty"`
+	CEF              bool          `json:"cef"`
+	ResolveBaseURL   string        `json:"resolve_base_url,omitempty"`
+	SigningKey       string        `json:"signing_key,omitempty"`
+	Metrics          bool          `json:"metrics"`
+	LogFile          string        `json:"log_file,omitempty"`
+	ReloadInterval   time.Duration `json:"reload_interval"`
+	ApprovalTimeout  time.Duration `json:"approval_timeout"`
+	TLSCert          string        `json:"tls_cert,omitempty"`
+	TLSKey           string        `json:"tls_key,omitempty"`
+	TLSAuto          bool          `json:"tls_auto"`
+	NoOpenClawBridge bool          `json:"no_openclaw_bridge"`
+	Verbose          bool          `json:"verbose"`
+}
+
+func (settings serveLaunchSettings) validate() error {
+	if !filepath.IsAbs(settings.WorkingDir) || settings.ConfigPath == "" || settings.AuditDir == "" || settings.Port < 1 || settings.Port > 65535 || net.ParseIP(settings.Addr) == nil {
+		return fmt.Errorf("restart settings have incomplete paths or listener configuration")
+	}
+	if settings.Mode != "enforce" && settings.Mode != "monitor" && settings.Mode != "disabled" {
+		return fmt.Errorf("restart settings have an invalid mode")
+	}
+	if (settings.TLSCert == "") != (settings.TLSKey == "") || (settings.TLSAuto && settings.TLSCert != "") {
+		return fmt.Errorf("restart settings have conflicting TLS configuration")
+	}
+	for _, value := range []string{settings.WorkingDir, settings.ConfigPath, settings.ConfigDir, settings.AuditDir, settings.Syslog, settings.ResolveBaseURL, settings.SigningKey, settings.LogFile, settings.TLSCert, settings.TLSKey} {
+		if len(value) > 4096 || strings.ContainsAny(value, "\x00\r\n") {
+			return fmt.Errorf("restart settings contain an unsupported path or address")
+		}
+	}
+	if settings.ResolveBaseURL != "" {
+		u, err := url.Parse(settings.ResolveBaseURL)
+		if err != nil || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") || u.User != nil || u.RawQuery != "" || u.Fragment != "" {
+			return fmt.Errorf("approval URL cannot be retained without copying possible credentials")
+		}
+	}
+	if settings.Syslog != "" {
+		if _, _, err := net.SplitHostPort(settings.Syslog); err != nil || strings.ContainsAny(settings.Syslog, "@/?#") {
+			return fmt.Errorf("syslog address cannot be retained safely")
+		}
+	}
+	return nil
+}
+
+func (settings serveLaunchSettings) arguments() []string {
+	args := []string{"serve", "--background", "--config", settings.ConfigPath,
+		"--audit-dir", settings.AuditDir, "--mode", settings.Mode, "--port", strconv.Itoa(settings.Port), "--addr", settings.Addr,
+		"--cef=" + strconv.FormatBool(settings.CEF), "--metrics=" + strconv.FormatBool(settings.Metrics), "--verbose=" + strconv.FormatBool(settings.Verbose),
+		"--reload-interval", settings.ReloadInterval.String(), "--approval-timeout", settings.ApprovalTimeout.String(),
+		"--tls-auto=" + strconv.FormatBool(settings.TLSAuto), "--no-openclaw-bridge=" + strconv.FormatBool(settings.NoOpenClawBridge)}
+	for _, option := range []struct{ name, value string }{
+		{"config-dir", settings.ConfigDir}, {"syslog", settings.Syslog}, {"resolve-base-url", settings.ResolveBaseURL},
+		{"signing-key", settings.SigningKey}, {"log-file", settings.LogFile}, {"tls-cert", settings.TLSCert}, {"tls-key", settings.TLSKey},
+	} {
+		if option.value != "" {
+			args = append(args, "--"+option.name, option.value)
+		}
+	}
+	return args
+}
+
+type serveRestarter func(commandRunner, string, io.Writer, io.Writer) error
+
+func preparePIDServeRestart(userHomeDir func() (string, error), binary string, pid int) (serveRestarter, error) {
+	home, err := userHomeDir()
+	if err != nil {
+		return nil, err
+	}
+	dir := filepath.Join(home, ".rampart")
+	state, err := readPrivateServeStateForRestart(dir)
+	if err != nil {
+		return nil, fmt.Errorf("cannot preserve this background service: %w", err)
+	}
+	if state.PID != pid || !samePath(state.Executable, binary) {
+		return nil, fmt.Errorf("cannot preserve this background service: private state does not match the running PID and upgraded executable; restart it manually with its original settings")
+	}
+	owned, _, err := isRampartServeProcess(pid)
+	if err != nil || !owned {
+		return nil, fmt.Errorf("cannot preserve background service: process ownership is unproven")
+	}
+	stateURL, err := validateLocalServeStateURL(state)
+	if err != nil {
+		return nil, err
+	}
+	observed, err := observeServiceRuntime(context.Background(), stateURL.String(), time.Second)
+	if err != nil {
+		return nil, fmt.Errorf("cannot preserve background service: its configured endpoint is not healthy")
+	}
+	if state.InstanceID != "" && (!runtimeIdentified(state.RuntimeIdentity) || observed.RuntimeIdentity != state.RuntimeIdentity) {
+		return nil, fmt.Errorf("cannot preserve background service: health and private process state identify different runtimes")
+	}
+	settings := state.Launch
+	if settings == nil {
+		if state.InstanceID != "" {
+			return nil, fmt.Errorf("this service could not save safe restart settings; restart it manually with its original settings before upgrading")
+		}
+		if cmp, ok := compareReleaseVersions(observed.Version, "v1.9.1"); !ok || cmp > 0 {
+			return nil, legacyLaunchError()
+		}
+		legacy, err := legacyDefaultServeLaunch(pid, home, binary)
+		if err != nil {
+			return nil, err
+		}
+		settings = &legacy
+	}
+	if err := settings.validate(); err != nil {
+		return nil, err
+	}
+	if settings.Port != state.Port || settings.Mode != observed.Mode || (settings.TLSAuto || settings.TLSCert != "") != (stateURL.Scheme == "https") {
+		return nil, fmt.Errorf("saved launch settings do not match the running service")
+	}
+	if info, err := os.Stat(settings.WorkingDir); err != nil || !info.IsDir() {
+		return nil, fmt.Errorf("the original service working directory is unavailable; restore it before upgrading")
+	}
+	// The running service already persisted its token. Refuse before stop if
+	// restarting would generate a replacement token or inherit an override.
+	if token, err := readPersistedToken(); err != nil || token == "" {
+		return nil, fmt.Errorf("the running service's private token is unavailable; restore it before upgrading")
+	}
+	captured := *settings
+	return captured.restart, nil
+}
+
+func (settings serveLaunchSettings) restart(runner commandRunner, executable string, stdout, stderr io.Writer) error {
+	cmd := runner(executable, settings.arguments()...)
+	cmd.Dir = settings.WorkingDir
+	cmd.Env = setEnvValue(os.Environ(), "RAMPART_TOKEN", "")
+	cmd.Stdout, cmd.Stderr = stdout, stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("upgrade: restart with preserved service settings: %w", err)
+	}
+	return nil
+}
+
+// Released v1.9.1 did not retain launch settings. Recover only the positively
+// identified ordinary background launch, never interpret general ps output as
+// shell syntax or guess custom flags. Service-manager definitions are handled
+// separately by upgrade and remain authoritative for their own launches.
+func legacyDefaultServeLaunch(pid int, home, executable string) (serveLaunchSettings, error) {
+	var settings serveLaunchSettings
+	logPath := filepath.Join(home, ".rampart", "serve.log")
+	var cwd string
+	var args []string
+	switch runtime.GOOS {
+	case "linux":
+		procDir := filepath.Join("/proc", strconv.Itoa(pid))
+		before, err := os.ReadFile(filepath.Join(procDir, "stat"))
+		if err != nil {
+			return settings, legacyLaunchError()
+		}
+		commandFile, err := os.Open(filepath.Join(procDir, "cmdline"))
+		if err != nil {
+			return settings, legacyLaunchError()
+		}
+		command, readErr := io.ReadAll(io.LimitReader(commandFile, 65537))
+		closeErr := commandFile.Close()
+		if readErr != nil || closeErr != nil || len(command) > 65536 {
+			return settings, legacyLaunchError()
+		}
+		cwd, err = os.Readlink(filepath.Join(procDir, "cwd"))
+		if err != nil {
+			return settings, legacyLaunchError()
+		}
+		after, err := os.ReadFile(filepath.Join(procDir, "stat"))
+		if err != nil || linuxProcessStart(before) == "" || linuxProcessStart(before) != linuxProcessStart(after) {
+			return settings, legacyLaunchError()
+		}
+		args = strings.Split(strings.TrimSuffix(string(command), "\x00"), "\x00")
+	case "darwin":
+		// A default launch with whitespace-bearing paths cannot be recovered
+		// unambiguously from ps. Preserve it through a manual migration instead.
+		if strings.ContainsAny(executable+logPath, " \t\r\n\"'") {
+			return settings, legacyLaunchError()
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		pidText := strconv.Itoa(pid)
+		before, err := exec.CommandContext(ctx, "ps", "-p", pidText, "-o", "lstart=").Output()
+		if err != nil {
+			return settings, legacyLaunchError()
+		}
+		command, err := exec.CommandContext(ctx, "ps", "-ww", "-p", pidText, "-o", "args=").Output()
+		if err != nil || len(command) > 65536 {
+			return settings, legacyLaunchError()
+		}
+		directory, err := exec.CommandContext(ctx, "lsof", "-a", "-p", pidText, "-d", "cwd", "-Fn").Output()
+		if err != nil || len(directory) > 8192 {
+			return settings, legacyLaunchError()
+		}
+		for _, line := range strings.Split(string(directory), "\n") {
+			if strings.HasPrefix(line, "n/") {
+				if cwd != "" {
+					return settings, legacyLaunchError()
+				}
+				cwd = line[1:]
+			}
+		}
+		after, err := exec.CommandContext(ctx, "ps", "-p", pidText, "-o", "lstart=").Output()
+		if err != nil || len(bytes.TrimSpace(before)) == 0 || !bytes.Equal(before, after) {
+			return settings, legacyLaunchError()
+		}
+		args = strings.Fields(string(command))
+	default:
+		return settings, legacyLaunchError()
+	}
+	if len(args) != 4 || !samePath(args[0], executable) || args[1] != "serve" || args[2] != "--log-file" || !samePath(args[3], logPath) || !filepath.IsAbs(cwd) {
+		return settings, legacyLaunchError()
+	}
+	owned, _, err := isRampartServeProcess(pid)
+	if err != nil || !owned {
+		return settings, legacyLaunchError()
+	}
+	return serveLaunchSettings{WorkingDir: cwd, ConfigPath: "rampart.yaml", AuditDir: filepath.Join(home, ".rampart", "audit"), Mode: "enforce", Port: 9090, Addr: "127.0.0.1", LogFile: logPath}, nil
+}
+
+func linuxProcessStart(stat []byte) string {
+	end := bytes.LastIndexByte(stat, ')')
+	if end < 0 {
+		return ""
+	}
+	fields := strings.Fields(string(stat[end+1:]))
+	if len(fields) < 20 {
+		return ""
+	}
+	return fields[19]
+}
+
+func serveLaunchCertificate(state serveState, home string, readFile func(string) ([]byte, error)) ([]byte, error) {
+	certPath := filepath.Join(home, ".rampart", "tls", "cert.pem")
+	if state.Launch != nil && state.Launch.TLSCert != "" {
+		if err := state.Launch.validate(); err != nil {
+			return nil, err
+		}
+		certPath = state.Launch.TLSCert
+		if !filepath.IsAbs(certPath) {
+			// Preserve kernel traversal through symlinks followed by '..', just
+			// as the original relative path was opened from the service CWD.
+			certPath = state.Launch.WorkingDir + string(os.PathSeparator) + certPath
+		}
+	}
+	info, err := os.Stat(certPath)
+	if err != nil || !info.Mode().IsRegular() || info.Size() > 1<<20 {
+		return nil, fmt.Errorf("previous service certificate is unavailable or not a bounded regular file; preserve the certificate reference for a manual restart")
+	}
+	data, err := readFile(certPath)
+	if err != nil || len(data) > 1<<20 {
+		return nil, fmt.Errorf("read previous service certificate")
+	}
+	roots := x509.NewCertPool()
+	if !roots.AppendCertsFromPEM(data) {
+		return nil, fmt.Errorf("previous service certificate is not valid PEM")
+	}
+	return append([]byte(nil), data...), nil
+}
+
+func legacyLaunchError() error {
+	return fmt.Errorf("legacy background launch settings or working directory cannot be reconstructed safely; stop and restart the service manually with its original flags using this CLI, then retry upgrade (the service has not been stopped)")
+}

--- a/cmd/rampart/cli/serve_launch_test.go
+++ b/cmd/rampart/cli/serve_launch_test.go
@@ -1,0 +1,251 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"encoding/pem"
+	"io"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/peg/rampart/internal/proxy"
+)
+
+func customServeLaunch(t *testing.T) serveLaunchSettings {
+	t.Helper()
+	return serveLaunchSettings{WorkingDir: t.TempDir(), ConfigPath: "policy files/custom.yaml", ConfigDir: "additional policies", AuditDir: "audit logs", Mode: "monitor", Port: 19099, Addr: "127.0.0.1", Syslog: "127.0.0.1:514", CEF: true, ResolveBaseURL: "https://approvals.example.invalid", SigningKey: "keys/signing.key", Metrics: true, LogFile: "logs/service.log", ReloadInterval: 3 * time.Second, ApprovalTimeout: 4 * time.Minute, TLSCert: "certs/service.pem", TLSKey: "certs/service.key", NoOpenClawBridge: true, Verbose: true}
+}
+
+func TestServeLaunchPreservesTypedOptionsAndWorkingDirectory(t *testing.T) {
+	settings := customServeLaunch(t)
+	if err := settings.validate(); err != nil {
+		t.Fatal(err)
+	}
+	root := NewRootCmd(context.Background(), io.Discard, io.Discard)
+	command, arguments, err := root.Find(settings.arguments())
+	if err != nil || command.Name() != "serve" {
+		t.Fatalf("find serve command: %v", err)
+	}
+	if err := command.ParseFlags(arguments); err != nil {
+		t.Fatal(err)
+	}
+	flags := command.Flags()
+	for flag, want := range map[string]string{"config": settings.ConfigPath, "config-dir": settings.ConfigDir, "audit-dir": settings.AuditDir, "mode": settings.Mode, "addr": settings.Addr, "syslog": settings.Syslog, "resolve-base-url": settings.ResolveBaseURL, "signing-key": settings.SigningKey, "log-file": settings.LogFile, "tls-cert": settings.TLSCert, "tls-key": settings.TLSKey} {
+		got, err := flags.GetString(flag)
+		if err != nil || got != want {
+			t.Errorf("%s=%q, want%q: %v", flag, got, want, err)
+		}
+	}
+	for flag, want := range map[string]bool{"background": true, "cef": true, "metrics": true, "verbose": true, "tls-auto": false, "no-openclaw-bridge": true} {
+		got, err := flags.GetBool(flag)
+		if err != nil || got != want {
+			t.Errorf("%s=%t, want%t: %v", flag, got, want, err)
+		}
+	}
+	if got, _ := flags.GetInt("port"); got != settings.Port {
+		t.Fatalf("port=%d", got)
+	}
+	for flag, want := range map[string]time.Duration{"reload-interval": settings.ReloadInterval, "approval-timeout": settings.ApprovalTimeout} {
+		if got, _ := flags.GetDuration(flag); got != want {
+			t.Errorf("%s=%s, want%s", flag, got, want)
+		}
+	}
+	t.Setenv("RAMPART_LAUNCH_TEST_HELPER", "1")
+	t.Setenv("RAMPART_TOKEN", "synthetic-upgrader-override-must-not-replace-service-token")
+	var args []string
+	var output bytes.Buffer
+	err = settings.restart(func(binary string, arguments ...string) *exec.Cmd {
+		if binary != "rampart-candidate" {
+			t.Errorf("binary=%q", binary)
+		}
+		args = append([]string(nil), arguments...)
+		return exec.Command(os.Args[0], "-test.run=^TestServeLaunchRestartHelper$")
+	}, "rampart-candidate", &output, io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var observed struct {
+		CWD          string
+		TokenPresent bool
+	}
+	if err := json.Unmarshal(output.Bytes(), &observed); err != nil {
+		t.Fatal(err)
+	}
+	wantDir, wantErr := os.Stat(settings.WorkingDir)
+	gotDir, gotErr := os.Stat(observed.CWD)
+	if wantErr != nil || gotErr != nil || !os.SameFile(wantDir, gotDir) || observed.TokenPresent || !reflect.DeepEqual(args, settings.arguments()) {
+		t.Fatalf("restart did not preserve launch semantics: %#v", observed)
+	}
+}
+
+func TestServeLaunchRestartHelper(t *testing.T) {
+	if os.Getenv("RAMPART_LAUNCH_TEST_HELPER") != "1" {
+		return
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		os.Exit(2)
+	}
+	_ = json.NewEncoder(os.Stdout).Encode(struct {
+		CWD          string
+		TokenPresent bool
+	}{cwd, os.Getenv("RAMPART_TOKEN") != ""})
+	os.Exit(0)
+}
+
+func TestServeStateKeepsRestartSettingsPrivateAndRejectsCredentialURLs(t *testing.T) {
+	dir := t.TempDir()
+	settings := customServeLaunch(t)
+	identity := proxy.RuntimeIdentity{InstanceID: "state-instance-0001", Version: "test", Commit: "test-commit", Mode: settings.Mode}
+	if err := writeServeState(dir, settings.Port, 4242, true, identity, &settings); err != nil {
+		t.Fatal(err)
+	}
+	state, err := readPrivateServeState(dir)
+	if err != nil || state.Launch == nil || *state.Launch != settings || state.RuntimeIdentity != identity {
+		t.Fatalf("private state round trip: %#v %v", state, err)
+	}
+	before, err := os.ReadFile(filepath.Join(dir, serveStateFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	settings.ResolveBaseURL = "https://operator:synthetic-secret@example.invalid/?token=synthetic-secret"
+	if err := writeServeState(dir, settings.Port, 4242, true, identity, &settings); err == nil {
+		t.Fatal("credential-bearing restart URL was persisted")
+	}
+	after, err := os.ReadFile(filepath.Join(dir, serveStateFile))
+	if err != nil || !bytes.Equal(before, after) || bytes.Contains(after, []byte("synthetic-secret")) {
+		t.Fatal("invalid launch altered private state")
+	}
+}
+
+func TestRestartRefusesUnknownLaunchFieldsWithoutBreakingDiscovery(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, ".rampart")
+	settings := customServeLaunch(t)
+	identity := proxy.RuntimeIdentity{InstanceID: "state-instance-0001", Version: "test", Commit: "test-commit", Mode: settings.Mode}
+	if err := writeServeState(dir, settings.Port, 4242, true, identity, &settings); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, serveStateFile)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data = bytes.Replace(data, []byte(`"launch":{`), []byte(`"launch":{"future_option":true,`), 1)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	state, err := readPrivateServeState(dir)
+	if err != nil || state.Port != settings.Port {
+		t.Fatalf("lightweight discovery rejected future state: %v", err)
+	}
+	if _, err := preparePIDServeRestart(func() (string, error) { return home, nil }, "unused-candidate", 4242); err == nil || !strings.Contains(err.Error(), "unsupported") {
+		t.Fatalf("unknown launch setting not refused at preparation: %v", err)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil || !bytes.Equal(data, after) {
+		t.Fatal("refusal changed runtime state")
+	}
+}
+
+func TestServeCertificatePreservesRelativeSymlinkTraversal(t *testing.T) {
+	home := t.TempDir()
+	settings := customServeLaunch(t)
+	actual := filepath.Join(settings.WorkingDir, "actual", "nested")
+	if err := os.MkdirAll(actual, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(actual, filepath.Join(settings.WorkingDir, "alias")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	server := httptest.NewTLSServer(nil)
+	defer server.Close()
+	certificate := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: server.Certificate().Raw})
+	if err := os.WriteFile(filepath.Join(settings.WorkingDir, "actual", "cert.pem"), certificate, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Cleaning alias/../cert.pem would select this invalid decoy instead.
+	if err := os.WriteFile(filepath.Join(settings.WorkingDir, "cert.pem"), []byte("not a certificate"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	settings.TLSCert = "alias/../cert.pem"
+	state := serveState{Launch: &settings}
+	got, err := serveLaunchCertificate(state, home, os.ReadFile)
+	if err != nil || !bytes.Equal(got, certificate) {
+		t.Fatalf("relative TLS traversal lost: %v", err)
+	}
+	settings.TLSCert = "missing.pem"
+	if _, err := serveLaunchCertificate(state, home, os.ReadFile); err == nil || !strings.Contains(err.Error(), "manual restart") {
+		t.Fatalf("missing cert: %v", err)
+	}
+}
+
+func TestUpgradePinsOwnedCustomTLSBeforeStopping(t *testing.T) {
+	home := t.TempDir()
+	settings := customServeLaunch(t)
+	settings.Mode = "enforce"
+	server := newUpgradeHealthServer(t, true, "v1.9.1")
+	defer server.Close()
+	u, _ := url.Parse(server.URL)
+	settings.Port, _ = strconv.Atoi(u.Port())
+	certificate := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: server.Certificate().Raw})
+	settings.TLSCert = "custom-cert.pem"
+	if err := os.WriteFile(filepath.Join(settings.WorkingDir, settings.TLSCert), certificate, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	state := serveState{URL: server.URL, Port: settings.Port, PID: 4242, Started: time.Now().Add(-time.Minute).UTC().Format(time.RFC3339Nano), Launch: &settings}
+	writeUpgradeServeState(t, home, state)
+	deps := testServeRestartVerifierDeps(func(int) (bool, string, error) { return true, "rampart serve", nil })
+	verifier, err := prepareServeRestartVerifierWithDeps(func() (string, error) { return home, nil }, os.ReadFile, deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state.Started = time.Now().UTC().Format(time.RFC3339Nano)
+	writeUpgradeServeState(t, home, state)
+	if err := verifier(context.Background(), "v1.9.1", time.Now().Add(-time.Second)); err != nil {
+		t.Fatalf("owned custom TLS activation: %v", err)
+	}
+	if err := os.Remove(filepath.Join(settings.WorkingDir, settings.TLSCert)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := prepareServeRestartVerifierWithDeps(func() (string, error) { return home, nil }, os.ReadFile, deps); err == nil || !strings.Contains(err.Error(), "before restart") {
+		t.Fatalf("missing TLS reference was not refused before stop: %v", err)
+	}
+}
+
+func TestUpgradeCurrentCLIDoesNotImplyCurrentService(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+	server := newUpgradeHealthServer(t, false, "v1.9.1")
+	defer server.Close()
+	t.Setenv("RAMPART_URL", server.URL)
+	var output bytes.Buffer
+	cmd := newUpgradeCmdWithDeps(&rootOptions{}, &upgradeDeps{
+		currentVersion: func(context.Context, commandRunner, func() (string, error)) (string, error) { return "v2.0.0", nil },
+		inspectServePID: func(func() (string, error), func(string) ([]byte, error)) (int, bool, error) {
+			t.Fatal("current CLI must not stop or claim ownership of the observed service")
+			return 0, false, nil
+		},
+	})
+	cmd.SetOut(&output)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"v2.0.0", "--yes", "--no-policy-update"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(output.String(), "Already on latest CLI (v2.0.0)") || !strings.Contains(output.String(), "Observed service: v1.9.1") || !strings.Contains(output.String(), "did not restart") {
+		t.Fatalf("runtime version distinction: %s", output.String())
+	}
+}

--- a/cmd/rampart/cli/serve_launch_test.go
+++ b/cmd/rampart/cli/serve_launch_test.go
@@ -176,14 +176,22 @@ func TestServeCertificatePreservesRelativeSymlinkTraversal(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(settings.WorkingDir, "actual", "cert.pem"), certificate, 0o600); err != nil {
 		t.Fatal(err)
 	}
-	// Cleaning alias/../cert.pem would select this invalid decoy instead.
-	if err := os.WriteFile(filepath.Join(settings.WorkingDir, "cert.pem"), []byte("not a certificate"), 0o600); err != nil {
+	// Keep both native destinations valid but distinct. Unix traversal through
+	// the symlink and Windows lexical path handling need not select the same file.
+	lexicalCertificate := append([]byte("\n"), certificate...)
+	if err := os.WriteFile(filepath.Join(settings.WorkingDir, "cert.pem"), lexicalCertificate, 0o600); err != nil {
 		t.Fatal(err)
 	}
 	settings.TLSCert = "alias/../cert.pem"
+	t.Chdir(settings.WorkingDir)
+	// The actual TLS loader opens the original relative argument from this CWD.
+	expected, err := os.ReadFile(settings.TLSCert)
+	if err != nil {
+		t.Fatal(err)
+	}
 	state := serveState{Launch: &settings}
 	got, err := serveLaunchCertificate(state, home, os.ReadFile)
-	if err != nil || !bytes.Equal(got, certificate) {
+	if err != nil || !bytes.Equal(got, expected) {
 		t.Fatalf("relative TLS traversal lost: %v", err)
 	}
 	settings.TLSCert = "missing.pem"
@@ -233,6 +241,7 @@ func TestUpgradeCurrentCLIDoesNotImplyCurrentService(t *testing.T) {
 	t.Setenv("RAMPART_URL", server.URL)
 	var output bytes.Buffer
 	cmd := newUpgradeCmdWithDeps(&rootOptions{}, &upgradeDeps{
+		goos:           "linux", // Exercise the self-upgrade branch; Windows installer refusal has separate coverage.
 		currentVersion: func(context.Context, commandRunner, func() (string, error)) (string, error) { return "v2.0.0", nil },
 		inspectServePID: func(func() (string, error), func(string) ([]byte, error)) (int, bool, error) {
 			t.Fatal("current CLI must not stop or claim ownership of the observed service")

--- a/cmd/rampart/cli/serve_log.go
+++ b/cmd/rampart/cli/serve_log.go
@@ -35,15 +35,11 @@ func openServeLog(path string, maxBytes int64, backups int) (*serveLog, error) {
 	if maxBytes <= 0 || backups < 1 {
 		return nil, fmt.Errorf("serve: invalid diagnostic log retention limits")
 	}
-	parent, err := filepath.EvalSymlinks(filepath.Dir(path))
-	if err != nil {
-		return nil, fmt.Errorf("serve: resolve log directory: %w", err)
-	}
-	parent, err = filepath.Abs(parent)
+	resolved, err := resolveServeLogPath(path)
 	if err != nil {
 		return nil, err
 	}
-	w := &serveLog{path: serveLogNativePath(filepath.Join(parent, filepath.Base(path))), maxBytes: maxBytes, backups: backups}
+	w := &serveLog{path: resolved, maxBytes: maxBytes, backups: backups}
 	if err := w.open(); err != nil {
 		return nil, err
 	}
@@ -56,6 +52,18 @@ func openServeLog(path string, maxBytes int64, backups int) (*serveLog, error) {
 		return nil, err
 	}
 	return w, nil
+}
+
+func resolveServeLogPath(path string) (string, error) {
+	parent, err := filepath.EvalSymlinks(filepath.Dir(path))
+	if err != nil {
+		return "", fmt.Errorf("serve: resolve log directory: %w", err)
+	}
+	parent, err = filepath.Abs(parent)
+	if err != nil {
+		return "", err
+	}
+	return serveLogNativePath(filepath.Join(parent, filepath.Base(path))), nil
 }
 
 func inspectServeLog(path string) (os.FileInfo, error) {

--- a/cmd/rampart/cli/serve_state.go
+++ b/cmd/rampart/cli/serve_state.go
@@ -19,11 +19,12 @@ import (
 // can discover the serve URL and port without requiring flags or env vars.
 type serveState struct {
 	proxy.RuntimeIdentity
-	URL        string `json:"url"`
-	Port       int    `json:"port"`
-	PID        int    `json:"pid"`
-	Started    string `json:"started"`
-	Executable string `json:"executable,omitempty"`
+	URL        string               `json:"url"`
+	Port       int                  `json:"port"`
+	PID        int                  `json:"pid"`
+	Started    string               `json:"started"`
+	Executable string               `json:"executable,omitempty"`
+	Launch     *serveLaunchSettings `json:"launch,omitempty"`
 }
 
 const (
@@ -32,7 +33,12 @@ const (
 )
 
 // writeServeState writes the serve state to ~/.rampart/serve.state.
-func writeServeState(dir string, port, pid int, tls bool, identity proxy.RuntimeIdentity) error {
+func writeServeState(dir string, port, pid int, tls bool, identity proxy.RuntimeIdentity, launch *serveLaunchSettings) error {
+	if launch != nil {
+		if err := launch.validate(); err != nil {
+			return err
+		}
+	}
 	scheme := "http"
 	if tls {
 		scheme = "https"
@@ -48,6 +54,7 @@ func writeServeState(dir string, port, pid int, tls bool, identity proxy.Runtime
 		PID:             pid,
 		Started:         time.Now().UTC().Format(time.RFC3339Nano),
 		Executable:      executable,
+		Launch:          launch,
 	}
 	data, err := json.Marshal(state)
 	if err != nil {

--- a/cmd/rampart/cli/serve_state.go
+++ b/cmd/rampart/cli/serve_state.go
@@ -11,11 +11,14 @@ import (
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/peg/rampart/internal/proxy"
 )
 
 // serveState is written by `rampart serve` so other commands (doctor, watch, log)
 // can discover the serve URL and port without requiring flags or env vars.
 type serveState struct {
+	proxy.RuntimeIdentity
 	URL        string `json:"url"`
 	Port       int    `json:"port"`
 	PID        int    `json:"pid"`
@@ -29,7 +32,7 @@ const (
 )
 
 // writeServeState writes the serve state to ~/.rampart/serve.state.
-func writeServeState(dir string, port, pid int, tls bool) error {
+func writeServeState(dir string, port, pid int, tls bool, identity proxy.RuntimeIdentity) error {
 	scheme := "http"
 	if tls {
 		scheme = "https"
@@ -39,11 +42,12 @@ func writeServeState(dir string, port, pid int, tls bool) error {
 		executable, _ = filepath.Abs(executable)
 	}
 	state := serveState{
-		URL:        fmt.Sprintf("%s://localhost:%d", scheme, port),
-		Port:       port,
-		PID:        pid,
-		Started:    time.Now().UTC().Format(time.RFC3339),
-		Executable: executable,
+		RuntimeIdentity: identity,
+		URL:             fmt.Sprintf("%s://localhost:%d", scheme, port),
+		Port:            port,
+		PID:             pid,
+		Started:         time.Now().UTC().Format(time.RFC3339Nano),
+		Executable:      executable,
 	}
 	data, err := json.Marshal(state)
 	if err != nil {

--- a/cmd/rampart/cli/serve_test.go
+++ b/cmd/rampart/cli/serve_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/peg/rampart/internal/engine"
+	"github.com/peg/rampart/internal/proxy"
 	"github.com/peg/rampart/policies"
 	"github.com/stretchr/testify/require"
 )
@@ -379,7 +380,7 @@ func TestServeStatePublishesPrivateExecutableIdentity(t *testing.T) {
 		t.Fatal(err)
 	}
 	const pid = 4242
-	if err := writeServeState(dir, 19090, pid, false); err != nil {
+	if err := writeServeState(dir, 19090, pid, false, proxy.RuntimeIdentity{}); err != nil {
 		t.Fatal(err)
 	}
 	want, err := os.Executable()

--- a/cmd/rampart/cli/serve_test.go
+++ b/cmd/rampart/cli/serve_test.go
@@ -380,7 +380,7 @@ func TestServeStatePublishesPrivateExecutableIdentity(t *testing.T) {
 		t.Fatal(err)
 	}
 	const pid = 4242
-	if err := writeServeState(dir, 19090, pid, false, proxy.RuntimeIdentity{}); err != nil {
+	if err := writeServeState(dir, 19090, pid, false, proxy.RuntimeIdentity{}, nil); err != nil {
 		t.Fatal(err)
 	}
 	want, err := os.Executable()

--- a/cmd/rampart/cli/service_runtime.go
+++ b/cmd/rampart/cli/service_runtime.go
@@ -1,0 +1,150 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/peg/rampart/internal/proxy"
+)
+
+// serviceRuntimeObservation records what the selected endpoint actually served.
+// It contains no credentials, PID, executable path, or process arguments.
+type serviceRuntimeObservation struct {
+	proxy.RuntimeIdentity
+	Endpoint string `json:"endpoint"`
+}
+
+func runtimeIdentified(identity proxy.RuntimeIdentity) bool {
+	if len(identity.InstanceID) < 16 || len(identity.InstanceID) > 128 || strings.TrimSpace(identity.Commit) == "" {
+		return false
+	}
+	for _, c := range identity.InstanceID {
+		if !((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-' || c == '_') {
+			return false
+		}
+	}
+	return strings.TrimSpace(identity.Version) != "" && (identity.Mode == "enforce" || identity.Mode == "monitor" || identity.Mode == "disabled")
+}
+
+func serviceEndpoint(raw string) (string, error) {
+	endpoint := strings.TrimRight(strings.TrimSpace(raw), "/")
+	u, err := url.Parse(endpoint)
+	if err != nil || u.Host == "" || u.Opaque != "" || (u.Scheme != "http" && u.Scheme != "https") ||
+		u.User != nil || u.RawQuery != "" || u.Fragment != "" || u.Path != "" {
+		return "", fmt.Errorf("service endpoint must be an absolute HTTP(S) origin without credentials, paths, queries, or fragments")
+	}
+	return endpoint, nil
+}
+
+func observeServiceRuntime(ctx context.Context, endpoint string, timeout time.Duration) (serviceRuntimeObservation, error) {
+	var observed serviceRuntimeObservation
+	endpoint, err := serviceEndpoint(endpoint)
+	if err != nil {
+		return observed, err
+	}
+	observed.Endpoint = endpoint
+	client, closeClient, err := serviceRuntimeClient(endpoint, timeout)
+	if err != nil {
+		return observed, err
+	}
+	defer closeClient()
+	health, err := fetchRampartHealth(ctx, client, endpoint+"/healthz")
+	if err != nil {
+		return observed, err
+	}
+	observed.RuntimeIdentity = health.RuntimeIdentity
+	return observed, nil
+}
+
+// serviceRuntimeClient is shared by health and preflight so both requests use
+// the same endpoint trust. No redirected request receives control credentials.
+func serviceRuntimeClient(endpoint string, timeout time.Duration) (*http.Client, func(), error) {
+	client := *rampartHTTPClient
+	client.Timeout = timeout
+	client.CheckRedirect = newRampartHTTPClient(timeout).CheckRedirect
+	if strings.HasPrefix(endpoint, "https://") && isLoopbackURL(endpoint) {
+		if home, err := os.UserHomeDir(); err == nil {
+			if _, certErr := os.Stat(filepath.Join(home, ".rampart", "tls", "cert.pem")); !os.IsNotExist(certErr) {
+				u, _ := url.Parse(endpoint)
+				return localServeHealthClient(u, home, os.ReadFile, timeout)
+			}
+		}
+	}
+	return &client, func() {}, nil
+}
+
+// integrationServiceEndpoint follows the endpoint consumed by that integration,
+// not an unrelated healthy default service. Local hooks do not require HTTP.
+func integrationServiceEndpoint(driver integrationDriver) (string, error) {
+	if !driver.ServiceRequired {
+		return "", nil
+	}
+	if driver.OpenClaw {
+		config, err := openClawAssuranceConfiguration()
+		if err != nil {
+			return "", err
+		}
+		return serviceEndpoint(config.Plugin.ServeURL)
+	}
+	endpoint, err := resolveServeURLStrict("", fmt.Sprintf("http://localhost:%d", defaultServePort))
+	if err != nil {
+		return "", err
+	}
+	return serviceEndpoint(endpoint)
+}
+
+func readPrivateServeState(dir string) (serveState, error) {
+	var state serveState
+	path := filepath.Join(dir, serveStateFile)
+	info, err := os.Lstat(path)
+	if err != nil {
+		return state, err
+	}
+	if !info.Mode().IsRegular() || info.Size() > maxServeStateFileBytes || (runtime.GOOS != "windows" && info.Mode().Perm()&0o077 != 0) {
+		return state, fmt.Errorf("serve.state is not a bounded private regular file")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return state, err
+	}
+	if len(data) > maxServeStateFileBytes {
+		return state, fmt.Errorf("serve.state exceeds size limit")
+	}
+	err = json.Unmarshal(data, &state)
+	return state, err
+}
+
+func ownedServiceRuntime(observed serviceRuntimeObservation) bool {
+	if !runtimeIdentified(observed.RuntimeIdentity) || !isLoopbackURL(observed.Endpoint) {
+		return false
+	}
+	dir, err := rampartDir()
+	if err != nil {
+		return false
+	}
+	state, err := readPrivateServeState(dir)
+	if err != nil || state.PID <= 0 || state.RuntimeIdentity != observed.RuntimeIdentity {
+		return false
+	}
+	stateURL, err := validateLocalServeStateURL(state)
+	if err != nil {
+		return false
+	}
+	endpoint, _ := url.Parse(observed.Endpoint)
+	if stateURL.Scheme != endpoint.Scheme || stateURL.Port() != endpoint.Port() {
+		return false
+	}
+	owned, _, err := isRampartServeProcess(state.PID)
+	return err == nil && owned
+}

--- a/cmd/rampart/cli/service_runtime.go
+++ b/cmd/rampart/cli/service_runtime.go
@@ -4,9 +4,11 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -75,6 +77,20 @@ func serviceRuntimeClient(endpoint string, timeout time.Duration) (*http.Client,
 	client.CheckRedirect = newRampartHTTPClient(timeout).CheckRedirect
 	if strings.HasPrefix(endpoint, "https://") && isLoopbackURL(endpoint) {
 		if home, err := os.UserHomeDir(); err == nil {
+			if state, err := readPrivateServeState(filepath.Join(home, ".rampart")); err == nil && state.Launch != nil && state.Launch.TLSCert != "" {
+				stateURL, stateErr := validateLocalServeStateURL(state)
+				u, _ := url.Parse(endpoint)
+				if stateErr == nil && stateURL.Scheme == u.Scheme && stateURL.Port() == u.Port() {
+					owned, _, identityErr := isRampartServeProcess(state.PID)
+					if identityErr == nil && owned {
+						certificate, certErr := serveLaunchCertificate(state, home, os.ReadFile)
+						if certErr != nil {
+							return nil, func() {}, certErr
+						}
+						return localServeHealthClient(u, home, os.ReadFile, timeout, certificate)
+					}
+				}
+			}
 			if _, certErr := os.Stat(filepath.Join(home, ".rampart", "tls", "cert.pem")); !os.IsNotExist(certErr) {
 				u, _ := url.Parse(endpoint)
 				return localServeHealthClient(u, home, os.ReadFile, timeout)
@@ -106,23 +122,51 @@ func integrationServiceEndpoint(driver integrationDriver) (string, error) {
 
 func readPrivateServeState(dir string) (serveState, error) {
 	var state serveState
-	path := filepath.Join(dir, serveStateFile)
-	info, err := os.Lstat(path)
+	data, err := readPrivateServeStateData(dir)
 	if err != nil {
 		return state, err
-	}
-	if !info.Mode().IsRegular() || info.Size() > maxServeStateFileBytes || (runtime.GOOS != "windows" && info.Mode().Perm()&0o077 != 0) {
-		return state, fmt.Errorf("serve.state is not a bounded private regular file")
-	}
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return state, err
-	}
-	if len(data) > maxServeStateFileBytes {
-		return state, fmt.Errorf("serve.state exceeds size limit")
 	}
 	err = json.Unmarshal(data, &state)
 	return state, err
+}
+
+// Restart preparation is stricter than health/URL discovery. An older CLI
+// must refuse newer launch options rather than discard them during a restart.
+func readPrivateServeStateForRestart(dir string) (serveState, error) {
+	var state serveState
+	data, err := readPrivateServeStateData(dir)
+	if err != nil {
+		return state, err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&state); err != nil {
+		return state, fmt.Errorf("saved runtime state has unsupported or invalid fields; restart manually with the original options before upgrading")
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		return state, fmt.Errorf("saved runtime state contains trailing data")
+	}
+	return state, nil
+}
+
+func readPrivateServeStateData(dir string) ([]byte, error) {
+	path := filepath.Join(dir, serveStateFile)
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() || info.Size() > maxServeStateFileBytes || (runtime.GOOS != "windows" && info.Mode().Perm()&0o077 != 0) {
+		return nil, fmt.Errorf("serve.state is not a bounded private regular file")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > maxServeStateFileBytes {
+		return nil, fmt.Errorf("serve.state exceeds size limit")
+	}
+	return data, nil
 }
 
 func ownedServiceRuntime(observed serviceRuntimeObservation) bool {

--- a/cmd/rampart/cli/service_runtime_test.go
+++ b/cmd/rampart/cli/service_runtime_test.go
@@ -1,0 +1,157 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/peg/rampart/internal/proxy"
+)
+
+func TestServiceReceiptRejectsReplacementAndModeChange(t *testing.T) {
+	for _, field := range []string{"instance", "build", "mode", "unavailable"} {
+		t.Run(field, func(t *testing.T) {
+			home := t.TempDir()
+			installOpenClawAssuranceFixture(t, home)
+			now := time.Now().UTC().Truncate(time.Second)
+			report := passingAssuranceReport("openclaw", now)
+			if err := writeVerificationReceipt(report); err != nil {
+				t.Fatal(err)
+			}
+			before, _ := findAssuranceStatus(collectIntegrationAssuranceStatuses(now), "openclaw")
+			if before.AssuranceLevel != assuranceHostVerified {
+				t.Fatalf("initial evidence: %#v", before)
+			}
+			// A healthy global/default endpoint cannot rescue the host's endpoint.
+			t.Setenv("RAMPART_URL", "http://127.0.0.1:19999")
+			rampartHTTPClient = &http.Client{Transport: redirectTestTransport(func(req *http.Request) (*http.Response, error) {
+				if req.URL.Host != "localhost:9090" {
+					t.Errorf("probed unrelated endpoint %s", req.URL.Host)
+				}
+				if field == "unavailable" {
+					return nil, io.EOF
+				}
+				response := statusTestHealthResponse(req, "enforce")
+				body, _ := io.ReadAll(response.Body)
+				switch field {
+				case "instance":
+					body = bytes.ReplaceAll(body, []byte("test-service-instance-0001"), []byte("test-service-instance-0002"))
+				case "build":
+					body = bytes.ReplaceAll(body, []byte("test-commit"), []byte("other-commit"))
+				case "mode":
+					body = bytes.ReplaceAll(body, []byte("enforce"), []byte("monitor"))
+				}
+				response.Body = io.NopCloser(bytes.NewReader(body))
+				return response, nil
+			})}
+			after, _ := findAssuranceStatus(collectIntegrationAssuranceStatuses(now), "openclaw")
+			if after.AssuranceLevel == assuranceHostVerified || after.StaleReason == "" {
+				t.Fatalf("stale runtime promoted: %#v", after)
+			}
+		})
+	}
+}
+
+func TestLegacyReceiptDoesNotAcquireRuntimeEvidence(t *testing.T) {
+	home := t.TempDir()
+	installOpenClawAssuranceFixture(t, home)
+	now := time.Now().UTC().Truncate(time.Second)
+	report := passingAssuranceReport("openclaw", now)
+	report.policyEndpoint = report.Runtime.Endpoint
+	report.Runtime = nil
+	if err := writeVerificationReceipt(report); err != nil {
+		t.Fatal(err)
+	}
+	status, _ := findAssuranceStatus(collectIntegrationAssuranceStatuses(now), "openclaw")
+	if status.AssuranceLevel != assuranceConfigured || status.StaleReason != "verification receipt lacks runtime identity" || status.Runtime != nil {
+		t.Fatalf("legacy receipt: %#v", status)
+	}
+}
+
+func TestVerificationRejectsRuntimeChangeDuringCanaries(t *testing.T) {
+	for _, change := range []string{"instance", "mode"} {
+		t.Run(change, func(t *testing.T) {
+			installVerificationToken(t, "verification-token")
+			probes := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/healthz" {
+					probes++
+					identity := proxy.RuntimeIdentity{InstanceID: "test-service-instance-0001", Version: "test", Commit: "test-commit", Mode: "enforce"}
+					if probes > 1 {
+						if change == "instance" {
+							identity.InstanceID = "test-service-instance-0002"
+						} else {
+							identity.Mode = "monitor"
+						}
+					}
+					uptime := 1
+					_ = json.NewEncoder(w).Encode(proxy.HealthResponse{RuntimeIdentity: identity, Service: "rampart", Status: "ok", UptimeSeconds: &uptime})
+					return
+				}
+				var request struct {
+					Params map[string]any `json:"params"`
+				}
+				if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+					t.Error(err)
+				}
+				decision := "deny"
+				if request.Params["command"] == "pwd" {
+					decision = "allow"
+				}
+				_ = json.NewEncoder(w).Encode(preflightResponse{Allowed: decision == "allow", Decision: decision})
+			}))
+			defer server.Close()
+			report := runBehavioralVerification(context.Background(), "policy", server.URL, time.Second)
+			if report.Runtime != nil || report.Summary.Failed != 1 || report.Summary.Passed != 5 || probes != 2 {
+				t.Fatalf("changed runtime report: %#v probes=%d", report, probes)
+			}
+		})
+	}
+}
+
+func TestVerificationOverrideCannotReplaceHostEndpoint(t *testing.T) {
+	installOpenClawAssuranceFixture(t, t.TempDir())
+	report := runBehavioralVerification(context.Background(), "openclaw", "http://127.0.0.1:19999", time.Second)
+	if report.Runtime != nil || report.Summary.Unverified != 1 || len(report.Checks) != 1 || !strings.Contains(report.Checks[0].Hint, "differs") {
+		t.Fatalf("mismatched override: %#v", report)
+	}
+}
+
+func TestReuseReportsLegacyAndRefusesNonEnforcingServiceWithoutMutation(t *testing.T) {
+	home := t.TempDir()
+	testSetHome(t, home)
+	path := filepath.Join(home, ".rampart", "token")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	const canary = "synthetic-private-token"
+	if err := os.WriteFile(path, []byte(canary), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, mode := range []string{"enforce", "monitor", "disabled"} {
+		var output bytes.Buffer
+		observed := serviceRuntimeObservation{Endpoint: "https://example.invalid", RuntimeIdentity: proxy.RuntimeIdentity{Version: "1.9.1", Mode: mode}}
+		err := reportReusableServe(&output, observed)
+		if (err == nil) != (mode == "enforce") {
+			t.Fatalf("mode=%s error=%v", mode, err)
+		}
+		if !strings.Contains(output.String(), "1.9.1") || !strings.Contains(output.String(), mode) || !strings.Contains(output.String(), "ownership unproven") || strings.Contains(output.String(), canary) {
+			t.Fatalf("reuse output: %s", output.String())
+		}
+	}
+	data, err := os.ReadFile(path)
+	if err != nil || string(data) != canary {
+		t.Fatal("reuse modified the existing token")
+	}
+}

--- a/cmd/rampart/cli/setup_openclaw_plugin.go
+++ b/cmd/rampart/cli/setup_openclaw_plugin.go
@@ -1921,9 +1921,11 @@ func ensureServeRunningForURL(w io.Writer, errW io.Writer, serveURL string) erro
 	if serveURL == "" {
 		return fmt.Errorf("rampart policy service URL is empty")
 	}
-	if isSetupServeReachableAt(serveURL) {
-		fmt.Fprintf(w, "✓ Rampart serve is running at %s\n", serveURL)
-		return nil
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	observed, healthErr := observeServiceRuntime(ctx, serveURL, 500*time.Millisecond)
+	cancel()
+	if healthErr == nil {
+		return reportReusableServe(w, observed)
 	}
 	defaultURL := fmt.Sprintf("http://localhost:%d", defaultServePort)
 	if serveURL != defaultURL {
@@ -1944,9 +1946,8 @@ func ensureServeRunningForURL(w io.Writer, errW io.Writer, serveURL string) erro
 		// Wait up to 3 seconds for serve to come up.
 		for i := 0; i < 6; i++ {
 			time.Sleep(500 * time.Millisecond)
-			if isSetupServeReachableAt(serveURL) {
-				fmt.Fprintln(w, "✓ Rampart serve started (system service)")
-				return nil
+			if observed, err := observeServiceRuntime(context.Background(), serveURL, 500*time.Millisecond); err == nil {
+				return reportReusableServe(w, observed)
 			}
 		}
 		fmt.Fprintln(errW, "⚠ rampart serve service install did not become reachable; trying background fallback")
@@ -1963,6 +1964,21 @@ func ensureServeRunningForURL(w io.Writer, errW io.Writer, serveURL string) erro
 	return nil
 }
 
+func reportReusableServe(w io.Writer, observed serviceRuntimeObservation) error {
+	ownership := "ownership unproven; service left unchanged"
+	if ownedServiceRuntime(observed) {
+		ownership = "owned local service"
+	}
+	fmt.Fprintf(w, "Rampart service at %s: version %s, mode %s (%s)\n", observed.Endpoint, observed.Version, observed.Mode, ownership)
+	if observed.Mode != "enforce" {
+		return fmt.Errorf("the configured service is in %s mode; restart it in enforce mode using its existing service definition or launch settings before protecting this integration", observed.Mode)
+	}
+	if !runtimeIdentified(observed.RuntimeIdentity) {
+		fmt.Fprintln(w, "Legacy service is available; per-start runtime assurance requires updating the service and reverifying.")
+	}
+	return nil
+}
+
 func startServeBackgroundFallback(rampartBin, serveURL string, w io.Writer, errW io.Writer) error {
 	cmd := osexec.Command(rampartBin, "serve", "--background")
 	cmd.Stdout = w
@@ -1972,9 +1988,8 @@ func startServeBackgroundFallback(rampartBin, serveURL string, w io.Writer, errW
 	}
 	for i := 0; i < 10; i++ {
 		time.Sleep(500 * time.Millisecond)
-		if isSetupServeReachableAt(serveURL) {
-			fmt.Fprintln(w, "✓ Rampart serve started (background fallback)")
-			return nil
+		if observed, err := observeServiceRuntime(context.Background(), serveURL, 500*time.Millisecond); err == nil {
+			return reportReusableServe(w, observed)
 		}
 	}
 	return fmt.Errorf("rampart serve --background did not become reachable after 5s")

--- a/cmd/rampart/cli/status.go
+++ b/cmd/rampart/cli/status.go
@@ -51,6 +51,8 @@ const statusSchemaVersion = "rampart.status.v1"
 type statusSnapshot struct {
 	generatedAt   time.Time
 	buildVersion  string
+	service       *serviceRuntimeObservation
+	serviceOwned  bool
 	protected     []string
 	integrations  []integrationAssuranceStatus
 	mode          string
@@ -67,6 +69,9 @@ type statusJSONOutput struct {
 	SchemaVersion string                       `json:"schema_version"`
 	GeneratedAt   time.Time                    `json:"generated_at"`
 	BuildVersion  string                       `json:"build_version"`
+	BuildCommit   string                       `json:"build_commit"`
+	Service       *serviceRuntimeObservation   `json:"service,omitempty"`
+	ServiceOwned  bool                         `json:"service_owned"`
 	Protected     []string                     `json:"protected_agents"`
 	Integrations  []integrationAssuranceStatus `json:"integrations"`
 	Mode          string                       `json:"mode"`
@@ -110,6 +115,17 @@ func runStatus(w io.Writer, jsonOut bool) error {
 		useColor,
 	)
 	fmt.Fprintln(w, box)
+	fmt.Fprintf(w, "CLI: %s (%s)\n", snapshot.buildVersion, build.Commit)
+	if snapshot.service != nil {
+		ownership := "ownership unproven"
+		if snapshot.serviceOwned {
+			ownership = "owned local service"
+		}
+		fmt.Fprintf(w, "Service: %s (%s), %s, %s · %s\n", snapshot.service.Version, snapshot.service.Commit, snapshot.service.Mode, ownership, snapshot.service.Endpoint)
+		if !runtimeIdentified(snapshot.service.RuntimeIdentity) {
+			fmt.Fprintln(w, "Service freshness is unavailable for this legacy health response; runtime-bound verification requires an updated service.")
+		}
+	}
 	printIntegrationAssurance(w, snapshot.integrations, snapshot.generatedAt)
 
 	printStatusHints(w, snapshot.serverRunning, snapshot.protected, snapshot.allow, snapshot.deny, snapshot.pending)
@@ -121,19 +137,31 @@ func collectStatusSnapshot(generatedAt time.Time) statusSnapshot {
 		generatedAt = time.Now().UTC()
 	}
 	protected := detectProtectedAgents()
-	health, healthErr := configuredServiceHealth()
+	endpoint, endpointErr := resolveServeURLStrict("", fmt.Sprintf("http://localhost:%d", defaultServePort))
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+	health, healthErr := observeServiceRuntime(ctx, endpoint, 150*time.Millisecond)
+	if endpointErr != nil {
+		healthErr = endpointErr
+	}
 	serverRunning := healthErr == nil
 	mode := "unknown"
+	var service *serviceRuntimeObservation
+	serviceOwned := false
 	if serverRunning {
 		mode = health.Mode
+		service = &health
+		serviceOwned = ownedServiceRuntime(health)
 	}
 	defaultAction := detectPolicyDefault()
 	allow, deny, pending, lastDeny := todayEventsAt(generatedAt)
 	return statusSnapshot{
 		generatedAt:   generatedAt,
 		buildVersion:  build.Version,
+		service:       service,
+		serviceOwned:  serviceOwned,
 		protected:     protected,
-		integrations:  collectIntegrationAssuranceStatuses(generatedAt, serverRunning),
+		integrations:  collectIntegrationAssuranceStatuses(generatedAt),
 		mode:          mode,
 		defaultAction: defaultAction,
 		serverRunning: serverRunning,
@@ -159,6 +187,9 @@ func writeStatusJSON(w io.Writer, snapshot statusSnapshot) error {
 		SchemaVersion: statusSchemaVersion,
 		GeneratedAt:   snapshot.generatedAt,
 		BuildVersion:  snapshot.buildVersion,
+		BuildCommit:   build.Commit,
+		Service:       snapshot.service,
+		ServiceOwned:  snapshot.serviceOwned,
 		Protected:     protected,
 		Integrations:  integrations,
 		Mode:          snapshot.mode,

--- a/cmd/rampart/cli/status_test.go
+++ b/cmd/rampart/cli/status_test.go
@@ -254,10 +254,6 @@ func TestStatusUnavailableConfiguredEndpointInvalidatesServiceReceipt(t *testing
 	if err := writeVerificationReceipt(passingAssuranceReport("cursor", now)); err != nil {
 		t.Fatal(err)
 	}
-	initial, ok := findAssuranceStatus(collectIntegrationAssuranceStatuses(now, true), "cursor")
-	if !ok || initial.AssuranceLevel != assuranceAdapterVerified {
-		t.Fatalf("initial Cursor assurance = %#v, found=%t", initial, ok)
-	}
 
 	var probes []string
 	oldClient := rampartHTTPClient
@@ -275,7 +271,7 @@ func TestStatusUnavailableConfiguredEndpointInvalidatesServiceReceipt(t *testing
 	if snapshot.serverRunning || snapshot.mode != "unknown" {
 		t.Fatalf("unavailable endpoint: running=%t mode=%q", snapshot.serverRunning, snapshot.mode)
 	}
-	if len(probes) != 1 || probes[0] != "127.0.0.1:19099" {
+	if len(probes) != 2 || probes[0] != "127.0.0.1:19099" || probes[1] != "127.0.0.1:19099" {
 		t.Fatalf("status probed endpoints other than its configured service: %v", probes)
 	}
 	status, ok := findAssuranceStatus(snapshot.integrations, "cursor")
@@ -289,7 +285,7 @@ func statusTestHealthResponse(req *http.Request, mode string) *http.Response {
 		StatusCode: http.StatusOK,
 		Request:    req,
 		Header:     make(http.Header),
-		Body:       io.NopCloser(strings.NewReader(fmt.Sprintf(`{"service":"rampart","status":"ok","mode":%q,"uptime_seconds":1,"version":"1.9.0"}`, mode))),
+		Body:       io.NopCloser(strings.NewReader(fmt.Sprintf(`{"service":"rampart","status":"ok","mode":%q,"uptime_seconds":1,"version":"1.9.0","commit":"test-commit","instance_id":"test-service-instance-0001"}`, mode))),
 	}
 }
 

--- a/cmd/rampart/cli/upgrade.go
+++ b/cmd/rampart/cli/upgrade.go
@@ -73,7 +73,7 @@ type upgradeDeps struct {
 	validateCandidate     func(context.Context, string, string) error
 	inspectServePID       func(func() (string, error), func(string) ([]byte, error)) (int, bool, error)
 	stopServe             func(int) error
-	restartServe          func(commandRunner, string, io.Writer, io.Writer) error
+	prepareServeRestart   func(func() (string, error), string, int) (serveRestarter, error)
 	detectSystemdService  func(commandRunner, func() (string, error), string) string
 	restartSystemdService func(commandRunner, string, io.Writer) error
 	detectLaunchdServices func(commandRunner, func() (string, error), string) []launchdService
@@ -105,7 +105,7 @@ func defaultUpgradeDeps() upgradeDeps {
 		validateCandidate:     validateUpgradeCandidate,
 		inspectServePID:       inspectServePID,
 		stopServe:             stopServeProcess,
-		restartServe:          restartServe,
+		prepareServeRestart:   preparePIDServeRestart,
 		detectSystemdService:  detectActiveSystemdService,
 		restartSystemdService: restartSystemdUserService,
 		detectLaunchdServices: detectActiveLaunchdServices,
@@ -175,8 +175,8 @@ func newUpgradeCmdWithDeps(_ *rootOptions, deps *upgradeDeps) *cobra.Command {
 		if deps.stopServe != nil {
 			resolved.stopServe = deps.stopServe
 		}
-		if deps.restartServe != nil {
-			resolved.restartServe = deps.restartServe
+		if deps.prepareServeRestart != nil {
+			resolved.prepareServeRestart = deps.prepareServeRestart
 		}
 		if deps.detectSystemdService != nil {
 			resolved.detectSystemdService = deps.detectSystemdService
@@ -277,7 +277,14 @@ func newUpgradeCmdWithDeps(_ *rootOptions, deps *upgradeDeps) *cobra.Command {
 			}
 
 			if current != "" && compareSemver(current, target) >= 0 {
-				fmt.Fprintf(cmd.OutOrStdout(), "Already on latest (%s)\n", target)
+				fmt.Fprintf(cmd.OutOrStdout(), "Already on latest CLI (%s)\n", target)
+				endpoint, endpointErr := resolveServeURLStrict("", fmt.Sprintf("http://localhost:%d", defaultServePort))
+				observed, healthErr := observeServiceRuntime(ctx, endpoint, 150*time.Millisecond)
+				if endpointErr == nil && healthErr == nil {
+					fmt.Fprintf(cmd.OutOrStdout(), "Observed service: %s (%s), mode %s; this check did not restart or verify its protection.\n", observed.Version, observed.Commit, observed.Mode)
+				} else {
+					fmt.Fprintln(cmd.OutOrStdout(), "No reachable service runtime was verified by this CLI version check.")
+				}
 				if !skipPolicyUpdate {
 					if err := resolved.updatePolicies(cmd.OutOrStdout(), dryRun); err != nil {
 						fmt.Fprintf(cmd.ErrOrStderr(), "⚠ policy update failed: %v\n", err)
@@ -409,6 +416,13 @@ func newUpgradeCmdWithDeps(_ *rootOptions, deps *upgradeDeps) *cobra.Command {
 			}
 
 			var restartVerifier serveRestartVerifier
+			var restartPID serveRestarter
+			if pidServeRunning {
+				restartPID, err = resolved.prepareServeRestart(resolved.userHomeDir, exePath, servePID)
+				if err != nil {
+					return fmt.Errorf("upgrade: prepare preserved background restart: %w", err)
+				}
+			}
 			if serveRunning {
 				restartVerifier, err = resolved.prepareServeVerifier(resolved.userHomeDir, resolved.readFile)
 				if err != nil {
@@ -426,7 +440,10 @@ func newUpgradeCmdWithDeps(_ *rootOptions, deps *upgradeDeps) *cobra.Command {
 			}
 			restartPIDRuntime := func(expectedVersion string) error {
 				restartedAt := time.Now()
-				if err := resolved.restartServe(resolved.commandRunner, exePath, cmd.OutOrStdout(), cmd.ErrOrStderr()); err != nil {
+				if restartPID == nil {
+					return fmt.Errorf("upgrade: preserved background restart is unavailable")
+				}
+				if err := restartPID(resolved.commandRunner, exePath, cmd.OutOrStdout(), cmd.ErrOrStderr()); err != nil {
 					return err
 				}
 				return verifyRestartedRuntime(expectedVersion, restartedAt)
@@ -1018,16 +1035,6 @@ func stopServeProcess(pid int) error {
 	}
 }
 
-func restartServe(runner commandRunner, binary string, stdout, stderr io.Writer) error {
-	cmd := runner(binary, "serve", "--background")
-	cmd.Stdout = stdout
-	cmd.Stderr = stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("upgrade: restart rampart serve: %w", err)
-	}
-	return nil
-}
-
 // serveRestartVerifier proves that a restart created a fresh, Rampart-owned
 // local runtime and that the runtime loaded the expected binary version.
 // Implementations must be bounded by ctx; upgrade keeps its rollback binary
@@ -1035,11 +1042,12 @@ func restartServe(runner commandRunner, binary string, stdout, stderr io.Writer)
 type serveRestartVerifier func(ctx context.Context, expectedVersion string, restartedAt time.Time) error
 
 type serveRestartVerifierDeps struct {
-	processIdentity func(int) (bool, string, error)
-	now             func() time.Time
-	timeout         time.Duration
-	pollInterval    time.Duration
-	requestTimeout  time.Duration
+	processIdentity    func(int) (bool, string, error)
+	now                func() time.Time
+	timeout            time.Duration
+	pollInterval       time.Duration
+	requestTimeout     time.Duration
+	trustedCertificate []byte
 }
 
 func defaultServeRestartVerifierDeps() serveRestartVerifierDeps {
@@ -1078,6 +1086,29 @@ func prepareServeRestartVerifierWithDeps(
 		return nil, fmt.Errorf("read existing %s: %w", statePath, err)
 	}
 	previousState = append([]byte(nil), previousState...)
+	var previous serveState
+	if previousExists && json.Unmarshal(previousState, &previous) == nil && strings.HasPrefix(previous.URL, "https://") {
+		if _, err := validateLocalServeStateURL(previous); err != nil {
+			return nil, err
+		}
+		if deps.processIdentity == nil {
+			return nil, fmt.Errorf("process identity verifier is unavailable before TLS restart")
+		}
+		if previous.Launch != nil {
+			private, err := readPrivateServeState(filepath.Join(home, ".rampart"))
+			if err != nil || private.PID != previous.PID || private.RuntimeIdentity != previous.RuntimeIdentity || private.Launch == nil || *private.Launch != *previous.Launch {
+				return nil, fmt.Errorf("previous TLS launch settings are not matching private runtime state")
+			}
+		}
+		owned, _, err := deps.processIdentity(previous.PID)
+		if err != nil || !owned {
+			return nil, fmt.Errorf("cannot pin TLS for an unowned previous runtime")
+		}
+		deps.trustedCertificate, err = serveLaunchCertificate(previous, home, readFile)
+		if err != nil {
+			return nil, fmt.Errorf("prepare TLS trust before restart: %w", err)
+		}
+	}
 
 	return func(ctx context.Context, expectedVersion string, restartedAt time.Time) error {
 		verifiedState, err := verifyRestartedServe(
@@ -1228,7 +1259,7 @@ func verifyRestartedServeState(
 		return nil, fmt.Errorf("serve.state pid %d is not Rampart-owned (%s)", state.PID, identity)
 	}
 
-	client, closeClient, err := localServeHealthClient(serveURL, home, readFile, deps.requestTimeout)
+	client, closeClient, err := localServeHealthClient(serveURL, home, readFile, deps.requestTimeout, deps.trustedCertificate)
 	if err != nil {
 		return nil, err
 	}
@@ -1318,6 +1349,7 @@ func localServeHealthClient(
 	home string,
 	readFile func(string) ([]byte, error),
 	requestTimeout time.Duration,
+	pinnedCertificate ...[]byte,
 ) (*http.Client, func(), error) {
 	dialer := &net.Dialer{Timeout: requestTimeout}
 	transport := &http.Transport{
@@ -1352,15 +1384,23 @@ func localServeHealthClient(
 		},
 	}
 	if serveURL.Scheme == "https" {
-		// serve.state intentionally contains no arbitrary trust path. Self-upgrade
-		// therefore supports HTTPS only for Rampart's tls-auto certificate. A
-		// custom --tls-cert service needs an explicit future fingerprint/source
-		// design; falling back to system roots or InsecureSkipVerify here would
-		// weaken the proof that the restarted local process is the managed one.
+		// A prepared restart pins the certificate read from the previous owned
+		// launch. Legacy state without a certificate reference supports tls-auto
+		// only; never fall back to insecure verification or arbitrary roots.
 		certPath := filepath.Join(home, ".rampart", "tls", "cert.pem")
-		certPEM, err := readFile(certPath)
-		if err != nil {
-			return nil, func() {}, fmt.Errorf("verify HTTPS runtime: read managed tls-auto certificate %s: %w (custom --tls-cert runtimes require a manual upgrade and restart)", certPath, err)
+		var certPEM []byte
+		if len(pinnedCertificate) > 0 {
+			certPEM = pinnedCertificate[0]
+		}
+		if len(certPEM) == 0 {
+			var err error
+			certPEM, err = readFile(certPath)
+			if err != nil {
+				return nil, func() {}, fmt.Errorf("verify HTTPS runtime: read managed tls-auto certificate %s: %w (legacy custom --tls-cert runtimes require a manual upgrade and restart)", certPath, err)
+			}
+		}
+		if len(certPEM) > 1<<20 {
+			return nil, func() {}, fmt.Errorf("verify HTTPS runtime: certificate exceeds size limit")
 		}
 		roots := x509.NewCertPool()
 		if !roots.AppendCertsFromPEM(certPEM) {

--- a/cmd/rampart/cli/upgrade.go
+++ b/cmd/rampart/cli/upgrade.go
@@ -74,6 +74,7 @@ type upgradeDeps struct {
 	inspectServePID       func(func() (string, error), func(string) ([]byte, error)) (int, bool, error)
 	stopServe             func(int) error
 	prepareServeRestart   func(func() (string, error), string, int) (serveRestarter, error)
+	captureServeCandidate func(func() (string, error), string, int, time.Time) (func() error, error)
 	detectSystemdService  func(commandRunner, func() (string, error), string) string
 	restartSystemdService func(commandRunner, string, io.Writer) error
 	detectLaunchdServices func(commandRunner, func() (string, error), string) []launchdService
@@ -106,6 +107,7 @@ func defaultUpgradeDeps() upgradeDeps {
 		inspectServePID:       inspectServePID,
 		stopServe:             stopServeProcess,
 		prepareServeRestart:   preparePIDServeRestart,
+		captureServeCandidate: captureServeCandidateCleanup,
 		detectSystemdService:  detectActiveSystemdService,
 		restartSystemdService: restartSystemdUserService,
 		detectLaunchdServices: detectActiveLaunchdServices,
@@ -177,6 +179,9 @@ func newUpgradeCmdWithDeps(_ *rootOptions, deps *upgradeDeps) *cobra.Command {
 		}
 		if deps.prepareServeRestart != nil {
 			resolved.prepareServeRestart = deps.prepareServeRestart
+		}
+		if deps.captureServeCandidate != nil {
+			resolved.captureServeCandidate = deps.captureServeCandidate
 		}
 		if deps.detectSystemdService != nil {
 			resolved.detectSystemdService = deps.detectSystemdService
@@ -438,13 +443,21 @@ func newUpgradeCmdWithDeps(_ *rootOptions, deps *upgradeDeps) *cobra.Command {
 				}
 				return nil
 			}
-			restartPIDRuntime := func(expectedVersion string) error {
+			var candidateCleanup func() error
+			var candidateCaptureErr error
+			restartPIDRuntime := func(expectedVersion string, captureCandidate bool) error {
 				restartedAt := time.Now()
 				if restartPID == nil {
 					return fmt.Errorf("upgrade: preserved background restart is unavailable")
 				}
 				if err := restartPID(resolved.commandRunner, exePath, cmd.OutOrStdout(), cmd.ErrOrStderr()); err != nil {
 					return err
+				}
+				if captureCandidate {
+					// Health may be the reason activation fails. Capture process
+					// ownership separately, before the health probe can race a
+					// replacement runtime or a changed private state file.
+					candidateCleanup, candidateCaptureErr = resolved.captureServeCandidate(resolved.userHomeDir, exePath, servePID, restartedAt)
 				}
 				return verifyRestartedRuntime(expectedVersion, restartedAt)
 			}
@@ -454,7 +467,7 @@ func newUpgradeCmdWithDeps(_ *rootOptions, deps *upgradeDeps) *cobra.Command {
 				if !pidServeNeedsRestart {
 					return
 				}
-				if restartErr := restartPIDRuntime(current); restartErr != nil {
+				if restartErr := restartPIDRuntime(current, false); restartErr != nil {
 					restartErr = fmt.Errorf("upgrade: restore previously running rampart serve: %w", restartErr)
 					if runErr == nil {
 						runErr = restartErr
@@ -529,7 +542,7 @@ func newUpgradeCmdWithDeps(_ *rootOptions, deps *upgradeDeps) *cobra.Command {
 			} else if len(activeLaunchd) > 0 {
 				runtimeRestartErrs = restartManagedServices(target)
 			} else if pidServeRunning {
-				if err := restartPIDRuntime(target); err != nil {
+				if err := restartPIDRuntime(target, true); err != nil {
 					runtimeRestartErrs = append(runtimeRestartErrs, err)
 				} else {
 					pidServeNeedsRestart = false
@@ -538,6 +551,21 @@ func newUpgradeCmdWithDeps(_ *rootOptions, deps *upgradeDeps) *cobra.Command {
 
 			if len(runtimeRestartErrs) > 0 {
 				restartCause := errors.Join(runtimeRestartErrs...)
+				if pidServeRunning {
+					// This is the authoritative recovery attempt. In particular,
+					// a refused cleanup must not fall through to a deferred restart.
+					pidServeNeedsRestart = false
+					cleanupErr := candidateCaptureErr
+					if cleanupErr == nil && candidateCleanup != nil {
+						cleanupErr = candidateCleanup()
+					}
+					if cleanupErr != nil {
+						return errors.Join(
+							fmt.Errorf("upgrade: candidate runtime activation failed: %w", restartCause),
+							fmt.Errorf("upgrade: recovery incomplete; failed candidate cleanup could not be confirmed; previous executable retained at %s: %w", backupPath, cleanupErr),
+						)
+					}
+				}
 				if rollbackErr := resolved.rename(backupPath, exePath); rollbackErr != nil {
 					return errors.Join(
 						fmt.Errorf("upgrade: candidate runtime activation failed: %w", restartCause),
@@ -550,11 +578,7 @@ func newUpgradeCmdWithDeps(_ *rootOptions, deps *upgradeDeps) *cobra.Command {
 				if activeSvc != "" || len(activeLaunchd) > 0 {
 					recoveryErrs = restartManagedServices(current)
 				} else if pidServeRunning {
-					// Recovery below is the one authoritative retry. Disable the
-					// deferred fallback first so a failed recovery is reported once
-					// instead of starting an uncontrolled third process attempt.
-					pidServeNeedsRestart = false
-					if recoveryErr := restartPIDRuntime(current); recoveryErr != nil {
+					if recoveryErr := restartPIDRuntime(current, false); recoveryErr != nil {
 						recoveryErrs = append(recoveryErrs, recoveryErr)
 					}
 				}

--- a/cmd/rampart/cli/upgrade.go
+++ b/cmd/rampart/cli/upgrade.go
@@ -1048,6 +1048,8 @@ type serveRestartVerifierDeps struct {
 	pollInterval       time.Duration
 	requestTimeout     time.Duration
 	trustedCertificate []byte
+	expectedEndpoint   *url.URL
+	expectedMode       string
 }
 
 func defaultServeRestartVerifierDeps() serveRestartVerifierDeps {
@@ -1079,36 +1081,65 @@ func prepareServeRestartVerifierWithDeps(
 	if strings.TrimSpace(home) == "" {
 		return nil, fmt.Errorf("resolve home directory: empty path")
 	}
-	statePath := filepath.Join(home, ".rampart", serveStateFile)
-	previousState, err := readFile(statePath)
-	previousExists := err == nil
-	if err != nil && !os.IsNotExist(err) {
-		return nil, fmt.Errorf("read existing %s: %w", statePath, err)
+	previousState, err := readPrivateServeStateData(filepath.Join(home, ".rampart"))
+	if err != nil {
+		return nil, fmt.Errorf("read previous runtime state before restart: %w", err)
 	}
-	previousState = append([]byte(nil), previousState...)
+	previousExists := true
 	var previous serveState
-	if previousExists && json.Unmarshal(previousState, &previous) == nil && strings.HasPrefix(previous.URL, "https://") {
-		if _, err := validateLocalServeStateURL(previous); err != nil {
-			return nil, err
-		}
-		if deps.processIdentity == nil {
-			return nil, fmt.Errorf("process identity verifier is unavailable before TLS restart")
-		}
-		if previous.Launch != nil {
-			private, err := readPrivateServeState(filepath.Join(home, ".rampart"))
-			if err != nil || private.PID != previous.PID || private.RuntimeIdentity != previous.RuntimeIdentity || private.Launch == nil || *private.Launch != *previous.Launch {
-				return nil, fmt.Errorf("previous TLS launch settings are not matching private runtime state")
-			}
-		}
-		owned, _, err := deps.processIdentity(previous.PID)
-		if err != nil || !owned {
-			return nil, fmt.Errorf("cannot pin TLS for an unowned previous runtime")
-		}
+	if json.Unmarshal(previousState, &previous) != nil {
+		return nil, fmt.Errorf("previous runtime state is unavailable or invalid; restore it before upgrading")
+	}
+	previousURL, err := validateLocalServeStateURL(previous)
+	if err != nil {
+		return nil, err
+	}
+	if deps.processIdentity == nil {
+		return nil, fmt.Errorf("process identity verifier is unavailable before restart")
+	}
+	owned, _, err := deps.processIdentity(previous.PID)
+	if err != nil || !owned {
+		return nil, fmt.Errorf("cannot preserve an unowned previous runtime")
+	}
+	if previousURL.Scheme == "https" {
 		deps.trustedCertificate, err = serveLaunchCertificate(previous, home, readFile)
 		if err != nil {
 			return nil, fmt.Errorf("prepare TLS trust before restart: %w", err)
 		}
 	}
+	if deps.requestTimeout <= 0 {
+		deps.requestTimeout = time.Second
+	}
+	client, closeClient, err := localServeHealthClient(previousURL, home, readFile, deps.requestTimeout, deps.trustedCertificate)
+	if err != nil {
+		return nil, err
+	}
+	defer closeClient()
+	healthURL := *previousURL
+	healthURL.Path = "/healthz"
+	health, err := fetchRampartHealth(context.Background(), client, healthURL.String())
+	if err != nil {
+		return nil, fmt.Errorf("observe previous runtime before restart: %w", err)
+	}
+	if !validUpgradeHealthService(health.Service, health.Version) {
+		return nil, fmt.Errorf("previous health response lacks the expected Rampart service identity")
+	}
+	if (previous.InstanceID != "" || health.InstanceID != "") && (!runtimeIdentified(previous.RuntimeIdentity) || previous.RuntimeIdentity != health.RuntimeIdentity) {
+		return nil, fmt.Errorf("previous runtime state does not match its health identity")
+	}
+	if previous.InstanceID == "" && health.InstanceID == "" {
+		if cmp, ok := compareReleaseVersions(health.Version, "v1.9.1"); !ok || cmp > 0 {
+			return nil, fmt.Errorf("previous runtime lacks instance identity; legacy preservation is limited to v1.9.1 and older")
+		}
+	}
+	if previous.Launch != nil && previous.Launch.Mode != health.Mode {
+		return nil, fmt.Errorf("previous launch mode does not match its health response")
+	}
+	// Pin the actual pre-upgrade endpoint and mode, including legacy services
+	// whose private state did not yet contain a mode. A healthy candidate must
+	// retain both, even if its own new state and health agree with each other.
+	deps.expectedEndpoint = previousURL
+	deps.expectedMode = health.Mode
 
 	return func(ctx context.Context, expectedVersion string, restartedAt time.Time) error {
 		verifiedState, err := verifyRestartedServe(
@@ -1235,8 +1266,8 @@ func verifyRestartedServeState(
 	if err != nil {
 		return nil, fmt.Errorf("fresh serve.state has invalid started time %q", state.Started)
 	}
-	// writeServeState uses RFC3339 second precision. Truncating the restart
-	// boundary avoids rejecting a daemon that starts later in the same second.
+	// Legacy state used second precision. Accept a restart in the same second;
+	// current state also has an instance identity to establish freshness.
 	if started.Before(restartedAt.UTC().Truncate(time.Second)) {
 		return nil, fmt.Errorf("serve.state predates this restart (%s)", started.UTC().Format(time.RFC3339Nano))
 	}
@@ -1247,6 +1278,9 @@ func verifyRestartedServeState(
 	serveURL, err := validateLocalServeStateURL(state)
 	if err != nil {
 		return nil, err
+	}
+	if previous := deps.expectedEndpoint; previous != nil && (serveURL.Scheme != previous.Scheme || !strings.EqualFold(serveURL.Hostname(), previous.Hostname()) || serveURL.Port() != previous.Port()) {
+		return nil, fmt.Errorf("restarted runtime endpoint differs from the previous service")
 	}
 	owned, identity, err := deps.processIdentity(state.PID)
 	if err != nil {
@@ -1274,6 +1308,9 @@ func verifyRestartedServeState(
 	}
 	if !validUpgradeHealthService(health.Service, expectedVersion) {
 		return nil, fmt.Errorf("unexpected health service identity %q", health.Service)
+	}
+	if deps.expectedMode != "" && health.Mode != deps.expectedMode {
+		return nil, fmt.Errorf("restarted runtime mode mismatch: expected %s, got %s", deps.expectedMode, health.Mode)
 	}
 	if expectedVersion != "" {
 		expected, expectedErr := normalizeVersion(expectedVersion)

--- a/cmd/rampart/cli/upgrade.go
+++ b/cmd/rampart/cli/upgrade.go
@@ -1254,6 +1254,17 @@ func verifyRestartedServeState(
 			return nil, fmt.Errorf("restarted runtime version mismatch: expected %s, got %q", expected, health.Version)
 		}
 	}
+	if state.InstanceID != "" || health.InstanceID != "" {
+		if !runtimeIdentified(state.RuntimeIdentity) || state.RuntimeIdentity != health.RuntimeIdentity {
+			return nil, fmt.Errorf("restarted runtime identity does not match fresh owned serve.state")
+		}
+		var previous serveState
+		if previousExists && json.Unmarshal(previousState, &previous) == nil && previous.InstanceID == state.InstanceID {
+			return nil, fmt.Errorf("restarted runtime reused the previous instance identity")
+		}
+	} else if cmp, ok := compareReleaseVersions(expectedVersion, "v1.9.1"); !ok || cmp > 0 {
+		return nil, fmt.Errorf("restarted runtime lacks instance identity; legacy recovery is limited to v1.9.1 and older")
+	}
 	return append([]byte(nil), stateData...), nil
 }
 

--- a/cmd/rampart/cli/upgrade_candidate_test.go
+++ b/cmd/rampart/cli/upgrade_candidate_test.go
@@ -123,7 +123,7 @@ func TestUpgradeRestoresPreviousBinaryWhenFinalValidationFails(t *testing.T) {
 			return 4242, true, nil
 		},
 		stopServe: func(int) error { return nil },
-		restartServe: func(_ commandRunner, binary string, _, _ io.Writer) error {
+		prepareServeRestart: preparedRestartForTest(func(_ commandRunner, binary string, _, _ io.Writer) error {
 			restarted++
 			got, err := os.ReadFile(binary)
 			if err != nil {
@@ -133,7 +133,7 @@ func TestUpgradeRestoresPreviousBinaryWhenFinalValidationFails(t *testing.T) {
 				return errors.New("restart did not observe restored binary")
 			}
 			return nil
-		},
+		}),
 		detectSystemdService: func(commandRunner, func() (string, error), string) string { return "" },
 		prepareServeVerifier: acceptServeRestartVerification,
 		validateCandidate: func(context.Context, string, string) error {

--- a/cmd/rampart/cli/upgrade_cleanup.go
+++ b/cmd/rampart/cli/upgrade_cleanup.go
@@ -1,0 +1,130 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0
+
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type serveCandidateCleanupDeps struct {
+	processIdentity func(int) (bool, string, error)
+	processStart    func(int) (string, error)
+	stop            func(int) error
+}
+
+// Capture the newly started process before probing its health. A failed health
+// proof gives no authority to stop whichever process happens to respond later.
+func captureServeCandidateCleanup(homeDir func() (string, error), executable string, previousPID int, restartedAt time.Time) (func() error, error) {
+	return captureServeCandidateCleanupWithDeps(homeDir, executable, previousPID, restartedAt, serveCandidateCleanupDeps{
+		processIdentity: isRampartServeProcess,
+		processStart:    serveProcessStart,
+		stop:            stopServeProcess,
+	})
+}
+
+func captureServeCandidateCleanupWithDeps(homeDir func() (string, error), executable string, previousPID int, restartedAt time.Time, deps serveCandidateCleanupDeps) (func() error, error) {
+	home, err := homeDir()
+	if err != nil || strings.TrimSpace(home) == "" {
+		return nil, fmt.Errorf("cannot resolve private runtime state for candidate cleanup")
+	}
+	dir := filepath.Join(home, ".rampart")
+	state, err := readPrivateServeStateForRestart(dir)
+	if err != nil {
+		return nil, fmt.Errorf("capture candidate runtime state: %w", err)
+	}
+	if state.PID <= 0 || state.PID == previousPID || !filepath.IsAbs(state.Executable) || !samePath(state.Executable, executable) || !runtimeIdentified(state.RuntimeIdentity) || state.Launch == nil {
+		return nil, fmt.Errorf("candidate cleanup requires a fresh identified process for the installed executable")
+	}
+	started, err := time.Parse(time.RFC3339Nano, state.Started)
+	if err != nil || started.Before(restartedAt) || started.After(time.Now().Add(5*time.Second)) {
+		return nil, fmt.Errorf("candidate cleanup state does not identify this restart")
+	}
+	if _, err := validateLocalServeStateURL(state); err != nil {
+		return nil, err
+	}
+	if err := state.Launch.validate(); err != nil {
+		return nil, err
+	}
+
+	// Check the complete private record and kernel birth marker on both sides
+	// of the existing executable/command ownership check. Reusing a PID, editing
+	// launch settings, or replacing the runtime must not transfer stop authority.
+	revalidate := func(expectedStart string) (string, error) {
+		current, err := readPrivateServeStateForRestart(dir)
+		if err != nil || !sameServeCandidateState(state, current) {
+			return "", fmt.Errorf("candidate runtime state changed; refusing cleanup")
+		}
+		before, err := deps.processStart(state.PID)
+		if err != nil || before == "" || (expectedStart != "" && before != expectedStart) {
+			return "", fmt.Errorf("candidate process birth identity is unavailable or changed; refusing cleanup")
+		}
+		owned, _, err := deps.processIdentity(state.PID)
+		if err != nil || !owned {
+			return "", fmt.Errorf("candidate process is no longer Rampart-owned; refusing cleanup")
+		}
+		current, err = readPrivateServeStateForRestart(dir)
+		if err != nil || !sameServeCandidateState(state, current) {
+			return "", fmt.Errorf("candidate runtime state changed during ownership verification; refusing cleanup")
+		}
+		after, err := deps.processStart(state.PID)
+		if err != nil || before != after {
+			return "", fmt.Errorf("candidate process changed during ownership verification; refusing cleanup")
+		}
+		return before, nil
+	}
+	start, err := revalidate("")
+	if err != nil {
+		return nil, err
+	}
+	return func() error {
+		if _, err := revalidate(start); err != nil {
+			return err
+		}
+		return deps.stop(state.PID)
+	}, nil
+}
+
+func sameServeCandidateState(a, b serveState) bool {
+	aLaunch, bLaunch := a.Launch, b.Launch
+	a.Launch, b.Launch = nil, nil
+	return a == b && aLaunch != nil && bLaunch != nil && *aLaunch == *bLaunch
+}
+
+// Birth markers supplement the existing process command/executable check;
+// health instance IDs alone do not authenticate an operating-system process.
+func serveProcessStart(pid int) (string, error) {
+	var start string
+	switch runtime.GOOS {
+	case "linux":
+		stat, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "stat"))
+		if err != nil {
+			return "", err
+		}
+		start = linuxProcessStart(stat)
+	case "darwin":
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, "ps", "-p", strconv.Itoa(pid), "-o", "lstart=")
+		cmd.Env = setEnvValue(os.Environ(), "LC_ALL", "C")
+		output, err := cmd.Output()
+		if err != nil {
+			return "", err
+		}
+		start = strings.TrimSpace(string(output))
+	default:
+		return "", fmt.Errorf("candidate process birth identity is unsupported on this platform")
+	}
+	if start == "" {
+		return "", fmt.Errorf("candidate process birth identity is empty")
+	}
+	return start, nil
+}

--- a/cmd/rampart/cli/upgrade_health_test.go
+++ b/cmd/rampart/cli/upgrade_health_test.go
@@ -16,7 +16,46 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/peg/rampart/internal/proxy"
 )
+
+func TestServeRestartVerifierBindsSameVersionHealthToOwnedInstance(t *testing.T) {
+	for _, tc := range []struct {
+		name, expected, stateID, healthID, previousID string
+		wantError                                     bool
+	}{
+		{"matching", "v2.0.0", "fresh-instance-0001", "fresh-instance-0001", "previous-instance-0001", false},
+		{"unrelated same version", "v2.0.0", "fresh-instance-0001", "other-instance-0001", "previous-instance-0001", true},
+		{"reused instance", "v2.0.0", "fresh-instance-0001", "fresh-instance-0001", "fresh-instance-0001", true},
+		{"modern identity missing", "v2.0.0", "", "", "previous-instance-0001", true},
+		{"legacy rollback", "v1.9.1", "", "", "previous-instance-0001", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			uptime := 1
+			identity := proxy.RuntimeIdentity{InstanceID: tc.healthID, Version: tc.expected, Commit: "same-build", Mode: "enforce"}
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_ = json.NewEncoder(w).Encode(proxy.HealthResponse{RuntimeIdentity: identity, Service: "rampart", Status: "ok", UptimeSeconds: &uptime})
+			}))
+			defer server.Close()
+			parsed, _ := url.Parse(server.URL)
+			port, _ := strconv.Atoi(parsed.Port())
+			state := serveState{URL: server.URL, Port: port, PID: 4242, Started: time.Now().UTC().Format(time.RFC3339Nano), RuntimeIdentity: identity}
+			state.InstanceID = tc.stateID
+			previous := state
+			previous.InstanceID = tc.previousID
+			previous.Started = time.Now().Add(-time.Minute).UTC().Format(time.RFC3339Nano)
+			data, _ := json.Marshal(state)
+			previousData, _ := json.Marshal(previous)
+			deps := testServeRestartVerifierDeps(func(int) (bool, string, error) { return true, "rampart serve", nil })
+			_, err := verifyRestartedServeState(context.Background(), home, os.ReadFile, data, tc.expected, previousData, true, time.Now().Add(-time.Second), deps)
+			if (err != nil) != tc.wantError {
+				t.Fatalf("activation error=%v, wantError=%t", err, tc.wantError)
+			}
+		})
+	}
+}
 
 func TestServeRestartVerifierRejectsStaleState(t *testing.T) {
 	home := t.TempDir()

--- a/cmd/rampart/cli/upgrade_health_test.go
+++ b/cmd/rampart/cli/upgrade_health_test.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -67,17 +68,97 @@ func TestServeRestartVerifierRejectsStaleState(t *testing.T) {
 	}
 	writeUpgradeServeState(t, home, state)
 
-	verifier, err := prepareServeRestartVerifierWithDeps(
-		func() (string, error) { return home, nil },
-		os.ReadFile,
-		testServeRestartVerifierDeps(func(int) (bool, string, error) { return true, "rampart serve", nil }),
-	)
+	previous, err := os.ReadFile(filepath.Join(home, ".rampart", serveStateFile))
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = verifier(context.Background(), "v1.4.1", time.Now())
+	_, err = verifyRestartedServe(context.Background(), home, os.ReadFile, "v1.4.1", previous, true, time.Now(),
+		testServeRestartVerifierDeps(func(int) (bool, string, error) { return true, "rampart serve", nil }))
 	if err == nil || !strings.Contains(err.Error(), "serve.state is stale") {
 		t.Fatalf("stale state error = %v", err)
+	}
+}
+
+func TestServeRestartVerifierPreservesObservedEndpointAndMode(t *testing.T) {
+	for _, tc := range []struct {
+		name, oldMode, newMode, changedEndpoint, wantError string
+		previousVersion, wantPrepareError                  string
+		legacy                                             bool
+	}{
+		{name: "enforce retained", oldMode: "enforce", newMode: "enforce"},
+		{name: "monitor retained", oldMode: "monitor", newMode: "monitor"},
+		{name: "disabled retained", oldMode: "disabled", newMode: "disabled"},
+		{name: "matching new state and health weakened", oldMode: "enforce", newMode: "monitor", wantError: "mode mismatch"},
+		{name: "changed port", oldMode: "enforce", newMode: "enforce", changedEndpoint: "port", wantError: "endpoint differs"},
+		{name: "changed TLS", oldMode: "enforce", newMode: "enforce", changedEndpoint: "scheme", wantError: "endpoint differs"},
+		{name: "legacy observed mode retained", oldMode: "monitor", newMode: "monitor", legacy: true},
+		{name: "legacy observed mode changed", oldMode: "monitor", newMode: "enforce", legacy: true, wantError: "mode mismatch"},
+		{name: "modern identity missing before restart", oldMode: "enforce", legacy: true, previousVersion: "2.0.0", wantPrepareError: "lacks instance identity"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			uptime := 1
+			oldIdentity := proxy.RuntimeIdentity{InstanceID: "previous-instance-0001", Version: "1.9.1", Commit: "previous-build", Mode: tc.oldMode}
+			if tc.previousVersion != "" {
+				oldIdentity.Version = tc.previousVersion
+			}
+			if tc.legacy {
+				oldIdentity.InstanceID = ""
+				oldIdentity.Commit = ""
+			}
+			var health atomic.Value
+			health.Store(proxy.HealthResponse{RuntimeIdentity: oldIdentity, Service: "rampart", Status: "ok", UptimeSeconds: &uptime})
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_ = json.NewEncoder(w).Encode(health.Load().(proxy.HealthResponse))
+			}))
+			defer server.Close()
+			u, _ := url.Parse(server.URL)
+			port, _ := strconv.Atoi(u.Port())
+			previous := serveState{URL: server.URL, Port: port, PID: 4242, Started: time.Now().Add(-time.Minute).UTC().Format(time.RFC3339Nano), RuntimeIdentity: oldIdentity}
+			if tc.legacy {
+				previous.RuntimeIdentity = proxy.RuntimeIdentity{}
+			}
+			writeUpgradeServeState(t, home, previous)
+			verifier, err := prepareServeRestartVerifierWithDeps(func() (string, error) { return home, nil }, os.ReadFile,
+				testServeRestartVerifierDeps(func(int) (bool, string, error) { return true, "rampart serve", nil }))
+			if tc.wantPrepareError != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantPrepareError) {
+					t.Fatalf("preparation error=%v, want %q", err, tc.wantPrepareError)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			candidate := previous
+			candidate.RuntimeIdentity = proxy.RuntimeIdentity{InstanceID: "candidate-instance-0001", Version: "2.0.0", Commit: "candidate-build", Mode: tc.newMode}
+			candidate.Started = time.Now().UTC().Format(time.RFC3339Nano)
+			switch tc.changedEndpoint {
+			case "port":
+				candidate.Port = port%65535 + 1
+				candidate.URL = "http://127.0.0.1:" + strconv.Itoa(candidate.Port)
+			case "scheme":
+				candidate.URL = strings.Replace(server.URL, "http://", "https://", 1)
+			}
+			health.Store(proxy.HealthResponse{RuntimeIdentity: candidate.RuntimeIdentity, Service: "rampart", Status: "ok", UptimeSeconds: &uptime})
+			writeUpgradeServeState(t, home, candidate)
+			err = verifier(context.Background(), "v2.0.0", time.Now().Add(-time.Second))
+			if tc.wantError == "" && err != nil || tc.wantError != "" && (err == nil || !strings.Contains(err.Error(), tc.wantError)) {
+				t.Fatalf("activation error=%v, want %q", err, tc.wantError)
+			}
+		})
+	}
+}
+
+func TestServeRestartPreparationRequiresPreviousRuntime(t *testing.T) {
+	home := t.TempDir()
+	_, err := prepareServeRestartVerifierWithDeps(func() (string, error) { return home, nil }, os.ReadFile,
+		testServeRestartVerifierDeps(func(int) (bool, string, error) {
+			t.Fatal("missing state must refuse before process inspection")
+			return false, "", nil
+		}))
+	if err == nil || !strings.Contains(err.Error(), "previous runtime state") {
+		t.Fatalf("missing baseline error: %v", err)
 	}
 }
 
@@ -219,15 +300,13 @@ func prepareUpgradeHealthVerifier(
 	processIdentity func(int) (bool, string, error),
 ) serveRestartVerifier {
 	t.Helper()
-	verifier, err := prepareServeRestartVerifierWithDeps(
-		func() (string, error) { return home, nil },
-		os.ReadFile,
-		testServeRestartVerifierDeps(processIdentity),
-	)
-	if err != nil {
-		t.Fatal(err)
+	// These cases isolate candidate health validation. Preparation and
+	// continuity against a live previous service are covered separately.
+	return func(ctx context.Context, version string, restartedAt time.Time) error {
+		_, err := verifyRestartedServe(ctx, home, os.ReadFile, version, nil, false, restartedAt,
+			testServeRestartVerifierDeps(processIdentity))
+		return err
 	}
-	return verifier
 }
 
 func testServeRestartVerifierDeps(processIdentity func(int) (bool, string, error)) serveRestartVerifierDeps {

--- a/cmd/rampart/cli/upgrade_lifecycle_test.go
+++ b/cmd/rampart/cli/upgrade_lifecycle_test.go
@@ -50,7 +50,7 @@ func TestUpgradeRestartsBackgroundServeWhenInstallFails(t *testing.T) {
 			stopped++
 			return nil
 		},
-		restartServe: func(_ commandRunner, binary string, _, _ io.Writer) error {
+		prepareServeRestart: preparedRestartForTest(func(_ commandRunner, binary string, _, _ io.Writer) error {
 			restarted++
 			got, err := os.ReadFile(binary)
 			if err != nil {
@@ -60,7 +60,7 @@ func TestUpgradeRestartsBackgroundServeWhenInstallFails(t *testing.T) {
 				t.Fatalf("rollback restart observed %q, want old binary", got)
 			}
 			return nil
-		},
+		}),
 		detectSystemdService: func(commandRunner, func() (string, error), string) string { return "" },
 		validateCandidate:    acceptUpgradeCandidate,
 		prepareServeVerifier: acceptServeRestartVerification,
@@ -219,7 +219,7 @@ func TestUpgradeRollsBackWhenBackgroundServeCannotLoadCandidate(t *testing.T) {
 			}
 			return nil
 		},
-		restartServe: func(_ commandRunner, binary string, _, _ io.Writer) error {
+		prepareServeRestart: preparedRestartForTest(func(_ commandRunner, binary string, _, _ io.Writer) error {
 			restarts++
 			got, err := os.ReadFile(binary)
 			if err != nil {
@@ -235,7 +235,7 @@ func TestUpgradeRollsBackWhenBackgroundServeCannotLoadCandidate(t *testing.T) {
 				t.Fatalf("recovery restart observed %q, want old binary", got)
 			}
 			return nil
-		},
+		}),
 		detectSystemdService: func(commandRunner, func() (string, error), string) string { return "" },
 		validateCandidate:    acceptUpgradeCandidate,
 		prepareServeVerifier: acceptServeRestartVerification,

--- a/cmd/rampart/cli/upgrade_lifecycle_test.go
+++ b/cmd/rampart/cli/upgrade_lifecycle_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -17,6 +18,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/peg/rampart/internal/proxy"
 )
 
 func TestUpgradeRestartsBackgroundServeWhenInstallFails(t *testing.T) {
@@ -88,6 +91,179 @@ func TestUpgradeRestartsBackgroundServeWhenInstallFails(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "restored previously running rampart serve") {
 		t.Fatalf("missing rollback confirmation: %q", out.String())
+	}
+}
+
+func TestUpgradeCleansOnlyCapturedFailedCandidateBeforeRollback(t *testing.T) {
+	skipOnWindows(t, "binary self-upgrade intentionally uses the Windows installer")
+	for _, scenario := range []string{"owned", "state replaced", "launch changed", "unowned replacement", "pid reused", "birth changes during check", "capture unavailable", "stop fails"} {
+		t.Run(scenario, func(t *testing.T) {
+			home := t.TempDir()
+			dir := filepath.Join(home, ".rampart")
+			if err := os.Mkdir(dir, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			exe := filepath.Join(home, "rampart")
+			if err := os.WriteFile(exe, []byte("old-binary"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			archive := makeArchive(t, "rampart", []byte("new-binary"))
+			sum := sha256.Sum256(archive)
+			checksums := []byte(hex.EncodeToString(sum[:]) + "  rampart_2.0.1_linux_" + runtime.GOARCH + ".tar.gz\n")
+			const oldPID, candidatePID = 4242, 4243
+			candidate := serveState{
+				RuntimeIdentity: proxy.RuntimeIdentity{InstanceID: "candidate-instance-1", Version: "2.0.1", Commit: "candidate", Mode: "monitor"},
+				URL:             "http://localhost:19090", Port: 19090, PID: candidatePID, Executable: exe,
+				Launch: &serveLaunchSettings{WorkingDir: home, ConfigPath: "custom.yaml", AuditDir: "custom-audit", Mode: "monitor", Addr: "127.0.0.1", Port: 19090},
+			}
+			writeState := func() {
+				t.Helper()
+				data, err := json.Marshal(candidate)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(dir, serveStateFile), data, 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			birth, owned, candidateAlive := "process-birth-1", true, false
+			restarts, proofs, oldStops, candidateStops := 0, 0, 0, 0
+			activationErr := errors.New("synthetic activation rejection")
+			deps := &upgradeDeps{
+				goos: "linux", goarch: runtime.GOARCH,
+				userHomeDir:    func() (string, error) { return home, nil },
+				executablePath: func() (string, error) { return exe, nil },
+				currentVersion: func(context.Context, commandRunner, func() (string, error)) (string, error) {
+					return "v2.0.0", nil
+				},
+				inspectServePID: func(func() (string, error), func(string) ([]byte, error)) (int, bool, error) {
+					return oldPID, true, nil
+				},
+				stopServe: func(pid int) error {
+					if pid != oldPID {
+						t.Fatalf("initial stop pid = %d", pid)
+					}
+					oldStops++
+					return nil
+				},
+				captureServeCandidate: func(homeDir func() (string, error), binary string, previousPID int, restartedAt time.Time) (func() error, error) {
+					if scenario == "capture unavailable" {
+						owned = false
+					}
+					return captureServeCandidateCleanupWithDeps(homeDir, binary, previousPID, restartedAt, serveCandidateCleanupDeps{
+						processStart: func(int) (string, error) { return birth, nil },
+						processIdentity: func(int) (bool, string, error) {
+							if proofs == 1 && scenario == "birth changes during check" {
+								birth = "process-birth-2"
+							}
+							return owned, "", nil
+						},
+						stop: func(pid int) error {
+							candidateStops++
+							got, err := os.ReadFile(exe)
+							if err != nil || string(got) != "new-binary" || pid != candidatePID || !candidateAlive {
+								t.Fatalf("cleanup must stop live captured candidate before binary rollback: pid=%d binary=%q err=%v", pid, got, err)
+							}
+							if scenario == "stop fails" {
+								return errors.New("synthetic stop failure")
+							}
+							candidateAlive = false
+							return nil
+						},
+					})
+				},
+				prepareServeRestart: preparedRestartForTest(func(_ commandRunner, binary string, _, _ io.Writer) error {
+					restarts++
+					got, err := os.ReadFile(binary)
+					if err != nil {
+						return err
+					}
+					if restarts == 1 {
+						if string(got) != "new-binary" {
+							t.Fatalf("candidate binary = %q", got)
+						}
+						candidateAlive = true
+						candidate.Started = time.Now().UTC().Format(time.RFC3339Nano)
+						writeState()
+					} else if candidateAlive || string(got) != "old-binary" {
+						t.Fatalf("recovery must follow candidate cleanup and binary rollback: alive=%v binary=%q", candidateAlive, got)
+					}
+					return nil
+				}),
+				prepareServeVerifier: func(func() (string, error), func(string) ([]byte, error)) (serveRestartVerifier, error) {
+					return func(_ context.Context, expected string, _ time.Time) error {
+						proofs++
+						if proofs > 1 {
+							if expected != "v2.0.0" || candidateAlive {
+								t.Fatalf("recovery proof version=%q candidateAlive=%v", expected, candidateAlive)
+							}
+							return nil
+						}
+						if expected != "v2.0.1" || !candidateAlive {
+							t.Fatalf("candidate proof version=%q candidateAlive=%v", expected, candidateAlive)
+						}
+						switch scenario {
+						case "state replaced":
+							candidate.InstanceID = "replacement-instance"
+							writeState()
+						case "launch changed":
+							candidate.Launch.ConfigPath = "replacement.yaml"
+							writeState()
+						case "unowned replacement":
+							owned = false
+						case "pid reused":
+							birth = "process-birth-2"
+						}
+						return activationErr
+					}, nil
+				},
+				detectSystemdService: func(commandRunner, func() (string, error), string) string { return "" },
+				validateCandidate:    acceptUpgradeCandidate,
+				downloadURL: func(_ context.Context, _ *http.Client, url string) ([]byte, error) {
+					if strings.HasSuffix(url, "checksums.txt") {
+						return checksums, nil
+					}
+					return archive, nil
+				},
+				pathEnv: func() string { return "" },
+			}
+			var out bytes.Buffer
+			cmd := newUpgradeCmdWithDeps(&rootOptions{}, deps)
+			cmd.SetOut(&out)
+			cmd.SetErr(io.Discard)
+			cmd.SetArgs([]string{"v2.0.1", "--yes", "--no-policy-update"})
+			err := cmd.Execute()
+			if !errors.Is(err, activationErr) || oldStops != 1 {
+				t.Fatalf("must preserve original activation failure after one old stop: err=%v stops=%d", err, oldStops)
+			}
+			got, readErr := os.ReadFile(exe)
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			if scenario == "owned" {
+				if candidateStops != 1 || restarts != 2 || proofs != 2 || string(got) != "old-binary" || !strings.Contains(err.Error(), "restored the previous Rampart executable and runtime") {
+					t.Fatalf("verified recovery missing: stops=%d restarts=%d proofs=%d binary=%q err=%v", candidateStops, restarts, proofs, got, err)
+				}
+			} else {
+				wantStops := 0
+				if scenario == "stop fails" {
+					wantStops = 1
+				}
+				if candidateStops != wantStops || !candidateAlive || restarts != 1 || proofs != 1 || string(got) != "new-binary" || !strings.Contains(err.Error(), "recovery incomplete") {
+					t.Fatalf("unsafe or misleading recovery: stops=%d alive=%v restarts=%d proofs=%d binary=%q err=%v", candidateStops, candidateAlive, restarts, proofs, got, err)
+				}
+				backups, globErr := filepath.Glob(filepath.Join(home, ".rampart-upgrade-backup-*"))
+				if globErr != nil || len(backups) != 1 {
+					t.Fatalf("previous executable backup not retained: %v, %v", backups, globErr)
+				}
+				if backup, err := os.ReadFile(backups[0]); err != nil || string(backup) != "old-binary" {
+					t.Fatalf("retained backup=%q err=%v", backup, err)
+				}
+			}
+			if strings.Contains(out.String(), "rampart binary upgraded") {
+				t.Fatalf("failed activation claimed upgrade success: %q", out.String())
+			}
+		})
 	}
 }
 

--- a/cmd/rampart/cli/upgrade_test.go
+++ b/cmd/rampart/cli/upgrade_test.go
@@ -120,7 +120,7 @@ func TestNewUpgradeCmdAlreadyLatest(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute returned error: %v", err)
 	}
-	if !strings.Contains(out.String(), "Already on latest (v1.2.3)") {
+	if !strings.Contains(out.String(), "Already on latest CLI (v1.2.3)") {
 		t.Fatalf("unexpected output: %q", out.String())
 	}
 }
@@ -864,4 +864,10 @@ policies:
 	if !strings.Contains(errOut.String(), "continuing automatically") {
 		t.Fatalf("missing non-interactive continuation note: %q", errOut.String())
 	}
+}
+
+// These lifecycle tests replace the owned process itself with a dependency.
+// Real launch capture and flag preservation are covered in serve_launch_test.
+func preparedRestartForTest(restart serveRestarter) func(func() (string, error), string, int) (serveRestarter, error) {
+	return func(func() (string, error), string, int) (serveRestarter, error) { return restart, nil }
 }

--- a/cmd/rampart/cli/verify.go
+++ b/cmd/rampart/cli/verify.go
@@ -129,12 +129,13 @@ func newVerifyCmd() *cobra.Command {
 		Short: "Actively verify that agent safety boundaries really block",
 		Long: `Run non-destructive behavioral canaries against Rampart's integration boundaries.
 
-The canaries never execute commands, read files, send messages, or contact an
-external network. Service-optional hooks verify their local installation,
-adapter and isolated audit behavior without HTTP. The policy target and
-service-backed integrations test the effective policy endpoint. OpenClaw also
-runs fixed canaries through the loaded before_tool_call implementation and
-compares its runtime observation with the CLI's observation.`,
+Safe canaries do not execute tools or contact their represented targets.
+Service-optional hooks verify their local installation, adapter and isolated
+audit behavior without HTTP. The policy target and service-backed integrations
+contact the configured policy endpoint, which may be remote. Verification
+inspects local configuration and adapter files. OpenClaw also runs fixed
+canaries through the loaded before_tool_call implementation and compares its
+runtime observation with the CLI's observation.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if all {

--- a/cmd/rampart/cli/verify.go
+++ b/cmd/rampart/cli/verify.go
@@ -1473,7 +1473,7 @@ func summarizeVerification(report verificationReport) verificationReport {
 
 func printVerificationReport(w io.Writer, report verificationReport) {
 	fmt.Fprintf(w, "Rampart behavioral verification — %s\n\n", report.Target)
-	fmt.Fprintln(w, "Safe canaries only: no commands, file reads, messages, or external network requests are executed.")
+	fmt.Fprintln(w, "Safe canaries do not execute tools or contact their represented targets.")
 	fmt.Fprintln(w, "HTTP checks use preflight; local adapter checks use temporary audit storage. Neither adds canary events to your audit log.")
 	fmt.Fprintln(w)
 	printVerificationResult(w, report)
@@ -1481,7 +1481,7 @@ func printVerificationReport(w io.Writer, report verificationReport) {
 
 func printVerificationBatchReport(w io.Writer, report verificationBatchReport) {
 	fmt.Fprintf(w, "Rampart behavioral verification — configured integrations with safe verifiers (%d targets)\n\n", report.Summary.Targets)
-	fmt.Fprintln(w, "Safe canaries only: no models, commands, file reads, messages, or external network requests are invoked.")
+	fmt.Fprintln(w, "Safe canaries do not invoke models, execute tools, or contact their represented targets.")
 	fmt.Fprintln(w, "HTTP checks use preflight; local adapter checks use temporary audit storage. Neither adds canary events to your audit log.")
 	fmt.Fprintln(w, "Static-only integrations are not included; use `rampart doctor` for their installation status.")
 	for index, result := range report.Results {

--- a/cmd/rampart/cli/verify.go
+++ b/cmd/rampart/cli/verify.go
@@ -44,6 +44,7 @@ type verificationCheck struct {
 	Actual   string             `json:"actual,omitempty"`
 	Message  string             `json:"message"`
 	Hint     string             `json:"hint,omitempty"`
+	runtime  *serviceRuntimeObservation
 }
 
 type verificationSummary struct {
@@ -72,13 +73,14 @@ func latestAuditEvent(auditDir string) (audit.Event, error) {
 }
 
 type verificationReport struct {
-	SchemaVersion  string              `json:"schema_version"`
-	GeneratedAt    string              `json:"generated_at"`
-	Target         string              `json:"target"`
-	SafeCanaries   bool                `json:"safe_canaries"`
-	Assurance      assuranceLevel      `json:"assurance_level"`
-	Summary        verificationSummary `json:"summary"`
-	Checks         []verificationCheck `json:"checks"`
+	SchemaVersion  string                     `json:"schema_version"`
+	GeneratedAt    string                     `json:"generated_at"`
+	Target         string                     `json:"target"`
+	SafeCanaries   bool                       `json:"safe_canaries"`
+	Assurance      assuranceLevel             `json:"assurance_level"`
+	Summary        verificationSummary        `json:"summary"`
+	Checks         []verificationCheck        `json:"checks"`
+	Runtime        *serviceRuntimeObservation `json:"runtime,omitempty"`
 	policyEndpoint string
 }
 
@@ -125,24 +127,21 @@ func newVerifyCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "verify [openclaw|claude-code|cline|codex|gemini|antigravity|copilot|cursor|policy]",
 		Short: "Actively verify that agent safety boundaries really block",
-		Long: `Run non-destructive behavioral canaries against the live Rampart policy path.
+		Long: `Run non-destructive behavioral canaries against Rampart's integration boundaries.
 
 The canaries never execute commands, read files, send messages, or contact an
-external network. They use Rampart's policy endpoint and a decoy path/domain
-to prove the decisions the installed integration would receive. OpenClaw
-verification also runs fixed canaries through the live before_tool_call
-implementation.`,
+external network. Service-optional hooks verify their local installation,
+adapter and isolated audit behavior without HTTP. The policy target and
+service-backed integrations test the effective policy endpoint. OpenClaw also
+runs fixed canaries through the loaded before_tool_call implementation and
+compares its runtime observation with the CLI's observation.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if all {
 				if len(args) > 0 {
 					return fmt.Errorf("verify: --all cannot be combined with target %q", args[0])
 				}
-				resolvedURL, err := resolveServeURLStrict(serveURL, fmt.Sprintf("http://localhost:%d", defaultServePort))
-				if err != nil {
-					return fmt.Errorf("verify: resolve serve URL: %w", err)
-				}
-				report, receiptErr := runAllBehavioralVerifications(cmd.Context(), resolvedURL, timeout)
+				report, receiptErr := runAllBehavioralVerifications(cmd.Context(), serveURL, timeout)
 				if jsonOut {
 					if err := json.NewEncoder(cmd.OutOrStdout()).Encode(report); err != nil {
 						return fmt.Errorf("verify: encode aggregate report: %w", err)
@@ -187,11 +186,7 @@ implementation.`,
 				target = driver.VerifyTarget
 			}
 
-			resolvedURL, err := resolveServeURLStrict(serveURL, fmt.Sprintf("http://localhost:%d", defaultServePort))
-			if err != nil {
-				return fmt.Errorf("verify: resolve serve URL: %w", err)
-			}
-			report := runBehavioralVerification(cmd.Context(), target, resolvedURL, timeout)
+			report := runBehavioralVerification(cmd.Context(), target, serveURL, timeout)
 			receiptErr := writeVerificationReceipt(report)
 			if jsonOut {
 				if err := json.NewEncoder(cmd.OutOrStdout()).Encode(report); err != nil {
@@ -356,22 +351,85 @@ func behavioralCanaries(target string) []behavioralCanary {
 	return canaries
 }
 
-func runBehavioralVerification(ctx context.Context, target, serveURL string, timeout time.Duration) verificationReport {
+func runBehavioralVerification(ctx context.Context, target, serveURL string, timeout time.Duration) (report verificationReport) {
 	if timeout <= 0 {
 		timeout = 5 * time.Second
 	}
-	report := verificationReport{
-		SchemaVersion:  verifyJSONSchemaVersion,
-		GeneratedAt:    time.Now().UTC().Format(time.RFC3339),
-		Target:         target,
-		SafeCanaries:   true,
-		Checks:         make([]verificationCheck, 0),
-		policyEndpoint: strings.TrimRight(serveURL, "/"),
+	report = verificationReport{
+		SchemaVersion: verifyJSONSchemaVersion,
+		GeneratedAt:   time.Now().UTC().Format(time.RFC3339),
+		Target:        target,
+		SafeCanaries:  true,
+		Checks:        make([]verificationCheck, 0),
 	}
+	driver, isIntegration := findIntegrationDriver(target)
+	if isIntegration && !driver.ServiceRequired {
+		if driver.VerifyChecks != nil {
+			report.Checks = append(report.Checks, driver.VerifyChecks(ctx, timeout)...)
+		}
+		return summarizeVerification(report)
+	}
+	var endpointErr error
+	if isIntegration {
+		var effective string
+		effective, endpointErr = integrationServiceEndpoint(driver)
+		if endpointErr == nil && serveURL != "" {
+			override, err := serviceEndpoint(serveURL)
+			if err != nil || override != effective {
+				endpointErr = fmt.Errorf("verification override differs from the integration's configured service; configure the host endpoint first or omit --serve-url")
+			}
+		}
+		serveURL = effective
+	} else {
+		serveURL, endpointErr = resolveServeURLStrict(serveURL, fmt.Sprintf("http://localhost:%d", defaultServePort))
+	}
+	if endpointErr != nil {
+		report.Checks = append(report.Checks, verificationCheck{ID: "service-runtime", Name: "Integration service identity", Status: verificationUnverified, Message: "The effective service endpoint could not be established", Hint: endpointErr.Error()})
+		return summarizeVerification(report)
+	}
+	report.policyEndpoint = serveURL
+	before, runtimeErr := observeServiceRuntime(ctx, serveURL, timeout)
+	if runtimeErr != nil {
+		report.Checks = append(report.Checks, verificationCheck{ID: "service-runtime", Name: "Integration service identity", Status: verificationUnverified, Message: "The selected Rampart service is unavailable or returned invalid health", Hint: "Start the configured service and rerun verification"})
+		return summarizeVerification(report)
+	}
+	if before.Mode != "enforce" {
+		report.Checks = append(report.Checks, verificationCheck{ID: "service-runtime", Name: "Integration service identity", Status: verificationFail, Actual: before.Mode, Message: "The selected service is not enforcing policy", Hint: "Start the service in enforce mode and rerun verification"})
+		return summarizeVerification(report)
+	}
+	hostRuntimeMatched := !driver.OpenClaw
+	defer func() {
+		after, err := observeServiceRuntime(ctx, serveURL, timeout)
+		switch {
+		case err != nil || before != after:
+			report.Runtime = nil
+			report.Checks = append(report.Checks, verificationCheck{ID: "service-runtime", Name: "Stable service runtime", Status: verificationFail, Message: "The service changed or became unavailable during verification; no runtime evidence was retained", Hint: "Rerun verification against a stable enforcing service"})
+		case !runtimeIdentified(before.RuntimeIdentity):
+			report.Checks = append(report.Checks, verificationCheck{ID: "service-runtime", Name: "Stable service runtime", Status: verificationUnverified, Message: "This legacy service does not expose a runtime instance and build identity", Hint: "Update the service, then rerun verification"})
+		default:
+			if hostRuntimeMatched {
+				report.Runtime = &before
+			}
+		}
+		report = summarizeVerification(report)
+	}()
 
 	if target != "policy" {
 		if driver, ok := findIntegrationDriver(target); ok && driver.VerifyChecks != nil {
-			report.Checks = append(report.Checks, driver.VerifyChecks(ctx, timeout)...)
+			checks := driver.VerifyChecks(ctx, timeout)
+			for i := range checks {
+				if driver.OpenClaw && checks[i].runtime != nil {
+					if *checks[i].runtime == before {
+						hostRuntimeMatched = true
+					} else {
+						checks[i].Status = verificationFail
+						checks[i].Actual = "loaded plugin uses a different runtime"
+						checks[i].Message = "The loaded OpenClaw plugin verified a different service endpoint or instance from the CLI"
+						checks[i].Hint = "Restart the OpenClaw gateway to load its current configuration, then verify again"
+					}
+				}
+			}
+			report.Checks = append(report.Checks, checks...)
 		}
 	}
 
@@ -399,7 +457,12 @@ func runBehavioralVerification(ctx context.Context, target, serveURL string, tim
 		return summarizeVerification(report)
 	}
 
-	client := newRampartHTTPClient(timeout)
+	client, closeClient, clientErr := serviceRuntimeClient(serveURL, timeout)
+	if clientErr != nil {
+		report.Checks = append(report.Checks, verificationCheck{ID: "policy-transport", Name: "Policy endpoint trust", Status: verificationUnverified, Message: "The selected service trust could not be established"})
+		return summarizeVerification(report)
+	}
+	defer closeClient()
 	for _, canary := range behavioralCanaries(target) {
 		report.Checks = append(report.Checks, runPreflightCanary(ctx, client, strings.TrimRight(serveURL, "/"), token, target, canary))
 	}
@@ -1159,11 +1222,48 @@ func verifyOpenClawPluginLive(ctx context.Context, timeout time.Duration) verifi
 		check.Hint = "Run `rampart protect openclaw --reinstall`, restart the gateway, and verify again"
 		return check
 	}
+	observed, err := pluginVerificationRuntime(pluginResult["runtime"])
+	if err != nil {
+		check.Status = verificationFail
+		check.Actual = "invalid loaded runtime observation"
+		check.Message = "The loaded plugin returned invalid runtime evidence"
+		check.Hint = "Reinstall the current plugin, restart the gateway, and verify again"
+		return check
+	}
+	if observed == nil {
+		check.Status = verificationUnverified
+		check.Actual = "canaries passed; loaded runtime unverified"
+		check.Message = "Plugin canaries passed, but the loaded plugin did not identify a stable enforcing service"
+		check.Hint = "Update Rampart and its plugin, restart the gateway, and verify again"
+		return check
+	}
+	check.runtime = observed
 
 	check.Status = verificationPass
 	check.Actual = "complete and current"
 	check.Message = "The current bundled plugin reached Rampart through its policy mapping path and returned every expected canary decision"
 	return check
+}
+
+func pluginVerificationRuntime(value any) (*serviceRuntimeObservation, error) {
+	if value == nil {
+		return nil, nil
+	}
+	data, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	var observed serviceRuntimeObservation
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&observed); err != nil {
+		return nil, err
+	}
+	endpoint, err := serviceEndpoint(observed.Endpoint)
+	if err != nil || endpoint != observed.Endpoint || !isLoopbackURL(endpoint) || !runtimeIdentified(observed.RuntimeIdentity) || observed.Mode != "enforce" {
+		return nil, fmt.Errorf("incomplete or non-enforcing runtime observation")
+	}
+	return &observed, nil
 }
 
 func verifyOpenClawManagedConfig(ctx context.Context, openclawBin string) error {
@@ -1374,7 +1474,7 @@ func summarizeVerification(report verificationReport) verificationReport {
 func printVerificationReport(w io.Writer, report verificationReport) {
 	fmt.Fprintf(w, "Rampart behavioral verification — %s\n\n", report.Target)
 	fmt.Fprintln(w, "Safe canaries only: no commands, file reads, messages, or external network requests are executed.")
-	fmt.Fprintln(w, "Verification uses the local admin path and does not add events to Rampart's audit log.")
+	fmt.Fprintln(w, "HTTP checks use preflight; local adapter checks use temporary audit storage. Neither adds canary events to your audit log.")
 	fmt.Fprintln(w)
 	printVerificationResult(w, report)
 }
@@ -1382,7 +1482,7 @@ func printVerificationReport(w io.Writer, report verificationReport) {
 func printVerificationBatchReport(w io.Writer, report verificationBatchReport) {
 	fmt.Fprintf(w, "Rampart behavioral verification — configured integrations with safe verifiers (%d targets)\n\n", report.Summary.Targets)
 	fmt.Fprintln(w, "Safe canaries only: no models, commands, file reads, messages, or external network requests are invoked.")
-	fmt.Fprintln(w, "Verification uses the local admin path and does not add events to Rampart's audit log.")
+	fmt.Fprintln(w, "HTTP checks use preflight; local adapter checks use temporary audit storage. Neither adds canary events to your audit log.")
 	fmt.Fprintln(w, "Static-only integrations are not included; use `rampart doctor` for their installation status.")
 	for index, result := range report.Results {
 		if index > 0 {

--- a/cmd/rampart/cli/verify_test.go
+++ b/cmd/rampart/cli/verify_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -16,7 +17,6 @@ import (
 	"time"
 
 	hermesplugin "github.com/peg/rampart/internal/plugin/hermes"
-	ocplugin "github.com/peg/rampart/internal/plugin/openclaw"
 )
 
 func TestConfiguredVerificationTargetsIncludesPolicyAndConfiguredHooks(t *testing.T) {
@@ -263,18 +263,41 @@ func TestVerifyClaudeAndClineAdaptersBlockCanary(t *testing.T) {
 	}
 }
 
-func TestVerifyOpenClawPluginLiveParsesGatewayPayload(t *testing.T) {
+func TestOpenClawVerificationBindsLoadedRuntime(t *testing.T) {
 	skipOnWindows(t, "test uses a POSIX OpenClaw shim")
-	stateDir := t.TempDir()
-	pluginDir := filepath.Join(stateDir, openclawPluginDir)
-	if err := ocplugin.Extract(pluginDir); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(stateDir, "openclaw.json"), []byte(`{"plugins":{"allow":["rampart"],"entries":{"rampart":{"enabled":true}}},"tools":{"exec":{"mode":"full"}}}`), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	bin := filepath.Join(t.TempDir(), "openclaw")
-	shim := `#!/bin/sh
+	for _, scenario := range []struct {
+		name string
+		want assuranceLevel
+	}{
+		{"matching", assuranceHostVerified},
+		{"legacy", assuranceUnverified},
+		{"different endpoint", assuranceDegraded},
+		{"different instance", assuranceDegraded},
+	} {
+		t.Run(scenario.name, func(t *testing.T) {
+			home := t.TempDir()
+			installOpenClawAssuranceFixture(t, home)
+			t.Setenv("RAMPART_TOKEN", "verification-token")
+			t.Setenv("RAMPART_URL", "")
+			identity := map[string]string{
+				"endpoint": "http://localhost:9090", "instance_id": "test-service-instance-0001",
+				"version": "1.9.0", "commit": "test-commit", "mode": "enforce",
+			}
+			switch scenario.name {
+			case "different endpoint":
+				identity["endpoint"] = "http://localhost:19090"
+			case "different instance":
+				identity["instance_id"] = "test-service-instance-0002"
+			}
+			runtimeJSON := ""
+			if scenario.name != "legacy" {
+				data, err := json.Marshal(identity)
+				if err != nil {
+					t.Fatal(err)
+				}
+				runtimeJSON = `"runtime":` + string(data) + ","
+			}
+			shim := `#!/bin/sh
 if [ "$1" = "config" ] && [ "$2" = "get" ]; then
   case "$3" in
     tools.exec) printf '%s\n' '{"mode":"full"}' ;;
@@ -285,17 +308,64 @@ if [ "$1" = "config" ] && [ "$2" = "get" ]; then
 fi
 printf '%s\n' '[state-migrations] Legacy state migration notes:'
 printf '%s\n' '- Left plugin install index in place because shared SQLite state has conflicting plugin install metadata for: rampart'
-printf '%s\n' '{"result":{"schema":"rampart.plugin.verify.v1","runtime":{"endpoint":"http://localhost:9090","instance_id":"test-service-instance-0001","version":"1.9.1","commit":"test-commit","mode":"enforce"},"safeCanaries":true,"ok":true,"checks":[{"id":"routine-command","expected":"allow","actual":"allow","pass":true},{"id":"destructive-command","expected":"deny","actual":"deny","pass":true},{"id":"external-deployment","expected":"ask","actual":"ask","pass":true},{"id":"cross-conversation-message","expected":"ask","actual":"ask","pass":true},{"id":"credential-shell-read","expected":"deny","actual":"deny","pass":true},{"id":"opaque-interpreter","expected":"ask","actual":"ask","pass":true}]}}'
+printf '%s\n' '{"result":{"schema":"rampart.plugin.verify.v1",{{runtime}}"safeCanaries":true,"ok":true,"checks":[{"id":"routine-command","expected":"allow","actual":"allow","pass":true},{"id":"destructive-command","expected":"deny","actual":"deny","pass":true},{"id":"external-deployment","expected":"ask","actual":"ask","pass":true},{"id":"cross-conversation-message","expected":"ask","actual":"ask","pass":true},{"id":"credential-shell-read","expected":"deny","actual":"deny","pass":true},{"id":"opaque-interpreter","expected":"ask","actual":"ask","pass":true}]}}'
 `
-	if err := os.WriteFile(bin, []byte(shim), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("OPENCLAW_STATE_DIR", stateDir)
-	t.Setenv("RAMPART_OPENCLAW_BIN", bin)
+			bin := os.Getenv("RAMPART_OPENCLAW_BIN")
+			if err := os.WriteFile(bin, []byte(strings.Replace(shim, "{{runtime}}", runtimeJSON, 1)), 0o700); err != nil {
+				t.Fatal(err)
+			}
 
-	check := verifyOpenClawPluginLive(context.Background(), time.Second)
-	if check.Status != verificationPass {
-		t.Fatalf("unexpected check: %#v", check)
+			healthProbes := 0
+			rampartHTTPClient = &http.Client{Transport: redirectTestTransport(func(req *http.Request) (*http.Response, error) {
+				if req.URL.Host != "localhost:9090" {
+					t.Fatalf("unexpected configured endpoint: %s", req.URL.Host)
+				}
+				if req.URL.Path == "/healthz" {
+					healthProbes++
+					return statusTestHealthResponse(req, "enforce"), nil
+				}
+				if !strings.HasPrefix(req.URL.Path, "/v1/preflight/") {
+					t.Fatalf("unexpected control path: %s", req.URL.Path)
+				}
+				var request struct {
+					Params map[string]any `json:"params"`
+				}
+				if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+					t.Fatal(err)
+				}
+				command, _ := request.Params["command"].(string)
+				decision := "deny"
+				switch {
+				case command == "pwd", request.Params["action"] == "read":
+					decision = "allow"
+				case strings.HasPrefix(command, "git push "), strings.HasPrefix(command, "python3 -c "), command == "npm publish", request.Params["action"] == "send":
+					decision = "ask"
+				}
+				data, err := json.Marshal(preflightResponse{Allowed: decision == "allow", Decision: decision})
+				if err != nil {
+					t.Fatal(err)
+				}
+				return &http.Response{StatusCode: http.StatusOK, Request: req, Header: make(http.Header), Body: io.NopCloser(bytes.NewReader(data))}, nil
+			})}
+			report := runBehavioralVerification(context.Background(), "openclaw", "", time.Second)
+			if report.Assurance != scenario.want || healthProbes != 2 {
+				t.Fatalf("verification assurance=%s want=%s probes=%d report=%#v", report.Assurance, scenario.want, healthProbes, report)
+			}
+			matched := scenario.name == "matching"
+			if (report.Runtime != nil) != matched {
+				t.Fatalf("loaded runtime association: %#v", report.Runtime)
+			}
+			if err := writeVerificationReceipt(report); err != nil {
+				t.Fatal(err)
+			}
+			receipt, err := readVerificationReceipt("openclaw")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if receipt.AssuranceLevel != scenario.want || (receipt.Runtime != nil) != matched {
+				t.Fatalf("receipt promoted different or missing loaded runtime: %#v", receipt)
+			}
+		})
 	}
 }
 

--- a/cmd/rampart/cli/verify_test.go
+++ b/cmd/rampart/cli/verify_test.go
@@ -51,7 +51,7 @@ func TestRunAllBehavioralVerificationsWritesAggregateEvidence(t *testing.T) {
 	if err := installCodexHooks(filepath.Join(home, ".codex", "hooks.json"), command, commandWindows, false); err != nil {
 		t.Fatal(err)
 	}
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(verificationTestHandler(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") != "Bearer verification-token" {
 			t.Fatalf("authorization = %q", r.Header.Get("Authorization"))
 		}
@@ -78,7 +78,7 @@ func TestRunAllBehavioralVerificationsWritesAggregateEvidence(t *testing.T) {
 	if report.SchemaVersion != verifyAllJSONSchemaVersion || !report.SafeCanaries {
 		t.Fatalf("unexpected aggregate metadata: %#v", report)
 	}
-	if report.Summary.Targets != 2 || report.Summary.PassedTargets != 2 || report.Summary.Checks != 12 {
+	if report.Summary.Targets != 2 || report.Summary.PassedTargets != 2 || report.Summary.Checks != 7 {
 		t.Fatalf("unexpected aggregate summary: %#v", report.Summary)
 	}
 	if len(report.Results) != 2 || report.Results[0].Target != "policy" || report.Results[1].Target != "codex" {
@@ -101,7 +101,7 @@ func TestVerifyAllRejectsExplicitTarget(t *testing.T) {
 
 func TestBehavioralVerificationSafeCanariesPass(t *testing.T) {
 	installVerificationToken(t, "verification-token")
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(verificationTestHandler(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") != "Bearer verification-token" {
 			t.Fatalf("authorization = %q", r.Header.Get("Authorization"))
 		}
@@ -132,7 +132,7 @@ func TestBehavioralVerificationSafeCanariesPass(t *testing.T) {
 
 func TestBehavioralVerificationDetectsWrongDecision(t *testing.T) {
 	installVerificationToken(t, "verification-token")
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	server := httptest.NewServer(verificationTestHandler(func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{"allowed": true, "decision": "allow"})
 	}))
 	defer server.Close()
@@ -146,7 +146,11 @@ func TestBehavioralVerificationDetectsWrongDecision(t *testing.T) {
 func TestBehavioralVerificationReportsMissingTokenAsUnverified(t *testing.T) {
 	testSetHome(t, t.TempDir())
 	t.Setenv("RAMPART_TOKEN", "")
-	report := runBehavioralVerification(context.Background(), "policy", "http://127.0.0.1:1", 50*time.Millisecond)
+	server := httptest.NewServer(verificationTestHandler(func(http.ResponseWriter, *http.Request) {
+		t.Error("preflight must not run without a token")
+	}))
+	defer server.Close()
+	report := runBehavioralVerification(context.Background(), "policy", server.URL, time.Second)
 	if report.Summary.Unverified != 5 || report.Summary.Failed != 0 {
 		t.Fatalf("unexpected summary: %#v", report.Summary)
 	}
@@ -160,7 +164,7 @@ func TestBehavioralVerificationReportsMissingTokenAsUnverified(t *testing.T) {
 func TestBehavioralVerificationUsesEnvironmentToken(t *testing.T) {
 	testSetHome(t, t.TempDir())
 	t.Setenv("RAMPART_TOKEN", "environment-verification-token")
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(verificationTestHandler(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") != "Bearer environment-verification-token" {
 			t.Fatalf("authorization = %q", r.Header.Get("Authorization"))
 		}
@@ -281,7 +285,7 @@ if [ "$1" = "config" ] && [ "$2" = "get" ]; then
 fi
 printf '%s\n' '[state-migrations] Legacy state migration notes:'
 printf '%s\n' '- Left plugin install index in place because shared SQLite state has conflicting plugin install metadata for: rampart'
-printf '%s\n' '{"result":{"schema":"rampart.plugin.verify.v1","safeCanaries":true,"ok":true,"checks":[{"id":"routine-command","expected":"allow","actual":"allow","pass":true},{"id":"destructive-command","expected":"deny","actual":"deny","pass":true},{"id":"external-deployment","expected":"ask","actual":"ask","pass":true},{"id":"cross-conversation-message","expected":"ask","actual":"ask","pass":true},{"id":"credential-shell-read","expected":"deny","actual":"deny","pass":true},{"id":"opaque-interpreter","expected":"ask","actual":"ask","pass":true}]}}'
+printf '%s\n' '{"result":{"schema":"rampart.plugin.verify.v1","runtime":{"endpoint":"http://localhost:9090","instance_id":"test-service-instance-0001","version":"1.9.1","commit":"test-commit","mode":"enforce"},"safeCanaries":true,"ok":true,"checks":[{"id":"routine-command","expected":"allow","actual":"allow","pass":true},{"id":"destructive-command","expected":"deny","actual":"deny","pass":true},{"id":"external-deployment","expected":"ask","actual":"ask","pass":true},{"id":"cross-conversation-message","expected":"ask","actual":"ask","pass":true},{"id":"credential-shell-read","expected":"deny","actual":"deny","pass":true},{"id":"opaque-interpreter","expected":"ask","actual":"ask","pass":true}]}}'
 `
 	if err := os.WriteFile(bin, []byte(shim), 0o755); err != nil {
 		t.Fatal(err)
@@ -435,5 +439,17 @@ func installVerificationToken(t *testing.T, token string) {
 	}
 	if err := os.WriteFile(filepath.Join(dir, "token"), []byte(token), 0o600); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// verificationTestHandler models the health contract around real HTTP preflight
+// fixtures without requiring bearer credentials on the public health endpoint.
+func verificationTestHandler(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/healthz" {
+			_ = json.NewEncoder(w).Encode(map[string]any{"service": "rampart", "status": "ok", "mode": "enforce", "uptime_seconds": 1, "version": "test", "commit": "test-commit", "instance_id": "test-service-instance-0001"})
+			return
+		}
+		next(w, r)
 	}
 }

--- a/docs-site/reference/cli-commands.md
+++ b/docs-site/reference/cli-commands.md
@@ -255,6 +255,12 @@ previous service. Existing custom TLS certificates are pinned before
 stopping the service. Missing settings, certificate trust or ownership cause
 the upgrade to stop before service interruption.
 
+If activation fails, upgrade stops the owned failed candidate before restoring
+the previous executable and runtime. If the candidate's saved state or process
+identity has changed, automatic recovery refuses to stop it. The error retains
+the original activation failure and reports the backup executable's location
+for manual recovery with the original service settings.
+
 The already-published v1.9.1 updater does not contain this launch-preservation
 logic: its background restart uses defaults. For a custom background service
 still managed by that older CLI, preserve its command and original working

--- a/docs-site/reference/cli-commands.md
+++ b/docs-site/reference/cli-commands.md
@@ -250,7 +250,8 @@ and key references. It reuses the existing private token file instead of an
 upgrading shell's `RAMPART_TOKEN` override. Systemd and launchd retain their
 existing owned service definitions. A restart must publish fresh owned state
 whose instance, build and mode match the health response; version alone does
-not establish activation. Existing custom TLS certificates are pinned before
+not establish activation. Its endpoint and observed mode must also match the
+previous service. Existing custom TLS certificates are pinned before
 stopping the service. Missing settings, certificate trust or ownership cause
 the upgrade to stop before service interruption.
 

--- a/docs-site/reference/cli-commands.md
+++ b/docs-site/reference/cli-commands.md
@@ -88,10 +88,26 @@ it does not contain prompts, commands, host output, credentials, or filesystem
 paths. OpenClaw's live plugin verifier earns `host_verified`; the ordinary
 native-hook commands earn `adapter_verified` because they invoke Rampart's
 adapter without asking a model to act. Receipts expire after seven days and are
-treated as stale when Rampart, the configured boundary, the selected policy
-endpoint, local policy-file metadata, or a detected host executable changes.
+treated as stale when Rampart, the configured boundary, local policy-file contents, or a detected host executable changes. Service-backed
+evidence additionally binds the effective policy endpoint.
 They are local status caches, not tamper-resistant
 attestations.
+
+Service-backed evidence includes the exact service origin, per-start instance
+identifier, service build and enforce mode. Health observations before and
+after verification must match. OpenClaw also returns this observation from the
+loaded gateway plugin; changing a config file without reloading that plugin
+cannot verify the new endpoint. An explicit `--serve-url` must match the
+integration's effective endpoint. Legacy services or loaded plugins without
+runtime observations remain visible but require updating and reverification
+before earning this evidence.
+
+Service-optional native hooks verify their installation, local adapter and
+isolated audit behavior without HTTP. Their adapter receipts remain meaningful
+when the service is stopped or replaced. Use `rampart verify policy` separately
+to test HTTP policy decisions. Runtime observations establish only the service
+observed during these probes; they do not attest remote policy contents,
+continuous enforcement, or host tool execution.
 
 ### `rampart setup claude-code`
 
@@ -466,6 +482,15 @@ receipts fall back to current configuration state and explain why proof must be
 rerun. Evidence for a service-required integration is also stale whenever the
 configured Rampart policy service is unavailable; another daemon on a different
 port does not satisfy that check.
+
+Status reports the CLI build separately from the observed `service` version,
+commit, mode and endpoint. `service_owned` requires matching private process
+state and OS process identity; an instance identifier alone does not establish
+ownership. Service-backed receipts become stale after a service instance,
+build or mode change. Healthy older services are displayed even when they
+cannot supply the newer freshness evidence. Protection reports the actual
+reused service and refuses monitor or disabled mode without changing an
+external service or replacing an existing service definition.
 
 `mode` comes from the configured service's health response and is `unknown`
 when that service cannot be reached or identified. Local hook enforcement can

--- a/docs-site/reference/cli-commands.md
+++ b/docs-site/reference/cli-commands.md
@@ -243,6 +243,32 @@ rampart setup --force        # Deprecated unattended compatibility path
 
 Upgrade Rampart to the latest or a specified release. Downloads from GitHub releases, verifies SHA256, atomically replaces the binary, and restarts a running background, systemd, or launchd Rampart service so it uses the new executable. Homebrew-managed installations must use `brew upgrade rampart`; Windows installations must rerun `install.ps1`.
 
+Background services started by current builds save typed launch settings in
+owner-only `serve.state`. An upgrade preserves the original working directory,
+policy and audit paths, mode, logging and approval options, and TLS certificate
+and key references. It reuses the existing private token file instead of an
+upgrading shell's `RAMPART_TOKEN` override. Systemd and launchd retain their
+existing owned service definitions. A restart must publish fresh owned state
+whose instance, build and mode match the health response; version alone does
+not establish activation. Existing custom TLS certificates are pinned before
+stopping the service. Missing settings, certificate trust or ownership cause
+the upgrade to stop before service interruption.
+
+The already-published v1.9.1 updater does not contain this launch-preservation
+logic: its background restart uses defaults. For a custom background service
+still managed by that older CLI, preserve its command and original working
+directory, stop it with `rampart serve stop`, update the binary using the
+[installation instructions](../getting-started/installation.md), then restart
+with the same explicit options from that directory. The ordinary v1.9.1
+background launch can also be recognized by a current CLI on Linux or macOS;
+ambiguous legacy custom launches require this manual migration. Do not replace
+an existing service definition with `serve install --force` to work around it.
+
+If the CLI is already current, upgrade reports the observed service's actual
+version and mode separately. That version check does not restart or verify
+service protection; use `rampart status` and the applicable `rampart verify`
+command after activation.
+
 ```bash
 rampart upgrade              # Upgrade to latest release
 rampart upgrade v0.8.0       # Upgrade to a specific version

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -1307,15 +1307,26 @@ Unauthenticated health check.
 ```json
 {
   "type": "object",
-  "required": ["status", "mode", "uptime_seconds", "version"],
+  "required": ["service", "status", "mode", "uptime_seconds", "version", "commit", "instance_id"],
   "properties": {
+    "service": { "type": "string", "const": "rampart" },
     "status": { "type": "string" },
     "mode": { "type": "string" },
     "uptime_seconds": { "type": "integer" },
-    "version": { "type": "string" }
+    "version": { "type": "string" },
+    "commit": { "type": "string" },
+    "instance_id": { "type": "string" }
   }
 }
 ```
+
+`instance_id` is an opaque identifier generated for each server start. It is
+shared with the owner's private `serve.state`; health never returns a PID,
+executable path, launch arguments, or token. The identifier provides freshness
+evidence, not authentication or process ownership. `commit` is build metadata
+(including development-build values), not a cryptographic attestation. Older services may omit
+`commit` and `instance_id`; clients can display their version and mode while
+withholding runtime-bound verification evidence.
 
 ### Status Codes
 - `200 OK`

--- a/internal/plugin/openclaw/index.js
+++ b/internal/plugin/openclaw/index.js
@@ -485,16 +485,17 @@ function toolDisplayName(toolName, originalToolName) {
 // ─── Rampart API client ───────────────────────────────────────────────────────
 
 const MAX_CONTROL_RESPONSE_BYTES = 1024 * 1024;
+const MAX_HEALTH_RESPONSE_BYTES = 4 * 1024;
 const POLICY_DECISIONS = new Set(["allow", "watch", "ask", "deny"]);
 const APPROVAL_SEVERITIES = new Set(["info", "warning", "critical"]);
 
 class InvalidControlResponseError extends Error {}
 
-async function readControlResponseText(response) {
+async function readControlResponseText(response, maxBytes = MAX_CONTROL_RESPONSE_BYTES) {
   const declaredLength = response?.headers?.get?.("content-length");
   if (declaredLength !== null && declaredLength !== undefined && declaredLength !== "") {
     const parsedLength = Number(declaredLength);
-    if (Number.isFinite(parsedLength) && parsedLength > MAX_CONTROL_RESPONSE_BYTES) {
+    if (Number.isFinite(parsedLength) && parsedLength > maxBytes) {
       await response?.body?.cancel?.().catch(() => {});
       throw new InvalidControlResponseError("Rampart response exceeded the size limit");
     }
@@ -512,7 +513,7 @@ async function readControlResponseText(response) {
         const { done, value } = await reader.read();
         if (done) break;
         total += value?.byteLength ?? 0;
-        if (total > MAX_CONTROL_RESPONSE_BYTES) {
+        if (total > maxBytes) {
           await reader.cancel().catch(() => {});
           throw new InvalidControlResponseError("Rampart response exceeded the size limit");
         }
@@ -528,14 +529,14 @@ async function readControlResponseText(response) {
   // production Fetch path above performs the limit before buffering the body.
   if (typeof response?.text === "function") {
     const text = await response.text();
-    if (new TextEncoder().encode(text).byteLength > MAX_CONTROL_RESPONSE_BYTES) {
+    if (new TextEncoder().encode(text).byteLength > maxBytes) {
       throw new InvalidControlResponseError("Rampart response exceeded the size limit");
     }
     return text;
   }
   if (typeof response?.json === "function") {
     const text = JSON.stringify(await response.json());
-    if (new TextEncoder().encode(text).byteLength > MAX_CONTROL_RESPONSE_BYTES) {
+    if (new TextEncoder().encode(text).byteLength > maxBytes) {
       throw new InvalidControlResponseError("Rampart response exceeded the size limit");
     }
     return text;
@@ -543,8 +544,8 @@ async function readControlResponseText(response) {
   throw new InvalidControlResponseError("Rampart response body is unreadable");
 }
 
-async function readControlResponseJSON(response) {
-  const text = await readControlResponseText(response);
+async function readControlResponseJSON(response, maxBytes = MAX_CONTROL_RESPONSE_BYTES) {
+  const text = await readControlResponseText(response, maxBytes);
   try {
     return JSON.parse(text);
   } catch (err) {
@@ -557,6 +558,42 @@ function isConsistentPolicyDecision(result) {
   if (!POLICY_DECISIONS.has(result.decision)) return false;
   if (typeof result.allowed !== "boolean") return false;
   return result.allowed === (result.decision === "allow" || result.decision === "watch");
+}
+
+// Observe the endpoint captured by this loaded plugin, so CLI verification
+// cannot attribute its canary decisions to a different configured service.
+// Health is public: never send the control token or return arbitrary fields.
+async function observeVerificationRuntime(serveUrl) {
+  if (typeof serveUrl !== "string" || !isTrustedServeUrl(serveUrl)) return null;
+  const endpoint = serveUrl.trim().replace(/\/+$/, "");
+  try {
+    const response = await fetch(`${endpoint}/healthz`, {
+      method: "GET",
+      redirect: "error",
+      signal: AbortSignal.timeout(3000),
+    });
+    if (response.status !== 200) {
+      await response?.body?.cancel?.().catch(() => {});
+      return null;
+    }
+    const health = await readControlResponseJSON(response, MAX_HEALTH_RESPONSE_BYTES);
+    if (!health || health.service !== "rampart" || health.status !== "ok" ||
+        health.mode !== "enforce" || !Number.isInteger(health.uptime_seconds) || health.uptime_seconds < 0 ||
+        typeof health.instance_id !== "string" || !/^[A-Za-z0-9_-]{16,128}$/.test(health.instance_id) ||
+        typeof health.version !== "string" || !health.version.trim() ||
+        typeof health.commit !== "string" || !health.commit.trim()) return null;
+    return {
+      endpoint,
+      instance_id: health.instance_id,
+      version: health.version,
+      commit: health.commit,
+      mode: health.mode,
+    };
+  } catch {
+    // Legacy, unavailable, malformed and redirected health provide no runtime
+    // proof. The fixed canary results are still useful to older CLI versions.
+    return null;
+  }
 }
 
 /**
@@ -939,6 +976,7 @@ export function register(api) {
   // tool. The canaries are fixed here rather than caller-supplied so this RPC
   // can never become an execution or arbitrary policy-probing surface.
   api.registerGatewayMethod("rampart.verify", async ({ respond }) => {
+    const before = await observeVerificationRuntime(serveUrl);
     const canaryCtx = {
       agentId: "rampart-verification",
       sessionKey: "rampart-verification",
@@ -1007,11 +1045,15 @@ export function register(api) {
         });
       }
     }
+    const after = await observeVerificationRuntime(serveUrl);
+    const stableRuntime = before && after &&
+      ["endpoint", "instance_id", "version", "commit", "mode"].every((key) => before[key] === after[key]);
     respond(true, {
       schema: "rampart.plugin.verify.v1",
       safeCanaries: true,
       ok: checks.every((check) => check.pass),
       checks,
+      ...(stableRuntime ? { runtime: before } : {}),
     });
   });
 

--- a/internal/plugin/openclaw/provider-surface-replay.mjs
+++ b/internal/plugin/openclaw/provider-surface-replay.mjs
@@ -437,35 +437,86 @@ assert(authError?.block === true, '401 auth error should block sensitive tool ca
 assert(authError.blockReason.includes('HTTP 401'), `auth block reason should mention HTTP 401: ${authError.blockReason}`);
 scenarios.push('auth-error-fail-closed');
 
-const liveVerification = await withPlugin({
-  name: 'live-behavioral-verification',
-  fetchImpl: async (url, opts = {}) => {
-    assert(String(url).includes('/v1/preflight/'), `unexpected verification URL: ${url}`);
-    const body = parseBody({ opts });
-    const tool = decodeURIComponent(String(url).split('/v1/preflight/')[1]);
-    let decision = 'allow';
-    if (tool === 'exec' && body.params.command === 'rm -rf /') decision = 'deny';
-    if (tool === 'exec' && body.params.command?.startsWith('git push ')) decision = 'ask';
-    if (tool === 'message' && body.params.rampart_consequence === 'openclaw:external-message') decision = 'ask';
-    if (tool === 'exec' && body.params.command?.startsWith('cat ~/.ssh/id_')) decision = 'deny';
-    if (tool === 'exec' && body.params.command?.startsWith('python3 -c ')) decision = 'ask';
-    assert(body.verification === true, 'verification calls must request side-effect-free preflight mode');
-    return fetchJson({ decision, allowed: decision === 'allow', action: { version: 1, tool, params: body.params, input: body.input } });
-  },
-  invoke: async ({ gatewayMethods }) => {
-    const verify = gatewayMethods['rampart.verify'];
-    assert(typeof verify === 'function', 'rampart.verify gateway method missing');
-    let response;
-    await verify({ respond: (ok, payload) => { response = { ok, payload }; } });
-    return response;
-  },
-});
+const verificationEndpoint = 'http://127.0.0.1:19091';
+const verificationHealth = {
+  service: 'rampart', status: 'ok', uptime_seconds: 1,
+  instance_id: 'verification-instance-0001', version: '2.0.0', commit: 'fixture-commit', mode: 'enforce',
+};
+
+async function runVerificationScenario(name, healthResponse) {
+  const requests = [];
+  let healthCalls = 0;
+  const response = await withPlugin({
+    name,
+    pluginConfig: { serveUrl: verificationEndpoint },
+    fetchImpl: async (url, opts = {}) => {
+      requests.push(String(url));
+      assert(opts.redirect === 'error', 'verification must reject redirects');
+      if (String(url) === `${verificationEndpoint}/healthz`) {
+        assert(opts.method === 'GET' && opts.signal, 'health must use a bounded GET');
+        assert(!opts.headers?.Authorization, 'health must not carry the control token');
+        return healthResponse(++healthCalls);
+      }
+      assert(String(url).startsWith(`${verificationEndpoint}/v1/preflight/`), `unexpected verification URL: ${url}`);
+      const body = parseBody({ opts });
+      const tool = decodeURIComponent(String(url).split('/v1/preflight/')[1]);
+      let decision = 'allow';
+      if (tool === 'exec' && body.params.command === 'rm -rf /') decision = 'deny';
+      if (tool === 'exec' && body.params.command?.startsWith('git push ')) decision = 'ask';
+      if (tool === 'message' && body.params.rampart_consequence === 'openclaw:external-message') decision = 'ask';
+      if (tool === 'exec' && body.params.command?.startsWith('cat ~/.ssh/id_')) decision = 'deny';
+      if (tool === 'exec' && body.params.command?.startsWith('python3 -c ')) decision = 'ask';
+      assert(body.verification === true, 'verification calls must request side-effect-free preflight mode');
+      return fetchJson({ decision, allowed: decision === 'allow', action: { version: 1, tool, params: body.params, input: body.input } });
+    },
+    invoke: async ({ gatewayMethods }) => {
+      const verify = gatewayMethods['rampart.verify'];
+      assert(typeof verify === 'function', 'rampart.verify gateway method missing');
+      let result;
+      await verify({ respond: (ok, payload) => { result = { ok, payload }; } });
+      return result;
+    },
+  });
+  assert(healthCalls === 2 && requests.length === 8, `${name}: expected health around six fixed canaries`);
+  assert(requests[0].endsWith('/healthz') && requests.at(-1).endsWith('/healthz'), `${name}: health must bracket canaries`);
+  return response;
+}
+
+const liveVerification = await runVerificationScenario('live-behavioral-verification', () => fetchJson({
+  ...verificationHealth, token: 'synthetic-private-value', pid: 42, executable: '/synthetic/private/path',
+}));
 assert(liveVerification?.ok === true, 'gateway verification RPC should respond successfully');
 assert(liveVerification.payload?.schema === 'rampart.plugin.verify.v1', 'verification schema missing');
 assert(liveVerification.payload?.safeCanaries === true, 'verification must identify safe canaries');
 assert(liveVerification.payload?.ok === true, `verification failed: ${JSON.stringify(liveVerification.payload)}`);
 assert(liveVerification.payload?.checks?.length === 6, 'expected six plugin policy canaries');
+assert(JSON.stringify(liveVerification.payload.runtime) === JSON.stringify({
+  endpoint: verificationEndpoint,
+  instance_id: verificationHealth.instance_id,
+  version: verificationHealth.version,
+  commit: verificationHealth.commit,
+  mode: verificationHealth.mode,
+}), 'runtime proof must contain only the loaded endpoint and stable public identity');
 scenarios.push('live-behavioral-verification');
+
+for (const [name, healthResponse] of [
+  ['legacy-runtime', () => fetchJson({ service: 'rampart', status: 'ok', uptime_seconds: 1, version: '1.9.1', mode: 'enforce' })],
+  ['restarted-runtime', (call) => fetchJson({ ...verificationHealth, instance_id: `verification-instance-000${call}` })],
+  ['changed-runtime-build', (call) => fetchJson({ ...verificationHealth, commit: `fixture-commit-${call}` })],
+  ['monitor-runtime', () => fetchJson({ ...verificationHealth, mode: 'monitor' })],
+  ['disabled-runtime', () => fetchJson({ ...verificationHealth, mode: 'disabled' })],
+  ['unavailable-runtime', () => { throw new Error('synthetic private error'); }],
+  ['redirected-runtime', () => new Response(null, { status: 302 })],
+  ['malformed-runtime', () => new Response('{')],
+  ['oversized-runtime', () => new Response(JSON.stringify({ ...verificationHealth, extra: 'x'.repeat(4096) }))],
+]) {
+  const result = await runVerificationScenario(name, healthResponse);
+  assert(result?.ok === true && result.payload?.ok === true, `${name}: legacy canary result contract changed`);
+  assert(result.payload?.checks?.length === 6, `${name}: fixed canaries missing`);
+  assert(!Object.hasOwn(result.payload, 'runtime'), `${name}: runtime evidence must be withheld`);
+  assert(!JSON.stringify(result).includes('synthetic private error'), `${name}: private health error reflected`);
+  scenarios.push(`verification-${name}`);
+}
 
 const degraded = await withPlugin({
   name: 'degraded-sensitive-exec-blocks',

--- a/internal/proxy/eval_handlers.go
+++ b/internal/proxy/eval_handlers.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/peg/rampart/internal/approval"
 	"github.com/peg/rampart/internal/audit"
-	"github.com/peg/rampart/internal/build"
 	"github.com/peg/rampart/internal/engine"
 )
 
@@ -814,11 +813,10 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleHealth(w http.ResponseWriter, _ *http.Request) {
 	uptime := int(time.Since(s.startedAt).Seconds())
-	writeJSON(w, http.StatusOK, map[string]any{
-		"service":        "rampart",
-		"status":         "ok",
-		"mode":           s.mode,
-		"uptime_seconds": uptime,
-		"version":        build.Version,
+	writeJSON(w, http.StatusOK, HealthResponse{
+		RuntimeIdentity: s.RuntimeIdentity(),
+		Service:         "rampart",
+		Status:          "ok",
+		UptimeSeconds:   &uptime,
 	})
 }

--- a/internal/proxy/runtime.go
+++ b/internal/proxy/runtime.go
@@ -1,0 +1,29 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0
+
+package proxy
+
+import "github.com/peg/rampart/internal/build"
+
+// RuntimeIdentity identifies one server start. InstanceID is freshness evidence,
+// not authentication or proof that the process belongs to the current user.
+// Process IDs, executable paths, and launch arguments remain in private state.
+type RuntimeIdentity struct {
+	InstanceID string `json:"instance_id,omitempty"`
+	Version    string `json:"version"`
+	Commit     string `json:"commit,omitempty"`
+	Mode       string `json:"mode"`
+}
+
+// HealthResponse is the unauthenticated, credential-free health contract.
+type HealthResponse struct {
+	RuntimeIdentity
+	Service       string `json:"service"`
+	Status        string `json:"status"`
+	UptimeSeconds *int   `json:"uptime_seconds"`
+}
+
+// RuntimeIdentity returns the identity shared by health and private serve.state.
+func (s *Server) RuntimeIdentity() RuntimeIdentity {
+	return RuntimeIdentity{InstanceID: s.instanceID, Version: build.Version, Commit: build.Commit, Mode: s.mode}
+}

--- a/internal/proxy/runtime_test.go
+++ b/internal/proxy/runtime_test.go
@@ -28,7 +28,7 @@ func TestHealthIdentifiesOnlyTheServerStart(t *testing.T) {
 	if health.RuntimeIdentity != first.RuntimeIdentity() || health.Mode != "monitor" {
 		t.Fatalf("health identity = %#v", health)
 	}
-	for _, private := range []string{"synthetic-private-token", "pid", "executable", "arguments"} {
+	for _, private := range []string{"synthetic-private-token", `"pid":`, `"executable":`, `"arguments":`} {
 		if strings.Contains(response.Body.String(), private) {
 			t.Fatalf("health exposed private field %s", private)
 		}

--- a/internal/proxy/runtime_test.go
+++ b/internal/proxy/runtime_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026 The Rampart Authors
+// Licensed under the Apache License, Version 2.0
+
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestHealthIdentifiesOnlyTheServerStart(t *testing.T) {
+	first := New(nil, nil, WithToken("synthetic-private-token"), WithMode("monitor"))
+	second := New(nil, nil, WithToken("synthetic-private-token"))
+	t.Cleanup(func() { _ = first.Shutdown(context.Background()) })
+	t.Cleanup(func() { _ = second.Shutdown(context.Background()) })
+	if first.RuntimeIdentity().InstanceID == "" || first.RuntimeIdentity().InstanceID == second.RuntimeIdentity().InstanceID {
+		t.Fatal("server starts must have distinct opaque identities")
+	}
+	response := httptest.NewRecorder()
+	first.handler().ServeHTTP(response, httptest.NewRequest("GET", "/healthz", nil))
+	var health HealthResponse
+	if err := json.Unmarshal(response.Body.Bytes(), &health); err != nil {
+		t.Fatal(err)
+	}
+	if health.RuntimeIdentity != first.RuntimeIdentity() || health.Mode != "monitor" {
+		t.Fatalf("health identity = %#v", health)
+	}
+	for _, private := range []string{"synthetic-private-token", "pid", "executable", "arguments"} {
+		if strings.Contains(response.Body.String(), private) {
+			t.Fatalf("health exposed private field %s", private)
+		}
+	}
+}

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -15,6 +15,7 @@ package proxy
 
 import (
 	"context"
+	"crypto/rand"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -57,6 +58,7 @@ type Server struct {
 	policyWriteMu       sync.Mutex
 	server              *http.Server
 	startedAt           time.Time
+	instanceID          string
 	notifyConfig        *engine.NotifyConfig
 	notificationSlots   chan struct{}
 	metricsEnabled      bool
@@ -178,7 +180,7 @@ func WithApprovalPersistenceFile(path string) Option {
 	}
 }
 
-// WithConfigPath sets the config path string shown in the /v1/policy endpoint.
+// WithConfigPath sets the config path string shown in the /v1/status endpoint.
 // Use "embedded:standard" when the embedded default policy is active.
 func WithConfigPath(path string) Option {
 	return func(s *Server) {
@@ -195,6 +197,7 @@ func New(eng *engine.Engine, sink audit.AuditSink, opts ...Option) *Server {
 		mode:              defaultMode,
 		logger:            slog.Default(),
 		startedAt:         time.Now().UTC(),
+		instanceID:        rand.Text(),
 		sse:               newSSEHub(),
 		stopCleanup:       make(chan struct{}),
 		notificationSlots: make(chan struct{}, maxConcurrentNotifications),


### PR DESCRIPTION
Upgrading a background service could discard its working directory and custom options. If the new service started but failed activation checks, it could also remain alive and prevent recovery. Save the effective launch settings privately, preserve the existing token and TLS references, and verify that the restarted service retains the previous endpoint and mode.

Capture the new candidate's process identity independently of health. Before rollback, revalidate its complete private state and process birth identity, stop that owned candidate, then restore and verify the previous executable and runtime. If ownership or state has changed, leave that process untouched, retain the backup, and report the original failure plus incomplete recovery.

Legacy default launches use conservative OS argument and working-directory inspection, including the released launcher's canonical log path. Ambiguous custom legacy settings require manual migration before interruption. Systemd and launchd keep their existing definitions. Canonical upgrade documentation explains that this new updater cannot retroactively change the custom-restart behavior shipped inside v1.9.1.

This builds on #436. The lifecycle change can be reviewed relative to that PR's head, `6ccaac2bdf17697d7d8fa22fd0ec21307ab38c1f`; its base remains staging for the required full CI.

Validation at `787a0f31b712246a8acd9edcddead8bca5cf1aec`:

- Focused race checks and strict docs/canonical-document checks passed. Source regressions cover typed flag parsing, unknown fields, path traversal, pinned TLS, prior endpoint/mode, changed process ownership, and joined rollback failures.
- Five isolated actual-process journeys passed on macOS arm64: custom activation; live-candidate rejection and verified rollback; changed-state refusal without signaling; migration of the actual released v1.9.1 default service; and refusal of an ambiguous v1.9.1 custom launch before interruption. The original aliased-home migration fixture passes after the canonical log-path correction.
- Those journeys use exact-source command logic with local archive/checksum input and real released/candidate executables. They preserve actual endpoint, mode and authentication, all non-CWD launch fields exactly, the CWD directory identity, and policy/audit/TLS bytes. Owned services, listeners and disposable homes were cleaned up. No provider calls were made.
- Full required source/security gate passed (`go test ./...`, `go vet ./...`, `make security-assurance`, diff checks). Exact-head Linux, macOS, Windows, package, container, policy, Python and documentation CI passed in [CI run 34565216569](https://github.com/peg/rampart/actions/runs/34565216569) and its associated docs check. Independent review found no unresolved material issue in this scoped change.

The first Windows run exposed Unix-only expectations in two tests. The certificate regression now compares with the actual loader's native relative open; the already-current CLI case explicitly exercises a supported self-upgrade branch while existing Windows installer-refusal coverage stays intact. Production behavior was unchanged by that test correction. All local and actual-process checks above were repeated on the updated head.

The process checks are conservative repeated OS observations, not atomic cross-platform process handles. Background-process acceptance does not establish installed systemd/launchd behavior or a public updater journey to an unpublished release. No release or expanded integration support is claimed.
