### PR TITLE
fix(openclaw): preserve complete approval reviews and explicit rejections

### DIFF
--- a/docs-site/integrations/openclaw.md
+++ b/docs-site/integrations/openclaw.md
@@ -178,10 +178,18 @@ rampart init --profile openclaw
 
 ## Complete action approval
 
-The native plugin offers `allow-once` and `deny`. It shows the complete
-represented arguments, targets and available host context with secrets redacted.
+The native plugin offers `allow-once` and `deny`. It shows the complete original
+execution arguments and derived targets with secrets redacted, together with
+the available agent, delegation depth, requester, origin and working directory.
 The approval belongs to OpenClaw; Rampart creates no second pending queue.
 Timeouts deny the call.
+
+Opaque session, run and tool-call identifiers remain in Rampart's service
+requests and audit records instead of consuming the visible review budget.
+OpenClaw separately retains its native tool-call, agent and session approval
+binding. A working directory already represented exactly in the original
+arguments is shown once; a distinct working directory is also included.
+Original arguments with these same field names are always retained.
 
 The policy input retains adapter-derived facts used by the Guard rules. Its
 `rampart_original_input` field preserves the original tool arguments for review
@@ -190,7 +198,8 @@ adapter's reserved fields. Those names cannot replace derived policy facts or
 host context. Native approval displays this original payload after redaction.
 
 OpenClaw's native hook description is limited to 512 characters and does not
-forward a complete-review attachment. If the complete rendered action exceeds
+forward a complete-review attachment. Compact presentation avoids duplicated
+metadata; it never truncates arguments or targets. If the final escaped review exceeds
 that limit, Rampart blocks it before creating an approval. Split it into smaller
 independently reviewable actions or configure an explicit operator-reviewed
 policy. An older Rampart service without the complete review response also

--- a/internal/plugin/openclaw/README.md
+++ b/internal/plugin/openclaw/README.md
@@ -43,7 +43,7 @@ Arguments:
 
 ## What to check
 
-- `ask` returns `requireApproval` only with a complete server-redacted action fitting the native 512-character description limit
+- `ask` returns `requireApproval` only with complete server-redacted execution arguments, targets and execution context fitting the native 512-character description limit; opaque correlation IDs remain bound outside that display
 - `deny` returns `block: true`
 - native approvals offer `allow-once` and `deny`; unsupported `allow-always` callbacks never create broader command/path rules
 - `allow` returns without rewriting executable tool parameters

--- a/internal/plugin/openclaw/approval-regression.mjs
+++ b/internal/plugin/openclaw/approval-regression.mjs
@@ -25,14 +25,20 @@ function assert(condition, message) {
   if (!condition) throw new Error(message);
 }
 
-async function runScenario({ name, toolResult, toolName = 'exec', params = { command: 'sudo true' }, resolution, includeAction = true }) {
+async function runScenario({ name, toolResult, toolName = 'exec', params = { command: 'sudo true' }, resolution, includeAction = true, context = {}, eventIds = {} }) {
   const { api, handlers, hookOpts, logs } = createApi();
   const fetchCalls = [];
   const originalFetch = global.fetch;
   global.fetch = async (url, opts = {}) => {
     fetchCalls.push({ url: String(url), opts });
     if (String(url).includes(`/v1/tool/${encodeURIComponent(toolName)}`)) {
-      return { ok: true, json: async () => ({ ...toolResult, ...(includeAction ? { action: toolResult.action ?? { version: 1, tool: toolName, params } } : {}) }) };
+      const request = JSON.parse(opts.body);
+      const action = toolResult.action ?? {
+        version: 1, tool: toolName, params: request.params, input: request.input,
+        agent: request.agent, session: request.session, run_id: request.run_id,
+        tool_call_id: request.tool_call_id, workdir: request.params.workdir,
+      };
+      return { ok: true, json: async () => ({ ...toolResult, ...(includeAction ? { action } : {}) }) };
     }
     if (String(url).includes('/v1/rules/learn')) {
       return { ok: true, status: 200, json: async () => ({ ok: true }) };
@@ -48,8 +54,9 @@ async function runScenario({ name, toolResult, toolName = 'exec', params = { com
       agentId: 'main',
       sessionKey: 'agent:main:discord:direct:449621595489828865',
       runId: `${name}-run`,
+      ...context,
     };
-    const result = await before({ toolName, params }, ctx);
+    const result = await before({ toolName, params, ...eventIds }, ctx);
     if (resolution && result?.requireApproval?.onResolution) {
       await result.requireApproval.onResolution(resolution);
     }
@@ -139,6 +146,84 @@ for (const original of [null, 'command', []]) {
 }
 const redacted = await runScenario({ name: 'redacted-review', params: { command: 'echo --token=synthetic-private' }, toolResult: { decision: 'ask', allowed: false, action: { version: 1, tool: 'exec', params: { command: 'echo --token=[REDACTED]' } } } });
 assert(!JSON.stringify(redacted.result).includes('synthetic-private'), 'plugin displayed raw local params instead of server-redacted review');
+
+function displayedAction(result) {
+  const description = result?.requireApproval?.description;
+  assert(typeof description === 'string', 'complete execution review missing');
+  const match = description.match(/^Action \(redacted\):\n```json\n([\s\S]*)\n```$/);
+  assert(match, 'execution arguments lost their fenced JSON presentation');
+  return JSON.parse(match[1]);
+}
+
+// Long real-world paths and requester facts must fit without spending the
+// native description budget on opaque correlation IDs or duplicate workdir.
+const workdir = '/srv/operations/monthly-maintenance/production-reporting/customer-services/active/workspace';
+const longParams = {
+  command: `/usr/bin/cp --backup=numbered ${workdir}/report.json ${workdir.replace('/workspace', '/dead-end')}/report.json`,
+  workdir,
+};
+const longContext = {
+  agentId: 'ops', sessionKey: `session-${'s'.repeat(120)}`,
+  requester: { channel: 'webchat', senderId: 'cli', senderIsOwner: true },
+};
+const longEventIds = { runId: `run-${'r'.repeat(120)}`, toolCallId: `call-${'t'.repeat(120)}` };
+const longReview = await runScenario({
+  name: 'long-execution-review-retains-binding', params: longParams,
+  context: longContext, eventIds: longEventIds,
+  toolResult: { decision: 'ask', allowed: false }, resolution: 'allow-once',
+});
+const longDisplayed = displayedAction(longReview.result);
+assert(JSON.stringify(longDisplayed.params) === JSON.stringify(longParams), 'long execution arguments changed or were shortened');
+assert(longDisplayed.agent === 'ops', 'agent identity missing from execution review');
+assert(JSON.stringify(longDisplayed.requester) === JSON.stringify(longContext.requester), 'requester facts missing');
+assert(!Object.hasOwn(longDisplayed, 'workdir'), 'identical workdir was repeated');
+const longRequest = JSON.parse(longReview.fetchCalls[0].opts.body);
+assert(longRequest.session === longContext.sessionKey && longRequest.run_id === longEventIds.runId && longRequest.tool_call_id === longEventIds.toolCallId, 'display compaction changed service/audit correlation');
+assert(longRequest.openclaw_hosted === true && longRequest.skip_pending_approval === true, 'native approval ownership changed');
+assert(longReview.result.params === undefined, 'approval rewrote executable arguments');
+for (const value of [longContext.sessionKey, longEventIds.runId, longEventIds.toolCallId]) {
+  assert(!longReview.result.requireApproval.description.includes(value), 'opaque correlation consumed execution-review budget');
+}
+
+for (const originalParams of [{ command: 'pwd' }, { command: 'pwd', workdir: '.' }]) {
+  const scoped = await runScenario({
+    name: 'distinct-execution-context', params: originalParams,
+    toolResult: { decision: 'ask', allowed: false, action: {
+      version: 1, tool: 'exec', agent: 'ops', agent_depth: 2, workdir: '/srv/operations',
+      params: {}, input: { rampart_original_input: originalParams },
+    } },
+  });
+  const displayed = displayedAction(scoped.result);
+  assert(displayed.workdir === '/srv/operations' && displayed.agent_depth === 2, 'distinct workdir or delegation depth was discarded');
+  assert(JSON.stringify(displayed.params) === JSON.stringify(originalParams), 'original relative workdir changed');
+}
+
+const targetParams = { paths: ['/srv/a', '/srv/b'], session: 'target-session', run_id: 'target-run', tool_call_id: 'target-call' };
+const targetFacts = { rampart_original_tool: 'apply_patch', rampart_targets: ['/srv/a', '/srv/b'], rampart_requester: { channel: 'webchat', senderId: 'cli' }, rampart_origin_channel: 'operations' };
+const targetsReview = await runScenario({
+  name: 'execution-fields-named-like-correlation', toolName: 'edit', params: targetParams,
+  toolResult: { decision: 'ask', allowed: false, action: {
+    version: 1, tool: 'edit', params: targetFacts, input: { rampart_original_input: targetParams },
+    session: 'opaque-session', run_id: 'opaque-run', tool_call_id: 'opaque-call',
+  } },
+});
+const targetsDisplayed = displayedAction(targetsReview.result);
+assert(JSON.stringify(targetsDisplayed.params) === JSON.stringify(targetParams), 'original arguments named like correlation IDs were discarded');
+assert(targetsDisplayed.tool === 'apply_patch' && targetsDisplayed.policy_class === 'edit', 'original tool or policy class missing');
+assert(JSON.stringify(targetsDisplayed.targets) === JSON.stringify(targetFacts.rampart_targets), 'derived targets missing');
+assert(JSON.stringify(targetsDisplayed.requester) === JSON.stringify(targetFacts.rampart_requester) && targetsDisplayed.origin_channel === 'operations', 'requester or origin missing');
+
+// Exercise the actual final escaped description boundary, including expansion
+// of markup and bidi characters. The transport accepts 512, never 513.
+const boundaryParams = { command: 'echo <`\u202e' };
+const boundaryBase = await runScenario({ name: 'escaped-boundary-base', params: boundaryParams, toolResult: { decision: 'ask', allowed: false } });
+const padding = 512 - boundaryBase.result.requireApproval.description.length;
+assert(padding > 0, 'boundary fixture unexpectedly too large');
+const boundary512 = await runScenario({ name: 'escaped-boundary-512', params: { command: boundaryParams.command + 'x'.repeat(padding) }, toolResult: { decision: 'ask', allowed: false } });
+assert(boundary512.result?.requireApproval?.description.length === 512, 'exact native escaped-text boundary was not accepted');
+assert(displayedAction(boundary512.result).params.command === boundaryParams.command + 'x'.repeat(padding), 'boundary action was shortened');
+const boundary513 = await runScenario({ name: 'escaped-boundary-513', params: { command: boundaryParams.command + 'x'.repeat(padding + 1) }, toolResult: { decision: 'ask', allowed: false } });
+assert(boundary513.result?.block && !boundary513.result.requireApproval, 'oversized final escaped text became approvable');
 
 console.log(JSON.stringify({
   ok: true,

--- a/internal/plugin/openclaw/degraded-mode-test.mjs
+++ b/internal/plugin/openclaw/degraded-mode-test.mjs
@@ -147,26 +147,31 @@ const oversizedResponse = await runScenario({
 });
 assert(oversizedResponse.result?.block === true, 'oversized response must fail closed');
 
-const slowBody = await runScenario({
-  name: 'slow-response-body',
-  toolName: 'exec',
-  pluginConfig: { timeoutMs: 5 },
-  fetchImpl: async (_url, opts) => new Response(new ReadableStream({
-    start(controller) {
-      const delayed = setTimeout(() => {
-        controller.enqueue(new TextEncoder().encode('{"decision":"allow","allowed":true}'));
-        controller.close();
-      }, 50);
-      opts.signal.addEventListener('abort', () => {
-        clearTimeout(delayed);
-        const error = new Error('response body aborted');
-        error.name = 'AbortError';
-        controller.error(error);
-      }, { once: true });
-    },
-  }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
-});
-assert(slowBody.result?.block === true, 'timeout must cover the complete response body');
+for (const status of [200, 401, 403]) {
+  const slowBody = await runScenario({
+    name: `slow-response-body-${status}`,
+    toolName: status === 200 ? 'exec' : 'read',
+    pluginConfig: { timeoutMs: 5, failOpenTools: ['read'] },
+    fetchImpl: async (_url, opts) => new Response(new ReadableStream({
+      start(controller) {
+        const delayed = setTimeout(() => {
+          controller.enqueue(new TextEncoder().encode('{"decision":"allow","allowed":true}'));
+          controller.close();
+        }, 50);
+        opts.signal.addEventListener('abort', () => {
+          clearTimeout(delayed);
+          const error = new Error('response body aborted');
+          error.name = 'AbortError';
+          controller.error(error);
+        }, { once: true });
+      },
+    }), { status, headers: { 'Content-Type': 'application/json' } }),
+  });
+  assert(slowBody.result?.block === true, `${status}: body timeout must not allow the tool`);
+  if (status !== 200) {
+    assert(slowBody.result.blockReason.includes(`HTTP ${status}`), 'body timeout lost the already received rejection');
+  }
+}
 
 const untrustedServeUrl = await runScenario({
   name: 'untrusted-serve-url',
@@ -191,4 +196,4 @@ for (const serveUrl of [
   assert(!JSON.stringify(scenario.logs).includes('password'), 'unsafe serveUrl credentials must not reach logs');
 }
 
-console.log(JSON.stringify({ ok: true, scenarios: ['unreachable-exec', 'unreachable-read-explicit-fail-open', 'unreachable-read-default-closed', 'server-error-write', 'timeout-edit', 'server-error-read-strict', 'client-error-read-explicit-fail-open', 'manual-redirect-read-explicit-fail-open', 'empty-object-response', 'array-response', 'missing-allowed-response', 'contradictory-allow-response', 'contradictory-deny-response', 'unknown-decision', 'redirect-read-explicit-fail-open', 'oversized-response', 'slow-response-body', 'untrusted-serve-url'] }, null, 2));
+console.log(JSON.stringify({ ok: true, scenarios: ['unreachable-exec', 'unreachable-read-explicit-fail-open', 'unreachable-read-default-closed', 'server-error-write', 'timeout-edit', 'server-error-read-strict', 'client-error-read-explicit-fail-open', 'manual-redirect-read-explicit-fail-open', 'empty-object-response', 'array-response', 'missing-allowed-response', 'contradictory-allow-response', 'contradictory-deny-response', 'unknown-decision', 'redirect-read-explicit-fail-open', 'oversized-response', 'slow-response-body-200', 'slow-response-body-401', 'slow-response-body-403', 'untrusted-serve-url'] }, null, 2));

--- a/internal/plugin/openclaw/index.js
+++ b/internal/plugin/openclaw/index.js
@@ -51,20 +51,24 @@ function nativeApprovalDescription(action) {
     const original = action.input.rampart_original_input;
     if (!original || typeof original !== "object" || Array.isArray(original)) return null;
   }
-  // Render original host arguments once. Policy-derived fields are not
-  // executable arguments; retain their tool class, all parsed targets and
-  // host-derived requester/context separately instead of duplicating input.
+  // Keep every original argument and execution-relevant host fact. Correlation
+  // IDs remain in the service request and audit, and the host retains its own
+  // approval binding. They need not consume the small human-review field.
+  // Only deduplicate workdir
+  // when the original arguments already contain the exact same value.
   const originalTool = action.params.rampart_original_tool ?? action.tool;
+  const originalParams = action.input?.rampart_original_input ?? action.input ?? action.params;
   const context = Object.fromEntries(
-    ["agent", "agent_depth", "session", "run_id", "tool_call_id", "workdir"]
-      .filter((key) => action[key] !== undefined && action[key] !== "")
+    ["agent", "agent_depth", "workdir"]
+      .filter((key) => action[key] !== undefined && action[key] !== "" &&
+        (key !== "workdir" || action[key] !== originalParams.workdir))
       .map((key) => [key, action[key]]),
   );
   const presented = {
     tool: originalTool,
     ...(originalTool !== action.tool ? { policy_class: action.tool } : {}),
-    params: action.input?.rampart_original_input ?? action.input ?? action.params,
-    ...(Object.keys(context).length ? { context } : {}),
+    params: originalParams,
+    ...context,
     ...(action.params.rampart_targets ? { targets: action.params.rampart_targets } : {}),
     ...(action.params.rampart_requester ? { requester: action.params.rampart_requester } : {}),
     ...(action.params.rampart_origin_channel ? { origin_channel: action.params.rampart_origin_channel } : {}),
@@ -75,7 +79,7 @@ function nativeApprovalDescription(action) {
     .replace(/`/g, "\\u0060")
     .replace(/</g, "\\u003c")
     .replace(/>/g, "\\u003e");
-  const description = `Complete action (secrets redacted):\n\`\`\`json\n${text}\n\`\`\``;
+  const description = `Action (redacted):\n\`\`\`json\n${text}\n\`\`\``;
   return description.length <= MAX_NATIVE_APPROVAL_DESCRIPTION ? description : null;
 }
 

--- a/internal/plugin/openclaw/index.js
+++ b/internal/plugin/openclaw/index.js
@@ -620,13 +620,14 @@ async function checkWithRampart(toolName, params, ctx, config, { verification = 
     });
 
     if (!resp.ok) {
-      // Authentication failures are explicit denies, and their bodies are
-      // bounded/drained without being reflected into logs or approval UI.
+      // 401 is an authentication failure; 403 may instead be a policy/access
+      // rejection. Both deny without reflecting their bounded/drained bodies.
       if (resp.status === 403 || resp.status === 401) {
         // Drain the bounded body for connection reuse, but never reflect an
-        // authentication response body into host logs or approval UI.
+        // rejection response body into host logs or approval UI.
         await readControlResponseText(resp);
-        return { allowed: false, decision: "deny", message: `Rampart authentication rejected (HTTP ${resp.status})` };
+        const rejection = resp.status === 401 ? "authentication rejected" : "request rejected";
+        return { allowed: false, decision: "deny", message: `Rampart ${rejection} (HTTP ${resp.status})` };
       }
       await resp?.body?.cancel?.().catch(() => {});
       // Redirects and other client errors indicate an incompatible or invalid

--- a/internal/plugin/openclaw/index.js
+++ b/internal/plugin/openclaw/index.js
@@ -625,7 +625,11 @@ async function checkWithRampart(toolName, params, ctx, config, { verification = 
       if (resp.status === 403 || resp.status === 401) {
         // Drain the bounded body for connection reuse, but never reflect an
         // rejection response body into host logs or approval UI.
-        await readControlResponseText(resp);
+        try {
+          await readControlResponseText(resp);
+        } catch {
+          // A failed body cannot undo a rejection status already received.
+        }
         const rejection = resp.status === 401 ? "authentication rejected" : "request rejected";
         return { allowed: false, decision: "deny", message: `Rampart ${rejection} (HTTP ${resp.status})` };
       }

--- a/internal/plugin/openclaw/provider-surface-replay.mjs
+++ b/internal/plugin/openclaw/provider-surface-replay.mjs
@@ -424,18 +424,27 @@ assert(
 assert(ask.result.requireApproval.timeoutReason.includes('denied'), 'approval should explain timeout denial');
 scenarios.push('write-tool-hosted-approval');
 
-const authError = await withPlugin({
-  name: 'auth-error-fail-closed',
-  fetchImpl: async () => ({ ok: false, status: 401, text: async () => '{"error":"invalid token"}' }),
-  invoke: async ({ handlers }) => {
-    const before = handlers.before_tool_call;
-    assert(typeof before === 'function', 'before_tool_call handler missing');
-    return await before({ toolName: 'exec', params: { command: 'sudo id' } }, ctx);
-  },
-});
-assert(authError?.block === true, '401 auth error should block sensitive tool calls');
-assert(authError.blockReason.includes('HTTP 401'), `auth block reason should mention HTTP 401: ${authError.blockReason}`);
-scenarios.push('auth-error-fail-closed');
+for (const [status, rejection, name] of [
+  [401, 'authentication rejected', 'auth-error-fail-closed'],
+  [403, 'request rejected', 'forbidden-response-fail-closed'],
+]) {
+  let drained = false;
+  const rejected = await withPlugin({
+    name,
+    fetchImpl: async () => ({ ok: false, status, text: async () => {
+      drained = true;
+      return '{"error":"synthetic-private-response"}';
+    } }),
+    invoke: async ({ handlers }) => {
+      const before = handlers.before_tool_call;
+      assert(typeof before === 'function', 'before_tool_call handler missing');
+      return await before({ toolName: 'exec', params: { command: 'sudo id' } }, ctx);
+    },
+  });
+  assert(rejected?.block === true && drained, `${status} rejection should drain and block`);
+  assert(rejected.blockReason === `rampart: Rampart ${rejection} (HTTP ${status})`, 'HTTP rejection was misclassified or reflected its body');
+  scenarios.push(name);
+}
 
 const liveVerification = await withPlugin({
   name: 'live-behavioral-verification',


### PR DESCRIPTION
OpenClaw's native hook approval description is limited to 512 characters. Opaque correlation IDs and a duplicated working directory could exhaust that budget even when the complete execution arguments fit. The formatter now preserves every original argument, derived target, requester/origin, agent/depth and distinct working directory while omitting opaque correlation IDs only from the human presentation. Service and audit correlation and OpenClaw's native approval binding remain intact. Reviews exceeding the final escaped-text limit still fail closed.

Explicit HTTP rejections now retain their denial even if the response body fails, and HTTP 403 uses a neutral request-rejected message rather than an authentication diagnosis. Responses remain bounded and their bodies are never reflected. Documentation describes the presentation and remaining review-size limit.

Validation:

- Regression coverage checks preserved arguments and identities, distinct working directories, escaping at 512/513 characters, rejection messages, and body-read failures through the registered hook. Final focused-head Node and Go embedded-plugin checks passed; strict docs passed for the unchanged documentation. Full combined-source validation is identified below.
- Actual OpenClaw 2026.9.4 gateway, native dispatcher and approval transport retained native sandboxing and approvals. On combined candidate `2ea16ca`, the original long-path action fit at 511 characters, approval resumed exactly one effect, and denial, repeat denial, changed-target review at 512 characters, plugin expiry and late resolution refusal passed. The strict host-exec route still required two operator decisions: one plugin approval and one native exec approval.
- On final combined candidate `0ff616c`, the HTTP 403 denial, blocked write during service outage and successful write after recovery passed. Owned test resources were removed. Full source/security checks also passed on this final candidate.

Limits: these are synthetic configured-host checks with a local scripted model peer, not a productivity benchmark or stock setup timing. Native exec advertised a 30-minute expiry; the bounded observer ended before expiry, so that case remains unverified and its earlier aggregate run remains failed. The separate 120-second plugin expiry was observed. Required GitHub checks must pass on the exact PR head before merge; the installed-host results retain the candidate identities listed above.
