### PR TITLE
fix(codex): explain separate native approvals

### DIFF
--- a/assurance/integrations.yaml
+++ b/assurance/integrations.yaml
@@ -202,6 +202,7 @@ integrations:
       - The verification command exercises installed configuration and the adapter; it does not invoke a model or prove host hook ingestion.
       - Codex hosted tools and specialized local tool paths that opt out of lifecycle hooks are not covered.
       - Approval actions require rampart serve because Codex PreToolUse does not currently accept an ask decision.
+      - Rampart approval does not authorize Codex sandbox escalation or native permission requests; the host may require a separate approval.
       - Codex controls hook timeout behavior; a host timeout cannot be claimed fail-closed.
       - Physical Windows host ingestion remains unverified.
 

--- a/cmd/rampart/cli/hook_codex.go
+++ b/cmd/rampart/cli/hook_codex.go
@@ -35,6 +35,8 @@ type codexHookInput struct {
 
 const maxCodexPatchPaths = 100
 
+const codexApprovalScopeNotice = "Approval here satisfies Rampart policy for this invocation. Codex may still require a separate sandbox or permission approval."
+
 func parseCodexInput(reader io.Reader) (*hookParseResult, error) {
 	var input codexHookInput
 	if err := json.NewDecoder(reader).Decode(&input); err != nil {
@@ -331,10 +333,14 @@ func resolveExternalHookApproval(
 		// this call waits in Rampart's approval queue.
 		errWriter: io.Discard,
 	}
+	approvalMessage := reason
+	if format == "codex" {
+		approvalMessage += "\n\n" + codexApprovalScopeNotice
+	}
 	result := client.requestApprovalCtx(
 		cmd.Context(),
 		call,
-		reason,
+		approvalMessage,
 		5*time.Minute,
 	)
 	if result == hookAsk {

--- a/cmd/rampart/cli/hook_codex_test.go
+++ b/cmd/rampart/cli/hook_codex_test.go
@@ -476,6 +476,11 @@ func TestResolveCodexApprovalPreservesExactToolIdentity(t *testing.T) {
 	if request.RunID != "session-1" || request.ToolCallID != "call-1" {
 		t.Fatalf("approval identity = run %q call %q", request.RunID, request.ToolCallID)
 	}
+	if !strings.Contains(request.Message, "approval required") ||
+		!strings.Contains(request.Message, "satisfies Rampart policy for this invocation") ||
+		!strings.Contains(request.Message, "Codex may still require a separate sandbox or permission approval") {
+		t.Fatalf("external review must retain the policy reason and explain native approval scope: %q", request.Message)
+	}
 }
 
 func runCodexHookOutput(t *testing.T, decision hookDecisionType, post bool) map[string]any {

--- a/cmd/rampart/cli/setup_codex.go
+++ b/cmd/rampart/cli/setup_codex.go
@@ -115,6 +115,8 @@ Run 'rampart setup codex --remove' to uninstall.`,
 			fmt.Fprintln(out, "  Covers Codex CLI, IDE extension, and desktop local tool calls.")
 			fmt.Fprintln(out, "  Codex will require review of this hook definition before first use.")
 			fmt.Fprintln(out, "  Open `/hooks` in Codex and trust the Rampart hooks.")
+			fmt.Fprintln(out, "  Rampart approvals do not replace Codex sandbox or permission approvals.")
+			fmt.Fprintln(out, "  Approval guidance: https://docs.rampart.sh/integrations/codex-cli/#decisions-and-approvals")
 			if removedWrapper {
 				fmt.Fprintf(out, "✓ Removed legacy preload wrapper at %s to prevent duplicate checks.\n", wrapperPath)
 			}

--- a/cmd/rampart/cli/setup_codex_test.go
+++ b/cmd/rampart/cli/setup_codex_test.go
@@ -31,6 +31,10 @@ func TestSetupCodexInstallsNativeHooksWithoutCodexOrPreload(t *testing.T) {
 	if !strings.Contains(stdout.String(), "Open `/hooks`") {
 		t.Fatalf("setup output must explain Codex hook trust:\n%s", stdout.String())
 	}
+	if !strings.Contains(stdout.String(), "Rampart approvals do not replace Codex sandbox or permission approvals") ||
+		!strings.Contains(stdout.String(), "https://docs.rampart.sh/integrations/codex-cli/#decisions-and-approvals") {
+		t.Fatalf("setup output must explain separate native approval and link to guidance:\n%s", stdout.String())
+	}
 	if _, err := os.Stat(filepath.Join(home, ".local", "bin", "codex")); !os.IsNotExist(err) {
 		t.Fatalf("native setup must not create a codex wrapper: %v", err)
 	}

--- a/docs-site/getting-started/support-matrix.md
+++ b/docs-site/getting-started/support-matrix.md
@@ -64,7 +64,7 @@ and the isolated latest-Hermes compatibility check for runtime evidence.
       <td data-label="Best path">Native lifecycle hooks<br><code>rampart setup codex</code></td>
       <td data-label="Bare protect">Yes</td>
       <td data-label="rampart serve">Not required for local allow/deny;<br>required for approval queue</td>
-      <td data-label="Approval UX">External Rampart queue; unavailable approval service denies</td>
+      <td data-label="Approval UX">External Rampart queue; native approval may also be required. Unavailable approval service denies</td>
       <td data-label="Support tier"><strong>Supported</strong><br>installed-hook and adapter verification</td>
     </tr>
     <tr class="tier-supported" data-integration="cline">

--- a/docs-site/integrations/codex-cli.md
+++ b/docs-site/integrations/codex-cli.md
@@ -43,8 +43,8 @@ not emit lifecycle hooks remain outside this boundary.
 
 ### Execution context visibility
 
-In Codex 0.153.2, the
-[unified execution handler](https://github.com/openai/codex/blob/rust-v0.153.2/codex-rs/core/src/tools/handlers/unified_exec/exec_command.rs)
+In Codex 0.154.0, the
+[unified execution handler](https://github.com/openai/codex/blob/6b9826e3aa83b1a5947db50f4332cb9c65f1b340/codex-rs/core/src/tools/handlers/unified_exec/exec_command.rs)
 reports `exec_command` as `Bash` with only `command` in `tool_input`. It omits
 the requested `workdir` and `shell`. The
 [hook's `cwd`](https://developers.openai.com/codex/hooks#common-input-fields)
@@ -68,6 +68,45 @@ rampart watch
 ```
 
 If the approval service is unavailable, the call is denied.
+
+### Why Codex may ask again
+
+Approving the Rampart request satisfies Rampart policy for that invocation.
+Codex may then request its own sandbox escalation or permission approval.
+Both decisions remain necessary when both policies require review. A Rampart
+approval does not grant Codex broader filesystem or network access, and a
+native denial still prevents execution.
+
+Codex 0.154.0 has a separate
+[`PermissionRequest` hook](https://learn.chatgpt.com/docs/hooks#permissionrequest)
+that can decide a pending native approval. Rampart does not automatically
+approve it: the
+[external hook input](https://github.com/openai/codex/blob/6b9826e3aa83b1a5947db50f4332cb9c65f1b340/codex-rs/hooks/src/events/permission_request.rs#L171)
+omits the tool-call ID, and its Bash input omits the requested execution
+directory and sandbox permissions. Those missing fields prevent safely
+binding a prior Rampart approval to the full native request. Deferring every
+Rampart `ask` to this hook would also miss calls that need no native approval.
+
+### Reduce routine reviews deliberately
+
+If you want a specific routine command to run without a Rampart review, add
+an explicit global user rule, for example:
+
+```bash
+rampart allow "python3 -m unittest -q" --global --tool exec
+```
+
+This authorizes the command whenever that rule matches. It does not pin the
+test files or their future contents: the same command can execute changed
+repository code. Choose this only when that continuing authority is intended;
+avoid broad interpreter patterns such as `python3 **`. Keep Codex's sandbox,
+permission rules and reviewer enabled. Other Rampart rules that require review,
+such as publication rules, can still produce a second approval alongside
+Codex's native request.
+
+This is an optional policy change, not an automatic handoff between approval
+systems. Rampart does not compile its policies into Codex prefix rules or
+change native permissions to suppress prompts.
 
 ## Verify
 


### PR DESCRIPTION
Codex can require its own sandbox or permission approval after Rampart approves the same invocation. The external review and setup output now explain that scope, and the integration guide and support contract describe the two independent decisions.

The guide explains why Codex's current `PermissionRequest` payload cannot safely consume a prior Rampart approval, and documents an optional exact-command user rule with its ongoing-authority and source-content limits. Enforcement, hook registration, native configuration, and approval outcomes remain unchanged; this change does not eliminate the second approval.

Validation:

- Full local source checks: `go test ./...`, `go vet ./...`, and `make security-assurance`; affected quick checks and focused race checks passed.
- Strict documentation build and `git diff --check` passed.
- Exact candidate exercised through Codex 0.154.0 with native workspace-write sandbox and user approval transport active, using a fixed local Responses peer without model/provider calls. Verified sandbox refusal, complete review scope, native denial after Rampart approval, execution after both approvals, fresh review for a repeated invocation, and correlated verified audit chains.
